### PR TITLE
fix(fast-element): add globalThis polyfill to fix trustedTypes polyfill

### DIFF
--- a/packages/web-components/fast-element/src/dom.ts
+++ b/packages/web-components/fast-element/src/dom.ts
@@ -3,16 +3,37 @@ import { Callable } from "./interfaces";
 const updateQueue = [] as Callable[];
 type TrustedTypesPolicy = { createHTML(html: string): string };
 
-// Tiny API-only polyfill for trustedTypes
-declare let trustedTypes: any;
 /* eslint-disable */
-if (typeof trustedTypes == "undefined") {
-    trustedTypes = { createPolicy: (n, r) => r };
+
+// Polyfill for globalThis
+declare const __magic__: any;
+
+(function () {
+    if (typeof globalThis === "object") return;
+
+    Object.defineProperty(Object.prototype, "__magic__", {
+        get: function () {
+            return this;
+        },
+        configurable: true,
+    });
+
+    __magic__.globalThis = __magic__;
+
+    delete (Object.prototype as any).__magic__;
+})();
+
+// API-only Polyfill for trustedTypes
+declare let trustedTypes: any;
+
+if (globalThis.trustedTypes === void 0) {
+    globalThis.trustedTypes = { createPolicy: (n, r) => r };
 }
 
 const fastHTMLPolicy: TrustedTypesPolicy = trustedTypes.createPolicy("fast-html", {
     createHTML: html => html,
 });
+
 /* eslint-enable */
 
 let htmlPolicy: TrustedTypesPolicy = fastHTMLPolicy;


### PR DESCRIPTION
# Description

During our release testing, we discovered that everything was completely broken in Firefox 🤣 What was the cause? Well, we recently removed our dependency on the `globalThis` standard as part of our `trustedTypes` polyfill. Unfortunately, Firefox did not like the way our polyfill attempted to patch the global object (without using `globalThis`). As a result, I have reverted our `trustedTypes` feature test and polyfll to be based on `globalThis` and have added a polyfill for `globalThis`.

At some point in the future, we'll be able to remove both of these polyfills, but we should probably have them baked in for now, since they are fairly small and prevent our customers from having to find and add implementations themselves.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.