### PR TITLE
fix(fast-element): do not notify when binding observer is disconnected

### DIFF
--- a/packages/web-components/fast-element/src/directives/binding.spec.ts
+++ b/packages/web-components/fast-element/src/directives/binding.spec.ts
@@ -133,15 +133,12 @@ describe("The binding directive", () => {
 
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
-            const newTemplate = html<Model>`This is a new template, different from before.
-            ${x => x.knownValue}`;
+            const newTemplate = html<Model>`This is a new template ${x => x.knownValue}`;
             model.value = newTemplate;
 
             await DOM.nextUpdate();
 
-            expect(toHTML(parentNode)).to.equal(
-                `This is a new template, different from before. value`
-            );
+            expect(toHTML(parentNode)).to.equal(`This is a new template value`);
         });
 
         it("reuses a previous view when the value changes back from a string", async () => {

--- a/packages/web-components/fast-element/src/directives/binding.spec.ts
+++ b/packages/web-components/fast-element/src/directives/binding.spec.ts
@@ -14,6 +14,7 @@ describe("The binding directive", () => {
 
         @observable value: any = null;
         @observable private trigger = 0;
+        @observable knownValue = "value";
 
         forceComputedUpdate() {
             this.trigger++;
@@ -67,22 +68,22 @@ describe("The binding directive", () => {
     context("when binding template content", () => {
         it("initially inserts a view based on the template", () => {
             const { behavior, parentNode } = contentBinding();
-            const template = html`This is a template.`;
+            const template = html<Model>`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
             behavior.bind(model, defaultExecutionContext);
 
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
         });
 
         it("removes an inserted view when the value changes to plain text", async () => {
             const { behavior, parentNode } = contentBinding();
-            const template = html`This is a template.`;
+            const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
             behavior.bind(model, defaultExecutionContext);
 
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
             model.value = "This is a test.";
 
@@ -93,12 +94,12 @@ describe("The binding directive", () => {
 
         it("removes an inserted view when the value changes to null", async () => {
             const { behavior, parentNode } = contentBinding();
-            const template = html`This is a template.`;
+            const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
             behavior.bind(model, defaultExecutionContext);
 
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
             model.value = null;
 
@@ -109,12 +110,12 @@ describe("The binding directive", () => {
 
         it("removes an inserted view when the value changes to undefined", async () => {
             const { behavior, parentNode } = contentBinding();
-            const template = html`This is a template.`;
+            const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
             behavior.bind(model, defaultExecutionContext);
 
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
             model.value = void 0;
 
@@ -125,26 +126,27 @@ describe("The binding directive", () => {
 
         it("updates an inserted view when the value changes to a new template", async () => {
             const { behavior, parentNode } = contentBinding();
-            const template = html`This is a template.`;
+            const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
             behavior.bind(model, defaultExecutionContext);
 
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
-            const newTemplate = html`This is a new template, different from before.`;
+            const newTemplate = html<Model>`This is a new template, different from before.
+            ${x => x.knownValue}`;
             model.value = newTemplate;
 
             await DOM.nextUpdate();
 
             expect(toHTML(parentNode)).to.equal(
-                `This is a new template, different from before.`
+                `This is a new template, different from before. value`
             );
         });
 
         it("reuses a previous view when the value changes back from a string", async () => {
             const { behavior, parentNode, node } = contentBinding();
-            const template = html`This is a template.`;
+            const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
             behavior.bind(model, defaultExecutionContext);
@@ -154,7 +156,7 @@ describe("The binding directive", () => {
 
             expect(view).to.be.instanceOf(HTMLView);
             expect(capturedTemplate).to.equal(template);
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
             model.value = "This is a test string.";
 
@@ -171,38 +173,38 @@ describe("The binding directive", () => {
 
             expect(newView).to.equal(view);
             expect(newCapturedTemplate).to.equal(capturedTemplate);
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
         });
 
         it("doesn't compose an already composed view", async () => {
             const { behavior, parentNode } = contentBinding("computedValue");
-            const template = html`This is a template.`;
+            const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
             behavior.bind(model, defaultExecutionContext);
 
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
             model.value = template;
             model.forceComputedUpdate();
 
             await DOM.nextUpdate();
 
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
         });
     });
 
     context("when unbinding template content", () => {
         it("unbinds a composed view", () => {
             const { behavior, node, parentNode } = contentBinding();
-            const template = html`This is a template.`;
+            const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
             behavior.bind(model, defaultExecutionContext);
 
             const newView = (node as any).$fastView as SyntheticView;
             expect(newView.source).to.equal(model);
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
             behavior.unbind();
 
@@ -211,14 +213,14 @@ describe("The binding directive", () => {
 
         it("rebinds a previously unbound composed view", () => {
             const { behavior, node, parentNode } = contentBinding();
-            const template = html`This is a template.`;
+            const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
             behavior.bind(model, defaultExecutionContext);
 
             const view = (node as any).$fastView as SyntheticView;
             expect(view.source).to.equal(model);
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
             behavior.unbind();
 
@@ -228,7 +230,7 @@ describe("The binding directive", () => {
 
             const newView = (node as any).$fastView as SyntheticView;
             expect(newView.source).to.equal(model);
-            expect(toHTML(parentNode)).to.equal(`This is a template.`);
+            expect(toHTML(parentNode)).to.equal(`This is a template. value`);
         });
     });
 });

--- a/packages/web-components/fast-element/src/observation/observable.spec.ts
+++ b/packages/web-components/fast-element/src/observation/observable.spec.ts
@@ -541,5 +541,28 @@ describe("The Observable", () => {
             value = observer.observe(model, defaultExecutionContext);
             expect(value).to.equal(binding(model));
         });
+
+        it("does not notify if disconnected", async () => {
+            let wasCalled = false;
+            const binding = (x: Model) => x.value;
+            const observer = Observable.binding(binding, {
+                handleChange() {
+                    wasCalled = true;
+                },
+            });
+
+            const model = new Model();
+
+            const value = observer.observe(model, defaultExecutionContext);
+            expect(value).to.equal(model.value);
+            expect(wasCalled).to.equal(false);
+
+            model.value++;
+            observer.disconnect();
+
+            await DOM.nextUpdate();
+
+            expect(wasCalled).to.equal(false);
+        });
     });
 });

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -456,7 +456,9 @@ class BindingObserverImplementation<TSource = any, TReturn = any, TParent = any>
 
     /** @internal */
     call(): void {
-        this.needsQueue = true;
-        this.notify(this);
+        if (this.last !== null) {
+            this.needsQueue = true;
+            this.notify(this);
+        }
     }
 }


### PR DESCRIPTION
# Description

Prevents the `BindingObserver` from notifying subscribers when it is disconnected.

## Motivation & context

Certain binding scenarios can cause a BindingObserver to register a change, but due to the async nature of batched updates, the observer may be disconnected before subscribers are notified (e.g. some conditional rendering scenarios). In this case, we do not want to notify the subscribers. Doing so can cause some error states as the subscribers may be bindings that are unbound and thus no longer have access to the source object to execute the lambda against. If that happens, null reference exceptions ensue.

The fix introduces a simple guard before notifying subscribers, based on already existing state in the BindingObserver. A test was added to verify the fix. I also made a few other improvements to binding tests in the process of tracking down the actual problem.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.