### PR TITLE
feat: allow color recipes to accept string color values

### DIFF
--- a/packages/web-components/fast-components/src/color/accent-foreground-cut.ts
+++ b/packages/web-components/fast-components/src/color/accent-foreground-cut.ts
@@ -21,11 +21,14 @@ function accentForegroundCutFactory(targetContrast: number): SwatchRecipe {
     function accentForegroundCutInternal(
         backgroundResolver: SwatchResolver
     ): SwatchResolver;
+    function accentForegroundCutInternal(colorLiteral: string): Swatch;
     function accentForegroundCutInternal(arg: any): any {
         return typeof arg === "function"
             ? (designSystem: FASTDesignSystem): Swatch => {
                   return accentForegroundCutAlgorithm(arg(designSystem), targetContrast);
               }
+            : typeof arg === "string"
+            ? accentForegroundCutAlgorithm(arg, targetContrast)
             : accentForegroundCutAlgorithm(accentBaseColor(arg), targetContrast);
     }
 

--- a/packages/web-components/fast-components/src/color/common.ts
+++ b/packages/web-components/fast-components/src/color/common.ts
@@ -72,6 +72,8 @@ export type DesignSystemResolverFromSwatchResolver<T> = (
     resolver: SwatchResolver
 ) => DesignSystemResolver<T>;
 
+export type DesignSystemResolverFromSwatch<T> = (colorLiteral: string) => T;
+
 /**
  * The states that a swatch can have
  * @internal
@@ -89,7 +91,8 @@ export enum SwatchFamilyType {
  * or resolves a ColorRecipe when provided a SwatchResolver
  */
 export type ColorRecipe<T> = DesignSystemResolver<T> &
-    DesignSystemResolverFromSwatchResolver<T>;
+    DesignSystemResolverFromSwatchResolver<T> &
+    DesignSystemResolverFromSwatch<T>;
 
 /**
  * @internal
@@ -101,6 +104,7 @@ export function colorRecipeFactory<T>(recipe: DesignSystemResolver<T>): ColorRec
     function curryRecipe(
         backgroundResolver: SwatchResolver
     ): (designSystem: FASTDesignSystem) => T;
+    function curryRecipe(colorLiteral: string): T;
     function curryRecipe(arg: any): any {
         if (typeof arg === "function") {
             return (designSystem: FASTDesignSystem): T => {
@@ -110,6 +114,8 @@ export function colorRecipeFactory<T>(recipe: DesignSystemResolver<T>): ColorRec
                     })
                 );
             };
+        } else if (typeof arg === "string") {
+            return arg;
         } else {
             return memoizedRecipe(arg);
         }
@@ -139,7 +145,7 @@ export function swatchFamilyToSwatchRecipeFactory<T extends SwatchFamily>(
     callback: SwatchFamilyResolver<T>
 ): SwatchRecipe {
     const memoizedRecipe: typeof callback = memoize(callback);
-    return (arg: FASTDesignSystem | SwatchResolver): any => {
+    return (arg: FASTDesignSystem | SwatchResolver | string): any => {
         if (typeof arg === "function") {
             return (designSystem: FASTDesignSystem): Swatch => {
                 return memoizedRecipe(
@@ -148,6 +154,8 @@ export function swatchFamilyToSwatchRecipeFactory<T extends SwatchFamily>(
                     })
                 )[type as string];
             };
+        } else if (typeof arg === "string") {
+            return arg;
         } else {
             return memoizedRecipe(arg)[type];
         }

--- a/packages/web-components/fast-components/src/color/common.ts
+++ b/packages/web-components/fast-components/src/color/common.ts
@@ -72,6 +72,9 @@ export type DesignSystemResolverFromSwatchResolver<T> = (
     resolver: SwatchResolver
 ) => DesignSystemResolver<T>;
 
+/**
+ * A function type that resolves a Swatch from a string literal.
+ */
 export type DesignSystemResolverFromSwatch<T> = (colorLiteral: string) => T;
 
 /**
@@ -131,6 +134,7 @@ export function colorRecipeFactory<T>(recipe: DesignSystemResolver<T>): ColorRec
  * the result of that function as background to the recipe. This is useful for applying text recipes to colors
  * other than the design system backgroundColor
  * 2. When provided a design system, the recipe will use that design-system to generate the color
+ * 3. When provided a color as a string literal it returns the same color back.
  */
 export type SwatchRecipe = ColorRecipe<Swatch>;
 

--- a/packages/web-components/fast-components/src/color/neutral-foreground-toggle.ts
+++ b/packages/web-components/fast-components/src/color/neutral-foreground-toggle.ts
@@ -21,6 +21,7 @@ function neutralForegroundToggleFactory(targetContrast: number): SwatchRecipe {
     function neutralForegroundToggleInternal(
         backgroundResolver: SwatchResolver
     ): SwatchResolver;
+    function neutralForegroundToggleInternal(colorLiteral: string): Swatch;
     function neutralForegroundToggleInternal(arg: any): any {
         return typeof arg === "function"
             ? (designSystem: FASTDesignSystem): Swatch => {

--- a/packages/web-components/fast-components/src/color/neutral-foreground.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-foreground.spec.ts
@@ -24,6 +24,18 @@ describe("neutralForeground", (): void => {
         expect(typeof neutralForegroundActive(() => "#FFF")).to.equal("function");
     });
 
+    it("should return a string when invoked with a string", (): void => {
+        expect(typeof neutralForegroundRest("#FFF")).to.equal("string");
+        expect(typeof neutralForegroundHover("#FFF")).to.equal("string");
+        expect(typeof neutralForegroundActive("#FFF")).to.equal("string");
+    });
+
+    it("should return same value when invoked with a string", (): void => {
+        expect(neutralForegroundRest("#FFF")).to.equal("#FFF");
+        expect(neutralForegroundHover("#FFF")).to.equal("#FFF");
+        expect(neutralForegroundActive("#FFF")).to.equal("#FFF");
+    });
+
     it("should operate on default design system if no design system is supplied", (): void => {
         const palette = fastDesignSystemDefaults.neutralPalette;
         const limitColor = palette[palette.length - 1];


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Altering SwatchRecipe to accept a string literal color value in addition to a DesignSystem or callback function. This required changes to the colorRecipeFactory and swatchFamilyToSwatchRecipeFactory as well as the Accent Foreground Cut and Neutral Foreground Toggle classes which implement the SwatchRecipe type.
Also added some tests to the Neutral Foreground spec to cover this scenario.

Closes #1708 

## Motivation & context

Allow color recipes to accept string color values #1708
https://github.com/microsoft/fast/issues/1708

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [X] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->
Not a breaking change. Existing functionality is unaffected. 

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [X] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [X] I have added tests for my changes.
- [X] I have tested my changes.
- [] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->