### PR TITLE
fix: address nested styling issues and provide a more intuitive API for nesting

### DIFF
--- a/packages/web-components/fast-components-msft/src/tree-item/fixtures/tree-item.html
+++ b/packages/web-components/fast-components-msft/src/tree-item/fixtures/tree-item.html
@@ -3,6 +3,12 @@
     <h4>Default</h4>
     <fast-tree-item>Tree item</fast-tree-item>
 
+    <h4>Nested</h4>
+    <fast-tree-item>
+        Tree item
+        <fast-tree-item>Nested tree item</fast-tree-item>
+    </fast-tree-item>
+
     <h4>Selected</h4>
     <fast-tree-item selected>Tree item</fast-tree-item>
 

--- a/packages/web-components/fast-components-msft/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components-msft/src/tree-item/tree-item.styles.ts
@@ -86,7 +86,7 @@ export const TreeItemStyles = css`
         ${
             /* Font size should be based off calc(1em + (design-unit + glyph-size-number) * 1px) - 
             update when density story is figured out */ ""
-        } font-size: calc(1em + var(--type-ramp-base-font-size));
+        } font-size: calc(1em + (var(--design-unit) + 16) * 1px);
     }
 
     .expand-collapse-button {
@@ -181,11 +181,6 @@ export const TreeItemStyles = css`
         position: absolute;
         ${/* value needs to be localized  */ ""}
         left: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
