### PR TITLE
fix: ensure badge always applies inline-style when attributes exist

### DIFF
--- a/packages/web-components/fast-foundation/src/badge/badge.template.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.template.ts
@@ -7,14 +7,7 @@ import { Badge } from "./badge";
  */
 export const BadgeTemplate = html<Badge>`
     <template class="${x => (x.circular ? "circular" : "")}">
-        <div
-            class="control"
-            part="control"
-            style="${x =>
-                x.fill || x.color
-                    ? `background-color: var(--badge-fill-${x.fill}); color: var(--badge-color-${x.color})`
-                    : void 0}"
-        >
+        <div class="control" part="control" style="${x => x.generateBadgeStyle()}">
             <slot></slot>
         </div>
     </template>

--- a/packages/web-components/fast-foundation/src/badge/badge.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.ts
@@ -41,7 +41,7 @@ export class Badge extends FASTElement {
         if (!this.fill && !this.color) {
             return;
         }
-        
+
         const fill: string = `background-color: var(--badge-fill-${this.fill});`;
         const color: string = `color: var(--badge-color-${this.color});`;
 

--- a/packages/web-components/fast-foundation/src/badge/badge.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.ts
@@ -36,4 +36,21 @@ export class Badge extends FASTElement {
      */
     @attr({ mode: "boolean" })
     public circular: boolean;
+
+    public generateBadgeStyle = () => {
+        if (!this.fill && !this.color) {
+            return;
+        }
+        
+        const fill: string = `background-color: var(--badge-fill-${this.fill});`;
+        const color: string = `color: var(--badge-color-${this.color});`;
+
+        if (this.fill && !this.color) {
+            return fill;
+        } else if (this.color && !this.fill) {
+            return color;
+        } else {
+            return `${color} ${fill}`;
+        }
+    };
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
The badge component had odd behavior when passing inline styles and there was a scenario you could end up in where nothing would be applied if fill was not passed. This change creates a function to ensure attributes are handled correctly here.

<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->