### PR TITLE
chore: typo in docs

### DIFF
--- a/sites/website/src/docs/design-systems/fast-frame.md
+++ b/sites/website/src/docs/design-systems/fast-frame.md
@@ -49,7 +49,7 @@ The FAST type ramp is exposed by the `FASTDesignSystemProvider` as CSS Custom Pr
 FAST Frame implements an adaptive color system that provides some unique advantages:
 - Ensure text meets [WCAG](https://www.w3.org/WAI/standards-guidelines/wcag/) contrast requirements.
 - Easily swap from light mode to dark, or anywhere in-between.
-- Color themeing through palette tinting.
+- Color theming through palette tinting.
 - Perceptually uniform UI across background colors.
 
 To accomplish these goals, FAST Frame makes heavy use of algorithmic colors; named colors that are a product of the Design System in which they are calculated. In the documentation below, these algorithmic colors will be referred to as [Recipes](/docs/design-systems/fast-frame#color-recipes). [Recipes](/docs/design-systems/fast-frame#color-recipes) operate on three primary inputs: [Palettes](/docs/design-systems/fast-frame#palettes), [the background color](/docs/design-systems/fast-frame#background-color), and [offsets / deltas](/docs/design-systems/fast-frame#offsets-deltas).

--- a/sites/website/src/docs/design-systems/overview.md
+++ b/sites/website/src/docs/design-systems/overview.md
@@ -42,7 +42,7 @@ const keyFrames = new KeyframeEffect(
 The Design System itself manifests through a [DesignSystemProvider](/docs/api/fast-foundation.designsystemprovider): it is the vessel through which the Design System is expressed. The [DesignSystemProvider](/docs/api/fast-foundation.designsystemprovider) is an HTML element that facilitates usage, configuration, and propagation of the Design System through a UI view. The [DesignSystemProvider](/docs/api/fast-foundation.designsystemprovider) is responsible for expressing the Design System both as a readable JavaScript property *and* as CSS custom properties.
 
 ### Design System flow
-The Design System is mutable and inherited. Think of the Design System as a flow of data through the DOM toward leaf nodes, where every [DesignSystemProvider](/docs/api/fast-foundation.designsystemprovider) element inherits Design System data from it's closest ancestor [DesignSystemProvider](/docs/api/fast-foundation.designsystemprovider) and provides opportunity to *change* that data for all descendent elements. Let's visualize this, and assume there is a `font-size-large` Design Token in the Design System:
+The Design System is mutable and inherited. Think of the Design System as a flow of data through the DOM toward leaf nodes, where every [DesignSystemProvider](/docs/api/fast-foundation.designsystemprovider) element inherits Design System data from its closest ancestor [DesignSystemProvider](/docs/api/fast-foundation.designsystemprovider) and provides opportunity to *change* that data for all descendent elements. Let's visualize this, and assume there is a `font-size-large` Design Token in the Design System:
 
 **Example: The Design System flows data down the DOM hierarchy**
 ```html


### PR DESCRIPTION
it's => its, themeing => theming