### PR TITLE
docs(fast-foundation): specify that fast-button delegates focus

### DIFF
--- a/packages/web-components/fast-foundation/src/button/button.spec.md
+++ b/packages/web-components/fast-foundation/src/button/button.spec.md
@@ -53,9 +53,11 @@ All "anchor" components will support all methods and attributes of the [anchor](
 #### Button
 ```html
 <host>
-  <slot name="start"></slot>
-  <slot></slot>
-  <slot name="end"></slot>
+  <button> <!-- focus defered to this element -->
+    <slot name="start"></slot>
+    <slot></slot>
+    <slot name="end"></slot>
+  </button>
 </host>
 ```
 #### Anchor
@@ -75,6 +77,4 @@ All "anchor" components will support all methods and attributes of the [anchor](
   - end: the content to place at the end of the the primary content
 
 ### Accessibility
-Button elements will appear utilize the button role and will behave as the native `button` element.
-
-Anchor elements will function slightly differently to preserve some of the native capabilities that come from anchors like opening anchors in new tabs, opening anchors in new tabs without navigating to them, and the augmented command menu that gets opened when right+clicking an anchor. They will create an *internal* anchor element to which attributes will get reflected. Focus will also be defered to this internal element.
+Both components create *internal* native elements to which attributes will get reflected. Focus will also be deferred to these internal elements.


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Both button components delegate focus which does not match the spec.

## Motivation & context

The spec should match the implementation. I'm assuming that the component is the source of truth in this case.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->