### PR TITLE
fix: changed setupDefault to set initialValue which will set dirtyValue fa…

### DIFF
--- a/packages/web-components/fast-components/src/slider/fixtures/base.html
+++ b/packages/web-components/fast-components/src/slider/fixtures/base.html
@@ -15,14 +15,13 @@
             >
                 Toggle orientation
             </button>
-            <fast-slider
-                id="switcher"
-                orientation="vertical"
-                min="0"
-                max="100"
-                step="10"
-                value="70"
+            <button
+                style="width: 90px; margin: 10px;"
+                onclick="const slider = document.getElementById('switcher'); const currentVal = Number(slider.getAttribute('value')); slider.setAttribute('value', (currentVal + 10).toString());"
             >
+                Change slider val
+            </button>
+            <fast-slider id="switcher" orientation="vertical" min="0" max="100" step="10">
                 <fast-slider-label position="0">
                     0&#8451;
                 </fast-slider-label>

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -1,4 +1,4 @@
-import { attr, observable } from "@microsoft/fast-element";
+import { attr } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -192,7 +192,7 @@ export abstract class FormAssociated<
      * @param next - the new value
      *
      * @remarks
-     * If elmements extending `FormAssociated` impelemnt a `valueChanged` method
+     * If elmements extending `FormAssociated` implement a `valueChanged` method
      * They must be sure to invoke `super.valueChanged(previous, next)` to ensure
      * proper functioning of `FormAssociated`
      */
@@ -223,7 +223,7 @@ export abstract class FormAssociated<
      * @param next - the new value
      *
      * @remarks
-     * If elmements extending `FormAssociated` impelemnt a `initialValueChanged` method
+     * If elements extending `FormAssociated` implement a `initialValueChanged` method
      * They must be sure to invoke `super.initialValueChanged(previous, next)` to ensure
      * proper functioning of `FormAssociated`
      */
@@ -252,7 +252,7 @@ export abstract class FormAssociated<
      * @param next - the new value
      *
      * @remarks
-     * If elmements extending `FormAssociated` impelemnt a `disabledChanged` method
+     * If elements extending `FormAssociated` implement a `disabledChanged` method
      * They must be sure to invoke `super.disabledChanged(previous, next)` to ensure
      * proper functioning of `FormAssociated`
      */
@@ -280,7 +280,7 @@ export abstract class FormAssociated<
      * @param next - the new value
      *
      * @remarks
-     * If elmements extending `FormAssociated` impelemnt a `nameChanged` method
+     * If elements extending `FormAssociated` implement a `nameChanged` method
      * They must be sure to invoke `super.nameChanged(previous, next)` to ensure
      * proper functioning of `FormAssociated`
      */
@@ -306,7 +306,7 @@ export abstract class FormAssociated<
      * @param next - the new value
      *
      * @remarks
-     * If elmements extending `FormAssociated` impelemnt a `requiredChanged` method
+     * If elements extending `FormAssociated` implement a `requiredChanged` method
      * They must be sure to invoke `super.requiredChanged(previous, next)` to ensure
      * proper functioning of `FormAssociated`
      */

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -1,4 +1,4 @@
-import { attr, booleanConverter, FASTElement } from "@microsoft/fast-element";
+import { attr, FASTElement } from "@microsoft/fast-element";
 import { keyCodeEnter, keyCodeSpace } from "@microsoft/fast-web-utilities";
 import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -130,7 +130,6 @@ export class Slider extends FormAssociated<HTMLInputElement>
         if (this.$fastController.isConnected) {
             this.setThumbPositionForOrientation(this.direction);
         }
-
         this.$emit("change");
     }
 
@@ -332,7 +331,9 @@ export class Slider extends FormAssociated<HTMLInputElement>
 
     private setupDefaultValue = (): void => {
         if (this.value === "") {
-            this.value = `${this.convertToConstrainedValue((this.max + this.min) / 2)}`;
+            this.initialValue = `${this.convertToConstrainedValue(
+                (this.max + this.min) / 2
+            )}`;
         }
     };
 


### PR DESCRIPTION
# Description
setting initialValue in setupDefault which will set dirtyValue to false after changing and allow binding to update the value after.
closes #3635 

Added to the fixtures a button to validate the change, each click attempts to increment the value of the slider.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
