### PR TITLE
fix(fast-element): better global support for older browsers

### DIFF
--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -5,6 +5,9 @@
 ```ts
 
 // @public
+export const $global: Global;
+
+// @public
 export interface Accessor {
     getValue(source: any): any;
     name: string;
@@ -311,6 +314,11 @@ export class FASTElementDefinition<TType extends Function = Function> {
 }
 
 // @public
+export type Global = typeof globalThis & {
+    trustedTypes: TrustedTypes;
+};
+
+// @public
 export function html<TSource = any, TParent = any>(strings: TemplateStringsArray, ...values: TemplateValue<TSource, TParent>[]): ViewTemplate<TSource, TParent>;
 
 // @public
@@ -479,6 +487,16 @@ export interface SyntheticViewTemplate<TSource = any, TParent = any> {
 export type TemplateValue<TScope, TParent = any> = Binding<TScope, any, TParent> | string | number | Directive | CaptureType<TScope>;
 
 // @public
+export type TrustedTypes = {
+    createPolicy(name: string, rules: TrustedTypesPolicy): TrustedTypesPolicy;
+};
+
+// @public
+export type TrustedTypesPolicy = {
+    createHTML(html: string): string;
+};
+
+// @public
 export interface ValueConverter {
     fromView(value: any): any;
     toView(value: any): any;
@@ -508,10 +526,6 @@ export function volatile(target: {}, name: any, descriptor: any): any;
 // @public
 export function when<TSource = any, TReturn = any>(binding: Binding<TSource, TReturn>, templateOrTemplateBinding: SyntheticViewTemplate | Binding<TSource, SyntheticViewTemplate>): CaptureType<TSource>;
 
-
-// Warnings were encountered during analysis:
-//
-// dist/dts/dom.d.ts:25:5 - (ae-forgotten-export) The symbol "TrustedTypesPolicy" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-element/src/dom.ts
+++ b/packages/web-components/fast-element/src/dom.ts
@@ -1,39 +1,15 @@
 import { Callable } from "./interfaces";
+import { TrustedTypesPolicy, $global } from "./platform";
 
 const updateQueue = [] as Callable[];
-type TrustedTypesPolicy = { createHTML(html: string): string };
 
 /* eslint-disable */
-
-// Polyfill for globalThis
-declare const __magic__: any;
-
-(function () {
-    if (typeof globalThis === "object") return;
-
-    Object.defineProperty(Object.prototype, "__magic__", {
-        get: function () {
-            return this;
-        },
-        configurable: true,
-    });
-
-    __magic__.globalThis = __magic__;
-
-    delete (Object.prototype as any).__magic__;
-})();
-
-// API-only Polyfill for trustedTypes
-declare let trustedTypes: any;
-
-if (globalThis.trustedTypes === void 0) {
-    globalThis.trustedTypes = { createPolicy: (n, r) => r };
-}
-
-const fastHTMLPolicy: TrustedTypesPolicy = trustedTypes.createPolicy("fast-html", {
-    createHTML: html => html,
-});
-
+const fastHTMLPolicy: TrustedTypesPolicy = $global.trustedTypes.createPolicy(
+    "fast-html",
+    {
+        createHTML: html => html,
+    }
+);
 /* eslint-enable */
 
 let htmlPolicy: TrustedTypesPolicy = fastHTMLPolicy;

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./platform";
 export * from "./template";
 export * from "./fast-element";
 export { FASTElementDefinition, PartialFASTElementDefinition } from "./fast-definitions";

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -5,7 +5,7 @@
 export type TrustedTypesPolicy = {
     /**
      * Creates trusted HTML.
-     * @param html The HTML to clear as trustworthy.
+     * @param html - The HTML to clear as trustworthy.
      */
     createHTML(html: string): string;
 };
@@ -17,8 +17,8 @@ export type TrustedTypesPolicy = {
 export type TrustedTypes = {
     /**
      * Creates a trusted types policy.
-     * @param name The policy name.
-     * @param rules The policy rules implementation.
+     * @param name - The policy name.
+     * @param rules - The policy rules implementation.
      */
     createPolicy(name: string, rules: TrustedTypesPolicy): TrustedTypesPolicy;
 };

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -1,0 +1,80 @@
+/**
+ * A policy for use with the standard trustedTypes platform API.
+ * @public
+ */
+export type TrustedTypesPolicy = {
+    /**
+     * Creates trusted HTML.
+     * @param html The HTML to clear as trustworthy.
+     */
+    createHTML(html: string): string;
+};
+
+/**
+ * Enables working with trusted types.
+ * @public
+ */
+export type TrustedTypes = {
+    /**
+     * Creates a trusted types policy.
+     * @param name The policy name.
+     * @param rules The policy rules implementation.
+     */
+    createPolicy(name: string, rules: TrustedTypesPolicy): TrustedTypesPolicy;
+};
+
+/**
+ * The platform global type.
+ * @public
+ */
+export type Global = typeof globalThis & {
+    /**
+     * Enables working with trusted types.
+     */
+    trustedTypes: TrustedTypes;
+};
+
+declare const global: any;
+
+/**
+ * A reference to globalThis, with support
+ * for browsers that don't yet support the spec.
+ * @public
+ */
+export const $global: Global = (function () {
+    if (typeof globalThis !== "undefined") {
+        // We're running in a modern environment.
+        return globalThis;
+    }
+
+    if (typeof global !== "undefined") {
+        // We're running in NodeJS
+        return global;
+    }
+
+    if (typeof self !== "undefined") {
+        // We're running in a worker.
+        return self;
+    }
+
+    if (typeof window !== "undefined") {
+        // We're running in the browser's main thread.
+        return window;
+    }
+
+    try {
+        // Hopefully we never get here...
+        // Not all environments allow eval and Function. Use only as a last resort:
+        // eslint-disable-next-line no-new-func
+        return new Function("return this")();
+    } catch {
+        // If all fails, give up and create an object.
+        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
+        return {};
+    }
+})();
+
+// API-only Polyfill for trustedTypes
+if ($global.trustedTypes === void 0) {
+    $global.trustedTypes = { createPolicy: (n, r) => r };
+}


### PR DESCRIPTION
# Description

Third time is the charm! Apparently my `globalThis` polyfill did not work on old versions of Safari and iOS. So, this PR introduces a `$global` export based on some code I've been using for a long time. Hopefully this concludes the saga.

Fixes #3862 

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

It's possible this could be considered a breaking change since we are no longer polyfilling `globalThis` but have replaced it with our own export `$global` which we use internally.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.