### PR TITLE
chore: example radios on website should be wrapped in a radiogroup

### DIFF
--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
@@ -141,10 +141,6 @@ export const FastFrameStyles = css`
         margin-inline-start: calc(var(--design-unit) * 2px + 2px);
     }
 
-    .control-container-column {
-        display: grid;
-    }
-
     .control-container-grid {
         display: grid;
         grid-template-columns: auto 1fr;
@@ -251,7 +247,17 @@ export const FastFrameStyles = css`
         background: transparent;
     }
 
-    fast-radio-group::part(positioning-region) {
+    fast-radio-group.example-radios {
+        margin: 0;
+    }
+
+    fast-radio-group.example-radios::part(positioning-region) {
+        display: grid;
+        grid-template-columns: auto;
+        height: 100%;
+    }
+
+    fast-radio-group.swatches::part(positioning-region) {
         display: grid;
         grid-gap: 10px;
         grid-auto-flow: column;

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -48,6 +48,7 @@ export const FastFrameTemplate = html<FastFrame>`
                         <div class="content-control-container" >
                             <label for="neutral-color-pickers">Neutral color</label>
                             <fast-radio-group
+                                class="swatches"
                                 name="neutral-color-pickers"
                                 value="${x => x.previewNeutralPalette[0]}"
                                 @change="${(x, c) =>
@@ -70,6 +71,7 @@ export const FastFrameTemplate = html<FastFrame>`
                             </fast-radio-group>
                             <label for="accent-color-pickers">Accent color</label>
                             <fast-radio-group
+                                class="swatches"
                                 name="accent-color-pickers"
                                 value="${x => x.previewAccentPalette[0]}"
                                 @change="${(x, c) =>
@@ -271,7 +273,7 @@ export const FastFrameTemplate = html<FastFrame>`
                         <fast-menu-item role="menuitem" aria-label="Example menu item">Menu item 4</fast-menu-item>
                     </fast-menu>
                     <div class="control-container">
-                        <fast-radio-group name="example radio group" orientation="vertical">
+                        <fast-radio-group class="example-radios" name="example radio group" orientation="vertical">
                             <fast-radio aria-label="Example radio 1">Radio 1</fast-radio>
                             <fast-radio aria-label="Example radio 2">Radio 2</fast-radio>
                         </fast-radio-group>

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -271,12 +271,10 @@ export const FastFrameTemplate = html<FastFrame>`
                         <fast-menu-item role="menuitem" aria-label="Example menu item">Menu item 4</fast-menu-item>
                     </fast-menu>
                     <div class="control-container">
-                        <div class="control-container-column">
-                            <fast-radio tabindex="${x =>
-                                x.setTabIndex()}" aria-label="Example radio 1">Radio 1</fast-radio>
-                            <fast-radio tabindex="${x =>
-                                x.setTabIndex()}" aria-label="Example radio 2">Radio 2</fast-radio>
-                        </div>
+                        <fast-radio-group name="example radio group" orientation="vertical">
+                            <fast-radio aria-label="Example radio 1">Radio 1</fast-radio>
+                            <fast-radio aria-label="Example radio 2">Radio 2</fast-radio>
+                        </fast-radio-group>
                         <div class="control-container-grid">
                             <fast-switch tabindex="${x =>
                                 x.setTabIndex()}" aria-label="Example toggle"></fast-switch>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
This PR fixes an issue where the example radios were not wrapped in a radiogroup and resulted in inaccessable behavior.
<!--- Describe your changes. -->

## Motivation & context
closes #3676 
<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->