### PR TITLE
fix: adds constraint validation to all form-associated elements

### DIFF
--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -393,11 +393,12 @@ export abstract class FormAssociated<T extends HTMLInputElement | HTMLTextAreaEl
     protected abstract proxy: T;
     reportValidity(): boolean;
     required: boolean;
-    protected requiredChanged(): void;
+    protected requiredChanged(prev: boolean, next: boolean): void;
     protected setFormValue(value: File | string | FormData | null, state?: File | string | FormData | null): void;
     // Warning: (ae-forgotten-export) The symbol "ValidityStateFlags" needs to be exported by the entry point index.d.ts
     // Warning: (ae-forgotten-export) The symbol "HTMLElement" needs to be exported by the entry point index.d.ts
     setValidity(flags: ValidityStateFlags, message?: string, anchor?: HTMLElement_2): void;
+    protected validate(): void;
     get validationMessage(): string;
     get validity(): ValidityState;
     value: string;
@@ -823,14 +824,10 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     // (undocumented)
     protected proxy: HTMLInputElement;
     readOnly: boolean;
-    // (undocumented)
-    protected requiredChanged(): void;
     size: number;
     spellcheck: boolean;
     type: TextFieldType;
-    // (undocumented)
-    protected valueChanged(prev: string, next: string): void;
-}
+    }
 
 // @internal
 export interface TextField extends StartEnd, DelegatesARIATextbox {

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -823,10 +823,14 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     // (undocumented)
     protected proxy: HTMLInputElement;
     readOnly: boolean;
+    // (undocumented)
+    protected requiredChanged(): void;
     size: number;
     spellcheck: boolean;
     type: TextFieldType;
-    }
+    // (undocumented)
+    protected valueChanged(prev: string, next: string): void;
+}
 
 // @internal
 export interface TextField extends StartEnd, DelegatesARIATextbox {

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
@@ -279,4 +279,28 @@ describe("Checkbox", () => {
             await disconnect();
         });
     });
+
+    describe("that is required", () => {
+        it("should be invalid when unchecked", async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+
+            element.required = true;
+            element.checked = false;
+
+            expect(element.validity.valueMissing).to.equal(true);
+
+            await disconnect();
+        });
+        it("should be valid when checked", async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+
+            element.required = true;
+            element.checked = true;
+
+            expect(element.validity.valueMissing).to.equal(false);
+            await disconnect();
+        });
+    });
 });

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -90,6 +90,8 @@ export class Checkbox extends FormAssociated<HTMLInputElement> {
         if (this.constructed) {
             this.$emit("change");
         }
+
+        this.validate();
     }
 
     protected proxy: HTMLInputElement = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -213,6 +213,7 @@ export abstract class FormAssociated<
         }
 
         this.setFormValue(this.value);
+        this.validate();
     }
 
     /**
@@ -319,12 +320,13 @@ export abstract class FormAssociated<
      * They must be sure to invoke `super.requiredChanged(previous, next)` to ensure
      * proper functioning of `FormAssociated`
      */
-    protected requiredChanged(): void {
+    protected requiredChanged(prev: boolean, next: boolean): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.required = this.required;
         }
 
         DOM.queueUpdate(() => this.classList.toggle("required", this.required));
+        this.validate();
     }
 
     /**
@@ -470,6 +472,16 @@ export abstract class FormAssociated<
     protected detachProxy() {
         this.removeChild(this.proxy);
         this.shadowRoot?.removeChild(this.proxySlot as HTMLSlotElement);
+    }
+
+    /**
+     * Sets the validity of the custom element. By default this uses the proxy element to determine
+     * validity, but this can be extended or replaced in implementation.
+     */
+    protected validate() {
+        if (this.proxy instanceof HTMLElement) {
+            this.setValidity(this.proxy.validity, this.proxy.validationMessage);
+        }
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/radio/radio.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.spec.ts
@@ -266,4 +266,31 @@ describe("Radio", () => {
             await disconnect();
         });
     });
