### PR TITLE
fix(fast-element): enable subtree observation in the children decorator

### DIFF
--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -138,6 +138,10 @@ export interface CaptureType<TSource> {
 }
 
 // @public
+export interface ChildListBehaviorOptions<T = any> extends NodeBehaviorOptions<T>, Omit<MutationObserverInit, "subtree" | "childList"> {
+}
+
+// @public
 export function children<T = any>(propertyOrOptions: (keyof T & string) | ChildrenBehaviorOptions<keyof T & string>): CaptureType<T>;
 
 // Warning: (ae-forgotten-export) The symbol "NodeObservationBehavior" needs to be exported by the entry point index.d.ts
@@ -150,11 +154,8 @@ export class ChildrenBehavior extends NodeObservationBehavior<ChildrenBehaviorOp
     observe(): void;
     }
 
-// Warning: (ae-forgotten-export) The symbol "NodeBehaviorBehaviorOptions" needs to be exported by the entry point index.d.ts
-//
 // @public
-export interface ChildrenBehaviorOptions<T = any> extends NodeBehaviorBehaviorOptions<T>, MutationObserverInit {
-}
+export type ChildrenBehaviorOptions<T = any> = ChildListBehaviorOptions<T> | SubtreeBehaviorOptions<T>;
 
 // @beta
 export interface CompilationResult {
@@ -350,6 +351,12 @@ export type Mutable<T> = {
 };
 
 // @public
+export interface NodeBehaviorOptions<T = any> {
+    filter?(value: Node, index: number, array: Node[]): boolean;
+    property: T;
+}
+
+// @public
 export interface Notifier {
     notify(args: any): void;
     readonly source: any;
@@ -448,7 +455,7 @@ export class SlottedBehavior extends NodeObservationBehavior<SlottedBehaviorOpti
 }
 
 // @public
-export interface SlottedBehaviorOptions<T = any> extends NodeBehaviorBehaviorOptions<T>, AssignedNodesOptions {
+export interface SlottedBehaviorOptions<T = any> extends NodeBehaviorOptions<T>, AssignedNodesOptions {
 }
 
 // @public
@@ -472,6 +479,12 @@ export class SubscriberSet implements Notifier {
     readonly source: any;
     subscribe(subscriber: Subscriber): void;
     unsubscribe(subscriber: Subscriber): void;
+}
+
+// @public
+export interface SubtreeBehaviorOptions<T = any> extends Omit<NodeBehaviorOptions<T>, "filter">, Omit<MutationObserverInit, "subtree" | "childList"> {
+    selector: string;
+    subtree: boolean;
 }
 
 // @public

--- a/packages/web-components/fast-element/docs/guide/using-directives.md
+++ b/packages/web-components/fast-element/docs/guide/using-directives.md
@@ -490,6 +490,8 @@ const template = html<FriendList>`
 `;
 ```
 
+If using the `subtree` option for `children` then a `selector` is *required* in place of a `filter`. This enables more efficient collection of the desired nodes in the presence of a potential large node quantity throughout the subtree.
+
 ### The `slotted` directive
 
 Sometimes you may want references to all nodes that are assigned to a particular slot. To accomplish this, use the `slotted` directive. (For more on slots, see [Working with Shadow DOM](./working-with-shadow-dom).)

--- a/packages/web-components/fast-element/src/directives/children.spec.ts
+++ b/packages/web-components/fast-element/src/directives/children.spec.ts
@@ -51,7 +51,6 @@ describe("The children", () => {
             const { host, children } = createDOM();
             const behavior = new ChildrenBehavior(host, {
                 property: "nodes",
-                childList: true,
             });
             const model = new Model();
 
@@ -64,7 +63,6 @@ describe("The children", () => {
             const { host, children } = createDOM("foo-bar");
             const behavior = new ChildrenBehavior(host, {
                 property: "nodes",
-                childList: true,
                 filter: elements("foo-bar"),
             });
             const model = new Model();
@@ -78,7 +76,6 @@ describe("The children", () => {
             const { host, children } = createDOM("foo-bar");
             const behavior = new ChildrenBehavior(host, {
                 property: "nodes",
-                childList: true,
             });
             const model = new Model();
 
@@ -97,7 +94,6 @@ describe("The children", () => {
             const { host, children } = createDOM("foo-bar");
             const behavior = new ChildrenBehavior(host, {
                 property: "nodes",
-                childList: true,
                 filter: elements("foo-bar"),
             });
             const model = new Model();
@@ -113,11 +109,50 @@ describe("The children", () => {
             expect(model.nodes).members(updatedChildren.filter(elements("foo-bar")));
         });
 
+        it("updates subtree nodes when they change with a selector", async () => {
+            const { host, children } = createDOM("foo-bar");
+            const subtreeElement = "foo-bar-baz";
+            const subtreeChildren: HTMLElement[] = [];
+
+            for (let child of children) {
+                for (let i = 0; i < 3; ++i) {
+                    const subChild = document.createElement("foo-bar-baz");
+                    subtreeChildren.push(subChild);
+                    child.appendChild(subChild);
+                }
+            }
+
+            const behavior = new ChildrenBehavior(host, {
+                property: "nodes",
+                subtree: true,
+                selector: subtreeElement,
+            });
+
+            const model = new Model();
+
+            behavior.bind(model);
+
+            expect(model.nodes).members(subtreeChildren);
+
+            const newChildren = createAndAppendChildren(host);
+
+            for (let child of newChildren) {
+                for (let i = 0; i < 3; ++i) {
+                    const subChild = document.createElement("foo-bar-baz");
+                    subtreeChildren.push(subChild);
+                    child.appendChild(subChild);
+                }
+            }
+
+            await DOM.nextUpdate();
+
+            expect(model.nodes).members(subtreeChildren);
+        });
+
         it("clears and unwatches when unbound", async () => {
             const { host, children } = createDOM("foo-bar");
             const behavior = new ChildrenBehavior(host, {
                 property: "nodes",
-                childList: true,
             });
             const model = new Model();
 

--- a/packages/web-components/fast-element/src/directives/node-observation.ts
+++ b/packages/web-components/fast-element/src/directives/node-observation.ts
@@ -6,7 +6,7 @@ import { Behavior } from "./behavior";
  * Options for configuring node observation behavior.
  * @public
  */
-export interface NodeBehaviorBehaviorOptions<T = any> {
+export interface NodeBehaviorOptions<T = any> {
     /**
      * The property to assign the observed nodes to.
      */
@@ -43,7 +43,7 @@ export function elements(selector?: string) {
  * A base class for node observation.
  * @internal
  */
-export abstract class NodeObservationBehavior<T extends NodeBehaviorBehaviorOptions>
+export abstract class NodeObservationBehavior<T extends NodeBehaviorOptions>
     implements Behavior {
     private source: any = null;
     private shouldUpdate!: boolean;

--- a/packages/web-components/fast-element/src/directives/slotted.ts
+++ b/packages/web-components/fast-element/src/directives/slotted.ts
@@ -1,13 +1,13 @@
 import { CaptureType } from "../template";
 import { AttachedBehaviorDirective } from "./directive";
-import { NodeBehaviorBehaviorOptions, NodeObservationBehavior } from "./node-observation";
+import { NodeBehaviorOptions, NodeObservationBehavior } from "./node-observation";
 
 /**
  * The options used to configure slotted node observation.
  * @public
  */
 export interface SlottedBehaviorOptions<T = any>
-    extends NodeBehaviorBehaviorOptions<T>,
+    extends NodeBehaviorOptions<T>,
         AssignedNodesOptions {}
 
 /**

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -25,4 +25,4 @@ export * from "./directives/when";
 export * from "./directives/repeat";
 export * from "./directives/slotted";
 export * from "./directives/children";
-export { elements } from "./directives/node-observation";
+export { elements, NodeBehaviorOptions } from "./directives/node-observation";


### PR DESCRIPTION
# Description

Fixes #3883 where `subtree` observation when using the `children` directive did not capture all relevant nodes.

## Motivation & context

While working with @eljefe223 on the new `fast-select` component, we discovered that the `children` decorator was not able to properly capture subtree descendants even when configured to do so. This PR fixes that issue by applying a selector to "all" children in the subtree case, fixing the incorrect assumption that nodes would always be direct children of the directive's target.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**

There were some modifications to interfaces to account for different configuration options but I don't think this will practically affect anyone.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.