### PR TITLE
fix: move focus ring to button host to allow padding

### DIFF
--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -39,6 +39,7 @@ export const BaseButtonStyles = css`
         min-width: calc(${heightNumber} * 1px);
         background-color: ${neutralFillRestBehavior.var};
         color: ${neutralForegroundRestBehavior.var};
+        border: calc(var(--outline-width) * 1px) solid transparent;
         border-radius: calc(var(--corner-radius) * 1px);
         fill: currentColor;
         cursor: pointer;
@@ -56,8 +57,8 @@ export const BaseButtonStyles = css`
         white-space: nowrap;
         outline: none;
         text-decoration: none;
-        border: calc(var(--outline-width) * 1px) solid transparent;
         color: inherit;
+        border: none;
         border-radius: inherit;
         fill: inherit;
         cursor: inherit;
@@ -71,11 +72,10 @@ export const BaseButtonStyles = css`
         background-color: ${neutralFillActiveBehavior.var};
     }
 
-    .control:${focusVisible} {
+    :host(:focus-within) {
         border: calc(var(--outline-width) * 1px) solid ${neutralFocusBehavior.var};
-        box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${
-            neutralFocusBehavior.var
-        };
+        box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px)
+            ${neutralFocusBehavior.var};
     }
 
     .control::-moz-focus-inner {
@@ -91,10 +91,8 @@ export const BaseButtonStyles = css`
     .start,
     .end,
     ::slotted(svg) {
-        ${
-            /* Glyph size and margin-left is temporary -
-            replace when adaptive typography is figured out */ ""
-        } width: 16px;
+        ${/* Glyph size and margin-left is temporary -
+            replace when adaptive typography is figured out */ ""} width: 16px;
         height: 16px;
     }
 
@@ -129,8 +127,9 @@ export const AccentButtonStyles = css`
         background: ${accentFillActiveBehavior.var};
     }
 
-    :host(.accent) .control:${focusVisible} {
-        box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${neutralFocusInnerAccentBehavior.var};
+    :host(.accent:focus-within) {
+        box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset
+            ${neutralFocusInnerAccentBehavior.var};
     }
 
     :host(.accent.disabled) {
@@ -154,13 +153,13 @@ export const HypertextStyles = css`
         height: auto;
         min-width: 0;
         background: transparent;
+        border: none;
+        box-shadow: none;
     }
 
     :host(.hypertext) .control {
         display: inline;
         padding: 0;
-        border: none;
-        box-shadow: none;
         border-radius: 0;
         line-height: 1;
     }
@@ -197,13 +196,13 @@ export const LightweightButtonStyles = css`
     :host(.lightweight) {
         background: transparent;
         color: ${accentForegroundRestBehavior.var};
+        border: none;
+        box-shadow: none;
     }
 
     :host(.lightweight) .control {
         padding: 0;
         height: initial;
-        border: none;
-        box-shadow: none;
         border-radius: 0;
     }
 
@@ -280,7 +279,7 @@ export const OutlineButtonStyles = css`
         border-color: inherit;
     }
 
-    :host(.outline) .control:${focusVisible} {
+    :host(.outline:focus-within) {
         border: calc(var(--outline-width) * 1px) solid ${neutralFocusBehavior.var});
         box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${neutralFocusBehavior.var};
     }


### PR DESCRIPTION
Moved the focus ring to the button/anchor host to allow for padding. Resolves #3790 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->