### PR TITLE
feat: add hover state for expand collapse button in tree-item

### DIFF
--- a/packages/web-components/fast-components/src/styles/recipes.ts
+++ b/packages/web-components/fast-components/src/styles/recipes.ts
@@ -10,6 +10,8 @@ import {
     neutralFillCard,
     neutralFillInput,
     neutralFillStealth,
+    neutralFillStealthRest,
+    neutralFillStealthHover,
     neutralFillToggle,
     neutralFocus,
     neutralFocusInnerAccent,
@@ -27,6 +29,7 @@ import {
     neutralLayerL3,
     neutralLayerL4,
     neutralOutline,
+    neutralFillStealthSelected,
 } from "../color/index";
 import { accentBaseColor } from "../fast-design-system";
 import { FASTDesignSystemProvider } from "../design-system-provider/index";
@@ -238,6 +241,7 @@ export const neutralFillStealthRestBehavior = cssCustomPropertyBehaviorFactory(
     x => neutralFillStealth(x).rest,
     FASTDesignSystemProvider.findProvider
 );
+
 /**
  * Behavior to resolve and make available the neutral-fill-stealth-hover CSS custom property.
  * @public
@@ -247,6 +251,7 @@ export const neutralFillStealthHoverBehavior = cssCustomPropertyBehaviorFactory(
     x => neutralFillStealth(x).hover,
     FASTDesignSystemProvider.findProvider
 );
+
 /**
  * Behavior to resolve and make available the neutral-fill-stealth-active CSS custom property.
  * @public
@@ -328,6 +333,7 @@ export const neutralFillInputHoverBehavior = cssCustomPropertyBehaviorFactory(
     x => neutralFillInput(x).hover,
     FASTDesignSystemProvider.findProvider
 );
+
 /**
  * Behavior to resolve and make available the neutral-fill-input-active CSS custom property.
  * @public
@@ -562,6 +568,19 @@ export const neutralLayerL3Behavior = cssCustomPropertyBehaviorFactory(
     neutralLayerL3,
     FASTDesignSystemProvider.findProvider
 );
+
+export const neutralStealthHoverBackgroundBehavior = cssCustomPropertyBehaviorFactory(
+    "neutral-stealth-hover-background",
+    x => neutralFillStealthHover(neutralFillStealthHover)(x),
+    FASTDesignSystemProvider.findProvider
+);
+
+export const neutralStealthHoverSelectedBackgroundBehavior = cssCustomPropertyBehaviorFactory(
+    "neutral-stealth-hover-selected-background",
+    x => neutralFillStealthHover(neutralFillStealthSelected)(x),
+    FASTDesignSystemProvider.findProvider
+);
+
 /**
  * Behavior to resolve and make available the neutral-layer-l4 CSS custom property.
  * @public

--- a/packages/web-components/fast-components/src/styles/recipes.ts
+++ b/packages/web-components/fast-components/src/styles/recipes.ts
@@ -10,8 +10,6 @@ import {
     neutralFillCard,
     neutralFillInput,
     neutralFillStealth,
-    neutralFillStealthRest,
-    neutralFillStealthHover,
     neutralFillToggle,
     neutralFocus,
     neutralFocusInnerAccent,
@@ -29,7 +27,6 @@ import {
     neutralLayerL3,
     neutralLayerL4,
     neutralOutline,
-    neutralFillStealthSelected,
 } from "../color/index";
 import { accentBaseColor } from "../fast-design-system";
 import { FASTDesignSystemProvider } from "../design-system-provider/index";
@@ -568,19 +565,6 @@ export const neutralLayerL3Behavior = cssCustomPropertyBehaviorFactory(
     neutralLayerL3,
     FASTDesignSystemProvider.findProvider
 );
-
-export const neutralStealthHoverBackgroundBehavior = cssCustomPropertyBehaviorFactory(
-    "neutral-stealth-hover-background",
-    x => neutralFillStealthHover(neutralFillStealthHover)(x),
-    FASTDesignSystemProvider.findProvider
-);
-
-export const neutralStealthHoverSelectedBackgroundBehavior = cssCustomPropertyBehaviorFactory(
-    "neutral-stealth-hover-selected-background",
-    x => neutralFillStealthHover(neutralFillStealthSelected)(x),
-    FASTDesignSystemProvider.findProvider
-);
-
 /**
  * Behavior to resolve and make available the neutral-layer-l4 CSS custom property.
  * @public

--- a/packages/web-components/fast-components/src/styles/size.ts
+++ b/packages/web-components/fast-components/src/styles/size.ts
@@ -5,6 +5,3 @@
  */
 export const heightNumber =
     "(var(--base-height-multiplier) + var(--density)) * var(--design-unit)";
-
-export const glyphSize =
-    "((var(--base-height-multiplier) / 2) * var(--design-unit)) + ((var(--design-unit) * var(--density)) / 2)";

--- a/packages/web-components/fast-components/src/styles/size.ts
+++ b/packages/web-components/fast-components/src/styles/size.ts
@@ -6,5 +6,5 @@
 export const heightNumber =
     "(var(--base-height-multiplier) + var(--density)) * var(--design-unit)";
 
-
-export const glyphSize = "((var(--base-height-multiplier) / 2) * var(--design-unit)) + ((var(--design-unit) * var(--density)) / 2)";
+export const glyphSize =
+    "((var(--base-height-multiplier) / 2) * var(--design-unit)) + ((var(--design-unit) * var(--density)) / 2)";

--- a/packages/web-components/fast-components/src/styles/size.ts
+++ b/packages/web-components/fast-components/src/styles/size.ts
@@ -5,3 +5,6 @@
  */
 export const heightNumber =
     "(var(--base-height-multiplier) + var(--density)) * var(--design-unit)";
+
+
+export const glyphSize = "((var(--base-height-multiplier) / 2) * var(--design-unit)) + ((var(--design-unit) * var(--density)) / 2)";

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -251,9 +251,6 @@ export const TreeItemStyles = css`
         :host .content-region .expand-collapse-glyph {
             fill: ${SystemColors.FieldText};
         }
-        :host(.nested) .expand-collapse-button:hover .expand-collapse-glyph {
-            fill: ${SystemColors.FieldText};
-        }
         :host .positioning-region:hover,
         :host([selected]) .positioning-region {
             background: ${SystemColors.Highlight};
@@ -297,6 +294,12 @@ export const TreeItemStyles = css`
         .expand-collapse-glyph,
         .start,
         .end {
+            fill: ${SystemColors.FieldText};
+        }
+        :host(.nested) .expand-collapse-button:hover {
+            background: ${SystemColors.Field};
+        }
+        :host(.nested) .expand-collapse-button:hover .expand-collapse-glyph {
             fill: ${SystemColors.FieldText};
         }
         `

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -1,20 +1,18 @@
 import { css } from "@microsoft/fast-element";
 import {
+    cssCustomPropertyBehaviorFactory,
     DirectionalStyleSheetBehavior,
     disabledCursor,
     display,
     focusVisible,
     forcedColorsStylesheetBehavior,
 } from "@microsoft/fast-foundation";
-
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
     accentForegroundRestBehavior,
     heightNumber,
     neutralFillStealthActiveBehavior,
-    neutralStealthHoverBackgroundBehavior,
     neutralFillStealthHoverBehavior,
-    neutralStealthHoverSelectedBackgroundBehavior,
     neutralFillStealthRestBehavior,
     neutralFillStealthSelectedBehavior,
     neutralFocusBehavior,
@@ -22,6 +20,8 @@ import {
     neutralForegroundActiveBehavior,
     neutralForegroundRestBehavior,
 } from "../styles/index";
+import { neutralFillStealthHover, neutralFillStealthSelected } from "../color/index";
+import { FASTDesignSystemProvider } from "../design-system-provider/index";
 
 const ltr = css`
     :host(.nested) .expand-collapse-button {
@@ -40,6 +40,18 @@ const rtl = css`
         right: calc(var(--focus-outline-width) * 1px);
     }
 `;
+
+const neutralStealthHoverOverHoverBehavior = cssCustomPropertyBehaviorFactory(
+    "neutral-stealth-hover-over-hover",
+    x => neutralFillStealthHover(neutralFillStealthHover)(x),
+    FASTDesignSystemProvider.findProvider
+);
+
+const neutralStealthHoverOverSelectedBehavior = cssCustomPropertyBehaviorFactory(
+    "neutral-stealth-hover-over-selected",
+    x => neutralFillStealthHover(neutralFillStealthSelected)(x),
+    FASTDesignSystemProvider.findProvider
+);
 
 export const TreeItemStyles = css`
     ${display("block")} :host {
@@ -175,12 +187,25 @@ export const TreeItemStyles = css`
         cursor: ${disabledCursor};
     }
 
+    :host(.nested) .content-region {
+        position: relative;
+        margin-inline-start: var(--expand-collapse-button-size);
+    }
+
+    :host(.nested) .expand-collapse-button {
+        position: absolute;
+    }
+
+    :host(.nested) .expand-collapse-button:hover {
+        background: ${neutralStealthHoverOverHoverBehavior.var};
+    }
+    
     :host([selected]) .positioning-region {
         background: ${neutralFillStealthSelectedBehavior.var};
     }
 
-    :host([selected]) .expand-collapse-button {
-        background: ${neutralStealthHoverSelectedBackgroundBehavior.var},
+    :host([selected]) .expand-collapse-button:hover {
+        background: ${neutralStealthHoverOverSelectedBehavior.var};
     }
 
     :host([selected])::after {
@@ -197,19 +222,6 @@ export const TreeItemStyles = css`
         border-radius: calc(var(--corner-radius) * 1px);
     }
 
-    :host(.nested) .content-region {
-        position: relative;
-        margin-inline-start: var(--expand-collapse-button-size);
-    }
-
-    :host(.nested) .expand-collapse-button {
-        position: absolute;
-    }
-
-    :host(.nested) .expand-collapse-button:hover {
-        background: ${neutralStealthHoverBackgroundBehavior.var};
-    }
-
     ::slotted(fast-tree-item) {
         --tree-item-nested-width: 1em;
         --expand-collapse-button-nested-width: calc(${heightNumber} * -1px);
@@ -218,9 +230,9 @@ export const TreeItemStyles = css`
     accentForegroundRestBehavior,
     neutralFillStealthSelectedBehavior,
     neutralFillStealthActiveBehavior,
-    neutralStealthHoverBackgroundBehavior,
+    neutralStealthHoverOverHoverBehavior,
     neutralFillStealthHoverBehavior,
-    neutralStealthHoverSelectedBackgroundBehavior,
+    neutralStealthHoverOverSelectedBehavior,
     neutralFillStealthRestBehavior,
     neutralFocusBehavior,
     neutralFocusInnerAccentBehavior,

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -42,13 +42,13 @@ const rtl = css`
     }
 `;
 
-const neutralStealthHoverOverHoverExpandCollapseButtonBehavior = cssCustomPropertyBehaviorFactory(
+const expandCollapseHoverBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-stealth-hover-over-hover",
     x => neutralFillStealthHover(neutralFillStealthHover)(x),
     FASTDesignSystemProvider.findProvider
 );
 
-const neutralStealthHoverOverSelectedExpandCollapseButtonBehavior = cssCustomPropertyBehaviorFactory(
+const selectedExpandCollapseHoverBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-stealth-hover-over-selected",
     x => neutralFillStealthHover(neutralFillStealthSelected)(x),
     FASTDesignSystemProvider.findProvider
@@ -198,7 +198,7 @@ export const TreeItemStyles = css`
     }
 
     :host(.nested) .expand-collapse-button:hover {
-        background: ${neutralStealthHoverOverHoverExpandCollapseButtonBehavior.var};
+        background: ${expandCollapseHoverBehavior.var};
     }
     
     :host([selected]) .positioning-region {
@@ -206,7 +206,7 @@ export const TreeItemStyles = css`
     }
 
     :host([selected]) .expand-collapse-button:hover {
-        background: ${neutralStealthHoverOverSelectedExpandCollapseButtonBehavior.var};
+        background: ${selectedExpandCollapseHoverBehavior.var};
     }
 
     :host([selected])::after {
@@ -231,9 +231,9 @@ export const TreeItemStyles = css`
     accentForegroundRestBehavior,
     neutralFillStealthSelectedBehavior,
     neutralFillStealthActiveBehavior,
-    neutralStealthHoverOverHoverExpandCollapseButtonBehavior,
+    expandCollapseHoverBehavior,
     neutralFillStealthHoverBehavior,
-    neutralStealthHoverOverSelectedExpandCollapseButtonBehavior,
+    selectedExpandCollapseHoverBehavior,
     neutralFillStealthRestBehavior,
     neutralFocusBehavior,
     neutralFocusInnerAccentBehavior,

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -250,9 +250,6 @@ export const TreeItemStyles = css`
         :host .content-region .expand-collapse-glyph {
             fill: ${SystemColors.FieldText};
         }
-        :host(.nested) .expand-collapse-button:hover {
-            background: ${SystemColors.Field};
-         }
         :host(.nested) .expand-collapse-button:hover .expand-collapse-glyph {
             fill: ${SystemColors.FieldText};
         }

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -246,6 +246,7 @@ export const TreeItemStyles = css`
             forced-color-adjust: none;
             border-color: transparent;
             background: ${SystemColors.Field};
+            color: ${SystemColors.FieldText};
         }
         :host .content-region .expand-collapse-glyph {
             fill: ${SystemColors.FieldText};
@@ -275,6 +276,7 @@ export const TreeItemStyles = css`
         :host(:${focusVisible}) .positioning-region {
             border-color: ${SystemColors.FieldText};
             box-shadow: 0 0 0 2px inset ${SystemColors.Field};
+            color: ${SystemColors.FieldText};
         }
         :host([disabled]) .content-region,
         :host([disabled]) .positioning-region:hover .content-region {
@@ -291,6 +293,11 @@ export const TreeItemStyles = css`
         }
         :host([disabled]) .positioning-region:hover {
             background: ${SystemColors.Field};
+        }
+        .expand-collapse-glyph,
+        .start,
+        .end {
+            fill: ${SystemColors.FieldText};
         }
         `
     )

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -12,7 +12,9 @@ import {
     accentForegroundRestBehavior,
     heightNumber,
     neutralFillStealthActiveBehavior,
+    neutralStealthHoverBackgroundBehavior,
     neutralFillStealthHoverBehavior,
+    neutralStealthHoverSelectedBackgroundBehavior,
     neutralFillStealthRestBehavior,
     neutralFillStealthSelectedBehavior,
     neutralFocusBehavior,
@@ -61,7 +63,7 @@ export const TreeItemStyles = css`
     }
 
     :host(:${focusVisible}) .positioning-region {
-        border: ${neutralFocusBehavior.var} 1px solid;
+        border: ${neutralFocusBehavior.var} calc(var(--outline-width) * 1px) solid;
         border-radius: calc(var(--corner-radius) * 1px);
         color: ${neutralForegroundActiveBehavior.var};
     }
@@ -70,8 +72,8 @@ export const TreeItemStyles = css`
         display: flex;
         position: relative;
         box-sizing: border-box;
-        border: transparent 1px solid;
-        height: calc(${heightNumber} * 1px);
+        border: transparent calc(var(--outline-width) * 1px) solid;
+        height: calc((${heightNumber} + 1) * 1px);
     }
 
     .positioning-region::before {
@@ -95,7 +97,7 @@ export const TreeItemStyles = css`
         white-space: nowrap;
         width: 100%;
         height: calc(${heightNumber} * 1px);
-        margin-inline-start: calc(var(--design-unit) * 2px + 2px);
+        margin-inline-start: calc(var(--design-unit) * 2px + 8px);
         font-size: var(--type-ramp-base-font-size);
         line-height: var(--type-ramp-base-line-height);
         font-weight: 400;
@@ -116,13 +118,15 @@ export const TreeItemStyles = css`
         ${
             /* Width and Height should be based off calc(glyph-size-number + (design-unit * 4) * 1px) - 
             update when density story is figured out */ ""
-        } width: var(--expand-collapse-button-size);
-        height: var(--expand-collapse-button-size);
+        } width: 35px;
+        height: 35px;
         padding: 0;
         display: flex;
         justify-content: center;
         align-items: center;
         cursor: pointer;
+        margin-left: 6px;
+        margin-right: 6px;
     }
 
     .expand-collapse-glyph {
@@ -175,6 +179,10 @@ export const TreeItemStyles = css`
         background: ${neutralFillStealthSelectedBehavior.var};
     }
 
+    :host([selected]) .expand-collapse-button {
+        background: ${neutralStealthHoverSelectedBackgroundBehavior.var},
+    }
+
     :host([selected])::after {
         content: "";
         display: block;
@@ -198,6 +206,10 @@ export const TreeItemStyles = css`
         position: absolute;
     }
 
+    :host(.nested) .expand-collapse-button:hover {
+        background: ${neutralStealthHoverBackgroundBehavior.var};
+    }
+
     ::slotted(fast-tree-item) {
         --tree-item-nested-width: 1em;
         --expand-collapse-button-nested-width: calc(${heightNumber} * -1px);
@@ -206,7 +218,9 @@ export const TreeItemStyles = css`
     accentForegroundRestBehavior,
     neutralFillStealthSelectedBehavior,
     neutralFillStealthActiveBehavior,
+    neutralStealthHoverBackgroundBehavior,
     neutralFillStealthHoverBehavior,
+    neutralStealthHoverSelectedBackgroundBehavior,
     neutralFillStealthRestBehavior,
     neutralFocusBehavior,
     neutralFocusInnerAccentBehavior,

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -10,7 +10,6 @@ import {
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
     accentForegroundRestBehavior,
-    glyphSize,
     heightNumber,
     neutralFillStealthActiveBehavior,
     neutralFillStealthHoverBehavior,
@@ -41,6 +40,9 @@ const rtl = css`
         right: calc(var(--focus-outline-width) * 1px);
     }
 `;
+
+export const expandCollapseButtonSize =
+    "((var(--base-height-multiplier) / 2) * var(--design-unit)) + ((var(--design-unit) * var(--density)) / 2)";
 
 const expandCollapseHoverBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-stealth-hover-over-hover",
@@ -131,8 +133,8 @@ export const TreeItemStyles = css`
         ${
             /* Width and Height should be based off calc(glyph-size-number + (design-unit * 4) * 1px) - 
             update when density story is figured out */ ""
-        } width: calc((${glyphSize} + (var(--design-unit) * 2)) * 1px);
-        height: calc((${glyphSize} + (var(--design-unit) * 2)) * 1px);
+        } width: calc((${expandCollapseButtonSize} + (var(--design-unit) * 2)) * 1px);
+        height: calc((${expandCollapseButtonSize} + (var(--design-unit) * 2)) * 1px);
         padding: 0;
         display: flex;
         justify-content: center;

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -104,7 +104,7 @@ export const TreeItemStyles = css`
     }
 
     .content-region {
-        display: flex;
+        display: inline-flex;
         align-items: center;
         white-space: nowrap;
         width: 100%;
@@ -130,8 +130,8 @@ export const TreeItemStyles = css`
         ${
             /* Width and Height should be based off calc(glyph-size-number + (design-unit * 4) * 1px) - 
             update when density story is figured out */ ""
-        } width: 35px;
-        height: 35px;
+        } width: 28px;
+        height: 28px;
         padding: 0;
         display: flex;
         justify-content: center;

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -10,6 +10,7 @@ import {
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
     accentForegroundRestBehavior,
+    glyphSize,
     heightNumber,
     neutralFillStealthActiveBehavior,
     neutralFillStealthHoverBehavior,
@@ -41,13 +42,13 @@ const rtl = css`
     }
 `;
 
-const neutralStealthHoverOverHoverBehavior = cssCustomPropertyBehaviorFactory(
+const neutralStealthHoverOverHoverExpandCollapseButtonBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-stealth-hover-over-hover",
     x => neutralFillStealthHover(neutralFillStealthHover)(x),
     FASTDesignSystemProvider.findProvider
 );
 
-const neutralStealthHoverOverSelectedBehavior = cssCustomPropertyBehaviorFactory(
+const neutralStealthHoverOverSelectedExpandCollapseButtonBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-stealth-hover-over-selected",
     x => neutralFillStealthHover(neutralFillStealthSelected)(x),
     FASTDesignSystemProvider.findProvider
@@ -130,8 +131,8 @@ export const TreeItemStyles = css`
         ${
             /* Width and Height should be based off calc(glyph-size-number + (design-unit * 4) * 1px) - 
             update when density story is figured out */ ""
-        } width: 28px;
-        height: 28px;
+        } width: calc((${glyphSize} + (var(--design-unit) * 2)) * 1px);
+        height: calc((${glyphSize} + (var(--design-unit) * 2)) * 1px);
         padding: 0;
         display: flex;
         justify-content: center;
@@ -197,7 +198,7 @@ export const TreeItemStyles = css`
     }
 
     :host(.nested) .expand-collapse-button:hover {
-        background: ${neutralStealthHoverOverHoverBehavior.var};
+        background: ${neutralStealthHoverOverHoverExpandCollapseButtonBehavior.var};
     }
     
     :host([selected]) .positioning-region {
@@ -205,7 +206,7 @@ export const TreeItemStyles = css`
     }
 
     :host([selected]) .expand-collapse-button:hover {
-        background: ${neutralStealthHoverOverSelectedBehavior.var};
+        background: ${neutralStealthHoverOverSelectedExpandCollapseButtonBehavior.var};
     }
 
     :host([selected])::after {
@@ -230,9 +231,9 @@ export const TreeItemStyles = css`
     accentForegroundRestBehavior,
     neutralFillStealthSelectedBehavior,
     neutralFillStealthActiveBehavior,
-    neutralStealthHoverOverHoverBehavior,
+    neutralStealthHoverOverHoverExpandCollapseButtonBehavior,
     neutralFillStealthHoverBehavior,
-    neutralStealthHoverOverSelectedBehavior,
+    neutralStealthHoverOverSelectedExpandCollapseButtonBehavior,
     neutralFillStealthRestBehavior,
     neutralFocusBehavior,
     neutralFocusInnerAccentBehavior,
@@ -247,6 +248,12 @@ export const TreeItemStyles = css`
             background: ${SystemColors.Field};
         }
         :host .content-region .expand-collapse-glyph {
+            fill: ${SystemColors.FieldText};
+        }
+        :host(.nested) .expand-collapse-button:hover {
+            background: ${SystemColors.Field};
+         }
+        :host(.nested) .expand-collapse-button:hover .expand-collapse-glyph {
             fill: ${SystemColors.FieldText};
         }
         :host .positioning-region:hover,


### PR DESCRIPTION
# Description
Adding hover style to the expand collapse button in tree items

The purpose of the background is to increase comprehension of the two different interactive elements within an item. We received interaction study indication that people had trouble understanding the difference between selecting a node and expanding it. The button area functions differently, but doesn't indicate such, so this change is to frame it to help differentiate the parts.

<img width="322" alt="Screen Shot 2020-08-26 at 5 06 05 PM" src="https://user-images.githubusercontent.com/25805778/91368740-b71aa280-e7be-11ea-9d85-b51874cd0331.png">
<img width="358" alt="Screen Shot 2020-08-26 at 5 06 11 PM" src="https://user-images.githubusercontent.com/25805778/91368750-bd108380-e7be-11ea-8544-455ca95cb613.png">



## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
