### PR TITLE
fix: allow null attributes when mapping from Monaco editor values to be treated as booleans

### DIFF
--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.spec.ts
@@ -158,6 +158,31 @@ describe("mapVSCodeParsedHTMLToDataDictionary", () => {
             },
         });
     });
+    test("should return a DataDictionary containing an HTML element with a JSON schema unspecified null attribute if an HTML element with a null attribute has been passed", () => {
+        const value = mapVSCodeParsedHTMLToDataDictionary({
+            value: ["<input data-id />"],
+            schemaDictionary: {
+                [inputSchema.id]: inputSchema,
+            },
+        });
+        const root: string = value[1];
+        expect(value[0][root]).toEqual({
+            schemaId: inputSchema.id,
+            data: {
+                "data-id": true,
+            },
+        });
+    });
+    test("should return a DataDictionary containing an HTML element with a JSON schema unspecified half written string attribute if an HTML element with an incomplete attribute has been passed", () => {
+        expect(() => {
+            mapVSCodeParsedHTMLToDataDictionary({
+                value: ["<input data-id= bar />"],
+                schemaDictionary: {
+                    [inputSchema.id]: inputSchema,
+                },
+            });
+        }).not.toThrow();
+    });
     test("should return a DataDictionary containing an HTML element nested inside another HTML element", () => {
         const value = mapVSCodeParsedHTMLToDataDictionary({
             value: ["<div>", "<input />", "</div>"],

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.ts
@@ -48,7 +48,14 @@ function mapAttributesAndSlotsToData(
                     return [attributeKey, parseFloat(JSON.parse(attributeValue))];
                 }
             }
-            return [attributeKey, JSON.parse(attributeValue)];
+
+            try {
+                const parsedValue = JSON.parse(attributeValue);
+
+                return [attributeKey, parsedValue === null ? true : parsedValue];
+            } catch (e) {
+                return [attributeKey, ""];
+            }
         })
         .reduce((previousValue, currentValue) => {
             return {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Changes the parser to attempt to parse an attribute as a string, when it is null (no value but present) it is considered `true`, and when an incomplete attribute is passed it is treated as an empty string.

An example of this:
```html
<input required />
```

Although `required` is considered `true`, the value from `vscode-html-languageservice` is `null`.

Additionally, an error will throw while typing in the Monaco editor because when "=" is passed after an attribute it will evaluate to a non-parsable string. This will be overcome by simply passing an empty string back when the value cannot be parsed.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->