### PR TITLE
feat(fast-element): enable parent context references in repeat scenarios

### DIFF
--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -206,7 +206,7 @@ export function customElement(nameOrDef: string | PartialFASTElementDefinition):
 export type DecoratorAttributeConfiguration = Omit<AttributeConfiguration, "property">;
 
 // @public
-export const defaultExecutionContext: ExecutionContext<any>;
+export const defaultExecutionContext: ExecutionContext<any, any>;
 
 // @public
 export abstract class Directive implements BehaviorFactory {
@@ -272,7 +272,7 @@ export interface ElementViewTemplate {
 export const emptyArray: readonly never[];
 
 // @public
-export class ExecutionContext<TParent = any> {
+export class ExecutionContext<TParent = any, TGrandparent = any> {
     get event(): Event;
     index: number;
     get isEven(): boolean;
@@ -282,6 +282,7 @@ export class ExecutionContext<TParent = any> {
     get isOdd(): boolean;
     length: number;
     parent: TParent;
+    parentContext: ExecutionContext<TGrandparent>;
 }
 
 // @public

--- a/packages/web-components/fast-element/docs/guide/using-directives.md
+++ b/packages/web-components/fast-element/docs/guide/using-directives.md
@@ -118,7 +118,8 @@ export class FriendList extends FASTElement {
 Similar to event handlers, within a `repeat` block you have access to a special context object. Here is a list of the properties that are available on the context:
 
 * `event` - The event object when inside an event handler.
-* `parent` - The parent scope when inside a `repeat` block.
+* `parent` - The parent view-model when inside a `repeat` block.
+* `parentContext` - The parent `ExecutionContext` when inside a `repeat` block. This is useful when repeats are nested and the inner-most repeat needs access to the root view-model.
 * `index` - The index of the current item when inside a `repeat` block (opt-in).
 * `length` - The length of the array when inside a `repeat` block (opt-in).
 * `isEven` - True if the index of the current item is even when inside a `repeat` block (opt-in).

--- a/packages/web-components/fast-element/src/directives/repeat.spec.ts
+++ b/packages/web-components/fast-element/src/directives/repeat.spec.ts
@@ -1,11 +1,7 @@
 import { expect } from "chai";
 import { repeat, RepeatDirective, RepeatBehavior } from "./repeat";
 import { html } from "../template";
-import {
-    defaultExecutionContext,
-    ExecutionContext,
-    observable,
-} from "../observation/observable";
+import { defaultExecutionContext, observable } from "../observation/observable";
 import { DOM } from "../dom";
 import { toHTML } from "../__test__/helpers";
 

--- a/packages/web-components/fast-element/src/directives/repeat.spec.ts
+++ b/packages/web-components/fast-element/src/directives/repeat.spec.ts
@@ -10,9 +10,7 @@ describe("The repeat", () => {
         it("returns a RepeatDirective", () => {
             const directive = repeat(
                 () => [],
-                html`
-                    test
-                `
+                html`test`
             );
             expect(directive).to.be.instanceOf(RepeatDirective);
         });
@@ -22,9 +20,7 @@ describe("The repeat", () => {
         it("creates a RepeatBehavior", () => {
             const directive = repeat(
                 () => [],
-                html`
-                    test
-                `
+                html`test`
             ) as RepeatDirective;
             const target = document.createComment("");
             const behavior = directive.createBehavior(target);
@@ -34,12 +30,8 @@ describe("The repeat", () => {
     });
 
     context("behavior", () => {
-        const itemTemplate = html<Item>`
-            ${x => x.name}
-        `;
-        const altItemTemplate = html<Item>`
-            *${x => x.name}
-        `;
+        const itemTemplate = html<Item>`${x => x.name}`;
+        const altItemTemplate = html<Item>`*${x => x.name}`;
         const oneThroughTen = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
         const zeroThroughTen = [0].concat(oneThroughTen);
 
@@ -272,15 +264,10 @@ describe("The repeat", () => {
 
         oneThroughTen.forEach(size => {
             it(`renders grandparent values from nested arrays of size ${size}`, async () => {
-                const deepItemTemplate = html<Item>`
-                    parent-${x => x.name}${repeat(
+                const deepItemTemplate = html<Item>`parent-${x => x.name}${repeat(
                         x => x.items!,
-                        html<Item>`
-                            child-${x => x.name}root-${(x, c) =>
-                                c.parentContext.parent.name}
-                        `
-                    )}
-                `;
+                        html<Item>`child-${x => x.name}root-${(x, c) =>
+                                c.parentContext.parent.name}`)}`;
 
                 const { parent, location } = createLocation();
                 const directive = repeat<ViewModel>(

--- a/packages/web-components/fast-element/src/directives/repeat.ts
+++ b/packages/web-components/fast-element/src/directives/repeat.ts
@@ -108,6 +108,7 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
         this.originalContext = context;
         this.childContext = Object.create(context);
         this.childContext!.parent = source;
+        this.childContext!.parentContext = this.originalContext;
 
         this.items = this.itemsBindingObserver.observe(source, this.originalContext);
         this.template = this.templateBindingObserver.observe(

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -258,7 +258,7 @@ export function setCurrentEvent(event: Event | null): void {
  * Provides additional contextual information available to behaviors and expressions.
  * @public
  */
-export class ExecutionContext<TParent = any> {
+export class ExecutionContext<TParent = any, TGrandparent = any> {
     /**
      * The index of the current item within a repeat context.
      */
@@ -273,6 +273,11 @@ export class ExecutionContext<TParent = any> {
      * The parent data object within a repeat context.
      */
     public parent: TParent = null as any;
+
+    /**
+     * The parent execution context when in nested context scenarios.
+     */
+    public parentContext: ExecutionContext<TGrandparent> = null as any;
 
     /**
      * The current event within an event handler.


### PR DESCRIPTION
# Description

This PR adds a `parentContext` property to the `ExecutionContext` which is now set by the `repeat` directive's behavior when it sets up its own per-item context. This enables nested repeat templates to access up the repeat context and always get to any higher level repeat or the root view model regardless of the level of nesting.

Closes #3848 

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.