+
+    describe("that is required", () => {
+        it("should be invalid when not checked", async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+            element.name = "name";
+            element.required = true;
+            element.value = "test";
+            expect(element.validity.valueMissing).to.equal(true);
+
+            await disconnect();
+        });
+
+        it("should be valid when checked", async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+
+            element.name = "name";
+            element.value = "test";
+            element.required = true;
+            element.checked = true;
+
+            expect(element.validity.valueMissing).to.equal(false);
+
+            await disconnect();
+        });
+    });
 });

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -132,6 +132,7 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
         super.connectedCallback();
 
         this.proxy.setAttribute("type", "radio");
+        this.validate();
 
         if (
             this.parentElement?.getAttribute("role") !== "radiogroup" &&
@@ -141,6 +142,7 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
                 this.setAttribute("tabindex", "0");
             }
         }
+
         this.updateForm();
     }
 

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -112,6 +112,8 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
         this.$emit("change");
         this.checkedAttribute = this.checked;
         this.updateForm();
+
+        this.validate();
     }
 
     protected proxy: HTMLInputElement = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -147,6 +147,8 @@ export class Slider extends FormAssociated<HTMLInputElement>
         if (this.proxy instanceof HTMLElement) {
             this.proxy.min = `${this.min}`;
         }
+
+        this.validate;
     }
 
     /**
@@ -162,6 +164,7 @@ export class Slider extends FormAssociated<HTMLInputElement>
         if (this.proxy instanceof HTMLElement) {
             this.proxy.max = `${this.max}`;
         }
+        this.validate();
     }
 
     /**
@@ -176,6 +179,8 @@ export class Slider extends FormAssociated<HTMLInputElement>
         if (this.proxy instanceof HTMLElement) {
             this.proxy.step = `${this.step}`;
         }
+
+        this.validate();
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/switch/switch.spec.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.spec.ts
@@ -231,4 +231,28 @@ describe("Switch", () => {
             await disconnect();
         });
     });
+
+    describe("that is required", () => {
+        it("should be invalid when unchecked", async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+
+            element.required = true;
+            element.checked = false;
+
+            expect(element.validity.valueMissing).to.equal(true);
+
+            await disconnect();
+        });
+        it("should be valid when checked", async () => {
+            const { element, connect, disconnect } = await setup();
+            await connect();
+
+            element.required = true;
+            element.checked = true;
+
+            expect(element.validity.valueMissing).to.equal(false);
+            await disconnect();
+        });
+    });
 });

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -92,6 +92,8 @@ export class Switch extends FormAssociated<HTMLInputElement> {
         this.$emit("change");
 
         this.checked ? this.classList.add("checked") : this.classList.remove("checked");
+
+        this.validate();
     }
 
     protected proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/text-field/text-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.spec.ts
@@ -4,12 +4,11 @@ import { fixture } from "../fixture";
 import { TextField, TextFieldTemplate as template, TextFieldTemplate } from "./index";
 import { TextFieldType } from "./text-field";
 
-
 @customElement({
     name: "fast-text-field",
     template,
 })
-class FASTTextField extends TextField { }
+class FASTTextField extends TextField {}
 
 async function setup() {
     const { element, connect, disconnect } = await fixture<FASTTextField>(
@@ -502,38 +501,53 @@ describe("TextField", () => {
             .forEach(type => {
                 describe(`of [type="${type}"]`, () => {
                     describe("that is [required]", () => {
-                        it("should be invalid when it's value property is an empty string", () => {
-                            const el = document.createElement("fast-text-field") as TextField;
-                            el.type = type;
-                            el.required = true;
-                            el.value = "";
+                        it("should be invalid when it's value property is an empty string", async () => {
+                            const { element, connect, disconnect } = await setup();
+                            await connect();
 
-                            expect(el.validity.valueMissing).to.equal(true);
+                            element.type = type;
+                            element.required = true;
+                            element.value = "";
+
+                            expect(element.validity.valueMissing).to.equal(true);
+
+                            await disconnect();
                         });
 
-                        it("should be valid when value property is a string that is non-empty", () => {
-                            const el = document.createElement("fast-text-field") as TextField;
-                            el.type = type;
+                        it("should be valid when value property is a string that is non-empty", async () => {
+                            const { element, connect, disconnect } = await setup();
+                            await connect();
 
-                            el.required = true;
-                            el.value = "some value";
+                            element.type = type;
 
-                            expect(el.validity.valueMissing).to.equal(false);
+                            element.required = true;
+                            element.value = "some value";
+
+                            expect(element.validity.valueMissing).to.equal(false);
+                            await disconnect();
                         });
                     });
                     describe("that has a [minlength] attribute", () => {
-                        it("should be valid if the value is an empty string", () => {
+                        it("should be valid if the value is an empty string", async () => {
+                            const { element, connect, disconnect } = await setup();
+                            await connect();
                             const value = "";
-                            const el = document.createElement("fast-text-field") as TextField;
+                            const el = document.createElement(
+                                "fast-text-field"
+                            ) as TextField;
                             el.type = type;
                             el.value = value;
                             el.minlength = value.length + 1;
 
                             expect(el.validity.tooShort).to.equal(false);
                         });
-                        it("should be valid if the value has a length less than the minlength", () => {
+                        it("should be valid if the value has a length less than the minlength", async () => {
+                            const { element, connect, disconnect } = await setup();
+                            await connect();
                             const value = "value";
-                            const el = document.createElement("fast-text-field") as TextField;
+                            const el = document.createElement(
+                                "fast-text-field"
+                            ) as TextField;
                             el.type = type;
                             el.value = value;
                             el.minlength = value.length + 1;
@@ -543,95 +557,108 @@ describe("TextField", () => {
                     });
 
                     describe("that has a [maxlength] attribute", () => {
-                        it("should be valid if the value is an empty string", () => {
+                        it("should be valid if the value is an empty string", async () => {
+                            const { element, connect, disconnect } = await setup();
+                            await connect();
+
                             const value = "";
-                            const el = document.createElement("fast-text-field") as TextField;
+                            const el = document.createElement(
+                                "fast-text-field"
+                            ) as TextField;
                             el.type = type;
                             el.value = value;
                             el.maxlength = value.length;
 
                             expect(el.validity.tooLong).to.equal(false);
                         });
-                        it("should be valid if the value has a exceeding the maxlength", () => {
+                        it("should be valid if the value has a exceeding the maxlength", async () => {
+                            const { element, connect, disconnect } = await setup();
+                            await connect();
                             const value = "value";
-                            const el = document.createElement("fast-text-field") as TextField;
-                            el.type = type;
-                            el.value = value;
-                            el.maxlength = value.length - 1;
+                            element.type = type;
+                            element.value = value;
+                            element.maxlength = value.length - 1;
 
-                            expect(el.validity.tooLong).to.equal(false);
+                            expect(element.validity.tooLong).to.equal(false);
                         });
-                        it("should be valid if the value has a length shorter than maxlength and the element is [required]", () => {
+                        it("should be valid if the value has a length shorter than maxlength and the element is [required]", async () => {
+                            const { element, connect, disconnect } = await setup();
+                            await connect();
                             const value = "value";
-                            const el = document.createElement("fast-text-field") as TextField;
-                            el.type = type;
-                            el.required = true;
-                            el.value = value;
-                            el.maxlength = value.length + 1;
+                            element.type = type;
+                            element.required = true;
+                            element.value = value;
+                            element.maxlength = value.length + 1;
 
-                            expect(el.validity.tooLong).to.equal(false);
+                            expect(element.validity.tooLong).to.equal(false);
                         });
                     });
 
                     describe("that has a [pattern] attribute", () => {
-                        it("should be valid if the value matches a pattern", () => {
+                        it("should be valid if the value matches a pattern", async () => {
+                            const { element, connect, disconnect } = await setup();
+                            await connect();
                             const value = "value";
-                            const el = document.createElement("fast-text-field") as TextField;
-                            el.type = type;
-                            el.required = true;
-                            el.pattern = value;
-                            el.value = value;
+                            element.type = type;
+                            element.required = true;
+                            element.pattern = value;
+                            element.value = value;
 
-                            expect(el.validity.patternMismatch).to.equal(false);
+                            expect(element.validity.patternMismatch).to.equal(false);
                         });
 
-                        it("should be invalid if the value does not match a pattern", () => {
+                        it("should be invalid if the value does not match a pattern", async () => {
+                            const { element, connect, disconnect } = await setup();
+                            await connect();
                             const value = "value";
-                            const el = document.createElement("fast-text-field") as TextField;
-                            el.type = type;
-                            el.required = true;
-                            el.pattern = value;
-                            el.value = "foo";
+                            element.type = type;
+                            element.required = true;
+                            element.pattern = value;
+                            element.value = "foo";
 
-                            expect(el.validity.patternMismatch).to.equal(true);
+                            expect(element.validity.patternMismatch).to.equal(true);
                         });
                     });
                 });
             });
         describe('of [type="email"]', () => {
-            it("should be valid when value is an empty string", () => {
-                const el = document.createElement("fast-text-field") as TextField;
-                el.type = TextFieldType.email;
-                el.required = true;
-                el.value = "";
+            it("should be valid when value is an empty string", async () => {
+                const { element, connect, disconnect } = await setup();
+                await connect();
+                element.type = TextFieldType.email;
+                element.required = true;
+                element.value = "";
 
-                expect(el.validity.typeMismatch).to.equal(false);
+                expect(element.validity.typeMismatch).to.equal(false);
             });
-            it("should be a typeMismatch when value is not a valid email", () => {
-                const el = document.createElement("fast-text-field") as TextField;
-                el.type = TextFieldType.email;
-                el.required = true;
-                el.value = "foobar";
+            it("should be a typeMismatch when value is not a valid email", async () => {
+                const { element, connect, disconnect } = await setup();
+                await connect();
+                element.type = TextFieldType.email;
+                element.required = true;
+                element.value = "foobar";
 
-                expect(el.validity.typeMismatch).to.equal(true);
+                expect(element.validity.typeMismatch).to.equal(true);
             });
         });
         describe('of [type="url"]', () => {
-            it("should be valid when value is an empty string", () => {
-                const el = document.createElement("fast-text-field") as TextField;
-                el.type = TextFieldType.url;
-                el.required = true;
-                el.value = "";
+            it("should be valid when value is an empty string", async () => {
+                const { element, connect, disconnect } = await setup();
+                await connect();
+                element.type = TextFieldType.url;
+                element.required = true;
+                element.value = "";
 
-                expect(el.validity.typeMismatch).to.equal(false);
+                expect(element.validity.typeMismatch).to.equal(false);
             });
-            it("should be a typeMismatch when value is not a valid URL", () => {
-                const el = document.createElement("fast-text-field") as TextField;
-                el.type = TextFieldType.url;
-                el.required = true;
-                el.value = "foobar";
+            it("should be a typeMismatch when value is not a valid URL", async () => {
+                const { element, connect, disconnect } = await setup();
+                await connect();
+                element.type = TextFieldType.url;
+                element.required = true;
+                element.value = "foobar";
 
-                expect(el.validity.typeMismatch).to.equal(true);
+                expect(element.validity.typeMismatch).to.equal(true);
             });
         });
     });

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -52,6 +52,7 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     private readOnlyChanged(): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.readOnly = this.readOnly;
+            this.validate();
         }
     }
 
@@ -66,6 +67,7 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     private autofocusChanged(): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.autofocus = this.autofocus;
+            this.validate();
         }
     }
 
@@ -95,6 +97,7 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     private typeChanged(): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.type = this.type;
+            this.validate();
         }
     }
 
@@ -109,6 +112,7 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     private listChanged(): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.setAttribute("list", this.list);
+            this.validate();
         }
     }
 
@@ -123,6 +127,7 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     private maxlengthChanged(): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.maxLength = this.maxlength;
+            this.validate();
         }
     }
 
@@ -137,6 +142,7 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     private minlengthChanged(): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.minLength = this.minlength;
+            this.validate();
         }
     }
 
@@ -151,6 +157,7 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     private patternChanged(): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.pattern = this.pattern;
+            this.validate();
         }
     }
 
@@ -203,6 +210,7 @@ export class TextField extends FormAssociated<HTMLInputElement> {
         super.connectedCallback();
 
         this.proxy.setAttribute("type", this.type);
+        this.validate();
 
         if (this.autofocus) {
             DOM.queueUpdate(() => {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
This change adds a mechanism to `FormAssociated` to set field validity after constraint property changes, including `value` and `required`. By default, this new `validate()` method sets validity to the validity of the *proxy* element, using the validationMessage of the proxy. This behavior can be overridden or extended for an implementing element.

closes #3761


<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->