### PR TITLE
fix: anchor (hypertext) line can render outside

### DIFF
--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -24,7 +24,7 @@ import {
  * @internal
  */
 export const BaseButtonStyles = css`
-    ${display("inline-flex")} :host {
+    ${display("inline-block")} :host {
         font-family: var(--body-font);
         outline: none;
         font-size: var(--type-ramp-base-font-size);


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Closes: #3667 

when `fast-anchor` `appearance` is set to `hypertext` the underline can render larger than the the text. Changing display from `inline-flex`  to `inline-block` fixes the issue and does not appear to negatively impact any other appearance with or without end and start slots.

Before:
![image](https://user-images.githubusercontent.com/37851214/89826755-963e2600-db0b-11ea-95f2-fec7354c5088.png)
![image](https://user-images.githubusercontent.com/37851214/89826964-dbfaee80-db0b-11ea-8793-746d12001a1b.png)

After:
![image](https://user-images.githubusercontent.com/37851214/89826815-a9e98c80-db0b-11ea-90aa-cc80774fccf7.png)

After for other appearances and layouts (Anchor and Button):
Anchor
![image](https://user-images.githubusercontent.com/37851214/89827050-fb921700-db0b-11ea-81d4-02f18a635473.png)

Button
![image](https://user-images.githubusercontent.com/37851214/89827100-149ac800-db0c-11ea-8f32-f41bf4028894.png)



## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->