### PR TITLE
fix: slider thumb does not respond to touch events, vertical sliders track parameters incorrect after scrolling page

### DIFF
--- a/packages/web-components/fast-components-msft/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components-msft/src/slider/slider.styles.ts
@@ -25,6 +25,7 @@ export const SliderStyles = css`
         --thumb-size: calc(${heightNumber} * 0.5);
         --thumb-translate: calc(var(--thumb-size) * 0.5);
         --track-overhang: calc((var(--design-unit) / 2) * -1);
+        --track-width: var(--design-unit);
         align-items: center;
         width: 100%;
         margin: calc(var(--design-unit) * 1px) 0;
@@ -85,15 +86,14 @@ export const SliderStyles = css`
         right: calc(var(--track-overhang) * 1px);
         left: calc(var(--track-overhang) * 1px);
         align-self: start;
-        margin-top: 6px;
-        height: 4px;
+        margin-top: calc((var(--design-unit) + 2) * 1px);
+        height: calc(var(--track-width) * 1px);
     }
     :host(.vertical) .track {
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
-        justify-self: start;
-        margin-left: 6px;
-        width: 4px;
+        margin-left: calc((var(--design-unit) + 2) * 1px);
+        width: calc(var(--track-width) * 1px);
         height: 100%;
     }
     .track {

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -25,6 +25,7 @@ export const SliderStyles = css`
         --thumb-size: calc(${heightNumber} * 0.5 - var(--design-unit));
         --thumb-translate: calc(var(--thumb-size) * 0.5);
         --track-overhang: calc((var(--design-unit) / 2) * -1);
+        --track-width: var(--design-unit);
         align-items: center;
         width: 100%;
         margin: calc(var(--design-unit) * 1px) 0;
@@ -87,15 +88,14 @@ export const SliderStyles = css`
         right: calc(var(--track-overhang) * 1px);
         left: calc(var(--track-overhang) * 1px);
         align-self: start;
-        margin-top: calc(var(--design-unit) * 1px);
-        height: 4px;
+        margin-top: calc((var(--design-unit) + 2) * 1px);
+        height: calc(var(--track-width) * 1px);
     }
     :host(.vertical) .track {
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
-        justify-self: start;
-        margin-left: calc(var(--design-unit) * 1px);
-        width: 4px;
+        margin-left: calc((var(--design-unit) + 2) * 1px);
+        width: calc(var(--track-width) * 1px);
         height: 100%;
     }
     .track {

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -535,6 +535,8 @@ export class Slider extends FormAssociated<HTMLInputElement> implements SliderCo
     // @internal (undocumented)
     trackHeight: number;
     // @internal (undocumented)
+    trackLeft: number;
+    // @internal (undocumented)
     trackMinHeight: number;
     // @internal (undocumented)
     trackMinWidth: number;

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -317,6 +317,7 @@ export class Slider extends FormAssociated<HTMLInputElement>
         this.addEventListener("keydown", this.keypressHandler);
         this.addEventListener("mousedown", this.clickHandler);
         this.thumb.addEventListener("mousedown", this.handleThumbMouseDown);
+        this.thumb.addEventListener("touchstart", this.handleThumbMouseDown);
     };
 
     private setupDefaultValue = (): void => {
@@ -341,6 +342,8 @@ export class Slider extends FormAssociated<HTMLInputElement>
         (event.target as HTMLElement).focus();
         window.addEventListener("mouseup", this.handleWindowMouseUp);
         window.addEventListener("mousemove", this.handleMouseMove);
+        window.addEventListener("touchmove", this.handleMouseMove);
+        window.addEventListener("touchend", this.handleWindowMouseUp);
         this.isDragging = true;
     };
 

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -224,6 +224,7 @@ export class Slider extends FormAssociated<HTMLInputElement>
         this.removeEventListener("keydown", this.keypressHandler);
         this.removeEventListener("mousedown", this.handleMouseDown);
         this.thumb.removeEventListener("mousedown", this.handleThumbMouseDown);
+        this.thumb.removeEventListener("touchstart", this.handleThumbMouseDown);
     }
 
     /**
@@ -403,6 +404,8 @@ export class Slider extends FormAssociated<HTMLInputElement>
         this.isDragging = false;
         window.removeEventListener("mouseup", this.handleWindowMouseUp);
         window.removeEventListener("mousemove", this.handleMouseMove);
+        window.removeEventListener("touchmove", this.handleMouseMove);
+        window.removeEventListener("touchend", this.handleWindowMouseUp);
     };
 
     private handleMouseDown = (e: MouseEvent) => {

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -411,6 +411,12 @@ export class Slider extends FormAssociated<HTMLInputElement>
                     ? e.pageX - this.getBoundingClientRect().left
                     : e.pageY;
 
+            if (this.orientation === Orientation.vertical) {
+                const clientRect: DOMRect = this.track.getBoundingClientRect();
+                this.trackHeight = clientRect.bottom;
+                this.trackMinHeight = clientRect.top;
+            }
+
             this.value = `${this.calculateNewValue(controlValue)}`;
             this.updateForm();
         }

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -291,7 +291,7 @@ export class Slider extends FormAssociated<HTMLInputElement>
             Number(this.max),
             direction
         );
-        const percentage: number = Math.fround((1 - newPct) * 100);
+        const percentage: number = Math.round((1 - newPct) * 100);
         if (this.orientation === Orientation.horizontal) {
             this.position = this.isDragging
                 ? `right: ${percentage}%; transition: all 0.1s ease;`


### PR DESCRIPTION
# Description
* added touch related events for dragging the slider thumb on mobile devices
* issue fixed when the vertical slider was further down the page scrolling could cause the track min and max to be incorrect.

<img width="538" alt="Screen Shot 2020-06-30 at 3 08 59 PM" src="https://user-images.githubusercontent.com/25805778/86181865-aa8e0c80-bae3-11ea-803d-60f0325ce9a0.png">

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.