### PR TITLE
chore: add @@ to escape blazor binding in doc cdn link

### DIFF
--- a/packages/web-components/fast-foundation/docs/integrations/blazor.md
+++ b/packages/web-components/fast-foundation/docs/integrations/blazor.md
@@ -26,7 +26,7 @@ Now that we've got our basic project setup, we need to add our web components sc
 To add a CDN script for `fast-components` use the following markup:
 
 ```html
-<script type="module" src="https://unpkg.com/@microsoft/fast-components"></script>
+<script type="module" src="https://unpkg.com/@@microsoft/fast-components"></script>
 ```
 
 The best place to put this is typically in your `index.html` file in the script section at the bottom of the `<body>`.


### PR DESCRIPTION
# Description
The previous link would cause a compilation error as it would interpret the '@' as a binding.

## Motivation & context
This occurs in the example script link in the getting started documentation for Blazor integration

## Issue type checklist
- [X ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [X] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.