### PR TITLE
fix: badge padding and fast-switch defaults on homepage fast-frame

### DIFF
--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
@@ -68,6 +68,7 @@ export const FastFrameStyles = css`
     }
 
     .content .content-badge {
+        --design-unit: 0;
         font-size: var(--type-ramp-minus-1-font-size);
         line-height: var(--type-ramp-minus-1-line-height);
         color: ${neutralForegroundHintBehavior.var};
@@ -190,9 +191,9 @@ export const FastFrameStyles = css`
     .hue-slider-track {
         height: 100%;
         border-radius: calc(var(--corner-radius) * 1px);
-        background-image: 
+        background-image:
             linear-gradient(
-                to right, 
+                to right,
                 rgb(255, 0, 0),
                 rgb(255, 77, 0),
                 rgb(255, 153, 0),
@@ -264,19 +265,19 @@ export const FastFrameStyles = css`
     }
 
     site-color-swatch {
-        margin: 0;      
+        margin: 0;
     }
 
     fast-slider-label {
         font-size: var(--type-ramp-minus-2-font-size);
         color: ${neutralForegroundHintBehavior.var};
     }
-    
+
     @media screen and (max-width: 1330px) {
         :host {
             --gutter: 10;
         }
-    
+
         fast-card {
             display: none;
         }
@@ -285,13 +286,13 @@ export const FastFrameStyles = css`
             grid-template-columns: minMax(300px, auto);
             border-radius: calc(var(--corner-radius) * 1px);
         }
-    
+
     }
     @media screen and (max-width: ${drawerBreakpoint}) {
         :host {
             --gutter: 10;
         }
-    
+
         fast-card {
             display: none;
         }
@@ -309,7 +310,7 @@ export const FastFrameStyles = css`
         .preview-expanded {
             transition: right .5s ease-in-out;
             right: -10%;
-        }    
+        }
 
         .wrapper {
             display: grid;
@@ -321,7 +322,7 @@ export const FastFrameStyles = css`
             display: inline-flex;
             visibility: visible;
         }
-        
+
         .tab-panel-expanded {
             opacity: 0;
             transition: opacity .5s ease-in-out;
@@ -331,7 +332,7 @@ export const FastFrameStyles = css`
             opacity: 1;
             transition: opacity .5s ease-in-out;
         }
-    
+
     }
     @media screen and (max-width: 480px) {
         .preview {
@@ -342,7 +343,7 @@ export const FastFrameStyles = css`
 
         .preview-expanded {
             right: -5%;
-        }    
+        }
 
         .wrapper {
             width: calc(100vw - 12vw);

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -214,6 +214,7 @@ export const FastFrameTemplate = html<FastFrame>`
                 </fast-tab-panel>
             </fast-tabs>
             <fast-design-system-provider
+                use-defaults
                 class="${x => (x.expanded ? "preview preview-expanded" : "preview")}"
                 base-layer-luminance="${x => x.baseLayerLuminance}"
                 background-color="${x => x.backgroundColor}"


### PR DESCRIPTION
# Description
Fixes style bugs on the homepage for the `.content-badge` and the Fast Frame `<fast-switch>`.

## Motivation & context
The `fast-switch` element requires `use-defaults` to display properly, and the new `.content-badge` shouldn't have padding.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
