### PR TITLE
feat: allow the autocompletion of a linked data value

### DIFF
--- a/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.spec.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.spec.tsx
@@ -166,7 +166,7 @@ describe("LinkedDataControl", () => {
 
         expect(renderedWithOneChild.find("DragItem")).toHaveLength(1);
     });
-    test("should fire a callback to update the data when the value is changed", () => {
+    test("should fire a callback to update the data when the value is an exact match", () => {
         const callback: any = jest.fn();
         const rendered: any = mount(
             <LinkedDataFormControlWithDragAndDrop
@@ -176,10 +176,8 @@ describe("LinkedDataControl", () => {
             />
         );
         const targetValue: any = { value: "omega" };
-        rendered
-            .find("input")
-            .simulate("change", { target: targetValue, currentTarget: targetValue });
-        rendered.find("input").simulate("keydown", { keyCode: keyCodeEnter });
+        const input: any = rendered.find("input");
+        input.simulate("change", { target: targetValue });
 
         expect(callback).toHaveBeenCalled();
         expect(callback.mock.calls[0][0]).toEqual({

--- a/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
@@ -288,28 +288,28 @@ class LinkedDataControl extends React.Component<
      * Change handler for editing the search term filter
      */
     private handleSearchTermUpdate = (e: React.ChangeEvent<HTMLInputElement>): void => {
-        const normalizedValue: string = e.currentTarget.value.toLowerCase();
+        const normalizedValue: string = e.target.value.toLowerCase();
         const hasSingleMatchedValue = this.matchExactValueWithASingleSchema(
-            e.currentTarget.value
+            e.target.value
         );
 
         // If an exact match is available, the linked data will be added
         if (hasSingleMatchedValue) {
-            this.addLinkedData(normalizedValue, e.currentTarget.value);
+            this.addLinkedData(normalizedValue, e.target.value);
         }
 
         this.setState({
-            searchTerm: hasSingleMatchedValue ? "" : e.currentTarget.value,
+            searchTerm: hasSingleMatchedValue ? "" : e.target.value,
         });
     };
 
-    private addLinkedData(normalizedValue: string, originalValue?: string): void {
+    private addLinkedData(normalizedValue: string, originalValue: string): void {
         const matchedNormalizedValue:
             | string
             | void = this.lazyMatchValueWithASingleSchema(normalizedValue);
-        const matchedOriginalValue: string | void = originalValue
-            ? this.matchExactValueWithASingleSchema(originalValue)
-            : undefined;
+        const matchedOriginalValue: string | void = this.matchExactValueWithASingleSchema(
+            originalValue
+        );
         const schemaId: string | void = matchedNormalizedValue || matchedOriginalValue;
 
         if (typeof schemaId !== "undefined") {

--- a/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
@@ -1,6 +1,6 @@
 import { ManagedClasses } from "@microsoft/fast-components-class-name-contracts-base";
 import React from "react";
-import { keyCodeEnter } from "@microsoft/fast-web-utilities";
+import { keyCodeEnter, keyCodeTab } from "@microsoft/fast-web-utilities";
 import { getDataFromSchema } from "@microsoft/fast-tooling";
 import manageJss, { ManagedJSSProps } from "@microsoft/fast-jss-manager-react";
 import styles, { LinkedDataControlClassNameContract } from "./control.linked-data.style";
@@ -212,27 +212,71 @@ class LinkedDataControl extends React.Component<
     private handleLinkedDataKeydown = (
         e: React.KeyboardEvent<HTMLInputElement>
     ): void => {
-        if (e.keyCode === keyCodeEnter && e.target === e.currentTarget) {
-            e.preventDefault();
+        if (e.target === e.currentTarget) {
+            // Enter adds linked data if the input value matches a schema lazily or exactly
+            if (e.keyCode === keyCodeEnter) {
+                e.preventDefault();
 
-            this.addLinkedData(e.currentTarget.value);
+                const normalizedValue = e.currentTarget.value.toLowerCase();
 
-            /**
-             * Adding items to the linked data causes the items to
-             * move the input down while the datalist remains in the same location,
-             * to prevent the datalist from overlapping the input
-             * the datalist is dismissed by defocusing and refocusing the input
-             */
-            (e.target as HTMLElement).blur();
-            (e.target as HTMLElement).focus();
+                if (
+                    this.lazyMatchValueWithASingleSchema(normalizedValue) ||
+                    this.matchExactValueWithASingleSchema(e.currentTarget.value)
+                ) {
+                    this.addLinkedData(normalizedValue, e.currentTarget.value);
 
-            this.setState({
-                searchTerm: "",
-            });
+                    /**
+                     * Adding items to the linked data causes the items to
+                     * move the input down while the datalist remains in the same location,
+                     * to prevent the datalist from overlapping the input
+                     * the datalist is dismissed by defocusing and refocusing the input
+                     */
+                    (e.target as HTMLElement).blur();
+                    (e.target as HTMLElement).focus();
+
+                    this.setState({
+                        searchTerm: "",
+                    });
+                }
+                // Tab performs an autocompete if there is a single schema it can match to
+            } else if (e.keyCode === keyCodeTab) {
+                e.preventDefault();
+
+                const normalizedValue = e.currentTarget.value.toLowerCase();
+                const matchedSchema = this.lazyMatchValueWithASingleSchema(
+                    normalizedValue
+                );
+
+                if (typeof matchedSchema === "string") {
+                    this.setState({
+                        searchTerm: this.props.schemaDictionary[matchedSchema].title,
+                    });
+                }
+            }
         }
     };
 
-    private matchValueWithSchema(value: string): string | void {
+    private lazyMatchValueWithASingleSchema(value: string): string | void {
+        const matchingSchemas: string[] = Object.keys(this.props.schemaDictionary).reduce<
+            string[]
+        >((previousValue: string[], currentValue: string): string[] => {
+            if (
+                this.props.schemaDictionary[currentValue].title
+                    .toLowerCase()
+                    .includes(value)
+            ) {
+                return previousValue.concat([currentValue]);
+            }
+
+            return previousValue;
+        }, []);
+
+        if (matchingSchemas.length === 1) {
+            return matchingSchemas[0];
+        }
+    }
+
+    private matchExactValueWithASingleSchema(value: string): string | void {
         return Object.keys(this.props.schemaDictionary).find(
             (schemaDictionaryKey: string) => {
                 return value === this.props.schemaDictionary[schemaDictionaryKey].title;
@@ -244,13 +288,29 @@ class LinkedDataControl extends React.Component<
      * Change handler for editing the search term filter
      */
     private handleSearchTermUpdate = (e: React.ChangeEvent<HTMLInputElement>): void => {
+        const normalizedValue: string = e.currentTarget.value.toLowerCase();
+        const hasSingleMatchedValue = this.matchExactValueWithASingleSchema(
+            e.currentTarget.value
+        );
+
+        // If an exact match is available, the linked data will be added
+        if (hasSingleMatchedValue) {
+            this.addLinkedData(normalizedValue, e.currentTarget.value);
+        }
+
         this.setState({
-            searchTerm: e.target.value,
+            searchTerm: hasSingleMatchedValue ? "" : e.currentTarget.value,
         });
     };
 
-    private addLinkedData(value: string): void {
-        const schemaId: string | void = this.matchValueWithSchema(value);
+    private addLinkedData(normalizedValue: string, originalValue?: string): void {
+        const matchedNormalizedValue:
+            | string
+            | void = this.lazyMatchValueWithASingleSchema(normalizedValue);
+        const matchedOriginalValue: string | void = originalValue
+            ? this.matchExactValueWithASingleSchema(originalValue)
+            : undefined;
+        const schemaId: string | void = matchedNormalizedValue || matchedOriginalValue;
 
         if (typeof schemaId !== "undefined") {
             this.props.onChange({


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

This change allows the autocompletion on the input of the linked data control in the `<Form />`.
Now, when `Tab` is pressed the value will autocomplete if there is a single matching item in the linked data list. If `Enter` is pressed the current value will be evaluated against lazily (lowercase values) or strictly (exact value) and if a single match can be found using either of these methods then the value will be added.

An example of where this helps:

Example 1: The list of supplied linked data includes:
```json
[
    "Foo",
    "foo"
]
```

When `"foo"` is typed, it will match `"Foo"` and `"foo"` in the dropdown, however if enter is pressed then it will match `"foo"` exactly and add this value.

Example 2: the list of supplied linked data includes:
```json
[
    "foo-Bar",
    "foo",
]
```

When `"foo-bar"` is typed it will match `"foo-Bar"` lazily and when enter is pressed it will add the linked data.
Likewise if `"foo-"` is typed and then `Tab` is pressed, it will autocomplete to `"foo-Bar"` and the next enter is pressed it will add the linked data.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->