### PR TITLE
feat(examples): add new example showing a list-box component

### DIFF
--- a/examples/list-box-sample/README.md
+++ b/examples/list-box-sample/README.md
@@ -1,0 +1,5 @@
+# ListBox Demo
+
+A list-box component (not production ready), written entirely with `fast-element`.
+
+> Question: Would this make a good tutorial if we polished it to production ready-ness?

--- a/examples/list-box-sample/index.html
+++ b/examples/list-box-sample/index.html
@@ -1,0 +1,11 @@
+<!DOCTYPE html>
+<html lang="en">
+    <head>
+        <meta charset="utf-8" />
+        <title>FAST Demo</title>
+    </head>
+    <body>
+        <fast-demo></fast-demo>
+        <script src="dist/bundle.js"></script>
+    </body>
+</html>

--- a/examples/list-box-sample/package.json
+++ b/examples/list-box-sample/package.json
@@ -1,0 +1,26 @@
+{
+  "name": "fast-todo-app",
+  "version": "1.0.0",
+  "description": "",
+  "main": "index.js",
+  "scripts": {
+    "build": "rimraf dist && webpack --config webpack.config.js --mode=production",
+    "dev": "webpack-dev-server",
+    "serve": "http-server -c-1"
+  },
+  "author": "",
+  "license": "ISC",
+  "dependencies": {
+    "@microsoft/fast-element": "latest",
+    "tslib": "^1.11.1"
+  },
+  "devDependencies": {
+    "http-server": "^0.12.1",
+    "rimraf": "^3.0.2",
+    "ts-loader": "^7.0.1",
+    "typescript": "^3.8.3",
+    "webpack": "^4.42.1",
+    "webpack-cli": "^3.3.11",
+    "webpack-dev-server": "^3.10.3"
+  }
+}

