### PR TITLE
fix(fast-element): do not remove developer comments when compiling templates

### DIFF
--- a/packages/web-components/fast-element/src/__test__/helpers.ts
+++ b/packages/web-components/fast-element/src/__test__/helpers.ts
@@ -1,6 +1,10 @@
-export function toHTML(node: Node): string {
+export function toHTML(node: Node, preserveCommentMarkup = false): string {
     return Array.from(node.childNodes)
         .map((x: any) => {
+            if (preserveCommentMarkup && x.nodeType === 8) {
+                return `<!--${x.textContent}-->`;
+            }
+
             return x.outerHTML || x.textContent;
         })
         .join("");

--- a/packages/web-components/fast-element/src/template-compiler.spec.ts
+++ b/packages/web-components/fast-element/src/template-compiler.spec.ts
@@ -341,7 +341,18 @@ describe("The template compiler", () => {
         });
     });
 
-    context("when compiling comments", () => {});
+    context("when compiling comments", () => {
+        it("preserves comments", () => {
+            const comment = `<!--This is a comment-->`;
+            const html = `
+                ${comment}
+                <a href="${inline(0)}">Link</a>
+            `;
+
+            const { fragment } = compile(html, [binding()]);
+            expect(toHTML(fragment, true)).to.contain(comment);
+        });
+    });
 
     context("when compiling hosts", () => {});
 });

--- a/packages/web-components/fast-element/src/template-compiler.ts
+++ b/packages/web-components/fast-element/src/template-compiler.ts
@@ -239,9 +239,6 @@ export function compileTemplate(
                     directive.targetIndex = compilationContext.targetIndex;
                     compilationContext.locatedDirectives++;
                     viewBehaviorFactories.push(directive);
-                } else {
-                    node.parentNode!.removeChild(node);
-                    compilationContext.targetIndex--;
                 }
         }
     }


### PR DESCRIPTION
# Description

The template compiler was overzealous in removing comments from a template. As a result, this caused the compiled template directive targeting to get out of sync with the tree walker results when HTML comments were present in the template. This PR simply removes the completely unnecessary code that was removing comments. If a developer wants to put comments in their code, we shouldn't mess with it anyway.

Closes #3777 

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.