### PR TITLE
fix: add form submission and reset behavior to Button

### DIFF
--- a/packages/web-components/fast-components/src/button/fixtures/button.html
+++ b/packages/web-components/fast-components/src/button/fixtures/button.html
@@ -86,4 +86,14 @@
 
     <h4>With aria-label</h4>
     <fast-button aria-label="Button with aria-label">Button</fast-button>
+
+    <form>
+        <input type="text" name="test" />
+        <fast-button type="submit">Submit</fast-button>
+    </form>
+
+    <form>
+        <input type="text" name="test-2" />
+        <fast-button type="reset">Reset</fast-button>
+    </form>
 </fast-design-system-provider>

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -132,7 +132,10 @@ export class Button extends FormAssociated<HTMLInputElement> {
     formmethod: string;
     formnovalidate: boolean;
     formtarget: "_self" | "_blank" | "_parent" | "_top";
-    name: string;
+    // @internal
+    handleFormReset: () => void;
+    // @internal
+    handleSubmission: () => void;
     // (undocumented)
     protected proxy: HTMLInputElement;
     type: "submit" | "reset" | "button";

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -132,10 +132,6 @@ export class Button extends FormAssociated<HTMLInputElement> {
     formmethod: string;
     formnovalidate: boolean;
     formtarget: "_self" | "_blank" | "_parent" | "_top";
-    // @internal
-    handleFormReset: () => void;
-    // @internal
-    handleSubmission: () => void;
     // (undocumented)
     protected proxy: HTMLInputElement;
     type: "submit" | "reset" | "button";

--- a/packages/web-components/fast-foundation/src/button/button.spec.ts
+++ b/packages/web-components/fast-foundation/src/button/button.spec.ts
@@ -1,0 +1,54 @@
+import { expect } from "chai";
+import { customElement, html, DOM } from "@microsoft/fast-element";
+import { classNames } from "@microsoft/fast-web-utilities";
+import { Button } from "./button";
+
+@customElement({
+    name: "test-button",
+    template: html`
+        <slot></slot>
+    `,
+})
+class TestElement extends Button {}
+
+describe("Button", () => {
+    describe("of type 'submit'", () => {
+        it("should submit the parent form when clicked", () => {
+            let wasSumbitted = false;
+            let event: any;
+            const form = document.createElement("form");
+            const submit = document.createElement("test-button");
+            submit.setAttribute("type", "submit");
+            form.appendChild(submit);
+            form.addEventListener("submit", e => {
+                e.preventDefault();
+                wasSumbitted = true;
+                event = e;
+            });
+            document.body.appendChild(form);
+
+            submit.click();
+
+            expect(wasSumbitted).to.equal(true);
+            expect(event.submitter).to.equal(submit["proxy"] as any);
+        });
+    });
+
+    describe("of type 'reset'", () => {
+        it("should submit the parent form when clicked", () => {
+            let wasReset = false;
+            const form = document.createElement("form");
+            const reset = document.createElement("test-button");
+            reset.setAttribute("type", "reset");
+            form.appendChild(reset);
+            document.body.appendChild(form);
+            form.addEventListener("reset", () => {
+                wasReset = true;
+            });
+
+            reset.click();
+
+            expect(wasReset).to.equal(true);
+        });
+    });
+});

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -141,9 +141,8 @@ export class Button extends FormAssociated<HTMLInputElement> {
 
     /**
      * Submits the parent form
-     * @internal
      */
-    public handleSubmission = () => {
+    private handleSubmission = () => {
         if (!this.form) {
             return;
         }
@@ -167,9 +166,8 @@ export class Button extends FormAssociated<HTMLInputElement> {
 
     /**
      * Resets the parent form
-     * @internal
      */
-    public handleFormReset = () => {
+    private handleFormReset = () => {
         this.form?.reset();
     };
 }

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -1,4 +1,4 @@
-import { attr } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
@@ -106,16 +106,6 @@ export class Button extends FormAssociated<HTMLInputElement> {
     }
 
     /**
-     * The name of the button
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: name
-     */
-    @attr
-    public name: string;
-
-    /**
      * The button type.
      *
      * @public
@@ -124,10 +114,18 @@ export class Button extends FormAssociated<HTMLInputElement> {
      */
     @attr
     public type: "submit" | "reset" | "button";
-    private typeChanged(): void {
+    private typeChanged(
+        previous: "submit" | "reset" | "button" | void,
+        next: "submit" | "reset" | "button"
+    ): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.type = this.type;
         }
+
+        next === "submit" && this.addEventListener("click", this.handleSubmission);
+        previous === "submit" && this.removeEventListener("click", this.handleSubmission);
+        next === "reset" && this.addEventListener("click", this.handleFormReset);
+        previous === "reset" && this.removeEventListener("click", this.handleFormReset);
     }
 
     protected proxy: HTMLInputElement = document.createElement("input");
@@ -138,10 +136,44 @@ export class Button extends FormAssociated<HTMLInputElement> {
     public connectedCallback(): void {
         super.connectedCallback();
 
-        this.proxy.setAttribute("type", `${this.type}`);
-
-        this.setFormValue(this.value, this.value);
+        this.proxy.setAttribute("type", this.type);
     }
+
+    /**
+     * Submits the parent form
+     * @internal
+     */
+    public handleSubmission = () => {
+        debugger;
+        if (!this.form) {
+            return;
+        }
+
+        const attached = this.proxy.isConnected;
+
+        if (!attached) {
+            super.attachProxy();
+        }
+
+        // Browser support for requestSubmit is not comprehensive
+        // so click the proxy if it isn't supported
+        typeof this.form.requestSubmit === "function"
+            ? this.form.requestSubmit(this.proxy)
+            : this.proxy.click();
+
+        if (!attached) {
+            super.detachProxy();
+        }
+    };
+
+    /**
+     * Resets the parent form
+     * @internal
+     */
+    public handleFormReset = () => {
+        debugger;
+        this.form?.reset();
+    };
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -144,7 +144,6 @@ export class Button extends FormAssociated<HTMLInputElement> {
      * @internal
      */
     public handleSubmission = () => {
-        debugger;
         if (!this.form) {
             return;
         }
@@ -171,7 +170,6 @@ export class Button extends FormAssociated<HTMLInputElement> {
      * @internal
      */
     public handleFormReset = () => {
-        debugger;
         this.form?.reset();
     };
 }

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -267,26 +267,7 @@ export abstract class FormAssociated<
         this.dirtyValue = false;
 
         if (!supportsElementInternals) {
-            this.proxy.style.display = "none";
-            this.appendChild(this.proxy);
-
-            this.proxyEventsToBlock.forEach(name =>
-                this.proxy.addEventListener(name, this.stopPropagation)
-            );
-
-            // These are typically mapped to the proxy during
-            // property change callbacks, but during initialization
-            // on the initial call of the callback, the proxy is
-            // still undefined. We should find a better way to address this.
-            this.proxy.disabled = this.disabled;
-            this.proxy.required = this.required;
-            if (typeof this.name === "string") {
-                this.proxy.name = this.name;
-            }
-
-            if (typeof this.value === "string") {
-                this.proxy.value = this.value;
-            }
+            this.attachProxy();
         }
     }
 

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -283,6 +283,7 @@ export abstract class FormAssociated<
             if (typeof this.name === "string") {
                 this.proxy.name = this.name;
             }
+
             if (typeof this.value === "string") {
                 this.proxy.value = this.value;
             }
@@ -342,6 +343,44 @@ export abstract class FormAssociated<
      */
     public formDisabledCallback(disabled: boolean): void {
         this.disabled = disabled;
+    }
+
+    private proxyInitialized: boolean = false;
+
+    /**
+     * Attach the proxy element to the DOM
+     */
+    protected attachProxy() {
+        if (!this.proxyInitialized) {
+            this.proxyInitialized = true;
+            this.proxy.style.display = "none";
+            this.proxyEventsToBlock.forEach(name =>
+                this.proxy.addEventListener(name, this.stopPropagation)
+            );
+
+            // These are typically mapped to the proxy during
+            // property change callbacks, but during initialization
+            // on the initial call of the callback, the proxy is
+            // still undefined. We should find a better way to address this.
+            this.proxy.disabled = this.disabled;
+            this.proxy.required = this.required;
+            if (typeof this.name === "string") {
+                this.proxy.name = this.name;
+            }
+
+            if (typeof this.value === "string") {
+                this.proxy.value = this.value;
+            }
+        }
+
+        this.appendChild(this.proxy);
+    }
+
+    /**
+     * Detach the proxy element from the DOM
+     */
+    protected detachProxy() {
+        this.removeChild(this.proxy);
     }
 
     /**


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
#3534 describes an issue where a `FASTButton[type=submit]` does not actually submit the parent form. In fixing this, I also noticed that a `FASTButton[type=reset]` does not reset the form. This introduces a fix to both behaviors.

A `FASTButton[type=reset]` will simply invoke the `reset()` method of the associated form element when clicked.

Submission behavior is a bit more complicated. The `FASTButton[type=submit]` will *try* to use the `requestSubmit()` method of the form if it exists, supplying the method with the button's proxy element as the submitting element (see #3534) for more info. If the `requestSubmit()` method is unavailable (Safari) then the proxy's `click()` method will be invoked.

closes #3534
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/en/contributing/working
-->