### PR TITLE
fix: update fast-card and component sampler color handling

### DIFF
--- a/packages/web-components/fast-components/src/card/card.styles.ts
+++ b/packages/web-components/fast-components/src/card/card.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
-import { elevation, neutralFillCardRestBehavior } from "../styles/index";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import { elevation, neutralFillCardRestBehavior } from "../styles/index";
 
 export const CardStyles = css`
     ${display("block")} :host {

--- a/packages/web-components/fast-components/src/card/card.styles.ts
+++ b/packages/web-components/fast-components/src/card/card.styles.ts
@@ -1,6 +1,6 @@
 import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
-import { elevation, neutralLayerCardBehavior } from "../styles/index";
+import { elevation, neutralFillCardRestBehavior } from "../styles/index";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 
 export const CardStyles = css`
@@ -11,12 +11,12 @@ export const CardStyles = css`
         height: var(--card-height, 100%);
         width: var(--card-width, 100%);
         box-sizing: border-box;
-        background: ${neutralLayerCardBehavior.var};
+        background: ${neutralFillCardRestBehavior.var};
         border-radius: calc(var(--corner-radius) * 1px);
         ${elevation}
     }
 `.withBehaviors(
-    neutralLayerCardBehavior,
+    neutralFillCardRestBehavior,
     forcedColorsStylesheetBehavior(
         css`
             :host {

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -30,7 +30,7 @@ export const FastFrameTemplate = html<FastFrame>`
                                 id="dark-mode-switch"
                                 :checked="${x => x.darkMode}"
                                 @change="${(x, c) =>
-                                    x.themeChange(c.event as CustomEvent)}"
+                                    x.modeChange(c.event as CustomEvent)}"
                             >
                                 <span slot="checked-message">On</span>
                                 <span slot="unchecked-message">Off</span>
@@ -47,25 +47,24 @@ export const FastFrameTemplate = html<FastFrame>`
                             Color is applied by using color recipes which require two color palettes, neutral and accent, applied to the design system. These palettes are customizable which allows for a wide range of styles.
                         </p>
                         <div class="content-control-container" >
-                            <label for="background-color-pickers">Background color</label>
+                            <label for="neutral-color-pickers">Neutral color</label>
                             <fast-radio-group
-                                name="background-color-pickers"
-                                value="${x => x.previewBackgroundPalette[0]}"
+                                name="neutral-color-pickers"
+                                value="${x => x.previewNeutralPalette[0]}"
                                 @change="${(x, c) =>
-                                    x.backgroundChangeHandler(c.event as CustomEvent)}"
+                                    x.neutralChangeHandler(c.event as CustomEvent)}"
                             >
                                 ${repeat(
-                                    x => x.previewBackgroundPalette,
+                                    x => x.previewNeutralPalette,
 
                                     html<string>`
                                         <site-color-swatch
                                             tabindex="0"
-                                            aria-label="background color ${x => x}"
+                                            aria-label="neutral color ${x => x}"
                                             value="${x => x}"
                                             background-color="${x => x}"
                                             checked="${(x, c) =>
-                                                x ===
-                                                c.parent.previewBackgroundPalette[0]}"
+                                                x === c.parent.previewNeutralPalette[0]}"
                                         ></site-color-swatch>
                                     `
                                 )}
@@ -207,10 +206,7 @@ export const FastFrameTemplate = html<FastFrame>`
             </fast-tabs>
             <fast-design-system-provider
                 class="${x => (x.expanded ? "preview preview-expanded" : "preview")}"
-                base-layer-luminance="${x =>
-                    x.darkMode
-                        ? StandardLuminance.DarkMode
-                        : StandardLuminance.LightMode}"
+                base-layer-luminance="${x => x.baseLayerLuminance}"
                 background-color="${x => x.backgroundColor}"
                 accent-base-color="${x => x.accentColor}"
                 density="${x => x.density}"
