### PR TITLE
chore: add https support for json-schema validation

### DIFF
--- a/packages/tooling/fast-tooling-react/README.md
+++ b/packages/tooling/fast-tooling-react/README.md
@@ -311,7 +311,7 @@ Form validation uses the [ajv](https://github.com/epoberezkin/ajv) package. The 
 
 ### JSON schema metadata
 
-The schema form generator can interpret most [JSON schemas](http://json-schema.org/), however there are some things to note when writing JSON schemas that make for a better UI.
+The schema form generator can interpret most [JSON schemas](https://json-schema.org/), however there are some things to note when writing JSON schemas that make for a better UI.
 
 #### Title
 
@@ -321,7 +321,7 @@ Example:
 
 ```json
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "id": "my-component",
     "title": "My component",
     "type": "object",
@@ -353,7 +353,7 @@ Example:
 
 ```json
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "id": "my-component",
     "title": "My component",
     "type": "object",
@@ -387,7 +387,7 @@ Example:
 
 ```json
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "id": "my-component",
     "title": "My component",
     "type": "object",
@@ -413,7 +413,7 @@ Example:
 
 ```json
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "id": "my-component",
     "title": "My component",
     "type": "object",
@@ -493,7 +493,7 @@ Example:
 
 ```json
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "id": "my-component",
     "title": "My component",
     "oneOf": [
@@ -529,7 +529,7 @@ Any enums will be converted to a select dropdown.
 
 ```json
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "id": "my-component",
     "title": "My component",
     "type": "object",

--- a/packages/tooling/fast-tooling-react/app/pages/navigation/children.schema.ts
+++ b/packages/tooling/fast-tooling-react/app/pages/navigation/children.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with children",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/app/pages/navigation/no-children.schema.ts
+++ b/packages/tooling/fast-tooling-react/app/pages/navigation/no-children.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component without children",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/app/pages/web-components/fancy-button.schema.ts
+++ b/packages/tooling/fast-tooling-react/app/pages/web-components/fancy-button.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema, ReservedElementMappingKeyword } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Fancy button",
     [ReservedElementMappingKeyword.mapsToTagName]: "fancy-button",
     description: "A test component's schema definition.",

--- a/packages/tooling/fast-tooling-react/app/pages/web-components/text.schema.ts
+++ b/packages/tooling/fast-tooling-react/app/pages/web-components/text.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Text",
     description: "A test component's schema definition.",
     type: "string",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/align-horizontal.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/align-horizontal.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with horizontal alignment",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/all-control-types.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/all-control-types.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with all control types",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/any-of.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/any-of.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with anyOf",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/arrays.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/arrays.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with array",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/badge.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/badge.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Badge",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/checkbox.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/checkbox.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with checkbox",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/children-plugin.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/children-plugin.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with custom properties ",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/children.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/children.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with children",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/component-plugin.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/component-plugin.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component interpreted by a plugin",
     description: "A test component's schema definition.",
     type: "string",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/const.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/const.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with const",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/control-plugin.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/control-plugin.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with custom controls",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/defaults.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/defaults.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with defaults",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/dictionary.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/dictionary.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with additional properties",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/disabled.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/disabled.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with all disabled types",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/general-example.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/general-example.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "General example",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/general.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/general.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "General example",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/invalid-data.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/invalid-data.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with invalid data",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/merged-one-of.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/merged-one-of.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     type: "object",
     id: "mergedOneOf",
     title: "Merged oneOf",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/nested-one-of.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/nested-one-of.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with a nested oneOf",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/null.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/null.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with null",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/number-field.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/number-field.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with number-field",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/objects.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/objects.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with objects",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/one-of-deeply-nested.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/one-of-deeply-nested.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Complex nesting arrays with oneOf",
     type: "object",
     id: "oneOfArrays",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/one-of.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/one-of.schema.ts
@@ -1,7 +1,7 @@
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with oneOf",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/text-field.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/text-field.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with text-field",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/text.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/text.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     description: "A test component's schema definition.",
     id: "text",
     title: "Text",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/textarea.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/textarea.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with text-field",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/tooltip.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/tooltip.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with tooltips",
     description: "A test component's schema definition.",
     type: "object",

--- a/packages/tooling/fast-tooling-react/src/css-editor/background/background.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/background/background.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS Background",
     "description": "A CSS background component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-background",

--- a/packages/tooling/fast-tooling-react/src/css-editor/border-radius/border-radius.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/border-radius/border-radius.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS border radius",
     "description": "A CSS border radius component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-border-radius",

--- a/packages/tooling/fast-tooling-react/src/css-editor/border/border.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/border/border.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS Border",
     "description": "A CSS border component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-border",

--- a/packages/tooling/fast-tooling-react/src/css-editor/box-shadow/box-shadow.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/box-shadow/box-shadow.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS box shadow",
     "description": "A CSS box shadow component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-box-shadow",

--- a/packages/tooling/fast-tooling-react/src/css-editor/color/color.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/color/color.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS Color",
     "description": "A CSS color component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-color",

--- a/packages/tooling/fast-tooling-react/src/css-editor/editor.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/editor.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS Editor",
     "description": "A CSS editor component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-editor",

--- a/packages/tooling/fast-tooling-react/src/css-editor/height/height.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/height/height.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS Height",
     "description": "A CSS height component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-height",

--- a/packages/tooling/fast-tooling-react/src/css-editor/position/position.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/position/position.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS Position",
     "description": "A CSS position component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-position",

--- a/packages/tooling/fast-tooling-react/src/css-editor/spacing/spacing.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/spacing/spacing.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS Spacing",
     "description": "A CSS spacing component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-spacing",

--- a/packages/tooling/fast-tooling-react/src/css-editor/width/width.schema.json
+++ b/packages/tooling/fast-tooling-react/src/css-editor/width/width.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/schema#",
+    "$schema": "https://json-schema.org/schema#",
     "title": "CSS Width",
     "description": "A CSS width component's schema definition.",
     "id": "@microsoft/fast-tooling-react/css-width",

--- a/packages/tooling/fast-tooling-wasm/app/schemas/number.default.schema.json
+++ b/packages/tooling/fast-tooling-wasm/app/schemas/number.default.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "number-default-schema",
     "type": "number",
     "default": 23

--- a/packages/tooling/fast-tooling-wasm/app/schemas/number.enum.schema.json
+++ b/packages/tooling/fast-tooling-wasm/app/schemas/number.enum.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "number-enum-schema",
     "type": "number",
     "enum": [

--- a/packages/tooling/fast-tooling-wasm/app/schemas/number.examples.schema.json
+++ b/packages/tooling/fast-tooling-wasm/app/schemas/number.examples.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "number-examples-schema",
     "type": "number",
     "examples": [

--- a/packages/tooling/fast-tooling-wasm/app/schemas/number.exclusive-maximum.schema.json
+++ b/packages/tooling/fast-tooling-wasm/app/schemas/number.exclusive-maximum.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "number-exclusive-maximum-schema",
     "type": "number",
     "exclusiveMaximum": 10

--- a/packages/tooling/fast-tooling-wasm/app/schemas/number.exclusive-minimum.schema.json
+++ b/packages/tooling/fast-tooling-wasm/app/schemas/number.exclusive-minimum.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "number-exclusive-minimum-schema",
     "type": "number",
     "exclusiveMinimum": 90

--- a/packages/tooling/fast-tooling-wasm/app/schemas/number.maximum.schema.json
+++ b/packages/tooling/fast-tooling-wasm/app/schemas/number.maximum.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "number-maximum-schema",
     "type": "number",
     "maximum": 10

--- a/packages/tooling/fast-tooling-wasm/app/schemas/number.minimum.schema.json
+++ b/packages/tooling/fast-tooling-wasm/app/schemas/number.minimum.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "number-minimum-schema",
     "type": "number",
     "minimum": 90

--- a/packages/tooling/fast-tooling-wasm/app/schemas/number.multiple-of.schema.json
+++ b/packages/tooling/fast-tooling-wasm/app/schemas/number.multiple-of.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "number-multiple-of-schema",
     "type": "number",
     "multipleOf": 5

--- a/packages/tooling/fast-tooling-wasm/app/schemas/number.schema.json
+++ b/packages/tooling/fast-tooling-wasm/app/schemas/number.schema.json
@@ -1,5 +1,5 @@
 {
-    "$schema": "http://json-schema.org/draft-07/schema",
+    "$schema": "https://json-schema.org/draft-07/schema",
     "$id": "number-schema",
     "type": "number",
     "examples": [

--- a/packages/tooling/fast-tooling/README.md
+++ b/packages/tooling/fast-tooling/README.md
@@ -25,7 +25,7 @@ FAST Tooling is a library agnostic specific set of utilities to assist in creati
 
 ### JSON Schema
 
-[JSON schema](http://json-schema.org/) are used by FAST tooling libraries for generating data and creating UI. They have been extended to provide additional hooks for plugin systems in the FAST tooling libraries. When providing a dictionary of JSON schema, use the `id` as a key, this is required for utilities to quickly access the correct JSON schema.
+[JSON schema](https://json-schema.org/) are used by FAST tooling libraries for generating data and creating UI. They have been extended to provide additional hooks for plugin systems in the FAST tooling libraries. When providing a dictionary of JSON schema, use the `id` as a key, this is required for utilities to quickly access the correct JSON schema.
 
 #### Nesting data
 
@@ -37,7 +37,7 @@ Example JSON Schema with linked data properties:
 import { linkedDataSchema } from "@microsoft/fast-tooling";
 
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Component with nested properties",
     type: "object",
     id: "nestable-component",

--- a/packages/tooling/fast-tooling/src/data-utilities/ajv-validation.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/ajv-validation.spec.ts
@@ -181,7 +181,7 @@ describe("AjvMapper", () => {
     });
     test("should convert ajv errors to the error format expected by the message system", () => {
         const schema: any = {
-            $schema: "http://json-schema.org/schema#",
+            $schema: "https://json-schema.org/schema#",
             id: "foo",
             type: "string",
         };
@@ -264,7 +264,7 @@ describe("AjvMapper", () => {
     });
     describe("should call the message callback if a data message has been sent", () => {
         const schema: any = {
-            $schema: "http://json-schema.org/schema#",
+            $schema: "https://json-schema.org/schema#",
             id: "foo",
             type: "string",
         };
@@ -353,7 +353,7 @@ describe("AjvMapper", () => {
         });
         test("with action type 'addLinkedData'", () => {
             const schema2: any = {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 id: "bar",
                 type: "boolean",
             };
@@ -575,24 +575,24 @@ describe("AjvMapper", () => {
     describe("should call the message callback if a custom validation message has been sent", () => {
         const containsValidSchema: any[] = [
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 id: "bar",
                 type: "string",
             },
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 id: "foo",
                 type: "number",
             },
         ];
         const containsInvalidSchema: any[] = [
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 id: "bar",
                 type: "string",
             },
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 id: "foo",
                 type: "boolean",
             },

--- a/packages/tooling/fast-tooling/src/data-utilities/ajv-validation.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/ajv-validation.ts
@@ -15,6 +15,20 @@ import {
 } from "../message-system";
 import { normalizeDataLocationToDotNotation } from "./location";
 
+export function enableHttpsSchema(ajv: Ajv.Ajv): Ajv.Ajv {
+    const _getSchema = ajv.getSchema.bind(ajv);
+
+    ajv.getSchema = function (keyRef: string): Ajv.ValidateFunction {
+        let schema: Ajv.ValidateFunction = _getSchema(keyRef);
+        if (!schema && keyRef && keyRef.indexOf("https:") === 0) {
+            schema = _getSchema(keyRef.replace("https:", "http:"));
+        }
+        return schema;
+    };
+
+    return ajv;
+}
+
 export interface AjvMapperConfig {
     /**
      * The message system
@@ -30,7 +44,9 @@ export class AjvMapper {
     private schemaDictionary: SchemaDictionary = {};
     private messageSystem: MessageSystem;
     private messageSystemConfig: { onMessage: (e: MessageEvent) => void };
-    private ajv: Ajv.Ajv = new Ajv({ schemaId: "auto", allErrors: true });
+    private ajv: Ajv.Ajv = enableHttpsSchema(
+        new Ajv({ schemaId: "auto", allErrors: true })
+    );
 
     constructor(config: AjvMapperConfig) {
         if (config.messageSystem !== undefined) {

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.spec.ts
@@ -1095,7 +1095,7 @@ describe("mapWebComponentDefinitionToJSONSchema", () => {
             })
         ).toEqual([
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 $id: name,
                 id: name,
                 title: `<${name}>`,
@@ -1143,7 +1143,7 @@ describe("mapWebComponentDefinitionToJSONSchema", () => {
             })
         ).toEqual([
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 $id: name,
                 id: name,
                 title: `<${name}>`,
@@ -1186,7 +1186,7 @@ describe("mapWebComponentDefinitionToJSONSchema", () => {
             })
         ).toEqual([
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 $id: name,
                 id: name,
                 title: `<${name}>`,
@@ -1229,7 +1229,7 @@ describe("mapWebComponentDefinitionToJSONSchema", () => {
             })
         ).toEqual([
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 $id: name,
                 id: name,
                 title: `<${name}>`,
@@ -1284,7 +1284,7 @@ describe("mapWebComponentDefinitionToJSONSchema", () => {
             })
         ).toEqual([
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 $id: name,
                 id: name,
                 title: `<${name}>`,
@@ -1341,7 +1341,7 @@ describe("mapWebComponentDefinitionToJSONSchema", () => {
             })
         ).toEqual([
             {
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 $id: name,
                 id: name,
                 title: `<${name}>`,

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.ts
@@ -473,7 +473,7 @@ export function mapWebComponentDefinitionToJSONSchema(
             i++
         ) {
             schemas.push({
-                $schema: "http://json-schema.org/schema#",
+                $schema: "https://json-schema.org/schema#",
                 $id: webComponentDefinition.tags[i].name,
                 id: webComponentDefinition.tags[i].name,
                 title: `<${webComponentDefinition.tags[i].name}>`,

--- a/packages/tooling/fast-tooling/src/schemas/linked-data.schema.spec.ts
+++ b/packages/tooling/fast-tooling/src/schemas/linked-data.schema.spec.ts
@@ -1,7 +1,10 @@
 import ajv from "ajv";
+import { enableHttpsSchema } from "../data-utilities/ajv-validation";
 import { linkedDataSchema } from "./index";
 
-const validator: ajv.Ajv = new ajv({ schemaId: "auto", allErrors: true });
+const validator: ajv.Ajv = enableHttpsSchema(
+    new ajv({ schemaId: "auto", allErrors: true })
+);
 const validationFn: ajv.ValidateFunction = validator.compile(linkedDataSchema);
 
 describe("linked data schema", () => {

--- a/packages/tooling/fast-tooling/src/schemas/web-component.schema.spec.ts
+++ b/packages/tooling/fast-tooling/src/schemas/web-component.schema.spec.ts
@@ -1,7 +1,10 @@
 import ajv from "ajv";
+import { enableHttpsSchema } from "../data-utilities/ajv-validation";
 import { webComponentSchema } from "./index";
 
-const validator: ajv.Ajv = new ajv({ schemaId: "auto", allErrors: true });
+const validator: ajv.Ajv = enableHttpsSchema(
+    new ajv({ schemaId: "auto", allErrors: true })
+);
 const validationFn: ajv.ValidateFunction = validator.compile(webComponentSchema);
 
 describe("web component schema", () => {

--- a/packages/tooling/fast-tooling/src/schemas/web-component.schema.ts
+++ b/packages/tooling/fast-tooling/src/schemas/web-component.schema.ts
@@ -4,7 +4,7 @@
  * Important: if it is updated, also update the "../data-utilities/web-component.ts" file
  */
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     $id: "https://fast.design/docs/custom-element-definition",
     title: "A definition for web components",
     type: "object",

--- a/packages/web-components/fast-components/build/generate-open-ui-definition.js
+++ b/packages/web-components/fast-components/build/generate-open-ui-definition.js
@@ -5,66 +5,68 @@ import chalk from "chalk";
 import Ajv from "ajv";
 import openUISchema from "../src/__test__/component.schema.json";
 import webComponentDefinitionSchema from "@microsoft/fast-tooling/dist/schemas/web-component.schema";
+import { enableHttpsSchema } from "@microsoft/fast-tooling/dist/data-utilities/ajv-validation";
 
-const ajv = new Ajv();
+const ajv = enableHttpsSchema(new Ajv());
 ajv.addSchema(webComponentDefinitionSchema);
 const validate = ajv.compile(openUISchema);
 const openUIDisplayName = "Open UI";
 const webComponentDisplayName = "Web Component";
 
 function getDefinitionLocations(definitionLocations, definitionKeys) {
-    return definitionLocations.reduce(
-        (accumulator, currentValue) => {
-            const pathItems = currentValue.split("/");
-            const definitionKey = pathItems[pathItems.length - 1].split(".")[0];
-            accumulator[definitionKey] = currentValue;
-            definitionKeys.push(definitionKey);
-    
-            return accumulator;
-        },
-        {}
-    );
+    return definitionLocations.reduce((accumulator, currentValue) => {
+        const pathItems = currentValue.split("/");
+        const definitionKey = pathItems[pathItems.length - 1].split(".")[0];
+        accumulator[definitionKey] = currentValue;
+        definitionKeys.push(definitionKey);
+
+        return accumulator;
+    }, {});
 }
 
 /**
  * This normalizes the Web Component definition so that it is acceptable
  * in the JSON schema
- * 
+ *
  * Web component definitions must always have strings as attribute values,
  * right now numbers and booleans can be specified, this aids when converting
  * to a JSON schema that the fast-tooling can use.
- * 
+ *
  * Here for our exported Open UI schema, it is changed to strings so that it will validate.
  */
 function definitionNormalizer(definition) {
     return {
         ...definition,
         tags: Array.isArray(definition.tags)
-            ? definition.tags.map((tag) => {
-                return {
-                    ...tag,
-                    attributes: Array.isArray(tag.attributes)
-                        ? tag.attributes.map((attribute) => {
-                            return {
-                                ...attribute,
-                                default: typeof attribute.default === "string"
-                                    ? attribute.default
-                                    : attribute.default === void 0
-                                    ? void 0
-                                    : `${attribute.default}`
-                            }
-                        })
-                        : void 0
-                }
-            })
-            : void 0
+            ? definition.tags.map(tag => {
+                  return {
+                      ...tag,
+                      attributes: Array.isArray(tag.attributes)
+                          ? tag.attributes.map(attribute => {
+                                return {
+                                    ...attribute,
+                                    default:
+                                        typeof attribute.default === "string"
+                                            ? attribute.default
+                                            : attribute.default === void 0
+                                            ? void 0
+                                            : `${attribute.default}`,
+                                };
+                            })
+                          : void 0,
+                  };
+              })
+            : void 0,
     };
 }
 
 /**
  * Get all json schema files from within the src directory
  */
-const openUIDefinitionLocationPattern = path.resolve(__dirname, "../src/**/*.open-ui.definition.json");
+const openUIDefinitionLocationPattern = path.resolve(
+    __dirname,
+    "../src/**/*.open-ui.definition.json"
+);
 const allOpenUIDefinitionLocations = glob.sync(openUIDefinitionLocationPattern);
 const allOpenUIDefinitionKeys = [];
 
@@ -80,8 +82,13 @@ const dictionaryOfOpenUIDefinitionLocations = getDefinitionLocations(
 /**
  * Get all component definition files from within the src directory
  */
-const webComponentDefinitionLocationPattern = path.resolve(__dirname, "../temp/**/*.definition.js");
-const allWebComponentDefinitionLocations = glob.sync(webComponentDefinitionLocationPattern);
+const webComponentDefinitionLocationPattern = path.resolve(
+    __dirname,
+    "../temp/**/*.definition.js"
+);
+const allWebComponentDefinitionLocations = glob.sync(
+    webComponentDefinitionLocationPattern
+);
 const allWebComponentDefinitionKeys = [];
 
 if (allWebComponentDefinitionLocations.length === 0) {
@@ -105,11 +112,13 @@ function throwErrorForMissingDefinition(
     secondDefinitionSetDisplayName
 ) {
     throw new Error(
-        chalk.red(`The following components have ${firstDefinitionSetDisplayName} definitions but no ${secondDefinitionSetDisplayName} definition:\n> ${firstDefinitionSet.filter(
-            (value) => {
-                return !secondDefinitionSet.includes(value);
-            }
-        ).join("\n> ")}`)
+        chalk.red(
+            `The following components have ${firstDefinitionSetDisplayName} definitions but no ${secondDefinitionSetDisplayName} definition:\n> ${firstDefinitionSet
+                .filter(value => {
+                    return !secondDefinitionSet.includes(value);
+                })
+                .join("\n> ")}`
+        )
     );
 }
 
@@ -134,19 +143,16 @@ if (allWebComponentDefinitionKeys.length < allOpenUIDefinitionKeys.length) {
 /**
  * Compile them together into the dist folder
  */
-allWebComponentDefinitionKeys.forEach((definitionKey) => {
+allWebComponentDefinitionKeys.forEach(definitionKey => {
     if (dictionaryOfOpenUIDefinitionLocations[definitionKey]) {
-        const definitionPath = path.resolve(
-            __dirname,
-            `../dist/esm/${definitionKey}/`
-        );
+        const definitionPath = path.resolve(__dirname, `../dist/esm/${definitionKey}/`);
 
         // Create directories if they don't exist
         // this assumes at minimum the dist/esm folder exists
         try {
             fs.accessSync(definitionPath);
         } catch (err) {
-            fs.mkdir(definitionPath, {}, (err) => {
+            fs.mkdir(definitionPath, {}, err => {
                 if (err) {
                     throw err;
                 }
@@ -154,55 +160,57 @@ allWebComponentDefinitionKeys.forEach((definitionKey) => {
         }
 
         const openUIDefinition = JSON.parse(
-            fs.readFileSync(
-                dictionaryOfOpenUIDefinitionLocations[definitionKey],
-                {
-                    encoding: "utf8"
-                }
-            )
+            fs.readFileSync(dictionaryOfOpenUIDefinitionLocations[definitionKey], {
+                encoding: "utf8",
+            })
         );
 
         import(dictionaryOfWebComponentDefinitionLocations[definitionKey])
-            .then((module) => {
-                try {
-                    const fileContents = {
-                        ...openUIDefinition,
-                        implementations: [
-                            {
-                                type: "web-component",
-                                implementation: definitionNormalizer(module[Object.keys(module)[0]])
-                            }
-                        ]
-                    };
+            .then(
+                module => {
+                    try {
+                        const fileContents = {
+                            ...openUIDefinition,
+                            implementations: [
+                                {
+                                    type: "web-component",
+                                    implementation: definitionNormalizer(
+                                        module[Object.keys(module)[0]]
+                                    ),
+                                },
+                            ],
+                        };
 
-                    // Test the file
-                    const valid = validate(fileContents);
+                        // Test the file
+                        const valid = validate(fileContents);
 
-                    if (!valid) {
-                        throw new Error(JSON.stringify(validate.errors, null, 2));
-                    }
-
-                    // Write the file
-                    fs.writeFile(
-                        path.resolve(
-                            definitionPath,
-                            `${definitionKey}.open-ui.definition.json`
-                        ),
-                        JSON.stringify(fileContents, null, 2),
-                        "utf8",
-                        (err) => {
-                            if (err) {
-                                throw err;
-                            }
+                        if (!valid) {
+                            throw new Error(JSON.stringify(validate.errors, null, 2));
                         }
-                    );
-                } catch (e) {
-                    throw e;
+
+                        // Write the file
+                        fs.writeFile(
+                            path.resolve(
+                                definitionPath,
+                                `${definitionKey}.open-ui.definition.json`
+                            ),
+                            JSON.stringify(fileContents, null, 2),
+                            "utf8",
+                            err => {
+                                if (err) {
+                                    throw err;
+                                }
+                            }
+                        );
+                    } catch (e) {
+                        throw e;
+                    }
+                },
+                reason => {
+                    throw new Error(reason);
                 }
-            }, (reason) => {
-                throw new Error(reason);
-            })
-            .catch((err) => {
+            )
+            .catch(err => {
                 if (err) {
                     throw new Error(err.toString());
                 }

--- a/packages/web-components/fast-components/src/__test__/component.schema.json
+++ b/packages/web-components/fast-components/src/__test__/component.schema.json
@@ -1,6 +1,6 @@
 {
     "$id": "component.schema.json",
-    "$schema": "http://json-schema.org/draft-07/schema#",
+    "$schema": "https://json-schema.org/draft-07/schema#",
     "title": "Component",
     "description": "A UI Component definition.",
     "type": "object",

--- a/sites/site-utilities/src/schemas/text.schema.ts
+++ b/sites/site-utilities/src/schemas/text.schema.ts
@@ -1,5 +1,5 @@
 export default {
-    $schema: "http://json-schema.org/schema#",
+    $schema: "https://json-schema.org/schema#",
     title: "Text",
     description: "A text strings schema definition.",
     type: "string",


### PR DESCRIPTION
chore: add https support for json-schema validation

# Description
AJV package does not support https. Created a wrapper function that will resolve https schemas as http if they fail. This will allow us to use https schemas in the interim until the AJV packages is updated to support https. Updated all json shcemas to use https.

## Motivation & context

Better security support for HTTPS to bring into compliance https://webscout/#/scans/757563/issues?issueId=3692645

## Issue type checklist

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
