### PR TITLE
fix: tree-view right and left arrow keyboarding should behave as wai-aria spec suggests

### DIFF
--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -235,10 +235,17 @@ export class TreeItem extends FASTElement {
             return;
         }
 
-        if (!this.expanded) {
+        if (!this.expanded && this.childItemLength() > 0) {
             this.setExpanded(true);
         } else {
-            this.focusNextNode(1);
+            if (this.childItems.length > 0) {
+                const childTreeItems: HTMLElement[] = this.childItems.filter(
+                    (item: HTMLElement) => {
+                        return isTreeItemElement(item);
+                    }
+                );
+                childTreeItems[0].focus();
+            }
         }
     }
 

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -215,9 +215,15 @@ export class TreeItem extends FASTElement {
         return isTreeItemElement(this.parentElement as Element);
     };
 
-    private childTreeItems(): HTMLElement[] {
+    private allChildTreeItems(): HTMLElement[] {
         return this.childItems.filter((item: HTMLElement) => {
             return isTreeItemElement(item);
+        });
+    }
+
+    private enabledChildTreeItems(): HTMLElement[] {
+        return this.childItems.filter((item: HTMLElement) => {
+            return isTreeItemElement(item) && !item.hasAttribute("disabled");
         });
     }
 
@@ -245,7 +251,7 @@ export class TreeItem extends FASTElement {
             this.setExpanded(true);
         } else {
             if (this.childItemLength() > 0) {
-                this.childTreeItems()[0].focus();
+                this.enabledChildTreeItems()[0].focus();
             }
         }
     }

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -215,6 +215,12 @@ export class TreeItem extends FASTElement {
         return isTreeItemElement(this.parentElement as Element);
     };
 
+    private childTreeItems(): HTMLElement[] {
+        return this.childItems.filter((item: HTMLElement) => {
+            return isTreeItemElement(item);
+        });
+    }
+
     private handleArrowLeft(): void {
         if (this.expanded) {
             this.setExpanded(false);
@@ -238,13 +244,8 @@ export class TreeItem extends FASTElement {
         if (!this.expanded && this.childItemLength() > 0) {
             this.setExpanded(true);
         } else {
-            if (this.childItems.length > 0) {
-                const childTreeItems: HTMLElement[] = this.childItems.filter(
-                    (item: HTMLElement) => {
-                        return isTreeItemElement(item);
-                    }
-                );
-                childTreeItems[0].focus();
+            if (this.childItemLength() > 0) {
+                this.childTreeItems()[0].focus();
             }
         }
     }

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -80,6 +80,9 @@ export class TreeItem extends FASTElement {
                     (node as TreeItem).nested = true;
                 }
             });
+            this.enabledChildTreeItems = this.items.filter((item: HTMLElement) => {
+                return isTreeItemElement(item) && !item.hasAttribute("disabled");
+            });
         }
     }
 
@@ -93,6 +96,7 @@ export class TreeItem extends FASTElement {
     public renderCollapsedChildren: boolean;
 
     private notifier: Notifier;
+    private enabledChildTreeItems: HTMLElement[] = [];
 
     private getParentTreeNode(): HTMLElement | null | undefined {
         const parentNode: Element | null | undefined = this.parentElement!.closest(
@@ -215,18 +219,6 @@ export class TreeItem extends FASTElement {
         return isTreeItemElement(this.parentElement as Element);
     };
 
-    private allChildTreeItems(): HTMLElement[] {
-        return this.childItems.filter((item: HTMLElement) => {
-            return isTreeItemElement(item);
-        });
-    }
-
-    private enabledChildTreeItems(): HTMLElement[] {
-        return this.childItems.filter((item: HTMLElement) => {
-            return isTreeItemElement(item) && !item.hasAttribute("disabled");
-        });
-    }
-
     private handleArrowLeft(): void {
         if (this.expanded) {
             this.setExpanded(false);
@@ -250,9 +242,8 @@ export class TreeItem extends FASTElement {
         if (!this.expanded && this.childItemLength() > 0) {
             this.setExpanded(true);
         } else {
-            const childTreeItems: HTMLElement[] = this.enabledChildTreeItems();
-            if (childTreeItems.length > 0) {
-                childTreeItems[0].focus();
+            if (this.enabledChildTreeItems.length > 0) {
+                this.enabledChildTreeItems[0].focus();
             }
         }
     }

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -250,8 +250,9 @@ export class TreeItem extends FASTElement {
         if (!this.expanded && this.childItemLength() > 0) {
             this.setExpanded(true);
         } else {
-            if (this.childItemLength() > 0) {
-                this.enabledChildTreeItems()[0].focus();
+            const childTreeItems: HTMLElement[] = this.enabledChildTreeItems();
+            if (childTreeItems.length > 0) {
+                childTreeItems[0].focus();
             }
         }
     }


### PR DESCRIPTION
# Description
* fixed a bug where hitting right arrow key on leaf node would mess up the next left arrow keydown
* right arrow key expands a node if not expanded, or moves to first child, or does nothing

closes #3886 

## Motivation & context
Expected keyboarding behavior for arrow keys and an example in action
https://w3c.github.io/aria-practices/#TreeView
https://w3c.github.io/aria-practices/examples/treeview/treeview-2/treeview-2a.html

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.


- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
