### PR TITLE
feat: move appearance attributes of anchor and button out of fast-foundation

### DIFF
--- a/packages/web-components/fast-components-msft/docs/api-report.md
+++ b/packages/web-components/fast-components-msft/docs/api-report.md
@@ -98,12 +98,18 @@ export const accentForegroundRestBehavior: import("@microsoft/fast-foundation").
 export const ambientShadow = "0 0 calc((var(--elevation) * 0.225px) + 2px) rgba(0, 0, 0, calc(.11 * (2 - var(--background-luminance, 1))))";
 
 // @public
+export type AnchorAppearance = ButtonAppearance | "hypertext";
+
+// @public
 export type BadgeAppearance = "accent" | "lightweight" | "neutral" | string;
 
 // Warning: (ae-internal-missing-underscore) The name "BaseButtonStyles" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
 export const BaseButtonStyles: import("@microsoft/fast-element").ElementStyles;
+
+// @public
+export type ButtonAppearance = "accent" | "lightweight" | "neutral" | "outline" | "stealth";
 
 // Warning: (ae-internal-missing-underscore) The name "directionalShadow" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -123,6 +129,9 @@ export class FASTAccordionItem extends AccordionItem {
 
 // @public
 export class FASTAnchor extends Anchor {
+    appearance: AnchorAppearance;
+    // (undocumented)
+    appearanceChanged(oldValue: AnchorAppearance, newValue: AnchorAppearance): void;
 }
 
 // @public
@@ -133,6 +142,9 @@ export class FASTBadge extends Badge {
 
 // @public
 export class FASTButton extends Button {
+    appearance: ButtonAppearance;
+    // (undocumented)
+    appearanceChanged(oldValue: ButtonAppearance, newValue: ButtonAppearance): void;
 }
 
 // @public

--- a/packages/web-components/fast-components-msft/src/anchor/index.ts
+++ b/packages/web-components/fast-components-msft/src/anchor/index.ts
@@ -1,6 +1,13 @@
-import { customElement } from "@microsoft/fast-element";
+import { attr, customElement } from "@microsoft/fast-element";
 import { Anchor, AnchorTemplate as template } from "@microsoft/fast-foundation";
 import { AnchorStyles as styles } from "./anchor.styles";
+import { ButtonAppearance } from "../button";
+
+/**
+ * Types of anchor appearance.
+ * @public
+ */
+export type AnchorAppearance = ButtonAppearance | "hypertext";
 
 /**
  * The FAST Anchor Element. Implements {@link @microsoft/fast-foundation#Anchor},
@@ -21,4 +28,23 @@ import { AnchorStyles as styles } from "./anchor.styles";
         delegatesFocus: true,
     },
 })
-export class FASTAnchor extends Anchor {}
+export class FASTAnchor extends Anchor {
+    /**
+     * The appearance the anchor should have.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: appearance
+     */
+    @attr
+    public appearance: AnchorAppearance = "neutral";
+    public appearanceChanged(
+        oldValue: AnchorAppearance,
+        newValue: AnchorAppearance
+    ): void {
+        if (oldValue !== newValue) {
+            this.classList.add(newValue);
+            this.classList.remove(oldValue);
+        }
+    }
+}

--- a/packages/web-components/fast-components-msft/src/button/index.ts
+++ b/packages/web-components/fast-components-msft/src/button/index.ts
@@ -1,6 +1,17 @@
-import { customElement } from "@microsoft/fast-element";
+import { attr, customElement } from "@microsoft/fast-element";
 import { Button, ButtonTemplate as template } from "@microsoft/fast-foundation";
 import { ButtonStyles as styles } from "./button.styles";
+
+/**
+ * Types of button appearance.
+ * @public
+ */
+export type ButtonAppearance =
+    | "accent"
+    | "lightweight"
+    | "neutral"
+    | "outline"
+    | "stealth";
 
 /**
  * The FAST Button Element. Implements {@link @microsoft/fast-foundation#Button},
@@ -21,4 +32,23 @@ import { ButtonStyles as styles } from "./button.styles";
         delegatesFocus: true,
     },
 })
-export class FASTButton extends Button {}
+export class FASTButton extends Button {
+    /**
+     * The appearance the button should have.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: appearance
+     */
+    @attr
+    public appearance: ButtonAppearance = "neutral";
+    public appearanceChanged(
+        oldValue: ButtonAppearance,
+        newValue: ButtonAppearance
+    ): void {
+        if (oldValue !== newValue) {
+            this.classList.add(newValue);
+            this.classList.remove(oldValue);
+        }
+    }
+}

