### PR TITLE
fix: wrapping set focus in dom.queueupdate

### DIFF
--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -204,11 +204,11 @@ export class TextField extends FormAssociated<HTMLInputElement> {
 
         this.proxy.setAttribute("type", this.type);
 
-        DOM.queueUpdate(() => {
-            if (this.autofocus) {
+        if (this.autofocus) {
+            DOM.queueUpdate(() => {
                 this.focus();
-            }
-        });
+            });
+        }
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -1,4 +1,4 @@
-import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
+import { attr, DOM, nullableNumberConverter, observable } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/index";
@@ -204,9 +204,11 @@ export class TextField extends FormAssociated<HTMLInputElement> {
 
         this.proxy.setAttribute("type", this.type);
 
-        if (this.autofocus) {
-            this.focus();
-        }
+        DOM.queueUpdate(() => {
+            if (this.autofocus) {
+                this.focus();
+            }
+        });
     }
 
     /**


### PR DESCRIPTION
## Description
Autofocus seems to work but in the context of other wrapping frameworks it might be happening too soon.
potentially closes #3685 


## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.