-    }
-
-    :host(.leaf) .content-region {
-        position: relative;
-        margin-inline-start: calc((${heightNumber} + (var(--design-unit) * 2) + 2) * 1px);
     }
 
     ::slotted(fast-tree-item) {

--- a/packages/web-components/fast-components-msft/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components-msft/src/tree-item/tree-item.styles.ts
@@ -183,6 +183,11 @@ export const TreeItemStyles = css`
         left: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
     }
 
+    :host(.leaf) .content-region {
+        position: relative;
+        margin-inline-start: calc((${heightNumber} + (var(--design-unit) * 2) + 2) * 1px);
+    }
+
     ::slotted(fast-tree-item) {
         --tree-item-nested-width: 1em;
         --expand-collapse-button-nested-width: calc(${heightNumber} * -1px);

--- a/packages/web-components/fast-components-msft/src/tree-view/fixtures/tree-view.html
+++ b/packages/web-components/fast-components-msft/src/tree-view/fixtures/tree-view.html
@@ -3,25 +3,30 @@
     <fast-tree-view render-collapsed-nodes="false">
         <fast-tree-item>
             Root item 1
-            <fast-tree-item slot="item">
+            <fast-divider slot="item"></fast-divider>
+            <fast-tree-item>
                 Flowers
-                <fast-tree-item slot="item" disabled>Daisy</fast-tree-item>
-                <fast-tree-item slot="item">Sunflower</fast-tree-item>
-                <fast-tree-item slot="item">Rose</fast-tree-item>
+                <fast-tree-item disabled>Daisy</fast-tree-item>
+                <fast-tree-item>Sunflower</fast-tree-item>
+                <fast-tree-item>Rose</fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item slot="item">Nested item 2</fast-tree-item>
-            <fast-tree-item slot="item">Nested item 3</fast-tree-item>
+            <fast-tree-item>Nested item 2</fast-tree-item>
+            <fast-tree-item>Nested item 3</fast-tree-item>
         </fast-tree-item>
         <fast-tree-item>
             Root item 2
-            <fast-tree-item slot="item">
+            <fast-divider slot="item"></fast-divider>
+            <fast-tree-item>
                 Flowers
-                <fast-tree-item slot="item" disabled>Daisy</fast-tree-item>
-                <fast-tree-item slot="item">Sunflower</fast-tree-item>
-                <fast-tree-item slot="item">Rose</fast-tree-item>
+                <fast-tree-item disabled>Daisy</fast-tree-item>
+                <fast-tree-item>Sunflower</fast-tree-item>
+                <fast-tree-item>Rose</fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item slot="item">Nested item 2</fast-tree-item>
-            <fast-tree-item slot="item">Nested item 3</fast-tree-item>
+            <fast-tree-item>Nested item 2</fast-tree-item>
+            <fast-tree-item>Nested item 3</fast-tree-item>
+        </fast-tree-item>
+        <fast-tree-item>
+            Root item 3 - Leaf Erikson
         </fast-tree-item>
     </fast-tree-view>
 
@@ -29,17 +34,17 @@
     <fast-tree-view>
         <fast-tree-item expanded>
             Root item
-            <fast-tree-item slot="item" expanded>
+            <fast-tree-item expanded>
                 Flowers
-                <fast-tree-item slot="item">Daisy</fast-tree-item>
-                <fast-tree-item slot="item">Sunflower</fast-tree-item>
-                <fast-tree-item slot="item">Rose</fast-tree-item>
+                <fast-tree-item>Daisy</fast-tree-item>
+                <fast-tree-item>Sunflower</fast-tree-item>
+                <fast-tree-item>Rose</fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item slot="item">
+            <fast-tree-item>
                 Planes
-                <fast-tree-item slot="item">Tomcat</fast-tree-item>
-                <fast-tree-item slot="item">Hawker Harrier</fast-tree-item>
-                <fast-tree-item slot="item">Cesna</fast-tree-item>
+                <fast-tree-item>Tomcat</fast-tree-item>
+                <fast-tree-item>Hawker Harrier</fast-tree-item>
+                <fast-tree-item>Cesna</fast-tree-item>
             </fast-tree-item>
         </fast-tree-item>
     </fast-tree-view>
@@ -48,17 +53,17 @@
     <fast-tree-view>
         <fast-tree-item expanded>
             Root item
-            <fast-tree-item slot="item">
+            <fast-tree-item>
                 Flowers
-                <fast-tree-item slot="item">Daisy</fast-tree-item>
-                <fast-tree-item slot="item">Sunflower</fast-tree-item>
-                <fast-tree-item slot="item">Rose</fast-tree-item>
+                <fast-tree-item>Daisy</fast-tree-item>
+                <fast-tree-item>Sunflower</fast-tree-item>
+                <fast-tree-item>Rose</fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item slot="item" expanded>
+            <fast-tree-item expanded>
                 Planes
-                <fast-tree-item slot="item" selected>Tomcat</fast-tree-item>
-                <fast-tree-item slot="item">Hawker Harrier</fast-tree-item>
-                <fast-tree-item slot="item">Cesna</fast-tree-item>
+                <fast-tree-item selected>Tomcat</fast-tree-item>
+                <fast-tree-item>Hawker Harrier</fast-tree-item>
+                <fast-tree-item>Cesna</fast-tree-item>
             </fast-tree-item>
         </fast-tree-item>
     </fast-tree-view>
@@ -78,7 +83,7 @@
                     d="M6.5,7.7h-1v-1h1V7.7z M10.6,7.7h-1v-1h1V7.7z M14.7,6.7v2.1h-1v2.6c0,0.2,0,0.4-0.1,0.6c-0.1,0.2-0.2,0.4-0.3,0.5c-0.1,0.1-0.3,0.3-0.5,0.3c-0.2,0.1-0.4,0.1-0.6,0.1H10l-3.5,3v-3H3.9c-0.2,0-0.4,0-0.6-0.1c-0.2-0.1-0.4-0.2-0.5-0.3c-0.1-0.1-0.3-0.3-0.3-0.5c-0.1-0.2-0.1-0.4-0.1-0.6V8.8h-1V6.7h1V5.2c0-0.2,0-0.4,0.1-0.6c0.1-0.2,0.2-0.4,0.3-0.5c0.1-0.1,0.3-0.3,0.5-0.3c0.2-0.1,0.4-0.1,0.6-0.1h3.6V1.9C7.3,1.8,7.2,1.7,7.1,1.5C7,1.4,7,1.2,7,1C7,0.9,7,0.8,7,0.6c0.1-0.1,0.1-0.2,0.2-0.3c0.1-0.1,0.2-0.2,0.3-0.2C7.7,0,7.9,0,8,0c0.1,0,0.3,0,0.4,0.1c0.1,0.1,0.2,0.1,0.3,0.2C8.8,0.4,8.9,0.5,9,0.6C9,0.8,9,0.9,9,1c0,0.2,0,0.4-0.1,0.5C8.8,1.7,8.7,1.8,8.5,1.9v1.7h3.6c0.2,0,0.4,0,0.6,0.1c0.2,0.1,0.4,0.2,0.5,0.3c0.1,0.1,0.3,0.3,0.3,0.5c0.1,0.2,0.1,0.4,0.1,0.6v1.5H14.7z M12.6,5.2c0-0.1-0.1-0.3-0.2-0.4c-0.1-0.1-0.2-0.2-0.4-0.2H3.9c-0.1,0-0.3,0.1-0.4,0.2C3.4,4.9,3.4,5,3.4,5.2v6.2c0,0.1,0.1,0.3,0.2,0.4c0.1,0.1,0.2,0.2,0.4,0.2h3.6v1.8l2.1-1.8h2.5c0.1,0,0.3-0.1,0.4-0.2c0.1-0.1,0.2-0.2,0.2-0.4V5.2z M5.8,8.9c0.3,0.3,0.6,0.5,1,0.7C7.2,9.7,7.6,9.8,8,9.8s0.8-0.1,1.2-0.2c0.4-0.2,0.7-0.4,1-0.7l0.7,0.7c-0.4,0.4-0.8,0.7-1.4,0.9c-0.5,0.2-1,0.3-1.6,0.3s-1.1-0.1-1.6-0.3c-0.5-0.2-1-0.5-1.3-0.9L5.8,8.9z"
                 />
             </svg>
-            <fast-tree-item expanded slot="item">
+            <fast-tree-item expanded>
                 Nested Root item 1
                 <svg
                     slot="start"
@@ -91,7 +96,7 @@
                         d="M6.5,7.7h-1v-1h1V7.7z M10.6,7.7h-1v-1h1V7.7z M14.7,6.7v2.1h-1v2.6c0,0.2,0,0.4-0.1,0.6c-0.1,0.2-0.2,0.4-0.3,0.5c-0.1,0.1-0.3,0.3-0.5,0.3c-0.2,0.1-0.4,0.1-0.6,0.1H10l-3.5,3v-3H3.9c-0.2,0-0.4,0-0.6-0.1c-0.2-0.1-0.4-0.2-0.5-0.3c-0.1-0.1-0.3-0.3-0.3-0.5c-0.1-0.2-0.1-0.4-0.1-0.6V8.8h-1V6.7h1V5.2c0-0.2,0-0.4,0.1-0.6c0.1-0.2,0.2-0.4,0.3-0.5c0.1-0.1,0.3-0.3,0.5-0.3c0.2-0.1,0.4-0.1,0.6-0.1h3.6V1.9C7.3,1.8,7.2,1.7,7.1,1.5C7,1.4,7,1.2,7,1C7,0.9,7,0.8,7,0.6c0.1-0.1,0.1-0.2,0.2-0.3c0.1-0.1,0.2-0.2,0.3-0.2C7.7,0,7.9,0,8,0c0.1,0,0.3,0,0.4,0.1c0.1,0.1,0.2,0.1,0.3,0.2C8.8,0.4,8.9,0.5,9,0.6C9,0.8,9,0.9,9,1c0,0.2,0,0.4-0.1,0.5C8.8,1.7,8.7,1.8,8.5,1.9v1.7h3.6c0.2,0,0.4,0,0.6,0.1c0.2,0.1,0.4,0.2,0.5,0.3c0.1,0.1,0.3,0.3,0.3,0.5c0.1,0.2,0.1,0.4,0.1,0.6v1.5H14.7z M12.6,5.2c0-0.1-0.1-0.3-0.2-0.4c-0.1-0.1-0.2-0.2-0.4-0.2H3.9c-0.1,0-0.3,0.1-0.4,0.2C3.4,4.9,3.4,5,3.4,5.2v6.2c0,0.1,0.1,0.3,0.2,0.4c0.1,0.1,0.2,0.2,0.4,0.2h3.6v1.8l2.1-1.8h2.5c0.1,0,0.3-0.1,0.4-0.2c0.1-0.1,0.2-0.2,0.2-0.4V5.2z M5.8,8.9c0.3,0.3,0.6,0.5,1,0.7C7.2,9.7,7.6,9.8,8,9.8s0.8-0.1,1.2-0.2c0.4-0.2,0.7-0.4,1-0.7l0.7,0.7c-0.4,0.4-0.8,0.7-1.4,0.9c-0.5,0.2-1,0.3-1.6,0.3s-1.1-0.1-1.6-0.3c-0.5-0.2-1-0.5-1.3-0.9L5.8,8.9z"
                     />
                 </svg>
-                <fast-tree-item slot="item">
+                <fast-tree-item>
                     <svg
                         slot="start"
                         width="16"
@@ -105,7 +110,7 @@
                     </svg>
                     Nested item 4
                 </fast-tree-item>
-                <fast-tree-item slot="item">
+                <fast-tree-item>
                     <svg
                         slot="start"
                         width="16"
@@ -120,7 +125,7 @@
                     Nested item 5
                 </fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item slot="item">
+            <fast-tree-item>
                 Nested item 2
                 <svg
                     slot="start"
@@ -134,7 +139,7 @@
                     />
                 </svg>
             </fast-tree-item>
-            <fast-tree-item slot="item">
+            <fast-tree-item>
                 Nested item 3
                 <svg
                     slot="start"

--- a/packages/web-components/fast-components-msft/src/tree-view/fixtures/tree-view.html
+++ b/packages/web-components/fast-components-msft/src/tree-view/fixtures/tree-view.html
@@ -3,7 +3,7 @@
     <fast-tree-view render-collapsed-nodes="false">
         <fast-tree-item>
             Root item 1
-            <fast-divider slot="item"></fast-divider>
+            <fast-divider></fast-divider>
             <fast-tree-item>
                 Flowers
                 <fast-tree-item disabled>Daisy</fast-tree-item>
@@ -15,7 +15,7 @@
         </fast-tree-item>
         <fast-tree-item>
             Root item 2
-            <fast-divider slot="item"></fast-divider>
+            <fast-divider></fast-divider>
             <fast-tree-item>
                 Flowers
                 <fast-tree-item disabled>Daisy</fast-tree-item>
@@ -28,6 +28,15 @@
         <fast-tree-item>
             Root item 3 - Leaf Erikson
         </fast-tree-item>
+    </fast-tree-view>
+
+    <h4>Flat tree</h4>
+    <fast-tree-view>
+        <fast-tree-item selected>Daisy</fast-tree-item>
+        <fast-tree-item>Sunflower</fast-tree-item>
+        <fast-tree-item>Rose</fast-tree-item>
+        <fast-tree-item>Petunia</fast-tree-item>
+        <fast-tree-item>Tulip</fast-tree-item>
     </fast-tree-view>
 
     <h4>Some expanded</h4>

--- a/packages/web-components/fast-components-msft/src/tree-view/fixtures/tree-view.html
+++ b/packages/web-components/fast-components-msft/src/tree-view/fixtures/tree-view.html
@@ -2,7 +2,18 @@
     <h4>With items (don't render collapsed nodes)</h4>
     <fast-tree-view render-collapsed-nodes="false">
         <fast-tree-item>
-            Root item
+            Root item 1
+            <fast-tree-item slot="item">
+                Flowers
+                <fast-tree-item slot="item" disabled>Daisy</fast-tree-item>
+                <fast-tree-item slot="item">Sunflower</fast-tree-item>
+                <fast-tree-item slot="item">Rose</fast-tree-item>
+            </fast-tree-item>
+            <fast-tree-item slot="item">Nested item 2</fast-tree-item>
+            <fast-tree-item slot="item">Nested item 3</fast-tree-item>
+        </fast-tree-item>
+        <fast-tree-item>
+            Root item 2
             <fast-tree-item slot="item">
                 Flowers
                 <fast-tree-item slot="item" disabled>Daisy</fast-tree-item>

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -184,6 +184,11 @@ export const TreeItemStyles = css`
         left: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
     }
 