--- a/packages/web-components/fast-components/src/anchor/index.ts
+++ b/packages/web-components/fast-components/src/anchor/index.ts
@@ -1,6 +1,13 @@
-import { customElement } from "@microsoft/fast-element";
+import { attr, customElement } from "@microsoft/fast-element";
 import { Anchor, AnchorTemplate as template } from "@microsoft/fast-foundation";
 import { AnchorStyles as styles } from "./anchor.styles";
+import { ButtonAppearance } from "../button";
+
+/**
+ * Types of anchor appearance.
+ * @public
+ */
+export type AnchorAppearance = ButtonAppearance | "hypertext";
 
 /**
  * The FAST Anchor Element. Implements {@link @microsoft/fast-foundation#Anchor},
@@ -21,4 +28,23 @@ import { AnchorStyles as styles } from "./anchor.styles";
         delegatesFocus: true,
     },
 })
-export class FASTAnchor extends Anchor {}
+export class FASTAnchor extends Anchor {
+    /**
+     * The appearance the anchor should have.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: appearance
+     */
+    @attr
+    public appearance: AnchorAppearance = "neutral";
+    public appearanceChanged(
+        oldValue: AnchorAppearance,
+        newValue: AnchorAppearance
+    ): void {
+        if (oldValue !== newValue) {
+            this.classList.add(newValue);
+            this.classList.remove(oldValue);
+        }
+    }
+}

--- a/packages/web-components/fast-components/src/button/index.ts
+++ b/packages/web-components/fast-components/src/button/index.ts
@@ -1,6 +1,17 @@
-import { customElement } from "@microsoft/fast-element";
+import { attr, customElement } from "@microsoft/fast-element";
 import { Button, ButtonTemplate as template } from "@microsoft/fast-foundation";
 import { ButtonStyles as styles } from "./button.styles";
+
+/**
+ * Types of button appearance.
+ * @public
+ */
+export type ButtonAppearance =
+    | "accent"
+    | "lightweight"
+    | "neutral"
+    | "outline"
+    | "stealth";
 
 /**
  * The FAST Button Element. Implements {@link @microsoft/fast-foundation#Button},
@@ -21,4 +32,23 @@ import { ButtonStyles as styles } from "./button.styles";
         delegatesFocus: true,
     },
 })
-export class FASTButton extends Button {}
+export class FASTButton extends Button {
+    /**
+     * The appearance the button should have.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: appearance
+     */
+    @attr
+    public appearance: ButtonAppearance = "neutral";
+    public appearanceChanged(
+        oldValue: ButtonAppearance,
+        newValue: ButtonAppearance
+    ): void {
+        if (oldValue !== newValue) {
+            this.classList.add(newValue);
+            this.classList.remove(oldValue);
+        }
+    }
+}

--- a/packages/web-components/fast-components/temp/api-report.md
+++ b/packages/web-components/fast-components/temp/api-report.md
@@ -617,12 +617,12 @@ export const neutralFillHoverBehavior: import("@microsoft/fast-foundation").CSSC
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInput" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInput: import("./common").ColorRecipe<FillSwatchFamily>;
+export const neutralFillInput: ColorRecipe<FillSwatchFamily>;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputActive" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInputActive: import("./common").ColorRecipe<string>;
+export const neutralFillInputActive: ColorRecipe<string>;
 
 // @public
 export const neutralFillInputActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
@@ -633,7 +633,7 @@ export const neutralFillInputFocusBehavior: import("@microsoft/fast-foundation")
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInputHover: import("./common").ColorRecipe<string>;
+export const neutralFillInputHover: ColorRecipe<string>;
 
 // @public
 export const neutralFillInputHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
@@ -641,7 +641,7 @@ export const neutralFillInputHoverBehavior: import("@microsoft/fast-foundation")
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInputRest: import("./common").ColorRecipe<string>;
+export const neutralFillInputRest: ColorRecipe<string>;
 
 // @public
 export const neutralFillInputRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
@@ -649,7 +649,7 @@ export const neutralFillInputRestBehavior: import("@microsoft/fast-foundation").
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputSelected" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInputSelected: import("./common").ColorRecipe<string>;
+export const neutralFillInputSelected: ColorRecipe<string>;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillRest" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/web-components/fast-components/temp/api-report.md
+++ b/packages/web-components/fast-components/temp/api-report.md
@@ -617,12 +617,12 @@ export const neutralFillHoverBehavior: import("@microsoft/fast-foundation").CSSC
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInput" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInput: ColorRecipe<FillSwatchFamily>;
+export const neutralFillInput: import("./common").ColorRecipe<FillSwatchFamily>;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputActive" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInputActive: ColorRecipe<string>;
+export const neutralFillInputActive: import("./common").ColorRecipe<string>;
 
 // @public
 export const neutralFillInputActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