@@ -218,6 +214,8 @@ export const FastFrameTemplate = html<FastFrame>`
                 outline-width="${x => x.outlineWidth}"
                 :accentPalette=${x =>
                     Array.isArray(x.accentPalette) ? x.accentPalette : null}
+                :neutralPalette=${x =>
+                    Array.isArray(x.neutralPalette) ? x.neutralPalette : null}
             >
                 <fast-design-system-provider
                     density="0"

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -1,4 +1,3 @@
-import { StandardLuminance } from "@microsoft/fast-components-styles-msft";
 import { html, repeat } from "@microsoft/fast-element";
 import ContextIcon from "svg/icon-context.svg";
 import ContrastIcon from "svg/icon-contrast.svg";

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
@@ -184,8 +184,15 @@ export class FastFrame extends FASTElement {
         this.saturation = accentColorHSL.s;
         this.lightness = accentColorHSL.l;
 
-        this.updateBackgroundColor();
-
         this.mql.addListener(this.resetExpandedResponsive);
+    }
+
+    /**
+     * @internal
+     */
+    public connectedCallback() {
+        super.connectedCallback();
+
+        this.updateBackgroundColor();
     }
 }

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
@@ -1,5 +1,12 @@
 import { FASTElement, attr, observable } from "@microsoft/fast-element";
-import { createColorPalette, FASTSlider } from "@microsoft/fast-components";
+import {
+    createColorPalette,
+    FASTSlider,
+    FASTDesignSystem,
+    fastDesignSystemDefaults,
+    StandardLuminance,
+    neutralLayerCardContainer,
+} from "@microsoft/fast-components";
 import {
     ColorHSL,
     ColorRGBA64,
@@ -16,18 +23,21 @@ export class FastFrame extends FASTElement {
     public accentColor: string = "#F33378";
 
     @attr({ attribute: "background-color" })
-    public backgroundColor: string = "#212121";
+    public backgroundColor: string;
 
     @attr
     public darkMode: boolean = true;
 
+    @attr
+    public baseLayerLuminance: number = StandardLuminance.DarkMode;
+
     @observable
-    public previewBackgroundPalette: string[] = [
-        "#212121",
-        "#2B2B2B",
-        "#333333",
-        "#3B3B3B",
-        "#424242",
+    public previewNeutralPalette: string[] = [
+        "#808080",
+        "#35719F",
+        "#2D5F2D",
+        "#5D437C",
+        "#A35436",
     ];
 
     @observable
@@ -39,12 +49,10 @@ export class FastFrame extends FASTElement {
         "#E1A054",
     ];
 
-    private darkPallette: string[] = this.previewBackgroundPalette;
-
     private mql: MediaQueryList = window.matchMedia(`(max-width: ${drawerBreakpoint})`);
 
     @observable
-    public lastSelectedIndex: number = 0;
+    public neutralPalette: string[];
 
     @observable
     public accentPalette: string[];
@@ -87,13 +95,12 @@ export class FastFrame extends FASTElement {
         }
     };
 
-    public backgroundChangeHandler = (e: CustomEvent): void => {
+    public neutralChangeHandler = (e: CustomEvent): void => {
         if (e.target instanceof SiteColorSwatch) {
             if (e.target.checked) {
-                this.backgroundColor = e.target.value;
-                this.lastSelectedIndex = Array.from(
-                    this.previewBackgroundPalette
-                ).indexOf(e.target.value);
+                const parsedColor = parseColorHexRGB(e.target.value);
+                this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64);
+                this.updateBackgroundColor();
             }
         }
     };
@@ -141,20 +148,25 @@ export class FastFrame extends FASTElement {
         this.accentPalette = createColorPalette(accentRGB);
     }
 
-    public themeChange = (e: CustomEvent): void => {
+    private updateBackgroundColor(): void {
+        const designSystem: FASTDesignSystem = Object.assign(
+            {},
+            fastDesignSystemDefaults,
+            {
+                baseLayerLuminance: this.baseLayerLuminance,
+                neutralPalette: this.neutralPalette,
+            }
+        );
+
+        this.backgroundColor = neutralLayerCardContainer(designSystem);
+    }
+
+    public modeChange = (e: CustomEvent): void => {
         this.darkMode = !this.darkMode;
-        if (!this.darkMode) {
-            this.previewBackgroundPalette = [
-                "#FFFFFF",
-                "#F0F0F0",
-                "#DEDEDE",
-                "#D6D6D6",
-                "#C4C4C4",
-            ];
-        } else {
-            this.previewBackgroundPalette = this.darkPallette;
-        }
-        this.backgroundColor = this.previewBackgroundPalette[this.lastSelectedIndex];
+        this.baseLayerLuminance = this.darkMode
+            ? StandardLuminance.DarkMode
+            : StandardLuminance.LightMode;
+        this.updateBackgroundColor();
     };
 
     private resetExpandedResponsive = (e): void => {
@@ -171,6 +183,8 @@ export class FastFrame extends FASTElement {
         this.hue = accentColorHSL.h;
         this.saturation = accentColorHSL.s;
         this.lightness = accentColorHSL.l;
+
+        this.updateBackgroundColor();
 
         this.mql.addListener(this.resetExpandedResponsive);
     }


### PR DESCRIPTION

# Description

Updated fast-card to use a relative color recipe.
Updated the fast.design site component sampler to better respond to changes of the neutral color and light or dark mode,

![image](https://user-images.githubusercontent.com/47367562/88964850-cf021380-d25e-11ea-893b-5de42baa8804.png)

## Motivation & context

A card has two applicable color recipes for it's background color, but the most flexible one is `neutralFillCardRest` because it will adjust the card background for whatever container it's in. `neutralLayerCard` is a fixed value intended for an optimized and backwards compatible case over `neutralLayerCardContainer` only. This was causing the fast.design component sampler to not reflect the color change correctly.

Further, the sampler is updated to adjust both the layer luminance and the neutral color used for the background. The latter shows off more of the color handling with the addition of non-grey swatches. The former more correctly applies light and dark mode, which is done setting the `baseLayerLuminance` and using a `layer` recipe for the background color instead of a fixed shade of grey that doesn't come from the neutral ramp.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->