### PR TITLE
feat:  Anchored region reliability/perf improvements

### DIFF
--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
@@ -27,8 +27,8 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
         const scalingViewportOffset: HTMLElement | null = document.getElementById(
             "viewport-scaling-offset"
         );
-        if (scalingViewportUpdate !== null) {
-            scalingViewportUpdate.addEventListener("scroll", handleScrollViaOffset);
+        if (scalingViewportOffset !== null) {
+            scalingViewportOffset.addEventListener("scroll", handleScrollViaOffset);
         }
     }
 });

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -449,36 +449,6 @@
             </div>
         </div>
 
-        <h4>Force getBoundingClientRect</h4>
-        <div
-            id="viewport-forcegbcr"
-            style="
-                position: relative;
-                height: 400px;
-                width: 400px;
-                background: lightgray;
-                overflow: scroll;
-            "
-        >
-            <div style="height: 1000px; width: 1000px;">
-                <button
-                    id="anchor-forcegbcr"
-                    style="margin-left: 500px; margin-top: 500px;"
-                >
-                    anchor
-                </button>
-                <fast-anchored-region
-                    use-gbcr="never"
-                    anchor="anchor-forcegbcr"
-                    viewport="viewport-forcegbcr"
-                    vertical-positioning-mode="dynamic"
-                    horizontal-positioning-mode="dynamic"
-                >
-                    <div style="height: 100px; width: 100px; background: yellow;"></div>
-                </fast-anchored-region>
-            </div>
-        </div>
-
         <h4>Start & End</h4>
         <div
             id="viewport-se"

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -12,7 +12,7 @@ It is envisioned that this component would be used as a building block for other
 
 - **Relative positioning:** Users can use it to position an element relative to another another element, like enabling a menu to open above or below a trigger button. Additionally, the same anchored region can change which element it is anchored to dynamically, for example a single tooltip instance in a page could be positioned next to any other element on the page by switching the anchor property of the anchored region that contains it.
 
-- **Responsive positioning:** Users can use it to position an element relative to another element based on available space, for example a menu could open upwards if the trigger button is near the bottom of the page, and downwards if it is nearer the top.
+- **Responsive positioning:** Users can use it to position an element relative to another element based on available space, for example a menu could open upwards if the trigger button is near the bottom of the page, and downwards if it is nearer the top.  Authors can call the component's update() function to reevaluate positioning.
 
 - **Responsive scaling:** Users can use it to create a layout region that dynamically sizes depending on space between the anchor and the viewport elements.
 
@@ -20,7 +20,7 @@ It is envisioned that this component would be used as a building block for other
 For a more in-depth understanding of how this component works under the covers please refer to the [intersection observer api](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). 
 
 ### Risks and Challenges
-- see discussion of `getBoundingClientRect` usage in the "Performance" section below.
+- must keep an eye on performance
 
 ---
 
@@ -190,7 +190,6 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 - vertical-inset - Boolean that indicates whether the region should overlap the anchor on the vertical axis. Default is false which places the region adjacent to the anchor element.
 - vertical-threshold - Numeric value that defines how small the region must be to the edge of the viewport to switch to the opposite side of the anchor. The component favors the default position until this value is crossed.  When there is not enough space on either side or the value is unset the side with the most space is chosen.
 - vertical-scaling - Can be 'anchor', 'fill' or 'content'. Default is 'content' 
-- use-gbcr - Whether the component uses calls to `getBoundingClientRect` to calculate positioning. Can be 'default', 'always' or 'never'.  Default behavior attempts to use gbcr if the initial attempt to use [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) fails to return usable data. 
 
 *Properties:*
 - anchorElement - Holds a reference to the HTMLElement currently being used as the anchor.  Can be set directly or be populated by setting the anchor attribute.
@@ -232,9 +231,10 @@ The anchored region is essentially a container around the slotted items.
 ## Implementation
 
 ### States
-Layout update checks in the component happen when:
-- intersection observer reports a collision with the viewport
-- resize observer reports a resize event on the anchor, the viewport, the component's `offsetParent` or the component itself.
+Positioning update checks in the component happen when:
+- an attribute or property is changed on the component
+- the component's "update()" function is called
+- resize observer reports a resize event on the anchor or the component itself.
 
 These layout checks analyse the DOM geometry based on callbacks and repositions the anchored region appropriately: top/bottom/unset for the vertical axis and left/right/unset for the horizontal axis. 
 