--- a/examples/list-box-sample/package.json
+++ b/examples/list-box-sample/package.json
@@ -1,5 +1,5 @@
 {
-  "name": "fast-todo-app",
+  "name": "fast-list-box-demo",
   "version": "1.0.0",
   "description": "",
   "main": "index.js",

--- a/examples/list-box-sample/src/fast-demo.ts
+++ b/examples/list-box-sample/src/fast-demo.ts
@@ -1,0 +1,122 @@
+import {
+    FASTElement,
+    customElement,
+    html,
+    observable,
+    repeat,
+    ref,
+    css,
+} from "@microsoft/fast-element";
+import { FASTListBox } from "./fast-list-box";
+
+class Person {
+    public readonly avatar: string;
+
+    constructor(public firstName: string, public lastName: string) {
+        this.avatar = `https://api.adorable.io/avatars/64/${this.firstName}@adorable.png`;
+    }
+
+    get fullName() {
+        return `${this.firstName} ${this.lastName}`;
+    }
+}
+
+const personTemplate = html<Person>`
+    <fast-list-item :value=${x => x} class="person">
+        <img src=${x => x.avatar} class="avatar" />
+        <span class="name">${x => x.fullName}</span>
+    </fast-list-item>
+`;
+
+const template = html<FASTDemo>`
+    <h1>ListBox Demo</h1>
+
+    <section>
+        <h2>Inline List</h2>
+        <fast-list-box @change=${(x, c) => x.onChange(c.event as any)}>
+            <fast-list-item value="One">One</fast-list-item>
+            <fast-list-item value="Two" selected>Two</fast-list-item>
+            <fast-list-item value="Three">Three</fast-list-item>
+            <fast-list-item value="Four">Four</fast-list-item>
+            <fast-list-item value="Five">Five</fast-list-item>
+        </fast-list-box>
+        Selected Value:
+        <span></span>
+    </section>
+
+    <section>
+        <h2>Hybrid List</h2>
+        <fast-list-box @change=${(x, c) => x.onChange(c.event as any)}>
+            <fast-list-item value="None" selected>None</fast-list-item>
+
+            ${repeat(
+                x => x.data,
+                html`
+                    <fast-list-item :value=${x => x}>${x => x}</fast-list-item>
+                `
+            )}
+        </fast-list-box>
+        Selected Value:
+        <span></span>
+    </section>
+
+    <section>
+        <h2>Bound List</h2>
+        <fast-list-box
+            :items=${x => x.data}
+            :selectedItem=${() => 2}
+            @change=${(x, c) => x.onChange(c.event as any)}
+        ></fast-list-box>
+        Selected Value:
+        <span></span>
+    </section>
+
+    <section>
+        <h2>Bound List (Custom Template)</h2>
+        <fast-list-box
+            :items=${x => x.people}
+            :itemTemplate=${personTemplate}
+            :selectedItem=${x => x.people[1]}
+            @change=${(x, c) => x.onChange(c.event as any)}
+        ></fast-list-box>
+        Selected Value:
+        <span></span>
+    </section>
+`;
+
+const styles = css`
+    .person {
+        display: flex;
+        align-items: center;
+        padding: 4px;
+    }
+
+    .person .name {
+        font-size: 64px;
+        margin-left: 8px;
+    }
+
+    .person .avatar {
+        border-radius: 50%;
+    }
+`;
+
+@customElement({
+    name: "fast-demo",
+    template,
+    shadowOptions: null,
+    styles,
+})
+export class FASTDemo extends FASTElement {
+    @observable data = [1, 2, 3, 4, 5];
+    @observable people = [new Person("John", "Doe"), new Person("Billy", "Bob")];
+
+    onChange(event: CustomEvent) {
+        const target = event.target as FASTListBox;
+        target.nextElementSibling!.innerHTML = JSON.stringify(
+            target.selectedItem,
+            null,
+            2
+        );
+    }
+}

--- a/examples/list-box-sample/src/fast-list-box.ts
+++ b/examples/list-box-sample/src/fast-list-box.ts
@@ -1,0 +1,104 @@
+import {
+    FASTElement,
+    customElement,
+    html,
+    observable,
+    DOM,
+    RepeatDirective,
+    RepeatBehavior,
+    css,
+    slotted,
+    elements,
+    ViewTemplate,
+} from "@microsoft/fast-element";
+import { FASTListItem } from "./fast-list-item";
+
+const template = html<FASTListBox>`
+    <template role="listbox">
+        <slot
+            ${slotted({ property: "listItems", filter: elements("fast-list-item") })}
+        ></slot>
+    </template>
+`;
+
+const defaultItemTemplate = html`
+    <fast-list-item :value=${x => x}>${x => x}</fast-list-item>
+`;
+
+const styles = css`
+    :host {
+        display: flex;
+        flex-direction: column;
+        border: 1px solid black;
+    }
+`;
+
+@customElement({
+    name: "fast-list-box",
+    template,
+    styles,
+})
+export class FASTListBox extends FASTElement {
+    private repeatBehavior?: RepeatBehavior;
+    private blockPlaceholder?: Node;
+
+    @observable itemTemplate?: ViewTemplate = defaultItemTemplate;
+
+    @observable items?: any[];
+    private itemsChanged(oldValue: any[], newValue: any[]) {
+        if (newValue && !this.repeatBehavior) {
+            this.blockPlaceholder = document.createComment("");
+            this.appendChild(this.blockPlaceholder);
+
+            this.repeatBehavior = new RepeatDirective(
+                x => x.items,
+                x => x.itemTemplate,
+                { positioning: false }
+            ).createBehavior(this.blockPlaceholder);
+
+            this.$fastController.addBehaviors([this.repeatBehavior!]);
+        }
+    }
+
+    @observable selectedItem?: any;
+    private selectedItemChanged() {
+        const found = this.listItems?.find(x => x.value === this.selectedItem);
+
+        if (found) {
+            this.select(found);
+        }
+    }
+
+    @observable listItems?: FASTListItem[];
+    @observable selectedListItem?: FASTListItem;
+    private listItemsChanged() {
+        if (this.listItems) {
+            const selected = this.listItems.find(x => x.selected);
+
+            if (selected) {
+                this.select(selected);
+            } else {
+                this.selectedItemChanged();
+            }
+        }
+    }
+
+    public select(item: FASTListItem) {
+        if (this.selectedListItem === item) {
+            return;
+        }
+
+        if (this.selectedListItem) {
+            this.selectedListItem.selected = false;
+        }
+
+        this.selectedListItem = item;
+
+        if (this.selectedListItem) {
+            this.selectedListItem.selected = true;
+            this.selectedItem = this.selectedListItem.value;
+        }
+
+        this.$emit("change");
+    }
+}

--- a/examples/list-box-sample/src/fast-list-item.ts
+++ b/examples/list-box-sample/src/fast-list-item.ts
@@ -1,0 +1,64 @@
+import {
+    FASTElement,
+    customElement,
+    html,
+    attr,
+    css,
+    observable,
+} from "@microsoft/fast-element";
+
+const template = html<FASTListItem>`
+    <template role="option" aria-selected=${x => x.selected} @click="${x => x.select()}">
+        <slot></slot>
+    </template>
+`;
+
+const styles = css`
+    :host {
+        display: block;
+        cursor: pointer;
+    }
+
+    :host(:hover) {
+        background: rgba(200, 200, 200, 0.25);
+    }
+
+    :host([selected]) {
+        background: rgba(0, 182, 255, 0.5);
+    }
+`;
+
+@customElement({
+    name: "fast-list-item",
+    template,
+    styles,
+})
+export class FASTListItem extends FASTElement {
+    private guard = false;
+
+    @attr({ mode: "boolean" }) selected: boolean = false;
+
+    @attr({ attribute: "value" }) valueAttribute?: string;
+    valueAttributeChanged() {
+        if (this.guard) {
+            return;
+        }
+
+        this.value = this.valueAttribute;
+    }
+
+    @observable value?: any;
+    valueChanged() {
+        if (typeof this.value === "object") {
+            return;
+        }
+
+        this.guard = true;
+        this.valueAttribute = this.value?.toString();
+        this.guard = false;
+    }
+
+    public select() {
+        (this.parentElement as any).select(this);
+    }
+}

--- a/examples/list-box-sample/src/main.ts
+++ b/examples/list-box-sample/src/main.ts
@@ -1,0 +1,7 @@
+import { FASTDemo } from "./fast-demo";
+import { FASTListBox } from "./fast-list-box";
+import { FASTListItem } from "./fast-list-item";
+
+FASTDemo;
+FASTListItem;
+FASTListBox;

--- a/examples/list-box-sample/tsconfig.json
+++ b/examples/list-box-sample/tsconfig.json
@@ -1,0 +1,28 @@
+{
+  "compilerOptions": {
+    "pretty": true,
+    "target": "ES2015",
+    "module": "ES2015",
+    "moduleResolution": "node",
+    "importHelpers": true,
+    "experimentalDecorators": true,
+    "emitDecoratorMetadata": true,
+    "declaration": true,
+    "declarationMap": true,
+    "sourceMap": true,
+    "noEmitOnError": true,
+    "skipLibCheck": true,
+    "preserveConstEnums": true,
+    "stripInternal": true,
+    "strict": true,
+    "outDir": "dist/build",
+    "rootDir": "src",
+    "lib": [
+      "dom",
+      "esnext"
+    ]
+  },
+  "include": [
+    "src"
+  ]
+}

--- a/examples/list-box-sample/webpack.config.js
+++ b/examples/list-box-sample/webpack.config.js
@@ -1,0 +1,39 @@
+const path = require("path");
+
+module.exports = function (env, { mode }) {
+    const production = mode === "production";
+    return {
+        mode: production ? "production" : "development",
+        devtool: production ? "source-maps" : "inline-source-map",
+        entry: {
+            app: ["./src/main.ts"],
+        },
+        output: {
+            filename: "bundle.js",
+        },
+        resolve: {
+            extensions: [".ts", ".js"],
+            modules: ["src", "node_modules"],
+        },
+        devServer: {
+            port: 9000,
+            historyApiFallback: true,
+            writeToDisk: true,
+            open: !process.env.CI,
+            lazy: false,
+        },
+        module: {
+            rules: [
+                {
+                    test: /\.ts$/i,
+                    use: [
+                        {
+                            loader: "ts-loader",
+                        },
+                    ],
+                    exclude: /node_modules/,
+                },
+            ],
+        },
+    };
+};


### PR DESCRIPTION
## Description

This is a PR intended primarily as an example. It demonstrates building a list-box component.

> Note: The component is not production-quality. For example, no keyboard navigation was implemented.

The approach is to create both the list and item components and design the list-box so that its items/rows exist in light dom and can be manually created. At the same time, the component supports setting data properties and templates which enable it to render the items on behalf of the developer. There are several demos which show these different usages.

By allowing the items to exist in the light dom and not requiring the component to be driven by data, it enables 3rd party frameworks to generate the items. Without that, we would have to force devs into using FAST's templating directly. With this approach, they can decide for themselves how they want to work with the component.

Of special note is how the repeat directive is used internally to render to the light dom only when an array of items is provided. A VirtualRepeatDirective could be constructed in a similarly reusable form for a data-grid type scenario.

<img width="888" alt="Screen Shot 2020-08-20 at 5 37 42 PM" src="https://user-images.githubusercontent.com/131485/90828395-eedfa100-e30b-11ea-9619-3ac717cfb341.png">

## Instructions

To run the example, first `npm install` in the specific example folder and then `npm run dev` to see it in action.