### PR TITLE
fix: use design system direction support for glyph in treeview

### DIFF
--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -1,5 +1,6 @@
 import { css } from "@microsoft/fast-element";
 import {
+    DirectionalStyleSheetBehavior,
     disabledCursor,
     display,
     focusVisible,
@@ -19,6 +20,18 @@ import {
     neutralForegroundActiveBehavior,
     neutralForegroundRestBehavior,
 } from "../styles/index";
+
+const ltr = css`
+    :host(.nested) .expand-collapse-button {
+        left: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
+    }
+`;
+
+const rtl = css`
+    :host(.nested) .expand-collapse-button {
+        right: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
+    }
+`;
 
 export const TreeItemStyles = css`
     ${display("block")} :host {
@@ -180,8 +193,6 @@ export const TreeItemStyles = css`
 
     :host(.nested) .expand-collapse-button {
         position: absolute;
-        ${/* value needs to be localized  */ ""}
-        left: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
     }
 
     ::slotted(fast-tree-item) {
@@ -198,6 +209,7 @@ export const TreeItemStyles = css`
     neutralFocusInnerAccentBehavior,
     neutralForegroundActiveBehavior,
     neutralForegroundRestBehavior,
+    new DirectionalStyleSheetBehavior(ltr, rtl),
     forcedColorsStylesheetBehavior(
         css`
         :host {

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -25,11 +25,17 @@ const ltr = css`
     :host(.nested) .expand-collapse-button {
         left: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
     }
+    :host([selected])::after {
+        left: calc(var(--focus-outline-width) * 1px);
+    }
 `;
 
 const rtl = css`
     :host(.nested) .expand-collapse-button {
         right: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
+    }
+    :host([selected])::after {
+        right: calc(var(--focus-outline-width) * 1px);
     }
 `;
 
@@ -178,11 +184,8 @@ export const TreeItemStyles = css`
         height: calc((${heightNumber} / 2) * 1px);
         ${
             /* The french fry background needs to be calculated based on the selected background state for this control.
-            We currently have no way of chaning that, so setting to accent-foreground-rest for the time being */ ""
+            We currently have no way of changing that, so setting to accent-foreground-rest for the time being */ ""
         } background: ${accentForegroundRestBehavior.var};
-        ${
-            /* value needs to be localized */ ""
-        } left: calc(var(--focus-outline-width) * 1px);
         border-radius: calc(var(--corner-radius) * 1px);
     }
 

--- a/sites/fast-component-explorer/app/preview.tsx
+++ b/sites/fast-component-explorer/app/preview.tsx
@@ -183,6 +183,8 @@ class Preview extends Foundation<
                 "min-height: 100vh; min-width: 100vw;"
             );
 
+            designSystemProvider.setAttribute("direction", this.state.direction);
+
             if (this.state.transparentBackground) {
                 designSystemProvider.setAttribute("no-paint", "");
             }


### PR DESCRIPTION
# Description
* Use the design system direction behavior to allow for rtl sensitive css
* Update component explorer to set the direction when updated in the design system provider

closes #3546

<img width="1070" alt="Screen Shot 2020-07-31 at 11 51 06 AM" src="https://user-images.githubusercontent.com/25805778/89067477-36ce6200-d324-11ea-90e8-c9d7eddb8532.png">
<img width="1051" alt="Screen Shot 2020-07-31 at 11 51 15 AM" src="https://user-images.githubusercontent.com/25805778/89067487-3cc44300-d324-11ea-96c9-c68dfa5b3b5c.png">


## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/en/contributing/standards) for this project.