@@ -247,11 +247,7 @@ None required.  Basically a positioned div that authors can decorate for accessi
 Authors may want to change default position from left to right or vice versa based on rtl settings, but that can't be predicted by the component itself.
 
 ### Performance
-The component needs information about the geometry of the surrounding DOM in order to function and it acquires this through either [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) events or calls to `getBoundingClientRect`.  
-
-By default the component relies on observer events, but in some cases that data may not be usable such as when there is an intervening element in the DOM hierarchy between the viewport and the anchor or the region itself.  When the component detects this condition it is able to fall back to expensive calls to `getBoundingClientRect`.
-
-Developers can use the "use-gbcr" attribute to limit this behavior to either always use calls to `getBoundingClientRect` to skip the cost of even trying to use the observer to begin with, or 'never' to block gbcr completely (presumably changing other aspects of their layout to allow the observer to function).
+The component uses [IntersectionObserver](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) events to determine positioning rather than more demanding calls to getBoundingClientRect.  Further performance improvements, like perhaps sharing a singleton intersection observer instance across anchored regions, should be considered.
 
 ### Dependencies
 [IntersectionObserver api](https://developer.mozilla.org/en-US/docs/Web/API/IntersectionObserver) is unsupported on IE, and [ResizeObserver](https://developer.mozilla.org/en-US/docs/Web/API/ResizeObserver) is unsupported on IE, Safari and Firefox.  Both are required by the component.  Authors who wish to use this component on these platforms will need to use polyfills.

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -368,7 +368,6 @@ export class AnchoredRegion extends FASTElement {
      * update position
      */
     public update = (): void => {
-
         if (this.viewportRect === null || this.regionDimension === null) {
             this.requestLayoutUpdate();
             return;
@@ -503,14 +502,11 @@ export class AnchoredRegion extends FASTElement {
      */
     private initializeIntersectionDetector = (): void => {
         this.disconnectIntersectionDetector();
-        this.intersectionDetector = new IntersectionObserver(
-            this.handleIntersection,
-            {
-                root: null,
-                rootMargin: "0px",
-                threshold: [0, 1],
-            }
-        );
+        this.intersectionDetector = new IntersectionObserver(this.handleIntersection, {
+            root: null,
+            rootMargin: "0px",
+            threshold: [0, 1],
+        });
     };
 
     /**
@@ -521,8 +517,8 @@ export class AnchoredRegion extends FASTElement {
 
         if (
             this.anchorElement === null ||
-            ((this.viewportElement !== null) &&
-            !this.viewportElement.contains(this.anchorElement))
+            (this.viewportElement !== null &&
+                !this.viewportElement.contains(this.anchorElement))
         ) {
             return;
         }
@@ -539,10 +535,7 @@ export class AnchoredRegion extends FASTElement {
      * starts intersection observer
      */
     private startIntersectionObserver = (): void => {
-        if (
-            this.anchorElement === null ||
-            this.pendingPositioningUpdate
-        ) {
+        if (this.anchorElement === null || this.pendingPositioningUpdate) {
             return;
         }
         if (this.intersectionDetector !== null) {
@@ -608,7 +601,6 @@ export class AnchoredRegion extends FASTElement {
      *  Handle intersections
      */
     private handleIntersection = (entries: IntersectionObserverEntry[]): void => {
-
         this.stopIntersectionObserver();
 
         let regionRect: DOMRect | ClientRect | null = null;


### PR DESCRIPTION
# Description
The current version of anchored region falls back to call to expensive getBoundingClientRect calls in circumstances when the provided viewport/anchor pair doesn't "work" with intersection observer as can happen with intervening "position: fixed" elements in the dom hierarchy.  I recently discovered that intersection observer seems to always work at returning an initial event with valid entries for any element when the viewport is null, so I modified anchored region to take advantage of that for reliability and performance.

The cost of this change is that anchored region no longer attempts to watch for intersection events to update its position, but instead with only update itself when prompted by a call to its "update()" function, when an attribute or property is changed, or when the anchor element or the component itself is resized.  

This hopefully gets us out of having to explain why the component behaves differently based on the local DOM structure  (many devs are not very familiar with the intricacies of intersection observer api).

## Motivation & context
Anchored region performance and reliability.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [x] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!-