### PR TITLE
fix: consistent with min-width, min-height is at least the thumb size

### DIFF
--- a/packages/web-components/fast-components/src/slider/fixtures/base.html
+++ b/packages/web-components/fast-components/src/slider/fixtures/base.html
@@ -8,7 +8,7 @@
         "
     >
         <h4>Toggle orientation</h4>
-        <div style="margin-bottom: 60px;">
+        <div style="margin-bottom: 60px; height: 200px;">
             <button
                 style="width: 90px; margin: 10px;"
                 onclick="const slider = document.getElementById('switcher'); slider.getAttribute('orientation') === 'horizontal' ? slider.setAttribute('orientation', 'vertical') : slider.setAttribute('orientation', 'horizontal');"
@@ -46,7 +46,11 @@
 
         <!-- Margin offsets vertical -->
         <h4>Vertical with top offset</h4>
-        <fast-slider orientation="vertical" , style="margin-left: 100px;"></fast-slider>
+        <fast-slider
+            orientation="vertical"
+            ,
+            style="margin-left: 100px; height: 120px;"
+        ></fast-slider>
 
         <!-- Negative positions -->
         <h4>Negative positions</h4>

--- a/packages/web-components/fast-components/src/slider/fixtures/base.html
+++ b/packages/web-components/fast-components/src/slider/fixtures/base.html
@@ -48,7 +48,6 @@
         <h4>Vertical with top offset</h4>
         <fast-slider
             orientation="vertical"
-            ,
             style="margin-left: 100px; height: 120px;"
         ></fast-slider>
 

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -105,7 +105,7 @@ export const SliderStyles = css`
     }
     :host(.vertical) {
         height: 100%;
-        min-height: calc(var(--design-unit) * 60px);
+        min-height: calc(var(--thumb-size) * 1px);
         min-width: calc(var(--design-unit) * 20px);
     }
     :host(.disabled) .label,

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -26,6 +26,7 @@ export const SliderStyles = css`
         --thumb-translate: calc(var(--thumb-size) * 0.5);
         --track-overhang: calc((var(--design-unit) / 2) * -1);
         --track-width: var(--design-unit);
+        --fast-slider-height: calc(var(--thumb-size) * 10);
         align-items: center;
         width: 100%;
         margin: calc(var(--design-unit) * 1px) 0;
@@ -104,7 +105,7 @@ export const SliderStyles = css`
         border-radius: calc(var(--corner-radius) * 1px);
     }
     :host(.vertical) {
-        height: 100%;
+        height: calc(var(--fast-slider-height) * 1px);
         min-height: calc(var(--thumb-size) * 1px);
         min-width: calc(var(--design-unit) * 20px);
     }

--- a/packages/web-components/fast-foundation/src/slider/README.md
+++ b/packages/web-components/fast-foundation/src/slider/README.md
@@ -5,7 +5,7 @@ sidebar_label: slider
 custom_edit_url: https://github.com/microsoft/fast/edit/master/packages/web-components/fast-foundation/src/slider/README.md
 ---
 
-An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected web-component.
+An implementation of a [range slider](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/Input/range) as a form-connected web-component. Note that if the slider is in vertical orientation by default the component will get a height using the css var `--fast-slider-height`, by default that equates to `(10px * var(--thumb-size))` or 160px. Inline style will override that height.
 
 ## Usage
 

--- a/packages/web-components/fast-foundation/src/slider/slider.spec.md
+++ b/packages/web-components/fast-foundation/src/slider/slider.spec.md
@@ -47,7 +47,7 @@ A designer can override any internal styling applied to the slotted labels, the 
 - `step` - limits the values of the `slider` to increments of the `step` value added to the minimum value of the 
 `slider`'s total range.  The default value is 1. The minimum and maximum values of a `slider`'s range are always valid results regardless of the `step` prop. The `step` prop is used as the value for incrementing the thumb by pressing the arrow keys.
  - `value` - Allows authors to specify the initial selected range of the `slider`.  It defaults to a (step constrained) value at the midpoint on the `slider`'s total range. In `range` mode `value` is expected to be a 2 element array where the lower value is the first value and upper value is the second.
- - `orientation` - horizontal or vertical values allowed.
+ - `orientation` - horizontal or vertical values allowed. Note that if the slider is in vertical orientation by default the component will get a height using the css var `--fast-slider-height`, by default that equates to `(10px * var(--thumb-size))` or 160px. Inline style will override that height.
  - `mode` - `single-value` | `range` | `adjust-from-upper` | `adjust-from-lower`. `adjust-from-upper` and `adjust-from-lower` are special single value modes where a progress indicator is shown on the right or left of the thumb respectively. `range` mode produces a lower and upper thumb that can be adjusted independently producing a progress indicator (foreground-track) in between the two thumbs.
 
 *Events*

--- a/packages/web-components/fast-foundation/src/slider/slider.template.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.template.ts
@@ -26,7 +26,6 @@ export const SliderTemplate = html<Slider>`
             <div ${ref("track")} part="track-container" class="track">
                 <slot name="track"></slot>
             </div>
-            <div></div>
             <slot></slot>
             <div
                 ${ref("thumb")}

--- a/yarn.lock
+++ b/yarn.lock
@@ -17377,7 +17377,7 @@ npm-registry-fetch@^4.0.0:
     npm-package-arg "^6.1.0"
     safe-buffer "^5.2.0"
 
-npm-registry-fetch@^8.0.2, npm-registry-fetch@^8.1.1:
+npm-registry-fetch@^8.0.2:
   version "8.1.4"
   resolved "https://registry.yarnpkg.com/npm-registry-fetch/-/npm-registry-fetch-8.1.4.tgz#438cc8f042f6c5309e9a91ad5ccb80d7f6ed47de"
   integrity sha512-UaLGFQP7VCuyBsb7S5P5od3av/Zy9JW6K5gbMigjZCYnEpIkWWRiLQTKVpxM4QocfPcsjm+xtyrDNm4jdqwNEg==


### PR DESCRIPTION
# Description
We now have a default height, --fast-slider-height,  of (--thumb-size * 10px), which should translate to 160px for our design defaults. There is also a min-height based on --thumb-size

Some rationale behind this decision, height:100% works different than width:100% in that if you don't have anything specifying an actual height then height:100% does nothing, whereas width:100% will have the control span all the width available. Because pages are intended to scroll vertically, the height is arbitrary
but pages are intended to span the full width. So that the slider doesn't appear broken at first we want to specify a default height that can easily be overridden by inline style.

closes #3644

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
