### PR TITLE
fix: mirror the arrow glyph of tree-item for rtl resting and expanded

### DIFF
--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -34,7 +34,7 @@ const ltr = css`
         left: calc(var(--focus-outline-width) * 1px);
     }
     :host(.expanded) > .positioning-region .expand-collapse-glyph {
-        ${/* transform needs to be localized */ ""} transform: rotate(0deg);
+        transform: rotate(0deg);
     }
 `;
 
@@ -49,7 +49,7 @@ const rtl = css`
         right: calc(var(--focus-outline-width) * 1px);
     }
     :host(.expanded) > .positioning-region .expand-collapse-glyph {
-        ${/* transform needs to be localized */ ""} transform: rotate(90deg);
+        transform: rotate(90deg);
     }
 `;
 

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -24,20 +24,32 @@ import { neutralFillStealthHover, neutralFillStealthSelected } from "../color/in
 import { FASTDesignSystemProvider } from "../design-system-provider/index";
 
 const ltr = css`
+    .expand-collapse-glyph {
+        transform: rotate(-45deg);
+    }
     :host(.nested) .expand-collapse-button {
         left: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
     }
     :host([selected])::after {
         left: calc(var(--focus-outline-width) * 1px);
     }
+    :host(.expanded) > .positioning-region .expand-collapse-glyph {
+        ${/* transform needs to be localized */ ""} transform: rotate(0deg);
+    }
 `;
 
 const rtl = css`
+    .expand-collapse-glyph {
+        transform: rotate(135deg);
+    }
     :host(.nested) .expand-collapse-button {
         right: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
     }
     :host([selected])::after {
         right: calc(var(--focus-outline-width) * 1px);
+    }
+    :host(.expanded) > .positioning-region .expand-collapse-glyph {
+        ${/* transform needs to be localized */ ""} transform: rotate(90deg);
     }
 `;
 
@@ -151,7 +163,7 @@ export const TreeItemStyles = css`
         } width: 16px;
         height: 16px;
         transition: transform 0.1s linear;
-        ${/* transform needs to be localized */ ""} transform: rotate(-45deg);
+
         pointer-events: none;
         fill: ${neutralForegroundRestBehavior.var};
     }
@@ -175,10 +187,6 @@ export const TreeItemStyles = css`
         ${
             /* need to swap out once we understand how horizontalSpacing will work */ ""
         } margin-inline-start: calc(var(--design-unit) * 2px + 2px);
-    }
-
-    :host(.expanded) > .positioning-region .expand-collapse-glyph {
-        ${/* transform needs to be localized */ ""} transform: rotate(0deg);
     }
 
     :host(.expanded) > .items {


### PR DESCRIPTION
# Description
Mirror the arrow glyph for rtl mode on the tree-item using direction behavior in css
closes #3800 

<img width="383" alt="Screen Shot 2020-08-31 at 4 05 30 PM" src="https://user-images.githubusercontent.com/25805778/91777399-8f538200-eba4-11ea-99f5-8a245fa0627a.png">
<img width="344" alt="Screen Shot 2020-08-31 at 4 05 34 PM" src="https://user-images.githubusercontent.com/25805778/91777408-92e70900-eba4-11ea-84e7-8929f38c9c4a.png">

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