+    :host(.leaf) .content-region {
+        position: relative;
+        margin-inline-start: calc((${heightNumber} + (var(--design-unit) * 2) + 2) * 1px);
+    }
+
     ::slotted(fast-tree-item) {
         --tree-item-nested-width: 1em;
         --expand-collapse-button-nested-width: calc(${heightNumber} * -1px);

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -87,7 +87,7 @@ export const TreeItemStyles = css`
         ${
             /* Font size should be based off calc(1em + (design-unit + glyph-size-number) * 1px) - 
             update when density story is figured out */ ""
-        } font-size: calc(1em + var(--type-ramp-base-font-size));
+        } font-size: calc(1em + (var(--design-unit) + 16) * 1px);
     }
 
     .expand-collapse-button {
@@ -182,11 +182,6 @@ export const TreeItemStyles = css`
         position: absolute;
         ${/* value needs to be localized  */ ""}
         left: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
-    }
-
-    :host(.leaf) .content-region {
-        position: relative;
-        margin-inline-start: calc((${heightNumber} + (var(--design-unit) * 2) + 2) * 1px);
     }
 
     ::slotted(fast-tree-item) {

--- a/packages/web-components/fast-components/src/tree-view/fixtures/tree-view.html
+++ b/packages/web-components/fast-components/src/tree-view/fixtures/tree-view.html
@@ -1,8 +1,10 @@
 <fast-design-system-provider use-defaults>
     <h4>With items (don't render collapsed nodes)</h4>
     <fast-tree-view render-collapsed-nodes="false">
+        <fast-divider></fast-divider>
         <fast-tree-item>
-            Root item
+            Root item 1
+            <fast-divider slot="item"></fast-divider>
             <fast-tree-item slot="item" expanded>
                 Flowers
                 <fast-tree-item slot="item">Daisy</fast-tree-item>
@@ -16,6 +18,21 @@
             </fast-tree-item>
             <fast-tree-item slot="item">Nested item 2</fast-tree-item>
             <fast-tree-item slot="item">Nested item 3</fast-tree-item>
+        </fast-tree-item>
+        <fast-tree-item>
+            Root item 2
+            <fast-tree-item slot="item">
+                Flowers
+                <fast-tree-item slot="item" disabled>Daisy</fast-tree-item>
+                <fast-tree-item slot="item">Sunflower</fast-tree-item>
+                <fast-tree-item slot="item">Rose</fast-tree-item>
+            </fast-tree-item>
+            <fast-tree-item slot="item">Nested item 2</fast-tree-item>
+            <fast-tree-item slot="item">Nested item 3</fast-tree-item>
+        </fast-tree-item>
+        <fast-tree-item>
+            Root item 3
+            <button>Test</button>
         </fast-tree-item>
     </fast-tree-view>
 

--- a/packages/web-components/fast-components/src/tree-view/fixtures/tree-view.html
+++ b/packages/web-components/fast-components/src/tree-view/fixtures/tree-view.html
@@ -5,34 +5,33 @@
         <fast-tree-item>
             Root item 1
             <fast-divider slot="item"></fast-divider>
-            <fast-tree-item slot="item" expanded>
+            <fast-tree-item expanded>
                 Flowers
-                <fast-tree-item slot="item">Daisy</fast-tree-item>
-                <fast-tree-item disabled slot="item">Sunflower</fast-tree-item>
-                <fast-tree-item slot="item" expanded>
+                <fast-tree-item>Daisy</fast-tree-item>
+                <fast-tree-item disabled>Sunflower</fast-tree-item>
+                <fast-tree-item expanded>
                     Rose
-                    <fast-tree-item slot="item">Pink</fast-tree-item>
-                    <fast-tree-item slot="item">Red</fast-tree-item>
-                    <fast-tree-item slot="item">White</fast-tree-item>
+                    <fast-tree-item>Pink</fast-tree-item>
+                    <fast-tree-item>Red</fast-tree-item>
+                    <fast-tree-item>White</fast-tree-item>
                 </fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item slot="item">Nested item 2</fast-tree-item>
-            <fast-tree-item slot="item">Nested item 3</fast-tree-item>
+            <fast-tree-item>Nested item 2</fast-tree-item>
+            <fast-tree-item>Nested item 3</fast-tree-item>
         </fast-tree-item>
         <fast-tree-item>
             Root item 2
-            <fast-tree-item slot="item">
+            <fast-tree-item>
                 Flowers
-                <fast-tree-item slot="item" disabled>Daisy</fast-tree-item>
-                <fast-tree-item slot="item">Sunflower</fast-tree-item>
-                <fast-tree-item slot="item">Rose</fast-tree-item>
+                <fast-tree-item disabled>Daisy</fast-tree-item>
+                <fast-tree-item>Sunflower</fast-tree-item>
+                <fast-tree-item>Rose</fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item slot="item">Nested item 2</fast-tree-item>
-            <fast-tree-item slot="item">Nested item 3</fast-tree-item>
+            <fast-tree-item>Nested item 2</fast-tree-item>
+            <fast-tree-item>Nested item 3</fast-tree-item>
         </fast-tree-item>
         <fast-tree-item>
             Root item 3
-            <button>Test</button>
         </fast-tree-item>
     </fast-tree-view>
 

--- a/packages/web-components/fast-components/src/tree-view/fixtures/tree-view.html
+++ b/packages/web-components/fast-components/src/tree-view/fixtures/tree-view.html
@@ -4,20 +4,14 @@
         <fast-divider></fast-divider>
         <fast-tree-item>
             Root item 1
-            <fast-divider slot="item"></fast-divider>
+            <fast-divider></fast-divider>
             <fast-tree-item expanded>
                 Flowers
                 <fast-tree-item>Daisy</fast-tree-item>
-                <button
-                    style="position: relative; margin-inline-start: 80px;"
-                    slot="item"
-                >
-                    click me
-                </button>
                 <fast-tree-item disabled>Sunflower</fast-tree-item>
                 <fast-tree-item expanded>
                     Rose
-                    <fast-divider role="presentation" slot="item"></fast-divider>
+                    <fast-divider role="presentation"></fast-divider>
                     <fast-tree-item>Pink</fast-tree-item>
                     <fast-tree-item>Red</fast-tree-item>
                     <fast-tree-item>White</fast-tree-item>
@@ -30,7 +24,7 @@
             Root item 2
             <fast-tree-item>
                 Flowers
-                <fast-divider slot="item"></fast-divider>
+                <fast-divider></fast-divider>
                 <fast-tree-item disabled>Daisy</fast-tree-item>
                 <fast-tree-item>Sunflower</fast-tree-item>
                 <fast-tree-item>Rose</fast-tree-item>
@@ -41,6 +35,15 @@
         <fast-tree-item>
             Root item 3
         </fast-tree-item>
+    </fast-tree-view>
+
+    <h4>Flat tree</h4>
+    <fast-tree-view>
+        <fast-tree-item>Daisy</fast-tree-item>
+        <fast-tree-item>Sunflower</fast-tree-item>
+        <fast-tree-item selected>Rose</fast-tree-item>
+        <fast-tree-item>Petunia</fast-tree-item>
+        <fast-tree-item>Tulip</fast-tree-item>
     </fast-tree-view>
 
     <h4>Some expanded</h4>

--- a/packages/web-components/fast-components/src/tree-view/fixtures/tree-view.html
+++ b/packages/web-components/fast-components/src/tree-view/fixtures/tree-view.html
@@ -8,9 +8,16 @@
             <fast-tree-item expanded>
                 Flowers
                 <fast-tree-item>Daisy</fast-tree-item>
+                <button
+                    style="position: relative; margin-inline-start: 80px;"
+                    slot="item"
+                >
+                    click me
+                </button>
                 <fast-tree-item disabled>Sunflower</fast-tree-item>
                 <fast-tree-item expanded>
                     Rose
+                    <fast-divider role="presentation" slot="item"></fast-divider>
                     <fast-tree-item>Pink</fast-tree-item>
                     <fast-tree-item>Red</fast-tree-item>
                     <fast-tree-item>White</fast-tree-item>
@@ -23,6 +30,7 @@
             Root item 2
             <fast-tree-item>
                 Flowers
+                <fast-divider slot="item"></fast-divider>
                 <fast-tree-item disabled>Daisy</fast-tree-item>
                 <fast-tree-item>Sunflower</fast-tree-item>
                 <fast-tree-item>Rose</fast-tree-item>
@@ -39,17 +47,17 @@
     <fast-tree-view>
         <fast-tree-item expanded>
             Root item
-            <fast-tree-item slot="item" expanded>
+            <fast-tree-item expanded>
                 Flowers
-                <fast-tree-item slot="item">Daisy</fast-tree-item>
-                <fast-tree-item slot="item">Sunflower</fast-tree-item>
-                <fast-tree-item slot="item">Rose</fast-tree-item>
+                <fast-tree-item>Daisy</fast-tree-item>
+                <fast-tree-item>Sunflower</fast-tree-item>
+                <fast-tree-item>Rose</fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item disabled slot="item">
+            <fast-tree-item disabled>
                 Planes
-                <fast-tree-item slot="item">Tomcat</fast-tree-item>
-                <fast-tree-item disabled slot="item">Hawker Harrier</fast-tree-item>
-                <fast-tree-item slot="item">Cesna</fast-tree-item>
+                <fast-tree-item>Tomcat</fast-tree-item>
+                <fast-tree-item disabled>Hawker Harrier</fast-tree-item>
+                <fast-tree-item>Cesna</fast-tree-item>
             </fast-tree-item>
         </fast-tree-item>
     </fast-tree-view>
@@ -58,17 +66,17 @@
     <fast-tree-view>
         <fast-tree-item expanded>
             Root item
-            <fast-tree-item slot="item">
+            <fast-tree-item>
                 Flowers
-                <fast-tree-item slot="item">Daisy</fast-tree-item>
-                <fast-tree-item slot="item">Sunflower</fast-tree-item>
-                <fast-tree-item slot="item">Rose</fast-tree-item>
+                <fast-tree-item>Daisy</fast-tree-item>
+                <fast-tree-item>Sunflower</fast-tree-item>
+                <fast-tree-item>Rose</fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item slot="item" expanded>
+            <fast-tree-item expanded>
                 Planes
-                <fast-tree-item slot="item" selected>Tomcat</fast-tree-item>
-                <fast-tree-item slot="item">Hawker Harrier</fast-tree-item>
-                <fast-tree-item slot="item">Cesna</fast-tree-item>
+                <fast-tree-item selected>Tomcat</fast-tree-item>
+                <fast-tree-item>Hawker Harrier</fast-tree-item>
+                <fast-tree-item>Cesna</fast-tree-item>
             </fast-tree-item>
         </fast-tree-item>
     </fast-tree-view>
@@ -88,7 +96,7 @@
                     d="M6.5,7.7h-1v-1h1V7.7z M10.6,7.7h-1v-1h1V7.7z M14.7,6.7v2.1h-1v2.6c0,0.2,0,0.4-0.1,0.6c-0.1,0.2-0.2,0.4-0.3,0.5c-0.1,0.1-0.3,0.3-0.5,0.3c-0.2,0.1-0.4,0.1-0.6,0.1H10l-3.5,3v-3H3.9c-0.2,0-0.4,0-0.6-0.1c-0.2-0.1-0.4-0.2-0.5-0.3c-0.1-0.1-0.3-0.3-0.3-0.5c-0.1-0.2-0.1-0.4-0.1-0.6V8.8h-1V6.7h1V5.2c0-0.2,0-0.4,0.1-0.6c0.1-0.2,0.2-0.4,0.3-0.5c0.1-0.1,0.3-0.3,0.5-0.3c0.2-0.1,0.4-0.1,0.6-0.1h3.6V1.9C7.3,1.8,7.2,1.7,7.1,1.5C7,1.4,7,1.2,7,1C7,0.9,7,0.8,7,0.6c0.1-0.1,0.1-0.2,0.2-0.3c0.1-0.1,0.2-0.2,0.3-0.2C7.7,0,7.9,0,8,0c0.1,0,0.3,0,0.4,0.1c0.1,0.1,0.2,0.1,0.3,0.2C8.8,0.4,8.9,0.5,9,0.6C9,0.8,9,0.9,9,1c0,0.2,0,0.4-0.1,0.5C8.8,1.7,8.7,1.8,8.5,1.9v1.7h3.6c0.2,0,0.4,0,0.6,0.1c0.2,0.1,0.4,0.2,0.5,0.3c0.1,0.1,0.3,0.3,0.3,0.5c0.1,0.2,0.1,0.4,0.1,0.6v1.5H14.7z M12.6,5.2c0-0.1-0.1-0.3-0.2-0.4c-0.1-0.1-0.2-0.2-0.4-0.2H3.9c-0.1,0-0.3,0.1-0.4,0.2C3.4,4.9,3.4,5,3.4,5.2v6.2c0,0.1,0.1,0.3,0.2,0.4c0.1,0.1,0.2,0.2,0.4,0.2h3.6v1.8l2.1-1.8h2.5c0.1,0,0.3-0.1,0.4-0.2c0.1-0.1,0.2-0.2,0.2-0.4V5.2z M5.8,8.9c0.3,0.3,0.6,0.5,1,0.7C7.2,9.7,7.6,9.8,8,9.8s0.8-0.1,1.2-0.2c0.4-0.2,0.7-0.4,1-0.7l0.7,0.7c-0.4,0.4-0.8,0.7-1.4,0.9c-0.5,0.2-1,0.3-1.6,0.3s-1.1-0.1-1.6-0.3c-0.5-0.2-1-0.5-1.3-0.9L5.8,8.9z"
                 />
             </svg>
-            <fast-tree-item expanded slot="item">
+            <fast-tree-item expanded>
                 Nested Root item 1
                 <svg
                     slot="start"
@@ -101,7 +109,7 @@
                         d="M6.5,7.7h-1v-1h1V7.7z M10.6,7.7h-1v-1h1V7.7z M14.7,6.7v2.1h-1v2.6c0,0.2,0,0.4-0.1,0.6c-0.1,0.2-0.2,0.4-0.3,0.5c-0.1,0.1-0.3,0.3-0.5,0.3c-0.2,0.1-0.4,0.1-0.6,0.1H10l-3.5,3v-3H3.9c-0.2,0-0.4,0-0.6-0.1c-0.2-0.1-0.4-0.2-0.5-0.3c-0.1-0.1-0.3-0.3-0.3-0.5c-0.1-0.2-0.1-0.4-0.1-0.6V8.8h-1V6.7h1V5.2c0-0.2,0-0.4,0.1-0.6c0.1-0.2,0.2-0.4,0.3-0.5c0.1-0.1,0.3-0.3,0.5-0.3c0.2-0.1,0.4-0.1,0.6-0.1h3.6V1.9C7.3,1.8,7.2,1.7,7.1,1.5C7,1.4,7,1.2,7,1C7,0.9,7,0.8,7,0.6c0.1-0.1,0.1-0.2,0.2-0.3c0.1-0.1,0.2-0.2,0.3-0.2C7.7,0,7.9,0,8,0c0.1,0,0.3,0,0.4,0.1c0.1,0.1,0.2,0.1,0.3,0.2C8.8,0.4,8.9,0.5,9,0.6C9,0.8,9,0.9,9,1c0,0.2,0,0.4-0.1,0.5C8.8,1.7,8.7,1.8,8.5,1.9v1.7h3.6c0.2,0,0.4,0,0.6,0.1c0.2,0.1,0.4,0.2,0.5,0.3c0.1,0.1,0.3,0.3,0.3,0.5c0.1,0.2,0.1,0.4,0.1,0.6v1.5H14.7z M12.6,5.2c0-0.1-0.1-0.3-0.2-0.4c-0.1-0.1-0.2-0.2-0.4-0.2H3.9c-0.1,0-0.3,0.1-0.4,0.2C3.4,4.9,3.4,5,3.4,5.2v6.2c0,0.1,0.1,0.3,0.2,0.4c0.1,0.1,0.2,0.2,0.4,0.2h3.6v1.8l2.1-1.8h2.5c0.1,0,0.3-0.1,0.4-0.2c0.1-0.1,0.2-0.2,0.2-0.4V5.2z M5.8,8.9c0.3,0.3,0.6,0.5,1,0.7C7.2,9.7,7.6,9.8,8,9.8s0.8-0.1,1.2-0.2c0.4-0.2,0.7-0.4,1-0.7l0.7,0.7c-0.4,0.4-0.8,0.7-1.4,0.9c-0.5,0.2-1,0.3-1.6,0.3s-1.1-0.1-1.6-0.3c-0.5-0.2-1-0.5-1.3-0.9L5.8,8.9z"
                     />
                 </svg>
-                <fast-tree-item slot="item">
+                <fast-tree-item>
                     <svg
                         slot="start"
                         width="16"
@@ -115,7 +123,7 @@
                     </svg>
                     Nested item 4
                 </fast-tree-item>
-                <fast-tree-item slot="item">
+                <fast-tree-item>
                     <svg
                         slot="start"
                         width="16"
@@ -130,7 +138,7 @@
                     Nested item 5
                 </fast-tree-item>
             </fast-tree-item>
-            <fast-tree-item slot="item">
+            <fast-tree-item>
                 Nested item 2
                 <svg
                     slot="start"
@@ -144,7 +152,7 @@
                     />
                 </svg>
             </fast-tree-item>
-            <fast-tree-item slot="item">
+            <fast-tree-item>
                 Nested item 3
                 <svg
                     slot="start"

--- a/packages/web-components/fast-components/temp/api-report.md
+++ b/packages/web-components/fast-components/temp/api-report.md
@@ -573,6 +573,12 @@ export class FASTTreeView extends TreeView {
 }
 
 // @public
+export const inlineEndBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+
+// @public
+export const inlineStartBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+
+// @public
 export function isDarkMode(designSystem: FASTDesignSystem): boolean;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralDividerRest" should be prefixed with an underscore because the declaration is marked as @internal

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -781,6 +781,8 @@ export enum TextFieldType {
 // @public
 export class TreeItem extends FASTElement {
     // (undocumented)
+    childItemLength(): number;
+    // (undocumented)
     childItems: HTMLElement[];
     // @internal (undocumented)
     connectedCallback(): void;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -781,8 +781,6 @@ export enum TextFieldType {
 // @public
 export class TreeItem extends FASTElement {
     // (undocumented)
-    childItemLength(): number;
-    // (undocumented)
     childItems: HTMLElement[];
     // @internal (undocumented)
     connectedCallback(): void;
@@ -806,6 +804,8 @@ export class TreeItem extends FASTElement {
     handleFocus: (e: Event) => void;
     // (undocumented)
     handleKeyDown: (e: KeyboardEvent) => void | boolean;
+    // (undocumented)
+    isNestedItem(): null | boolean;
     // (undocumented)
     items: HTMLElement[];
     // (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -810,7 +810,6 @@ export class TreeItem extends FASTElement {
     isNestedItem(): null | boolean;
     // (undocumented)
     items: HTMLElement[];
-    // (undocumented)
     nested: boolean;
     // (undocumented)
     renderCollapsedChildren: boolean;

--- a/packages/web-components/fast-foundation/src/tree-item/README.md
+++ b/packages/web-components/fast-foundation/src/tree-item/README.md
@@ -14,7 +14,6 @@ An implementation of a [tree-item](https://w3c.github.io/aria/#treeitem) as a we
     <fast-tree-view>
         Root
         <fast-tree-item>Item 1</fast-tree-item>
-        <fast-divider slot="item"></fast-divider>
         <fast-tree-item>Item 2</fast-tree-item>
     </fast-tree-view>
 </fast-design-system-provider>

--- a/packages/web-components/fast-foundation/src/tree-item/README.md
+++ b/packages/web-components/fast-foundation/src/tree-item/README.md
@@ -13,8 +13,9 @@ An implementation of a [tree-item](https://w3c.github.io/aria/#treeitem) as a we
 <fast-design-system-provider use-defaults>
     <fast-tree-view>
         Root
-        <fast-tree-item slot="item">Item 1</fast-tree-item>
-        <fast-tree-item slot="item">Item 2</fast-tree-item>
+        <fast-tree-item>Item 1</fast-tree-item>
+        <fast-divider slot="item"></fast-divider>
+        <fast-tree-item>Item 2</fast-tree-item>
     </fast-tree-view>
 </fast-design-system-provider>
 ```

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -32,7 +32,7 @@ export const TreeItemTemplate = html<TreeItem>`
         >
             <div class="content-region" part="content-region">
                 ${when(
-                    x => x.childItems && x.childItems.length > 0,
+                    x => x.childItems && x.childItemLength() > 0,
                     html<TreeItem>`
                         <div
                             aria-hidden="true"
@@ -61,7 +61,7 @@ export const TreeItemTemplate = html<TreeItem>`
         ${when(
             x =>
                 x.childItems &&
-                x.childItems.length > 0 &&
+                x.childItemLength() > 0 &&
                 (x.expanded || x.renderCollapsedChildren),
             html<TreeItem>`
                 <div role="group" class="items" part="items">

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -12,14 +12,20 @@ export const TreeItemTemplate = html<TreeItem>`
         tabindex="${x => (x.disabled ? null : x.focusable ? 0 : -1)}"
         class="${x => (x.expanded ? "expanded" : "")} ${x =>
             x.selected ? "selected" : ""} ${x => (x.nested ? "nested" : "")}
-            ${x => (x.disabled ? "disabled" : "")}"
+            ${x => (x.disabled ? "disabled" : "")}
+            ${x => (x.childItems && x.childItems.length > 0 ? "" : "leaf")}"
         aria-expanded="${x => (x.expanded ? x.expanded : void 0)}"
         aria-selected="${x => x.selected}"
         aria-disabled="${x => x.disabled}"
         @focus="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
         @blur="${(x, c) => x.handleBlur(c.event as FocusEvent)}"
         @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
-        ${children({ property: "childItems", filter: elements("[slot='item']") })}
+        ${children({
+            property: "childItems",
+            filter: (value: Node, index: number, array: Node[]) => {
+                return value instanceof HTMLElement;
+            },
+        })}
     >
         <div
             class="positioning-region"

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -23,9 +23,7 @@ export const TreeItemTemplate = html<TreeItem>`
         @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
         ${children({
             property: "childItems",
-            filter: (value: Node, index: number, array: Node[]) => {
-                return value instanceof HTMLElement;
-            },
+            filter: elements(),
         })}
     >
         <div

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -9,6 +9,7 @@ import { TreeItem } from "./tree-item";
 export const TreeItemTemplate = html<TreeItem>`
     <template
         role="treeitem"
+        slot="item"
         tabindex="${x => (x.disabled ? null : x.focusable ? 0 : -1)}"
         class="${x => (x.expanded ? "expanded" : "")} ${x =>
             x.selected ? "selected" : ""} ${x => (x.nested ? "nested" : "")}

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -9,12 +9,11 @@ import { TreeItem } from "./tree-item";
 export const TreeItemTemplate = html<TreeItem>`
     <template
         role="treeitem"
-        slot="item"
-        tabindex="${x => (x.disabled ? null : x.focusable ? 0 : -1)}"
+        slot="${x => (x.isNestedItem() ? "item" : void 0)}"
+        tabindex="${x => (x.disabled ? void 0 : x.focusable ? 0 : -1)}"
         class="${x => (x.expanded ? "expanded" : "")} ${x =>
             x.selected ? "selected" : ""} ${x => (x.nested ? "nested" : "")}
-            ${x => (x.disabled ? "disabled" : "")}
-            ${x => (x.childItems && x.childItems.length > 0 ? "" : "leaf")}"
+            ${x => (x.disabled ? "disabled" : "")}"
         aria-expanded="${x => (x.expanded ? x.expanded : void 0)}"
         aria-selected="${x => x.selected}"
         aria-disabled="${x => x.disabled}"

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -83,7 +83,13 @@ export class TreeItem extends FASTElement {
         }
     }
 
-    @attr
+    /**
+     * Tracks the nested state of the item
+     * @public
+     * @remarks
+     * HTML Attribute: nested
+     */
+    @attr({ mode: "boolean" })
     public nested: boolean;
 
     @observable
@@ -200,12 +206,12 @@ export class TreeItem extends FASTElement {
     };
 
     public childItemLength(): number {
-        const treeChildrens: HTMLElement[] = this.childItems.filter(
+        const treeChildren: HTMLElement[] = this.childItems.filter(
             (item: HTMLElement) => {
                 return isTreeItemElement(item);
             }
         );
-        return treeChildrens ? treeChildrens.length : 0;
+        return treeChildren ? treeChildren.length : 0;
     }
 
     public isNestedItem(): null | boolean {

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -75,7 +75,7 @@ export class TreeItem extends FASTElement {
     private itemsChanged(oldValue, newValue): void {
         if (this.$fastController.isConnected) {
             this.items.forEach((node: HTMLElement) => {
-                if (node instanceof TreeItem) {
+                if (isTreeItemElement(node)) {
                     // TODO: maybe not require it to be a TreeItem?
                     (node as TreeItem).nested = true;
                 }
@@ -197,6 +197,15 @@ export class TreeItem extends FASTElement {
             this.handleSelected(e);
         }
     };
+
+    public childItemLength(): number {
+        const treeChildrens: HTMLElement[] = this.childItems.filter(
+            (item: HTMLElement) => {
+                return isTreeItemElement(item);
+            }
+        );
+        return treeChildrens ? treeChildrens.length : 0;
+    }
 
     private handleArrowLeft(): void {
         if (this.expanded) {

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -74,16 +74,16 @@ export class TreeItem extends FASTElement {
     public items: HTMLElement[];
     private itemsChanged(oldValue, newValue): void {
         if (this.$fastController.isConnected) {
-            this.items.forEach((node: HTMLElement) => {
-                if (isTreeItemElement(node)) {
-                    // TODO: maybe not require it to be a TreeItem?
-                    (node as TreeItem).nested = true;
-                }
-            });
+            // this.items.forEach((node: HTMLElement) => {
+            //     if (isTreeItemElement(node)) {
+            //         // TODO: maybe not require it to be a TreeItem?
+            //         (node as TreeItem).nested = true;
+            //     }
+            // });
         }
     }
 
-    @observable
+    @attr
     public nested: boolean;
 
     @observable
@@ -105,6 +105,7 @@ export class TreeItem extends FASTElement {
         super.connectedCallback();
 
         const parentTreeNode: HTMLElement | null | undefined = this.getParentTreeNode();
+
         if (parentTreeNode) {
             if (parentTreeNode.hasAttribute("render-collapsed-nodes")) {
                 this.renderCollapsedChildren =
@@ -198,13 +199,10 @@ export class TreeItem extends FASTElement {
         }
     };
 
-    public childItemLength(): number {
-        const treeChildrens: HTMLElement[] = this.childItems.filter(
-            (item: HTMLElement) => {
-                return isTreeItemElement(item);
-            }
+    public isNestedItem(): null | boolean {
+        return (
+            this.parentElement && this.parentElement.getAttribute("role") === "treeitem"
         );
-        return treeChildrens ? treeChildrens.length : 0;
     }
 
     private handleArrowLeft(): void {

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -74,12 +74,12 @@ export class TreeItem extends FASTElement {
     public items: HTMLElement[];
     private itemsChanged(oldValue, newValue): void {
         if (this.$fastController.isConnected) {
-            // this.items.forEach((node: HTMLElement) => {
-            //     if (isTreeItemElement(node)) {
-            //         // TODO: maybe not require it to be a TreeItem?
-            //         (node as TreeItem).nested = true;
-            //     }
-            // });
+            this.items.forEach((node: HTMLElement) => {
+                if (isTreeItemElement(node)) {
+                    // TODO: maybe not require it to be a TreeItem?
+                    (node as TreeItem).nested = true;
+                }
+            });
         }
     }
 
@@ -198,6 +198,15 @@ export class TreeItem extends FASTElement {
             this.handleSelected(e);
         }
     };
+
+    public childItemLength(): number {
+        const treeChildrens: HTMLElement[] = this.childItems.filter(
+            (item: HTMLElement) => {
+                return isTreeItemElement(item);
+            }
+        );
+        return treeChildrens ? treeChildrens.length : 0;
+    }
 
     public isNestedItem(): null | boolean {
         return (

--- a/packages/web-components/fast-foundation/src/tree-view/README.md
+++ b/packages/web-components/fast-foundation/src/tree-view/README.md
@@ -6,7 +6,6 @@ custom_edit_url: https://github.com/microsoft/fast/edit/master/packages/web-comp
 ---
 
 An implementation of a [tree](https://w3c.github.io/aria/#tree) as a web-component.
-The `fast-tree-view` supports other elements being included in the tree structure with the introduction of `slot="item"`.
 
 ## Usage
 
@@ -16,10 +15,8 @@ The `fast-tree-view` supports other elements being included in the tree structur
         Root
         <fast-tree-item>
             Item 1
-            <fast-divider slot="item"></fast-divider>
-            <fast-tree-item>
-                Sub-item 1
-            </fast-tree-item>
+            <fast-tree-item>Sub-item 1</fast-tree-item>
+            <fast-tree-item>Sub-item 2</fast-tree-item>
         </fast-tree-item>
         <fast-tree-item>Item 2</fast-tree-item>
     </fast-tree-view>

--- a/packages/web-components/fast-foundation/src/tree-view/README.md
+++ b/packages/web-components/fast-foundation/src/tree-view/README.md
@@ -6,6 +6,7 @@ custom_edit_url: https://github.com/microsoft/fast/edit/master/packages/web-comp
 ---
 
 An implementation of a [tree](https://w3c.github.io/aria/#tree) as a web-component.
+The `fast-tree-view` supports other elements being included in the tree structure with the introduction of `slot="item"`.
 
 ## Usage
 
@@ -13,8 +14,14 @@ An implementation of a [tree](https://w3c.github.io/aria/#tree) as a web-compone
 <fast-design-system-provider use-defaults>
     <fast-tree-view>
         Root
-        <fast-tree-item slot="item">Item 1</fast-tree-item>
-        <fast-tree-item slot="item">Item 2</fast-tree-item>
+        <fast-tree-item>
+            Item 1
+            <fast-divider slot="item"></fast-divider>
+            <fast-tree-item>
+                Sub-item 1
+            </fast-tree-item>
+        </fast-tree-item>
+        <fast-tree-item>Item 2</fast-tree-item>
     </fast-tree-view>
 </fast-design-system-provider>
 ```

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
@@ -14,7 +14,6 @@ export const TreeViewTemplate = html<TreeView>`
         @focus="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
         @blur="${(x, c) => x.handleBlur(c.event as FocusEvent)}"
     >
-        <slot></slot>
-        <slot name="item" ${slotted("slottedTreeItems")}></slot>
+        <slot ${slotted("slottedTreeItems")}></slot>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
@@ -14,6 +14,7 @@ export const TreeViewTemplate = html<TreeView>`
         @focus="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
         @blur="${(x, c) => x.handleBlur(c.event as FocusEvent)}"
     >
-        <slot ${slotted("slottedTreeItems")}></slot>
+        <slot></slot>
+        <slot name="item" ${slotted("slottedTreeItems")}></slot>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -37,7 +37,6 @@ export class TreeView extends FASTElement {
             // check if any tree items have nested items
             // if they do, apply the nested attribute
             if (this.checkForNestedItems()) {
-                console.log("yes nested items!");
                 this.slottedTreeItems.forEach(node => {
                     if (isTreeItemElement(node)) {
                         node.setAttribute("nested", "true");

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -23,6 +23,9 @@ export class TreeView extends FASTElement {
     @observable
     private lastFocused: HTMLElement;
 
+    @observable
+    private nested: boolean;
+
     @observable slottedTreeItems: HTMLElement[];
     private slottedTreeItemsChanged(oldValue, newValue): void {
         if (this.$fastController.isConnected) {
@@ -30,7 +33,24 @@ export class TreeView extends FASTElement {
             this.resetItems();
             this.treeItems = this.getVisibleNodes();
             this.setItems();
+
+            // check if any tree items have nested items
+            // if they do, apply the nested attribute
+            if (this.checkForNestedItems()) {
+                console.log("yes nested items!");
+                this.slottedTreeItems.forEach(node => {
+                    if (isTreeItemElement(node)) {
+                        node.setAttribute("nested", "true");
+                    }
+                });
+            }
         }
+    }
+
+    private checkForNestedItems(): boolean {
+        return this.slottedTreeItems.some((node: HTMLElement) => {
+            return isTreeItemElement(node) && node.querySelector("[role='treeitem'");
+        });
     }
 
     private treeItems: HTMLElement[];

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -48,7 +48,7 @@ export class TreeView extends FASTElement {
 
     private checkForNestedItems(): boolean {
         return this.slottedTreeItems.some((node: HTMLElement) => {
-            return isTreeItemElement(node) && node.querySelector("[role='treeitem'");
+            return isTreeItemElement(node) && node.querySelector("[role='treeitem']");
         });
     }
 

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -39,7 +39,7 @@ export class TreeView extends FASTElement {
             if (this.checkForNestedItems()) {
                 this.slottedTreeItems.forEach(node => {
                     if (isTreeItemElement(node)) {
-                        node.setAttribute("nested", "true");
+                        node.setAttribute("nested", "");
                     }
                 });
             }

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -179,7 +179,7 @@ export class TreeView extends FASTElement {
         const treeItems: HTMLElement[] = [];
         if (this.slottedTreeItems !== undefined) {
             this.slottedTreeItems.forEach((item: any) => {
-                if (item instanceof HTMLElement) {
+                if (isTreeItemElement(item)) {
                     treeItems.push(item as any);
                 }
             });


### PR DESCRIPTION
## Description
Tree items at the root level were not styled correctly if they did not have children, indentation was incorrect. Also this fix allow developers to add arbitrary elements into the tree view structure.

closes #3516

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

