### PR TITLE
fix: fast-components type ramp should use design system defaults

### DIFF
--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -164,109 +164,109 @@ export class FASTDesignSystemProvider extends DesignSystemProvider
 
     @designSystemProperty({
         attribute: "type-ramp-minus-2-font-size",
-        default: "10px",
+        default: fastDesignSystemDefaults.typeRampMinus2FontSize,
     })
     public typeRampMinus2FontSize: string;
 
     @designSystemProperty({
         attribute: "type-ramp-minus-2-line-height",
-        default: "16px",
+        default: fastDesignSystemDefaults.typeRampMinus2LineHeight,
     })
     public typeRampMinus2LineHeight: string;
 
     @designSystemProperty({
         attribute: "type-ramp-minus-1-font-size",
-        default: "12px",
+        default: fastDesignSystemDefaults.typeRampMinus1FontSize,
     })
     public typeRampMinus1FontSize: string;
 
     @designSystemProperty({
         attribute: "type-ramp-minus-1-line-height",
-        default: "16px",
+        default: fastDesignSystemDefaults.typeRampMinus1LineHeight,
     })
     public typeRampMinus1LineHeight: string;
 
     @designSystemProperty({
         attribute: "type-ramp-base-font-size",
-        default: "14px",
+        default: fastDesignSystemDefaults.typeRampBaseFontSize,
     })
     public typeRampBaseFontSize: string;
 
     @designSystemProperty({
         attribute: "type-ramp-base-line-height",
-        default: "20px",
+        default: fastDesignSystemDefaults.typeRampBaseLineHeight,
     })
     public typeRampBaseLineHeight: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-1-font-size",
-        default: "16px",
+        default: fastDesignSystemDefaults.typeRampPlus1FontSize,
     })
     public typeRampPlus1FontSize: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-1-line-height",
-        default: "24px",
+        default: fastDesignSystemDefaults.typeRampPlus1LineHeight,
     })
     public typeRampPlus1LineHeight: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-2-font-size",
-        default: "20px",
+        default: fastDesignSystemDefaults.typeRampPlus2FontSize,
     })
     public typeRampPlus2FontSize: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-2-line-height",
-        default: "28px",
+        default: fastDesignSystemDefaults.typeRampPlus2LineHeight,
     })
     public typeRampPlus2LineHeight: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-3-font-size",
-        default: "28px",
+        default: fastDesignSystemDefaults.typeRampPlus3FontSize,
     })
     public typeRampPlus3FontSize: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-3-line-height",
-        default: "36px",
+        default: fastDesignSystemDefaults.typeRampPlus3LineHeight,
     })
     public typeRampPlus3LineHeight: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-4-font-size",
-        default: "34px",
+        default: fastDesignSystemDefaults.typeRampPlus4FontSize,
     })
     public typeRampPlus4FontSize: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-4-line-height",
-        default: "44px",
+        default: fastDesignSystemDefaults.typeRampPlus4LineHeight,
     })
     public typeRampPlus4LineHeight: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-5-font-size",
-        default: "46px",
+        default: fastDesignSystemDefaults.typeRampPlus5FontSize,
     })
     public typeRampPlus5FontSize: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-5-line-height",
-        default: "56px",
+        default: fastDesignSystemDefaults.typeRampPlus5LineHeight,
     })
     public typeRampPlus5LineHeight: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-6-font-size",
-        default: "60px",
+        default: fastDesignSystemDefaults.typeRampPlus6FontSize,
     })
     public typeRampPlus6FontSize: string;
 
     @designSystemProperty({
         attribute: "type-ramp-plus-6-line-height",
-        default: "72px",
+        default: fastDesignSystemDefaults.typeRampPlus6LineHeight,
     })
     public typeRampPlus6LineHeight: string;
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Type ramp values in `fast-design-system-provider` are hard coded rather than using values set in `fastDesignSystemDefaults`.

## Motivation & context

Fixes unexpected behavior of design system property values not changing when defaults are changed.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->