### PR TITLE
fix: add aria label to the components in fast frame section on the website

### DIFF
--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -5,8 +5,6 @@ import ContrastIcon from "svg/icon-contrast.svg";
 import DownloadIcon from "svg/icon-download.svg";
 import PaletteIcon from "svg/icon-palette.svg";
 import PlayIcon from "svg/icon-play.svg";
-import ScreenIcon from "svg/icon-screen.svg";
-import ShareIcon from "svg/icon-share.svg";
 import SwatchesIcon from "svg/icon-swatches.svg";
 import { FastFrame } from "./fast-frame";
 import { ColorHSL, hslToRGB } from "@microsoft/fast-colors";
@@ -15,7 +13,7 @@ export const FastFrameTemplate = html<FastFrame>`
     <template>
         <div class="wrapper">
             <fast-tabs orientation="vertical" id="myTab" activeId="TabTwo">
-                <fast-tab id="contrast-tab" title="Mode">${ContrastIcon}</fast-tab>
+                <fast-tab id="contrast-tab" title="Dark Mode">${ContrastIcon}</fast-tab>
                 <fast-tab id="palette-tab" title="Color">${PaletteIcon}</fast-tab>
                 <fast-tab id="style-tab" title="Styles">${SwatchesIcon}</fast-tab>
                 <fast-tab-panel id="contrast-tab-panel" class="${x =>
@@ -62,6 +60,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     html<string>`
                                         <site-color-swatch
                                             tabindex="0"
+                                            aria-label="background color"
                                             value="${x => x}"
                                             background-color="${x => x}"
                                             checked="${(x, c) =>
@@ -84,6 +83,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     html<string>`
                                         <site-color-swatch
                                             tabindex="0"
+                                            aria-label="accent color"
                                             value="${x => x}"
                                             background-color="${x => x}"
                                             checked="${(x, c) =>
@@ -147,7 +147,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     position="0"
                                 >
                                     0
-                                </fast-slider-label>            
+                                </fast-slider-label>
                                 <fast-slider-label
                                     hide-mark
                                     position="20"
@@ -170,7 +170,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     position="1"
                                 >
                                     1PX
-                                </fast-slider-label>            
+                                </fast-slider-label>
                                 <fast-slider-label
                                     hide-mark
                                     position="6"
@@ -193,7 +193,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     position="-3"
                                 >
                                     -3
-                                </fast-slider-label>            
+                                </fast-slider-label>
                                 <fast-slider-label
                                     hide-mark
                                     position="3"
@@ -264,33 +264,36 @@ export const FastFrameTemplate = html<FastFrame>`
                 <div
                     class="preview-controls"
                 >
-                    <fast-progress></fast-progress>
-                    <fast-menu tabindex="${x => x.setTabIndex()}">
-                        <fast-menu-item role="menuitem">Menu item 1</fast-menu-item>
-                        <fast-menu-item role="menuitem">Menu item 2</fast-menu-item>
-                        <fast-menu-item role="menuitem">Menu item 3</fast-menu-item>
+                    <fast-progress aria-label="Example progress bar"></fast-progress>
+                    <fast-menu tabindex="${x =>
+                        x.setTabIndex()}" aria-label="Example menu">
+                        <fast-menu-item role="menuitem" aria-label="Example menu item">Menu item 1</fast-menu-item>
+                        <fast-menu-item role="menuitem" aria-label="Example menu item">Menu item 2</fast-menu-item>
+                        <fast-menu-item role="menuitem" aria-label="Example menu item">Menu item 3</fast-menu-item>
                         <hr />
-                        <fast-menu-item role="menuitem">Menu item 4</fast-menu-item>
+                        <fast-menu-item role="menuitem" aria-label="Example menu item">Menu item 4</fast-menu-item>
                     </fast-menu>
                     <div class="control-container">
                         <div class="control-container-column">
                             <fast-radio tabindex="${x =>
-                                x.setTabIndex()}">Radio 1</fast-radio>
+                                x.setTabIndex()}" aria-label="Example radio 1">Radio 1</fast-radio>
                             <fast-radio tabindex="${x =>
-                                x.setTabIndex()}">Radio 2</fast-radio>
+                                x.setTabIndex()}" aria-label="Example radio 2">Radio 2</fast-radio>
                         </div>
                         <div class="control-container-grid">
-                            <fast-switch tabindex="${x => x.setTabIndex()}"></fast-switch>
+                            <fast-switch tabindex="${x =>
+                                x.setTabIndex()}" aria-label="Example toggle"></fast-switch>
                             <p>Toggle</p>
                             <fast-checkbox tabindex="${x =>
-                                x.setTabIndex()}" class="checkbox"></fast-checkbox>
+                                x.setTabIndex()}" class="checkbox" aria-label="Example checkbox"></fast-checkbox>
                             <p class="checkbox-label">Checkbox</p>
                         </div>
                     </div>
                     <fast-text-field placeholder="Text field" tabindex="${x =>
-                        x.setTabIndex()}"></fast-text-field>
+                        x.setTabIndex()}" aria-label="Example text field"></fast-text-field>
                     <div class="control-container-2">
-                        <fast-slider tabindex="${x => x.setTabIndex()}"></fast-slider>
+                        <fast-slider tabindex="${x =>
+                            x.setTabIndex()}" aria-label="Example slider"></fast-slider>
                         <fast-flipper></fast-flipper>
                         <fast-flipper disabled></fast-flipper>
                     </div>

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -60,7 +60,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     html<string>`
                                         <site-color-swatch
                                             tabindex="0"
-                                            aria-label="${x => x}"
+                                            aria-label="background color ${x => x}"
                                             value="${x => x}"
                                             background-color="${x => x}"
                                             checked="${(x, c) =>
@@ -83,7 +83,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     html<string>`
                                         <site-color-swatch
                                             tabindex="0"
-                                            aria-label="${x => x}"
+                                            aria-label="accent color ${x => x}"
                                             value="${x => x}"
                                             background-color="${x => x}"
                                             checked="${(x, c) =>

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -60,7 +60,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     html<string>`
                                         <site-color-swatch
                                             tabindex="0"
-                                            aria-label="background color"
+                                            aria-label="${x => x}"
                                             value="${x => x}"
                                             background-color="${x => x}"
                                             checked="${(x, c) =>
@@ -83,7 +83,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                     html<string>`
                                         <site-color-swatch
                                             tabindex="0"
-                                            aria-label="accent color"
+                                            aria-label="${x => x}"
                                             value="${x => x}"
                                             background-color="${x => x}"
                                             checked="${(x, c) =>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Since all of these components in fast-frame are considered examples, to be consistent, they all prefixed with "Example"

Changed to read "dark mode" as that is more specific than "mode"
![image](https://user-images.githubusercontent.com/37851220/87096530-e6b62100-c1f7-11ea-9166-8425bde75b2b.png)
 
Notes:
- I would like to update the slider component to have something like an "aria-value-now-unit" attribute. To be able to have the screen reader also read out the type of unit, like pixels, inches, etc. Currently, as you change the numbers on the slider, for example, border-radius, visualizing "3 pixels" is better than "3".
![image](https://user-images.githubusercontent.com/37851220/87099340-4dd6d400-c1fe-11ea-8977-25d3a627b08d.png)
- There is know bug that NVDA will not read out aria-label on host element components, like an anchor, button, and text field.


## Motivation & context

Fixes #3465 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->