### PR TITLE
fix: radio button should not be unselected with mouse click

### DIFF
--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -165,8 +165,8 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
      * @internal
      */
     public clickHandler = (e: MouseEvent): void => {
-        if (!this.disabled && !this.readOnly) {
-            this.checked = !this.checked;
+        if (!this.disabled && !this.readOnly && !this.checked) {
+            this.checked = true;
         }
     };
 }


### PR DESCRIPTION
# Description

If a radio button has been checked, clicking it again with the mouse should not toggle it to unchecked.
closes #3887 

## Motivation & context

Looking at the behavior on
https://www.w3.org/TR/2016/WD-wai-aria-practices-1.1-20160317/examples/radio/radio.html
and
https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/radio

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
