### PR TITLE
feat: basic menu item check state toggling

### DIFF
--- a/packages/web-components/fast-components/src/menu/fixtures/menu.html
+++ b/packages/web-components/fast-components/src/menu/fixtures/menu.html
@@ -47,7 +47,7 @@
         <div role="menuitem">Menu item 3</div>
     </fast-menu>
 
-    <h4>With radio buttons</h4>
+    <h4>With radio buttons and checkboxes</h4>
     <fast-menu>
         <fast-menu-item>Menu item 1</fast-menu-item>
         <fast-menu-item>Menu item 2</fast-menu-item>
@@ -55,5 +55,8 @@
         <fast-divider></fast-divider>
         <fast-menu-item role="menuitemradio">Menu item 4</fast-menu-item>
         <fast-menu-item role="menuitemradio">Menu item 5</fast-menu-item>
+        <fast-divider></fast-divider>
+        <fast-menu-item role="menuitemcheckbox">Menu item 4</fast-menu-item>
+        <fast-menu-item role="menuitemcheckbox">Menu item 5</fast-menu-item>
     </fast-menu>
 </fast-design-system-provider>

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -87,8 +87,8 @@ export class MenuItem extends FASTElement {
         }
 
         switch (this.role) {
-            case "menuitemcheckbox":
-            case "menuitemradio":
+            case MenuItemRole.menuitemcheckbox:
+            case MenuItemRole.menuitemradio:
                 this.checked = !this.checked;
                 break;
         }

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -1,4 +1,5 @@
 import { attr, booleanConverter, FASTElement } from "@microsoft/fast-element";
+import { keyCodeEnter, keyCodeSpace } from "@microsoft/fast-web-utilities";
 import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 
@@ -63,7 +64,12 @@ export class MenuItem extends FASTElement {
      * @internal
      */
     public handleMenuItemKeyDown = (e: KeyboardEvent): boolean => {
-        this.change();
+        switch (e.keyCode) {
+            case keyCodeEnter:
+            case keyCodeSpace:
+                this.invoke();
+                return false;
+        }
 
         return true;
     };
@@ -72,10 +78,21 @@ export class MenuItem extends FASTElement {
      * @internal
      */
     public handleMenuItemClick = (e: MouseEvent): void => {
-        this.change();
+        this.invoke();
     };
 
-    private change = (): void => {
+    private invoke = (): void => {
+        if (this.disabled) {
+            return;
+        }
+
+        switch (this.role) {
+            case "menuitemcheckbox":
+            case "menuitemradio":
+                this.checked = !this.checked;
+                break;
+        }
+
         this.$emit("change");
     };
 }


### PR DESCRIPTION
# Description
Adding a basic checked state toggling to radio and checkbox type menu items.  Currently both have the same behavior but radio type items are expected to have radio group capabilities added at a later date.

## Motivation & context
https://github.com/microsoft/fast/issues/3481

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.
