### PR TITLE
fix: update min-width of fast-slider to design-unit * 1px

### DIFF
--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -82,7 +82,7 @@ export const SliderStyles = css`
         transform: translateY(calc(var(--thumb-translate) * 1px));
     }
     :host(.horizontal) {
-        min-width: calc(var(--design-unit) * 1px);
+        min-width: calc(var(--thumb-size) * 1px);
     }
     :host(.horizontal) .track {
         right: calc(var(--track-overhang) * 1px);

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -82,7 +82,7 @@ export const SliderStyles = css`
         transform: translateY(calc(var(--thumb-translate) * 1px));
     }
     :host(.horizontal) {
-        min-width: calc(var(--design-unit) * 60px);
+        min-width: calc(var(--design-unit) * 1px);
     }
     :host(.horizontal) .track {
         right: calc(var(--track-overhang) * 1px);


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

As explained on #3634, the min-width default value (design-unit * 60px) is not a number that give enough flexibility for a default instance of the slider, preventing us to change the width from 100% to 0% unless override the default of min-width

## Motivation & context

#3634 Is the cause of this pull request, and as discussed on Discord the value is being changed to `design-unit * 1px`, but I would like to have more discussion around it.

## Findings

While doing the change I have discovered the same issue will happen with a `fast-slider` in a vertical mode, and I believe the fix here will not be as simple as setting it to `design-unit * 1px` because doing that the slider will normally appear with a height of `4px` in case of fast design system provider, on Firefox when you don't have set the height manually it appears as 160px but the `min-height` remains as auto 

I have been playing with the slider and discovered a few things that can help to take a decision:

- For the normal `input range` both in vertical and horizontal the min-width and min-height are set to `auto` on Firefox, and the min-width to `0` on Edge 
- The width and height are who have a computed value which is dynamically set based on the context
  - Width is set to an arbitrary value (129px on my case on edge) when the input element is added into a div or directly into the body
  - Width is set to 100% when the parent is `display: grid`


Possibly the most straightforward solution will be to leave everything as it is right now and document that min-width and min-height are set to `design-unit * 60px`, any thoughts? 


<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->