### PR TITLE
fix(fast-element): style element styles should work with the document

### DIFF
--- a/packages/web-components/fast-element/src/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { AdoptedStyleSheetsStyles, StyleTarget } from "./styles";
+import { AdoptedStyleSheetsStyles, StyleElementStyles, StyleTarget } from "./styles";
 import { DOM } from "./dom";
 
 if (DOM.supportsAdoptedStyleSheets) {
@@ -39,3 +39,36 @@ if (DOM.supportsAdoptedStyleSheets) {
         });
     });
 }
+
+describe("StyleSheetStyles", () => {
+    it("can add and remove from the document directly", () => {
+        const styles = ``;
+        const elementStyles = new StyleElementStyles([styles]);
+        document.body.innerHTML = "";
+
+        elementStyles.addStylesTo(document);
+
+        expect(document.body.childNodes[0]).to.be.instanceof(HTMLStyleElement);
+
+        elementStyles.removeStylesFrom(document);
+
+        expect(document.body.childNodes.length).to.equal(0);
+    });
+
+    it("can add and remove from a ShadowRoot", () => {
+        const styles = ``;
+        const elementStyles = new StyleElementStyles([styles]);
+        document.body.innerHTML = "";
+
+        const element = document.createElement("div");
+        const shadowRoot = element.attachShadow({ mode: "open" });
+
+        elementStyles.addStylesTo(shadowRoot);
+
+        expect(shadowRoot.childNodes[0]).to.be.instanceof(HTMLStyleElement);
+
+        elementStyles.removeStylesFrom(shadowRoot);
+
+        expect(shadowRoot.childNodes.length).to.equal(0);
+    });
+});

--- a/packages/web-components/fast-element/src/styles.ts
+++ b/packages/web-components/fast-element/src/styles.ts
@@ -165,7 +165,10 @@ function getNextStyleClass(): string {
     return `fast-style-class-${++styleClassId}`;
 }
 
-class StyleElementStyles extends ElementStyles {
+/**
+ * @internal
+ */
+export class StyleElementStyles extends ElementStyles {
     private readonly styleSheets: string[];
     private readonly styleClass: string;
     public readonly behaviors: ReadonlyArray<Behavior> | null = null;
@@ -181,6 +184,10 @@ class StyleElementStyles extends ElementStyles {
         const styleSheets = this.styleSheets;
         const styleClass = this.styleClass;
 
+        if (target === document) {
+            target = document.body;
+        }
+
         for (let i = styleSheets.length - 1; i > -1; --i) {
             const element = document.createElement("style");
             element.innerHTML = styleSheets[i];
@@ -190,6 +197,10 @@ class StyleElementStyles extends ElementStyles {
     }
 
     public removeStylesFrom(target: StyleTarget): void {
+        if (target === document) {
+            target = document.body;
+        }
+
         const styles: NodeListOf<HTMLStyleElement> = target.querySelectorAll(
             `.${this.styleClass}`
         );


### PR DESCRIPTION
# Description

This PR fixes issue #3476 which prevented `StyleElementStyles` from working properly against the `document` element in browsers without native support for `adoptedStyleSheets`.

## Motivation & context

Inside `fast-element` the `ElementStyles` base class abstracts away the particular style association implementation so that we can apply styles regardless of whether or not the browser supports `adopedStyleSheets`. Browsers like Firefox do not yet support this feature, so at runtime the `StyleElementStyles` concrete implementation is selected for use. With `adoptedStyleSheets` both `ShadowRoot` and `document` support the feature, so styles can easily be added globally or to the shadow root. However, `HTMLStyleElement` instances cannot be added as a child node of `document` as a work around, because `document` can only have a single `body` child node. This fix changes `StyleElementStyles` so that it recognizes the special case of `document` and forwards the style association to the `body` element instead.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

This is not a breaking change.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.