### PR TITLE
fix: label on sketch picker input is using the correct color

### DIFF
--- a/sites/fast-color-explorer/app/control-pane.tsx
+++ b/sites/fast-color-explorer/app/control-pane.tsx
@@ -132,6 +132,9 @@ const styles: any = (
                     boxShadow: `0 0 0 2px ${neutralFocus(designSystem)} inset !important`,
                 },
             },
+            ".sketch-picker .flexbox-fix span": {
+                color: `${neutralForegroundRest(designSystem)} !important`,
+            },
         },
         controlPane: {
             position: "relative",


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Add `sketch-picker .flexbox-fix span` style selector to fix the label color on the sketch picker input. This resolves the color-contrast fail from the Accessibility Insight results,
https://webcompliance.trafficmanager.net/ScanResultsApi/GetAccessibilityScanReport?siteId=3b40f9fe-a96d-4751-25f1-08d7e21203a9&urlId=242795

before
![image](https://user-images.githubusercontent.com/37851220/91350692-e370f780-e79b-11ea-8ec3-914fab19712e.png)

after
![image](https://user-images.githubusercontent.com/37851220/91350700-e966d880-e79b-11ea-8ac3-4c07eb20e8af.png)


## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->