### PR TITLE
feat: anchored region sizing options & other fixes

### DIFF
--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -65,9 +65,9 @@
                 anchor="anchor-scaling" 
                 viewport="viewport-scaling"
                 vertical-positioning-mode="dynamic"
-                vertical-scaling="true"
+                vertical-scaling="availablespace"
                 horizontal-positioning-mode="dynamic"
-                horizontal-scaling="true"
+                horizontal-scaling="availablespace"
             >
                 <div style="height:100%; width: 100%; background: yellow">
                 </div>
@@ -219,6 +219,32 @@
         </div>
     </div>
 
+    <h4>Size to anchor</h4>
+    <div 
+        id="viewport-anchor-sized"
+        style="position: relative; height:400px; width: 400px; background: lightgray; overflow: scroll;"
+    >
+        <div
+            style="height:1000px; width: 1000px;"
+        >
+            <fast-anchored-region 
+                anchor="anchor-anchor-sized" 
+                viewport="viewport-anchor-sized"
+                vertical-positioning-mode="dynamic"
+                vertical-scaling="anchor"
+                horizontal-positioning-mode="dynamic"
+                horizontal-scaling="anchor"
+                horizontal-inset="true"
+            >
+                <div style="height:100%; width: 100%; background: yellow">
+                </div>
+            </fast-anchored-region>
+            <button id="anchor-anchor-sized" style="margin-left: 500px; margin-top: 500px;">
+                anchor
+            </button>
+        </div>
+    </div>
+
     <h4>RTL-scaling</h4>
     <div 
         id="viewport-rtl-scaling"
@@ -235,9 +261,9 @@
                 anchor="anchor-rtl-scaling" 
                 viewport="viewport-rtl-scaling"
                 vertical-positioning-mode="dynamic"
-                vertical-scaling="true"
+                vertical-scaling="availablespace"
                 horizontal-positioning-mode="dynamic"
-                horizontal-scaling="true"
+                horizontal-scaling="availablespace"
             >
                 <div style="height:100%; width: 100%; background: yellow">
                 </div>

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -191,6 +191,11 @@ A region that renders below the anchor until that space is less than 100px.
 </div>
 ```
 
+The anchored region can be configured to scale to either the size of the content in it's slot, to the size of the element it is anchored to, or the available space between the anchor and the edge of the viewport element by setting the vertical/horizontal scaling attribute:
+- "anchor" - size to match anchor
+- "availablespace" - size to match space between the anchor and the viewport edge
+- "content" - the default, matches the size of the content in the region's slot. 
+
 The dimensions of the anchored region will match the dimensions of the content unless scaling is enabled on a particular axis (verticalscalingenabled & horizontalscalingenabled) in which case it will fill all available space between the anchor and viewport.
 
 The component allows users to set a "Positioning Mode" on each axis which defines how the component will behave:
@@ -214,13 +219,13 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 - horizontal-default-position - Can be 'start', 'end', 'left', 'right' or 'unset'.  Default is 'unset'
 - horizontal-inset - Boolean that indicates whether the region should overlap the anchor on the horizontal axis. Default is false which places the region adjacent to the anchor element.
 - horizontal-threshold - Numeric value that defines how small in pixels the region must be to the edge of the viewport to switch to the opposite side of the anchor. The component favors the default position until this value is crossed.  When there is not enough space on either side or the value is unset the side with the most space is chosen.
-- horizontal-scaling-enabled - The region is sized from code to match available space, in other scenarios the region gets sized via content size.
+- horizontal-scaling - Can be "anchor", "availablespace" or "content". Default is "content" 
 
 - vertical-positioning-mode - Can be 'uncontrolled', 'locktodefault' or 'dynamic'.  Default is 'uncontrolled'.
 - vertical-default-position - Can be 'top', 'bottom' or 'unset'. Default is unset.
 - vertical-inset - Boolean that indicates whether the region should overlap the anchor on the vertical axis. Default is false which places the region adjacent to the anchor element.
 - vertical-threshold - Numeric value that defines how small the region must be to the edge of the viewport to switch to the opposite side of the anchor. The component favors the default position until this value is crossed.  When there is not enough space on either side or the value is unset the side with the most space is chosen.
-- vertical-scaling-enabled - The region is sized from code to match available space, in other scenarios the region gets sized via content size.
+- vertical-scaling - Can be "anchor", "availablespace" or "content". Default is "content" 
 
 - horizontal-position - read only, the current horizontal position of the component. Possible values are 'left', 'right' or 'unset'.
 - vertical-position - read only, the current vertical position of the component. Possible values are 'top', 'bottom' or 'unset'.

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.template.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.template.ts
@@ -2,7 +2,10 @@ import { html, ref, when } from "@microsoft/fast-element";
 import { AnchoredRegion } from "./anchored-region";
 
 export const AnchoredRegionTemplate = html<AnchoredRegion>`
-    <div class="region" part="region" ${ref("region")} style=${x => x.regionStyle}>
-        ${when(x => x.initialLayoutComplete, html`<slot></slot>`)}
-    </div>
+    <template ${ref("root")}>
+        <div class="region" part="region" ${ref("region")} style=${x => x.regionStyle}>
+            ${when(x => x.initialLayoutComplete, html<AnchoredRegion>`<slot></slot>`)}
+        </div>
+        <template> </template
+    ></template>
 `;

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.template.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.template.ts
@@ -6,6 +6,5 @@ export const AnchoredRegionTemplate = html<AnchoredRegion>`
         <div class="region" part="region" ${ref("region")} style=${x => x.regionStyle}>
             ${when(x => x.initialLayoutComplete, html<AnchoredRegion>`<slot></slot>`)}
         </div>
-        <template> </template
-    ></template>
+    </template>
 `;


### PR DESCRIPTION
# Description

While building the tooltip component I made some fixes/additions to anchored region.  These include:

- the "scaling" bool has been replaced with a scaling scaling mode enum which allows the region to size itseft according to the content, the anchor element or the available space.
- renamed vars and functions to replace "positioner" with "region" for consistency
- template now has a root "template" element (needed to fix an issue getting ref that had a parent node in dom)

## Motivation & context
- needed changes for tooltip development, first time anchored region excersized in real world scenario

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.
*note: since we're not yet exporting the anchored region in the package I'm not considering the api change around scaling a breaking change

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
