### PR TITLE
fix(fast-element): workaround for adoptedStyleSheets Chromium bug

### DIFF
--- a/packages/web-components/fast-element/src/template-compiler.spec.ts
+++ b/packages/web-components/fast-element/src/template-compiler.spec.ts
@@ -4,7 +4,10 @@ import { BindingDirective } from "./directives/binding";
 import { compileTemplate } from "./template-compiler";
 import { Directive } from "./directives/directive";
 import { defaultExecutionContext } from "./observation/observable";
-import { toHTML } from "./__test__/helpers";
+import { toHTML, uniqueElementName } from "./__test__/helpers";
+import { html } from "./template";
+import { css, StyleTarget } from "./styles";
+import { FASTElement, customElement } from "./fast-element";
 
 describe("The template compiler", () => {
     function compile(html: string, directives: Directive[]) {
@@ -355,4 +358,44 @@ describe("The template compiler", () => {
     });
 
     context("when compiling hosts", () => {});
+
+    if (DOM.supportsAdoptedStyleSheets) {
+        it("handles templates with adoptedStyleSheets", () => {
+            const name = uniqueElementName();
+
+            @customElement({
+                name,
+                template: html`
+                    <div></div>
+                `,
+                styles: css`
+                    :host {
+                        display: "block";
+                    }
+                `,
+            })
+            class TestElement extends FASTElement {}
+
+            const viewTemplate = html`<${name}></${name}>`;
+
+            const host = document.createElement("div");
+            document.body.appendChild(host);
+
+            const view = viewTemplate.create();
+            view.appendTo(host);
+
+            const testElement = host.firstElementChild!;
+            const shadowRoot = testElement!.shadowRoot!;
+
+            expect((shadowRoot as StyleTarget).adoptedStyleSheets!.length).to.equal(1);
+
+            view.remove();
+
+            expect((shadowRoot as StyleTarget).adoptedStyleSheets!.length).to.equal(1);
+
+            view.appendTo(host);
+
+            expect((shadowRoot as StyleTarget).adoptedStyleSheets!.length).to.equal(1);
+        });
+    }
 });

--- a/packages/web-components/fast-element/src/template-compiler.ts
+++ b/packages/web-components/fast-element/src/template-compiler.ts
@@ -210,6 +210,10 @@ export function compileTemplate(
     compileAttributes(template, directives, hostBehaviorFactories, true);
 
     const fragment = template.content;
+
+    // https://bugs.chromium.org/p/chromium/issues/detail?id=1111864
+    document.adoptNode(fragment);
+
     const viewBehaviorFactories: BehaviorFactory[] = [];
     const directiveCount = directives.length;
     const walker = DOM.createTemplateWalker(fragment);


### PR DESCRIPTION
# Description

This PR adds one line of code to ensure all compiled template content is "adopted" into the main document. This prevents a particular bug in adoptedStyleSheets that causes the style sheets to be removed if the content is shifted in and out of the document and its original document fragment.

Fixes #3670 

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
