### PR TITLE
fix: the accent button will now show active color when clicked

### DIFF
--- a/packages/web-components/fast-components-msft/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components-msft/src/styles/patterns/button.ts
@@ -122,7 +122,7 @@ export const AccentButtonStyles = css`
     }
 
     :host(.accent:active) .control:active {
-        background: ${accentFillActiveBehavior.var}${accentFillActiveBehavior.var};
+        background: ${accentFillActiveBehavior.var};
     }
 
     :host(.accent) .control:${focusVisible} {

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -120,7 +120,7 @@ export const AccentButtonStyles = css`
     }
 
     :host(.accent:active) .control:active {
-        background: ${accentFillActiveBehavior.var}${accentFillActiveBehavior.var};
+        background: ${accentFillActiveBehavior.var};
     }
 
     :host(.accent) .control:${focusVisible} {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Removed a duplicate `accentFillActiveBehavior.var` on the accent button's, active background value.


![accent-btn](https://user-images.githubusercontent.com/37851220/86955254-21428f80-c10c-11ea-8e1f-c86f02ab28d2.gif)

## Motivation & context

closes #3451 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->