### PR TITLE
fix: correct tabs animation when using home/end touch

### DIFF
--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -248,13 +248,11 @@ export class Tabs extends FASTElement {
         switch (keyCode) {
             case keyCodeHome:
                 event.preventDefault();
-                this.activeTabIndex = 0;
-                this.setComponent();
+                this.adjust(-this.activeTabIndex);
                 break;
             case keyCodeEnd:
                 event.preventDefault();
-                this.activeTabIndex = this.tabs.length - 1;
-                this.setComponent();
+                this.adjust(this.tabs.length - this.activeTabIndex - 1);
                 break;
         }
     };


### PR DESCRIPTION
see the issue for details

# Description

Change the way we select the active tab when using home or end touch on a keyboard. I use the same mechanism than when using left and right touch. It make animation smoother than directly set where the active tab should be.

Before :

![bad](https://user-images.githubusercontent.com/4435536/90182492-564c9c80-ddb2-11ea-9e05-ee54193416b5.gif)

After :

![good](https://user-images.githubusercontent.com/4435536/90182498-59478d00-ddb2-11ea-9980-1ef4527c97fc.gif)

## Motivation & context

see the issue for details : https://github.com/microsoft/fast/issues/3692

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