@@ -633,7 +633,7 @@ export const neutralFillInputFocusBehavior: import("@microsoft/fast-foundation")
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInputHover: ColorRecipe<string>;
+export const neutralFillInputHover: import("./common").ColorRecipe<string>;
 
 // @public
 export const neutralFillInputHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
@@ -641,7 +641,7 @@ export const neutralFillInputHoverBehavior: import("@microsoft/fast-foundation")
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInputRest: ColorRecipe<string>;
+export const neutralFillInputRest: import("./common").ColorRecipe<string>;
 
 // @public
 export const neutralFillInputRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
@@ -649,7 +649,7 @@ export const neutralFillInputRestBehavior: import("@microsoft/fast-foundation").
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputSelected" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export const neutralFillInputSelected: ColorRecipe<string>;
+export const neutralFillInputSelected: import("./common").ColorRecipe<string>;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillRest" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -56,7 +56,6 @@ export const AccordionTemplate: import("@microsoft/fast-element").ViewTemplate<A
 //
 // @public
 export class Anchor extends FASTElement {
-    appearance: AnchorAppearance;
     download: string;
     href: string;
     hreflang: string;
@@ -70,9 +69,6 @@ export class Anchor extends FASTElement {
 // @internal
 export interface Anchor extends StartEnd {
 }
-
-// @public
-export type AnchorAppearance = ButtonAppearance | "hypertext";
 
 // @public
 export const AnchorTemplate: import("@microsoft/fast-element").ViewTemplate<Anchor, any>;
@@ -105,7 +101,6 @@ export class BaseProgress extends FASTElement {
 // @public
 export class Button extends FormAssociated<HTMLInputElement> {
     constructor();
-    appearance: ButtonAppearance;
     autofocus: boolean;
     // @internal (undocumented)
     connectedCallback(): void;
@@ -125,9 +120,6 @@ export class Button extends FormAssociated<HTMLInputElement> {
 // @internal
 export interface Button extends StartEnd {
 }
-
-// @public
-export type ButtonAppearance = "accent" | "lightweight" | "neutral" | "outline" | "stealth";
 
 // @public
 export const ButtonTemplate: import("@microsoft/fast-element").ViewTemplate<Button, any>;

--- a/packages/web-components/fast-foundation/src/anchor/README.md
+++ b/packages/web-components/fast-foundation/src/anchor/README.md
@@ -5,7 +5,7 @@ sidebar_label: anchor
 custom_edit_url: https://github.com/microsoft/fast/edit/master/packages/web-components/fast-foundation/src/anchor/README.md
 ---
 
-`fast-anchor` is a web component implementation of an [HTML anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a). The component supports the same visual appearances as the button component (accent, lightweight, neutral, outline, stealth) as well as a hypertext appearance for use inline with text.
+`fast-anchor` is a web component implementation of an [HTML anchor element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a). The `fast-components` and `fast-components-msft` components support the same visual appearances as the button component (accent, lightweight, neutral, outline, stealth) as well as a hypertext appearance for use inline with text.
 
 ## Usage
 

--- a/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
@@ -7,24 +7,22 @@ import { Anchor } from "./anchor";
  * @public
  */
 export const AnchorTemplate = html<Anchor>`
-    <template>
-        <a
-            class="control"
-            part="control"
-            download="${x => x.download}"
-            href="${x => x.href}"
-            hreflang="${x => x.hreflang}"
-            ping="${x => x.ping}"
-            referrerpolicy="${x => x.referrerpolicy}"
-            rel="${x => x.rel}"
-            target="${x => x.target}"
-            type="${x => x.type}"
-        >
-            ${startTemplate}
-            <span class="content" part="content">
-                <slot></slot>
-            </span>
-            ${endTemplate}
-        </a>
-    </template>
+    <a
+        class="control"
+        part="control"
+        download="${x => x.download}"
+        href="${x => x.href}"
+        hreflang="${x => x.hreflang}"
+        ping="${x => x.ping}"
+        referrerpolicy="${x => x.referrerpolicy}"
+        rel="${x => x.rel}"
+        target="${x => x.target}"
+        type="${x => x.type}"
+    >
+        ${startTemplate}
+        <span class="content" part="content">
+            <slot></slot>
+        </span>
+        ${endTemplate}
+    </a>
 `;

--- a/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
@@ -7,7 +7,7 @@ import { Anchor } from "./anchor";
  * @public
  */
 export const AnchorTemplate = html<Anchor>`
-    <template class="${x => x.appearance}">
+    <template>
         <a
             class="control"
             part="control"

--- a/packages/web-components/fast-foundation/src/anchor/anchor.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.ts
@@ -1,13 +1,6 @@
 import { attr, FASTElement } from "@microsoft/fast-element";
-import { ButtonAppearance } from "../button/button";
 import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
-
-/**
- * Types of anchor appearance.
- * @public
- */
-export type AnchorAppearance = ButtonAppearance | "hypertext";
 
 /**
  * An Anchor Custom HTML Element.
@@ -16,16 +9,6 @@ export type AnchorAppearance = ButtonAppearance | "hypertext";
  * @public
  */
 export class Anchor extends FASTElement {
-    /**
-     * The appearance the anchor should have.
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: appearance
-     */
-    @attr
-    public appearance: AnchorAppearance = "neutral";
-
     /**
      * Prompts the user to save the linked URL. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a | <a> element } for more information.
      * @public

--- a/packages/web-components/fast-foundation/src/button/README.md
+++ b/packages/web-components/fast-foundation/src/button/README.md
@@ -5,7 +5,7 @@ sidebar_label: button
 custom_edit_url: https://github.com/microsoft/fast/edit/master/packages/web-components/fast-foundation/src/button/README.md
 ---
 
-`fast-button` is a web component implementation of an [HTML button element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button). The component supports several visual appearances (accent, lightweight, neutral, outline, stealth).
+`fast-button` is a web component implementation of an [HTML button element](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button). The `fast-components` and `fast-components-msft` components supports several visual appearances (accent, lightweight, neutral, outline, stealth).
 
 ## Usage
 

--- a/packages/web-components/fast-foundation/src/button/button.template.ts
+++ b/packages/web-components/fast-foundation/src/button/button.template.ts
@@ -6,7 +6,7 @@ import { Button } from "./button";
  * @public
  */
 export const ButtonTemplate = html<Button>`
-    <template class="${x => x.appearance}">
+    <template>
         <button
             class="control"
             part="control"

--- a/packages/web-components/fast-foundation/src/button/button.template.ts
+++ b/packages/web-components/fast-foundation/src/button/button.template.ts
@@ -6,27 +6,25 @@ import { Button } from "./button";
  * @public
  */
 export const ButtonTemplate = html<Button>`
-    <template>
-        <button
-            class="control"
-            part="control"
-            ?autofocus=${x => x.autofocus}
-            ?disabled=${x => x.disabled}
-            form=${x => x.formId}
-            formaction=${x => x.formaction}
-            formenctype=${x => x.formenctype}
-            formmethod=${x => x.formmethod}
-            formnovalidate=${x => x.formnovalidate}
-            formtarget=${x => x.formtarget}
-            name=${x => x.name}
-            type=${x => x.type}
-            value=${x => x.value}
-        >
-            ${startTemplate}
-            <span class="content" part="content">
-                <slot></slot>
-            </span>
-            ${endTemplate}
-        </button>
-    </template>
+    <button
+        class="control"
+        part="control"
+        ?autofocus=${x => x.autofocus}
+        ?disabled=${x => x.disabled}
+        form=${x => x.formId}
+        formaction=${x => x.formaction}
+        formenctype=${x => x.formenctype}
+        formmethod=${x => x.formmethod}
+        formnovalidate=${x => x.formnovalidate}
+        formtarget=${x => x.formtarget}
+        name=${x => x.name}
+        type=${x => x.type}
+        value=${x => x.value}
+    >
+        ${startTemplate}
+        <span class="content" part="content">
+            <slot></slot>
+        </span>
+        ${endTemplate}
+    </button>
 `;

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -4,33 +4,12 @@ import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 
 /**
- * Types of button appearance.
- * @public
- */
-export type ButtonAppearance =
-    | "accent"
-    | "lightweight"
-    | "neutral"
-    | "outline"
-    | "stealth";
-
-/**
  * An Button Custom HTML Element.
  * Based largely on the {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button | <button> element }.
  *
  * @public
  */
 export class Button extends FormAssociated<HTMLInputElement> {
-    /**
-     * The appearance the button should have.
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: appearance
-     */
-    @attr
-    public appearance: ButtonAppearance = "neutral";
-
     /**
      * Determines if the element should receive document focus on page load.
      *


### PR DESCRIPTION
# Description
Currently, the appearance attribute isn't a standardized attribute across all anchors and buttons. Even if the attribute existed, we don't see semantic alignment across what those appearances are. This change moves the appearance attribute into the implementation for a given design system - FAST and MSFT.

This opens up the ability to extend the foundation anchor or button without that additional attribute. For instance, if I have a navigation item with a fixed appearance, it's less-than-ideal to have an appearance attribute on that component where it's not needed.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [x] This change causes current functionality to break.

<!--- If yes, describe the impact. -->
For those using fast-foundation and leveraging the appearance attribute, this breaks and would require the addition of the appearance attr along with an `appearanceChanged` implementation to fix. For anyone using the components, this change will be transparent.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->