### PR TITLE
fix: remove placeholder functions for boolean attributes in dialog component

### DIFF
--- a/packages/web-components/fast-foundation/src/dialog/dialog.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.ts
@@ -118,7 +118,7 @@ export class Dialog extends FASTElement {
         document.removeEventListener("keydown", this.handleDocumentKeydown);
 
         // if we are trapping focus remove the focusin listener
-        if (this.shouldDialogTrapFocus()) {
+        if (this.trapFocus) {
             document.removeEventListener("focusin", this.handleDocumentFocus);
         }
     }
@@ -134,7 +134,7 @@ export class Dialog extends FASTElement {
     }
 
     private trapFocusChanged = (): void => {
-        if (this.shouldDialogTrapFocus()) {
+        if (this.trapFocus) {
             // Add an event listener for focusin events if we should be trapping focus
             document.addEventListener("focusin", this.handleDocumentFocus);
 
@@ -149,7 +149,7 @@ export class Dialog extends FASTElement {
     };
 
     private handleDocumentKeydown = (e: KeyboardEvent): void => {
-        if (!e.defaultPrevented && !this.isDialogHidden()) {
+        if (!e.defaultPrevented && !this.hidden) {
             switch (e.keyCode) {
                 case keyCodeEscape:
                     this.dismiss();
@@ -170,7 +170,7 @@ export class Dialog extends FASTElement {
     };
 
     private handleTabKeyDown = (e: KeyboardEvent): void => {
-        if (!this.shouldDialogTrapFocus()) {
+        if (!this.trapFocus) {
             return;
         }
 
@@ -209,26 +209,6 @@ export class Dialog extends FASTElement {
      * we should only focus if focus has not already been brought to the dialog
      */
     private shouldForceFocus = (currentFocusElement: Element | null): boolean => {
-        return !this.isDialogHidden() && !this.contains(currentFocusElement);
+        return !this.hidden && !this.contains(currentFocusElement);
     };
-
-    /**
-     * TODO: Issue #2742 - https://github.com/microsoft/fast/issues/2742
-     * This is a placeholder function to check if the hidden attribute is present
-     * Currently there is not support for boolean attributes.
-     * Once support is added, we will simply use this.hidden.
-     */
-    private isDialogHidden(): boolean {
-        return typeof this.hidden !== "boolean";
-    }
-
-    /**
-     * TODO: Issue #2742 - https://github.com/microsoft/fast/issues/2742
-     * This is a placeholder function to check if the trapFocus attribute is present
-     * Currently there is not support for boolean attributes.
-     * Once support is added, we will simply use this.trapFocus.
-     */
-    private shouldDialogTrapFocus(): boolean {
-        return typeof this.trapFocus === "boolean";
-    }
 }


### PR DESCRIPTION
# Description

Ran into this while trying to hide the Dialog component in order to apply some CSS transitions, where it would still trap focus when hidden. The related issue is closed and the project tests pass after making the change (and my hidden dialogues no longer trap the focus).

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

Changes the dialog component, but doesn't change any part of the public interface.

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.