### PR TITLE
fix: replaced template literal with reference to --var on label color style in radio group

### DIFF
--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -4,7 +4,7 @@
     <h4>Defaults</h4>
     <div>
         <fast-radio-group name="numbers">
-            <label style="color: ${neutralForegroundRestBehavior.var};" slot="label">
+            <label style="color: --var(neutral-foreground-rest);" slot="label">
                 Numbers
             </label>
             <fast-radio value="one">One</fast-radio>
@@ -14,7 +14,7 @@
 
     <div>
         <fast-radio-group orientation="vertical" name="trees">
-            <label style="color: ${neutralForegroundRestBehavior.var};" slot="label">
+            <label style="color: --var(neutral-foreground-rest);" slot="label">
                 Trees
             </label>
             <fast-radio value="fir">Fir</fast-radio>
@@ -26,7 +26,7 @@
 
     <div style="display: flex; flex-direction: column; margin-top: 12px;">
         <fast-radio-group name="players">
-            <label style="color: ${neutralForegroundRestBehavior.var};" slot="label">
+            <label style="color: --var(neutral-foreground-rest);" slot="label">
                 Best basketball players
             </label>
             <fast-radio value="airjordan">Michael Jordan</fast-radio>
@@ -34,14 +34,14 @@
     </div>
 
     <div style="display: flex; flex-direction: column; margin-top: 12px;">
-        <label style="color: ${neutralForegroundRestBehavior.var};">
+        <label style="color: --var(neutral-foreground-rest);">
             Single radio (no group)
         </label>
         <fast-radio value="single-life">Single life</fast-radio>
     </div>
 
     <div style="display: flex; flex-direction: column; margin-top: 12px;">
-        <label style="color: ${neutralForegroundRestBehavior.var};" id="label1">
+        <label style="color: --var(neutral-foreground-rest);" id="label1">
             Outside label
         </label>
         <fast-radio-group required="true" aria-labelledby="label1" name="fruits">
@@ -72,7 +72,7 @@
     </div>
 
     <div style="display: flex; flex-direction: column; margin-top: 12px;">
-        <label style="color: ${neutralForegroundRestBehavior.var};" id="label2">
+        <label style="color: --var(neutral-foreground-rest);" id="label2">
             Disabled radio group
         </label>
         <fast-radio-group disabled aria-labelledby="label2" name="cars">
@@ -82,7 +82,7 @@
     </div>
 
     <div style="display: flex; flex-direction: column; margin-top: 12px;">
-        <label style="color: ${neutralForegroundRestBehavior.var};" id="label3">
+        <label style="color: --var(neutral-foreground-rest);" id="label3">
             readonly radio group
         </label>
         <fast-radio-group readonly aria-labelledby="label3" name="office">
@@ -92,7 +92,7 @@
     </div>
 
     <div style="display: flex; flex-direction: column; margin-top: 12px;">
-        <label style="color: ${neutralForegroundRestBehavior.var};" id="label4">
+        <label style="color: --var(neutral-foreground-rest);" id="label4">
             Preset selected-value
         </label>
         <fast-radio-group value="maverick" aria-labelledby="label4" name="best-pilot">


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Replaced `${neutralForegroundRestBehavior.var}` with `--var(neutral-foreground-rest)` on the label's color style.
It looks like this was only happening in the `radio-group` fixture file, in fast-components.

## Motivation & context

Fixes #3505 

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->