### PR TITLE
fix: hypertext and lightweight display and min-width styles

### DIFF
--- a/packages/web-components/fast-components/src/anchor/fixtures/anchor.html
+++ b/packages/web-components/fast-components/src/anchor/fixtures/anchor.html
@@ -20,7 +20,9 @@
     <h4>Hypertext</h4>
     <fast-anchor href="#" appearance="hypertext">Anchor</fast-anchor>
     <br />
+    <br />
     <fast-anchor appearance="hypertext">Anchor (no href)</fast-anchor>
+
     <p>
         Lorem ipsum dolor sit amet consectetur adipisicing elit. Nesciunt ut aliquam quas
         quod ipsam cupiditate, voluptate, corrupti
@@ -28,9 +30,23 @@
         dicta perspiciatis commodi consequatur reprehenderit laborum aliquid minima.
         Neque, recusandae. Adipisci.
     </p>
+    <br />
+    <fast-anchor href="https://fast.design" appearance="hypertext">
+        The next anchor is intentionally short, and this anchor is intentionally long
+    </fast-anchor>
+
+    <br />
+    <br />
+    <fast-anchor href="https://fast.design" appearance="hypertext">Hi</fast-anchor>
 
     <h4>Lightweight</h4>
     <fast-anchor href="#" appearance="lightweight">Anchor</fast-anchor>
+    <br />
+    <fast-anchor href="#" appearance="lightweight">
+        The next anchor is intentionally short, and this anchor is intentionally long
+    </fast-anchor>
+    <br />
+    <fast-anchor href="#" appearance="lightweight">Hi</fast-anchor>
 
     <h4>Outline</h4>
     <fast-anchor href="#" appearance="outline">Anchor</fast-anchor>

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -24,7 +24,7 @@ import {
  * @internal
  */
 export const BaseButtonStyles = css`
-    ${display("inline-block")} :host {
+    ${display("inline-flex")} :host {
         font-family: var(--body-font);
         outline: none;
         font-size: var(--type-ramp-base-font-size);
@@ -86,7 +86,7 @@ export const BaseButtonStyles = css`
     .end,
     ::slotted(svg) {
         ${
-            /* Glyph size and margin-left is temporary - 
+            /* Glyph size and margin-left is temporary -
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;
@@ -146,6 +146,7 @@ export const HypertextStyles = css`
         font-size: inherit;
         line-height: inherit;
         height: auto;
+        min-width: 0;
         background: transparent;
     }
 


### PR DESCRIPTION
# Description
- reset `min-width` on hyperlink anchors and buttons
- restore `display: inline-flex` on anchors and buttons

## Motivation & context
The switch from `inline-flex` to `inline-block` in #3674 caused elements on the homepage to become misaligned. 

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->