### PR TITLE
fix: cursor should be disabledCursor when switch is readonly or disabled, otherwise pointer

### DIFF
--- a/packages/web-components/fast-components/src/switch/fixtures/base.html
+++ b/packages/web-components/fast-components/src/switch/fixtures/base.html
@@ -11,7 +11,7 @@
             <span slot="checked-message">On</span>
             <span slot="unchecked-message">Off</span>
         </fast-switch>
-        <fast-switch disabled>
+        <fast-switch>
             Theme
             <span slot="checked-message">Dark</span>
             <span slot="unchecked-message">Light</span>

--- a/packages/web-components/fast-components/src/switch/fixtures/base.html
+++ b/packages/web-components/fast-components/src/switch/fixtures/base.html
@@ -11,10 +11,15 @@
             <span slot="checked-message">On</span>
             <span slot="unchecked-message">Off</span>
         </fast-switch>
-        <fast-switch>
+        <fast-switch disabled>
             Theme
             <span slot="checked-message">Dark</span>
             <span slot="unchecked-message">Light</span>
+        </fast-switch>
+        <fast-switch readonly checked>
+            Readonly
+            <span slot="checked-message">Yes</span>
+            <span slot="unchecked-message">No</span>
         </fast-switch>
     </div>
 

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -63,10 +63,17 @@ export const SwitchStyles = css`
         border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
     }
 
-    :host(:not([disabled])) .switch:hover {
+    .switch:hover {
         background: ${neutralFillInputHoverBehavior.var};
         border-color: ${neutralOutlineHoverBehavior.var};
         cursor: pointer;
+    }
+
+    host([disabled]) .switch:hover,
+    host([readonly]) .switch:hover {
+        background: ${neutralFillInputHoverBehavior.var};
+        border-color: ${neutralOutlineHoverBehavior.var};
+        cursor: ${disabledCursor};
     }
 
     :host(:not([disabled])) .switch:active {
@@ -97,6 +104,11 @@ export const SwitchStyles = css`
         line-height: var(--type-ramp-base-line-height);
     }
 
+    :host([disabled]) .status-message,
+    :host([readonly]) .status-message {
+        cursor: ${disabledCursor};
+    }
+
     .label {
         color: ${neutralForegroundRestBehavior.var};
 
@@ -105,6 +117,7 @@ export const SwitchStyles = css`
         } margin-inline-end: calc(var(--design-unit) * 2px + 2px);
         font-size: var(--type-ramp-base-font-size);
         line-height: var(--type-ramp-base-line-height);
+        cursor: pointer;
     }
 
     .label__hidden {


### PR DESCRIPTION
# Description
When hovering over any part of switch the cursor should be the disabled cursor if the control is readonly or disabled and pointer otherwise

closes #3893 

Style changes only, and added test of readonly in the fixture
![switch-readonly-take2](https://user-images.githubusercontent.com/25805778/93118923-da29cb00-f675-11ea-82fc-b4722359f261.jpg)


## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
