### PR TITLE
feat(fast-element): enable custom element to accept a styles array

### DIFF
--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -170,6 +170,9 @@ export interface CompilationResult {
 export function compileTemplate(template: HTMLTemplateElement, directives: ReadonlyArray<Directive>): CompilationResult;
 
 // @public
+export type ComposableStyles = string | ElementStyles | CSSStyleSheet;
+
+// @public
 export class Controller extends PropertyChangeNotifier {
     // @internal
     constructor(element: HTMLElement, definition: FASTElementDefinition);
@@ -192,8 +195,6 @@ export class Controller extends PropertyChangeNotifier {
     readonly view: ElementView | null;
 }
 
-// Warning: (ae-forgotten-export) The symbol "ComposableStyles" needs to be exported by the entry point index.d.ts
-//
 // @public
 export function css(strings: TemplateStringsArray, ...values: ComposableStyles[]): ElementStyles;
 
@@ -235,11 +236,15 @@ export const DOM: Readonly<{
 export function elements(selector?: string): (value: Node, index: number, array: Node[]) => boolean;
 
 // @public
+export type ElementStyleFactory = (styles: ReadonlyArray<ComposableStyles>) => ElementStyles;
+
+// @public
 export abstract class ElementStyles {
     // @internal (undocumented)
     abstract addStylesTo(target: StyleTarget): void;
     // @internal (undocumented)
     abstract readonly behaviors: ReadonlyArray<Behavior> | null;
+    static readonly create: ElementStyleFactory;
     static find(key: string): ElementStyles | null;
     // @internal (undocumented)
     abstract removeStylesFrom(target: StyleTarget): void;
@@ -377,7 +382,7 @@ export interface PartialFASTElementDefinition {
     readonly elementOptions?: ElementDefinitionOptions;
     readonly name: string;
     readonly shadowOptions?: Partial<ShadowRootInit> | null;
-    readonly styles?: ComposableStyles;
+    readonly styles?: ComposableStyles | ComposableStyles[];
     readonly template?: ElementViewTemplate;
 }
 

--- a/packages/web-components/fast-element/docs/guide/leveraging-css.md
+++ b/packages/web-components/fast-element/docs/guide/leveraging-css.md
@@ -125,7 +125,7 @@ const styles = css`
 Rather than simply concatenating CSS strings, the `css` helper understands that `normalize` is `ElementStyles` and is able to re-use the same Constructable StyleSheet instance as any other component that uses `normalize`. 
 
 :::note
-You can also pass a CSS string or a [CSSStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet) instance directly to the element definition, without needing to use the `css` helper and it will automatically be converted into `ElementStyles`. The advantage of using the `css` helper is that it enables the rich composition and reuse of styles described above, with automatic runtime caching for memory efficiency and performance.
+You can also pass a CSS `string` or a [CSSStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet) instance directly to the element definition, or even a mixed array of `string`, `CSSStyleSheet`, or `ElementStyles`.
 :::
 
 ## Shadow DOM styling

--- a/packages/web-components/fast-element/src/fast-definitions.spec.ts
+++ b/packages/web-components/fast-element/src/fast-definitions.spec.ts
@@ -1,0 +1,116 @@
+import { expect } from "chai";
+import { DOM } from "./dom";
+import { FASTElementDefinition } from "./fast-definitions";
+import { ElementStyles } from "./styles";
+
+describe("FASTElementDefinition", () => {
+    class MyElement {}
+
+    context("styles", () => {
+        it("can accept a string", () => {
+            const styles = ".class { color: red; }";
+            const options = {
+                name: "test-element",
+                styles,
+            };
+
+            const def = new FASTElementDefinition(MyElement, options);
+            expect(def.styles!.styles).to.contain(styles);
+        });
+
+        it("can accept multiple strings", () => {
+            const css1 = ".class { color: red; }";
+            const css2 = ".class2 { color: red; }";
+            const options = {
+                name: "test-element",
+                styles: [css1, css2],
+            };
+            const def = new FASTElementDefinition(MyElement, options);
+            expect(def.styles!.styles).to.contain(css1);
+            expect(def.styles!.styles.indexOf(css1)).to.equal(0);
+            expect(def.styles!.styles).to.contain(css2);
+        });
+
+        it("can accept ElementStyles", () => {
+            const css = ".class { color: red; }";
+            const styles = ElementStyles.create([css]);
+            const options = {
+                name: "test-element",
+                styles,
+            };
+            const def = new FASTElementDefinition(MyElement, options);
+            expect(def.styles).to.equal(styles);
+        });
+
+        it("can accept multiple ElementStyles", () => {
+            const css1 = ".class { color: red; }";
+            const css2 = ".class2 { color: red; }";
+            const existingStyles1 = ElementStyles.create([css1]);
+            const existingStyles2 = ElementStyles.create([css2]);
+            const options = {
+                name: "test-element",
+                styles: [existingStyles1, existingStyles2],
+            };
+            const def = new FASTElementDefinition(MyElement, options);
+            expect(def.styles!.styles).to.contain(existingStyles1);
+            expect(def.styles!.styles.indexOf(existingStyles1)).to.equal(0);
+            expect(def.styles!.styles).to.contain(existingStyles2);
+        });
+
+        it("can accept mixed strings and ElementStyles", () => {
+            const css1 = ".class { color: red; }";
+            const css2 = ".class2 { color: red; }";
+            const existingStyles2 = ElementStyles.create([css2]);
+            const options = {
+                name: "test-element",
+                styles: [css1, existingStyles2],
+            };
+            const def = new FASTElementDefinition(MyElement, options);
+            expect(def.styles!.styles).to.contain(css1);
+            expect(def.styles!.styles.indexOf(css1)).to.equal(0);
+            expect(def.styles!.styles).to.contain(existingStyles2);
+        });
+
+        if (DOM.supportsAdoptedStyleSheets) {
+            it("can accept a CSSStyleSheet", () => {
+                const styles = new CSSStyleSheet();
+                const options = {
+                    name: "test-element",
+                    styles,
+                };
+                const def = new FASTElementDefinition(MyElement, options);
+                expect(def.styles!.styles).to.contain(styles);
+            });
+
+            it("can create from multiple CSSStyleSheets", () => {
+                const styleSheet1 = new CSSStyleSheet();
+                const styleSheet2 = new CSSStyleSheet();
+                const options = {
+                    name: "test-element",
+                    styles: [styleSheet1, styleSheet2],
+                };
+                const def = new FASTElementDefinition(MyElement, options);
+                expect(def.styles!.styles).to.contain(styleSheet1);
+                expect(def.styles!.styles.indexOf(styleSheet1)).to.equal(0);
+                expect(def.styles!.styles).to.contain(styleSheet2);
+            });
+
+            it("can create from mixed strings, ElementStyles, and CSSStyleSheets", () => {
+                const css1 = ".class { color: red; }";
+                const css2 = ".class2 { color: red; }";
+                const existingStyles2 = ElementStyles.create([css2]);
+                const styleSheet3 = new CSSStyleSheet();
+                const options = {
+                    name: "test-element",
+                    styles: [css1, existingStyles2, styleSheet3],
+                };
+                const def = new FASTElementDefinition(MyElement, options);
+                expect(def.styles!.styles).to.contain(css1);
+                expect(def.styles!.styles.indexOf(css1)).to.equal(0);
+                expect(def.styles!.styles).to.contain(existingStyles2);
+                expect(def.styles!.styles.indexOf(existingStyles2)).to.equal(1);
+                expect(def.styles!.styles).to.contain(styleSheet3);
+            });
+        }
+    });
+});

--- a/packages/web-components/fast-element/src/fast-definitions.spec.ts
+++ b/packages/web-components/fast-element/src/fast-definitions.spec.ts
@@ -82,7 +82,7 @@ describe("FASTElementDefinition", () => {
                 expect(def.styles!.styles).to.contain(styles);
             });
 
-            it("can create from multiple CSSStyleSheets", () => {
+            it("can accept multiple CSSStyleSheets", () => {
                 const styleSheet1 = new CSSStyleSheet();
                 const styleSheet2 = new CSSStyleSheet();
                 const options = {
@@ -95,7 +95,7 @@ describe("FASTElementDefinition", () => {
                 expect(def.styles!.styles).to.contain(styleSheet2);
             });
 
-            it("can create from mixed strings, ElementStyles, and CSSStyleSheets", () => {
+            it("can accept mixed strings, ElementStyles, and CSSStyleSheets", () => {
                 const css1 = ".class { color: red; }";
                 const css2 = ".class2 { color: red; }";
                 const existingStyles2 = ElementStyles.create([css2]);

--- a/packages/web-components/fast-element/src/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/fast-definitions.ts
@@ -1,5 +1,5 @@
 import { ElementViewTemplate } from "./template";
-import { ElementStyles, css, ComposableStyles } from "./styles";
+import { ElementStyles, ComposableStyles } from "./styles";
 import { AttributeConfiguration, AttributeDefinition } from "./attributes";
 import { Observable } from "./observation/observable";
 import { Mutable } from "./interfaces";
@@ -24,9 +24,9 @@ export interface PartialFASTElementDefinition {
     readonly template?: ElementViewTemplate;
 
     /**
-     * The styles to associated with the custom element.
+     * The styles to associate with the custom element.
      */
-    readonly styles?: ComposableStyles;
+    readonly styles?: ComposableStyles | ComposableStyles[];
 
     /**
      * The custom attributes of the custom element.
@@ -87,7 +87,7 @@ export class FASTElementDefinition<TType extends Function = Function> {
     public readonly template?: ElementViewTemplate;
 
     /**
-     * The styles to associated with the custom element.
+     * The styles to associate with the custom element.
      */
     public readonly styles?: ElementStyles;
 
@@ -149,12 +149,13 @@ export class FASTElementDefinition<TType extends Function = Function> {
                 : { ...defaultElementOptions, ...nameOrConfig.elementOptions };
 
         this.styles =
-            nameOrConfig.styles !== void 0 &&
-            !(nameOrConfig.styles instanceof ElementStyles)
-                ? css`
-                      ${nameOrConfig.styles}
-                  `
-                : nameOrConfig.styles;
+            nameOrConfig.styles === void 0
+                ? void 0
+                : Array.isArray(nameOrConfig.styles)
+                ? ElementStyles.create(nameOrConfig.styles)
+                : nameOrConfig.styles instanceof ElementStyles
+                ? nameOrConfig.styles
+                : ElementStyles.create([nameOrConfig.styles]);
     }
 
     /**

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -6,7 +6,13 @@ export * from "./attributes";
 export * from "./controller";
 export * from "./interfaces";
 export * from "./template-compiler";
-export { css, ElementStyles, StyleTarget } from "./styles";
+export {
+    css,
+    ElementStyles,
+    ElementStyleFactory,
+    ComposableStyles,
+    StyleTarget,
+} from "./styles";
 export * from "./view";
 export * from "./observation/observable";
 export * from "./observation/notifier";

--- a/packages/web-components/fast-element/src/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles.spec.ts
@@ -1,5 +1,10 @@
 import { expect } from "chai";
-import { AdoptedStyleSheetsStyles, StyleElementStyles, StyleTarget } from "./styles";
+import {
+    AdoptedStyleSheetsStyles,
+    StyleElementStyles,
+    StyleTarget,
+    ElementStyles,
+} from "./styles";
 import { DOM } from "./dom";
 
 if (DOM.supportsAdoptedStyleSheets) {
@@ -71,4 +76,79 @@ describe("StyleSheetStyles", () => {
 
         expect(shadowRoot.childNodes.length).to.equal(0);
     });
+});
+
+describe("ElementStyles", () => {
+    it("can create from a string", () => {
+        const css = ".class { color: red; }";
+        const styles = ElementStyles.create([css]);
+        expect(styles.styles).to.contain(css);
+    });
+
+    it("can create from multiple strings", () => {
+        const css1 = ".class { color: red; }";
+        const css2 = ".class2 { color: red; }";
+        const styles = ElementStyles.create([css1, css2]);
+        expect(styles.styles).to.contain(css1);
+        expect(styles.styles.indexOf(css1)).to.equal(0);
+        expect(styles.styles).to.contain(css2);
+    });
+
+    it("can create from an ElementStyles", () => {
+        const css = ".class { color: red; }";
+        const existingStyles = ElementStyles.create([css]);
+        const styles = ElementStyles.create([existingStyles]);
+        expect(styles.styles).to.contain(existingStyles);
+    });
+
+    it("can create from multiple ElementStyles", () => {
+        const css1 = ".class { color: red; }";
+        const css2 = ".class2 { color: red; }";
+        const existingStyles1 = ElementStyles.create([css1]);
+        const existingStyles2 = ElementStyles.create([css2]);
+        const styles = ElementStyles.create([existingStyles1, existingStyles2]);
+        expect(styles.styles).to.contain(existingStyles1);
+        expect(styles.styles.indexOf(existingStyles1)).to.equal(0);
+        expect(styles.styles).to.contain(existingStyles2);
+    });
+
+    it("can create from mixed strings and ElementStyles", () => {
+        const css1 = ".class { color: red; }";
+        const css2 = ".class2 { color: red; }";
+        const existingStyles2 = ElementStyles.create([css2]);
+        const styles = ElementStyles.create([css1, existingStyles2]);
+        expect(styles.styles).to.contain(css1);
+        expect(styles.styles.indexOf(css1)).to.equal(0);
+        expect(styles.styles).to.contain(existingStyles2);
+    });
+
+    if (DOM.supportsAdoptedStyleSheets) {
+        it("can create from a CSSStyleSheet", () => {
+            const styleSheet = new CSSStyleSheet();
+            const styles = ElementStyles.create([styleSheet]);
+            expect(styles.styles).to.contain(styleSheet);
+        });
+
+        it("can create from multiple CSSStyleSheets", () => {
+            const styleSheet1 = new CSSStyleSheet();
+            const styleSheet2 = new CSSStyleSheet();
+            const styles = ElementStyles.create([styleSheet1, styleSheet2]);
+            expect(styles.styles).to.contain(styleSheet1);
+            expect(styles.styles.indexOf(styleSheet1)).to.equal(0);
+            expect(styles.styles).to.contain(styleSheet2);
+        });
+
+        it("can create from mixed strings, ElementStyles, and CSSStyleSheets", () => {
+            const css1 = ".class { color: red; }";
+            const css2 = ".class2 { color: red; }";
+            const existingStyles2 = ElementStyles.create([css2]);
+            const styleSheet3 = new CSSStyleSheet();
+            const styles = ElementStyles.create([css1, existingStyles2, styleSheet3]);
+            expect(styles.styles).to.contain(css1);
+            expect(styles.styles.indexOf(css1)).to.equal(0);
+            expect(styles.styles).to.contain(existingStyles2);
+            expect(styles.styles.indexOf(existingStyles2)).to.equal(1);
+            expect(styles.styles).to.contain(styleSheet3);
+        });
+    }
 });


### PR DESCRIPTION
# Description

This PR enables the `PartialFASTElementDefinition` used by the `@customElement` decorator and `FASTElementDefinition` class to receive an array of `ComposableStyle` instances in addition to the previously supported single instance. Additionally, `ElementStyles.create` has been exposed as an imperative mechanism for creating `ElementStyles` instances and is now used internally by the `FASTElementDefinition` and `css` helper.

## Motivation & context

Closes #3868

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.