### PR TITLE
fix: render buttons instead of spans for navigation-menu-item

### DIFF
--- a/packages/tooling/fast-tooling-react/src/navigation-menu/navigation-menu-item.tsx
+++ b/packages/tooling/fast-tooling-react/src/navigation-menu/navigation-menu-item.tsx
@@ -85,15 +85,14 @@ export default class NavigationMenuItem extends Foundation<
             );
         } else if (typeof this.props.onLocationUpdate === "function") {
             return (
-                <span
+                <button
                     onClick={this.handleLocationUpdate}
                     aria-controls={this.id}
                     role={"menuitem"}
-                    tabIndex={0}
                     className={this.generateListItemClassNames()}
                 >
                     {this.props.displayName}
-                </span>
+                </button>
             );
         }
 

--- a/packages/tooling/fast-tooling-react/src/navigation-menu/navigation-menu.spec.tsx
+++ b/packages/tooling/fast-tooling-react/src/navigation-menu/navigation-menu.spec.tsx
@@ -71,13 +71,13 @@ describe("NavigationMenu", () => {
 
         expect(rendered.find("a")).toHaveLength(2);
     });
-    test("should show items as spans if the `onLocationUpdate` callback has been included", () => {
+    test("should show items as buttons if the `onLocationUpdate` callback has been included", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
             <NavigationMenu {...navigationMenuPropsShallow} onLocationUpdate={callback} />
         );
 
-        expect(rendered.find("span")).toHaveLength(2);
+        expect(rendered.find("button")).toHaveLength(2);
     });
     test("should show items as buttons if the item contains its own items", () => {
         const rendered: any = mount(<NavigationMenu {...navigationMenuPropsNested} />);
@@ -136,7 +136,7 @@ describe("NavigationMenu", () => {
 
         expect(callback).toBeCalledTimes(0);
 
-        rendered.find("span").at(0).simulate("click");
+        rendered.find("button").at(0).simulate("click");
 
         expect(callback).toBeCalledTimes(1);
         expect(callback.mock.calls[0][0]).toBe("foo-location");


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->

render `<button/>` instead of `<span/>` for navigation-menu-items when `onLocationUpdate` callback is included

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

Currently, navigation-menu-item children that include the `onLocationUpdate` callback can only be selected on a mouse click. The enter/space keys do not work. This change enables keyboard navigation to select these items.

For example, the [Components explorer](https://explore.fast.design/components/fast-accordion) navigation menu cannot be navigated by keyboard.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->