### PR TITLE
feat(fast-element): improve trustedTypes polyfill to not use globalThis

### DIFF
--- a/packages/web-components/fast-element/src/dom.ts
+++ b/packages/web-components/fast-element/src/dom.ts
@@ -4,17 +4,15 @@ const updateQueue = [] as Callable[];
 type TrustedTypesPolicy = { createHTML(html: string): string };
 
 // Tiny API-only polyfill for trustedTypes
+declare let trustedTypes: any;
 /* eslint-disable */
-if (globalThis.trustedTypes === void 0) {
-    globalThis.trustedTypes = { createPolicy: (name, rules) => rules };
+if (typeof trustedTypes == "undefined") {
+    trustedTypes = { createPolicy: (n, r) => r };
 }
 
-const fastHTMLPolicy: TrustedTypesPolicy = globalThis.trustedTypes.createPolicy(
-    "fast-html",
-    {
-        createHTML: html => html,
-    }
-);
+const fastHTMLPolicy: TrustedTypesPolicy = trustedTypes.createPolicy("fast-html", {
+    createHTML: html => html,
+});
 /* eslint-enable */
 
 let htmlPolicy: TrustedTypesPolicy = fastHTMLPolicy;


### PR DESCRIPTION
# Description

This PR improves our `trustedTypes` polyfill so that it does not rely on `globalThis`, which itself may not be implemented in all environments.

Closes #3783 

## Motivation & context

Some folks are trying to use `fast-element` in browsers that do not implement `globalThis`. Instead of increasing our library or the app developer's code by requiring a polyfill for `globalThis`, this PR removes the need for `globalThis` altogether. It was possible do this since `globalThis` was only used in one place and that usage was easy to re-work without `globalThis`.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.