### PR TITLE
fix: removing un-needed nbsp; in slider-label and radio-group templates

### DIFF
--- a/packages/web-components/fast-components-msft/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components-msft/src/slider-label/slider-label.styles.ts
@@ -38,7 +38,6 @@ export const SliderLabelStyles = css`
         justify-self: center;
         align-self: center;
         white-space: nowrap;
-        justify-self: center;
         max-width: 30px;
         margin: 2px 0;
     }

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -48,7 +48,6 @@ export const SliderLabelStyles = css`
         justify-self: center;
         align-self: center;
         white-space: nowrap;
-        justify-self: center;
         max-width: 30px;
         margin: 2px 0;
     }

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
@@ -18,7 +18,7 @@ export const RadioGroupTemplate = html<RadioGroup>`
                 x.orientation === Orientation.horizontal ? "horizontal" : "vertical"}"
             part="positioning-region"
         >
-            <slot ${slotted("slottedRadioButtons")}>&nbsp;</slot>
+            <slot ${slotted("slottedRadioButtons")}></slot>
         </div>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
@@ -17,9 +17,7 @@ export const SliderLabelTemplate = html<SliderLabel>`
                 ${when(
                     x => !x.hideMark,
                     html`
-                        &nbsp;
                         <div class="mark"></div>
-                        &nbsp;
                     `
                 )}
                 <div class="label">

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -1,4 +1,4 @@
-import { children, html, ref, slotted, when, elements } from "@microsoft/fast-element";
+import { children, elements, html, ref, slotted, when } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end";
 import { TreeItem } from "./tree-item";
 


### PR DESCRIPTION
# Description
Some &nbsp; entries got accidentally injected into the slider label and radio group templates causing styling issues, removing them from the templates.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
