### PR TITLE
fix: use margin-inline-start to fix mis-aligned thumb on slider in rtl and vertical orientation

### DIFF
--- a/packages/web-components/fast-components/src/slider/fixtures/base.html
+++ b/packages/web-components/fast-components/src/slider/fixtures/base.html
@@ -17,7 +17,7 @@
             </button>
             <button
                 style="width: 90px; margin: 10px;"
-                onclick="const slider = document.getElementById('switcher'); const currentVal = Number(slider.getAttribute('value')); slider.setAttribute('value', (currentVal + 10).toString());"
+                onclick="const slider = document.getElementById('switcher'); const currentVal = Number(slider.value); slider.value = (currentVal + 10);"
             >
                 Change slider val
             </button>

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -1,5 +1,6 @@
 import { css } from "@microsoft/fast-element";
 import {
+    DirectionalStyleSheetBehavior,
     disabledCursor,
     display,
     focusVisible,
@@ -15,6 +16,18 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/index";
+
+const ltr = css`
+    :host(.vertical) .track {
+        margin-left: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
+    }
+`;
+
+const rtl = css`
+    :host(.vertical) .track {
+        margin-right: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
+    }
+`;
 
 export const SliderStyles = css`
     :host([hidden]) {
@@ -95,7 +108,6 @@ export const SliderStyles = css`
     :host(.vertical) .track {
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
-        margin-left: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
         width: calc(var(--track-width) * 1px);
         height: 100%;
     }
@@ -125,6 +137,7 @@ export const SliderStyles = css`
     neutralForegroundRestBehavior,
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
+    new DirectionalStyleSheetBehavior(ltr, rtl),
     forcedColorsStylesheetBehavior(
         css`
             .thumb-cursor {

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -1,6 +1,5 @@
 import { css } from "@microsoft/fast-element";
 import {
-    DirectionalStyleSheetBehavior,
     disabledCursor,
     display,
     focusVisible,
@@ -16,18 +15,6 @@ import {
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
 } from "../styles/index";
-
-const ltr = css`
-    :host(.vertical) .track {
-        margin-left: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
-    }
-`;
-
-const rtl = css`
-    :host(.vertical) .track {
-        margin-right: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
-    }
-`;
 
 export const SliderStyles = css`
     :host([hidden]) {
@@ -109,6 +96,7 @@ export const SliderStyles = css`
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
         width: calc(var(--track-width) * 1px);
+        margin-inline-start: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
         height: 100%;
     }
     .track {
@@ -137,7 +125,6 @@ export const SliderStyles = css`
     neutralForegroundRestBehavior,
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
-    new DirectionalStyleSheetBehavior(ltr, rtl),
     forcedColorsStylesheetBehavior(
         css`
             .thumb-cursor {


### PR DESCRIPTION
# Description
There was a margin-left being set to align the track properly in vertical mode, but that wasn't correct in RTL. Modified css to utilize use margin-inline-start which adjusts in rtl mode appropriately.
closes #3818 

<img width="623" alt="Screen Shot 2020-08-31 at 3 33 25 PM" src="https://user-images.githubusercontent.com/25805778/91775204-5f55b000-eb9f-11ea-8d14-a8343a350816.png">


## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.


**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
