### PR TITLE
fix: density type is a number

### DIFF
--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -140,7 +140,7 @@ export class FASTDesignSystemProvider extends DesignSystemProvider
         default: fastDesignSystemDefaults.density,
         converter: nullableNumberConverter,
     })
-    public density: 0;
+    public density: number;
 
     /**
      * The grid-unit that UI dimensions are derived from in pixels.


### PR DESCRIPTION
I see no reason for density to be type `0`