### PR TITLE
fix: tree view item should have a click handler on root element

### DIFF
--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -935,9 +935,9 @@ export class TreeItem extends FASTElement {
     // (undocumented)
     handleChange(source: any, propertyName: string): void;
     // (undocumented)
-    handleContainerClick: (e: MouseEvent) => void;
+    handleClick: (e: MouseEvent) => void;
     // (undocumented)
-    handleExpandCollapseButtonClick: () => void;
+    handleExpandCollapseButtonClick: (e: MouseEvent) => void;
     // (undocumented)
     handleFocus: (e: Event) => void;
     // (undocumented)

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.spec.ts
@@ -341,7 +341,7 @@ describe("TreeItem", () => {
             await disconnect();
         });
 
-        it("should toggle the selected state when the positioning region is clicked", async () => {
+        it("should toggle the selected state when the component is clicked", async () => {
             const { element, connect, disconnect } = await setup();
             const nestedItem = document.createElement("fast-tree-item");
 
@@ -350,17 +350,14 @@ describe("TreeItem", () => {
             await connect();
             await DOM.nextUpdate();
 
-            let container = element.shadowRoot?.querySelector(
-                ".positioning-region"
-            ) as any;
-            container?.click();
+            element.click();
 
             await DOM.nextUpdate();
 
             expect(element.selected).to.equal(true);
             expect(element.getAttribute("aria-selected")).to.equal("true");
 
-            container?.click();
+            element.click();
 
             await DOM.nextUpdate();
 
@@ -370,7 +367,7 @@ describe("TreeItem", () => {
             await disconnect();
         });
 
-        it("should NOT toggle the selected state when the positioning region is clicked and the element is disabled", async () => {
+        it("should NOT toggle the selected state when the element is clicked when disabled", async () => {
             const { element, connect, disconnect } = await setup();
             const nestedItem = document.createElement("fast-tree-item");
 
@@ -380,10 +377,7 @@ describe("TreeItem", () => {
             await connect();
             await DOM.nextUpdate();
 
-            let container = element.shadowRoot?.querySelector(
-                ".positioning-region"
-            ) as any;
-            container?.click();
+            element.click();
 
             await DOM.nextUpdate();
 

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -20,6 +20,7 @@ export const TreeItemTemplate = html<TreeItem>`
         @focus="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
         @blur="${(x, c) => x.handleBlur(c.event as FocusEvent)}"
         @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
+        @click="${(x, c) => x.handleClick(c.event as MouseEvent)}"
         ${children({
             property: "childItems",
             filter: elements(),
@@ -28,7 +29,6 @@ export const TreeItemTemplate = html<TreeItem>`
         <div
             class="positioning-region"
             part="positioning-region"
-            @click="${(x, c) => x.handleContainerClick(c.event as MouseEvent)}"
         >
             <div class="content-region" part="content-region">
                 ${when(
@@ -38,7 +38,7 @@ export const TreeItemTemplate = html<TreeItem>`
                             aria-hidden="true"
                             class="expand-collapse-button"
                             part="expand-collapse-button"
-                            @click="${x => x.handleExpandCollapseButtonClick()}"
+                            @click="${(x, c) => x.handleExpandCollapseButtonClick(c.event as MouseEvent)}"
                             ${ref("expandCollapseButton")}
                         >
                             <slot name="expand-collapse-glyph">

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -26,10 +26,7 @@ export const TreeItemTemplate = html<TreeItem>`
             filter: elements(),
         })}
     >
-        <div
-            class="positioning-region"
-            part="positioning-region"
-        >
+        <div class="positioning-region" part="positioning-region">
             <div class="content-region" part="content-region">
                 ${when(
                     x => x.childItems && x.childItemLength() > 0,
@@ -38,7 +35,8 @@ export const TreeItemTemplate = html<TreeItem>`
                             aria-hidden="true"
                             class="expand-collapse-button"
                             part="expand-collapse-button"
-                            @click="${(x, c) => x.handleExpandCollapseButtonClick(c.event as MouseEvent)}"
+                            @click="${(x, c) =>
+                                x.handleExpandCollapseButtonClick(c.event as MouseEvent)}"
                             ${ref("expandCollapseButton")}
                         >
                             <slot name="expand-collapse-glyph">

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -162,25 +162,27 @@ export class TreeItem extends FASTElement {
 
         switch (e.keyCode) {
             case keyCodeArrowLeft:
+                e.preventDefault();
                 this.handleArrowLeft();
                 break;
             case keyCodeArrowRight:
+                e.preventDefault();
                 this.handleArrowRight();
                 break;
             case keyCodeArrowDown:
-                // preventDefault to ensure we don't scroll the page
                 e.preventDefault();
                 this.focusNextNode(1);
                 break;
             case keyCodeArrowUp:
-                // preventDefault to ensure we don't scroll the page
                 e.preventDefault();
                 this.focusNextNode(-1);
                 break;
             case keyCodeEnter:
+                e.preventDefault();
                 this.handleSelected(e);
                 break;
             case keyCodeSpace:
+                e.preventDefault();
                 this.handleSpaceBar();
                 break;
         }
@@ -188,21 +190,20 @@ export class TreeItem extends FASTElement {
         return true;
     };
 
-    public handleExpandCollapseButtonClick = (): void => {
+    public handleExpandCollapseButtonClick = (e: MouseEvent): void => {
         if (!this.disabled) {
+            e.preventDefault();
             this.setExpanded(!this.expanded);
         }
     };
 
-    public handleContainerClick = (e: MouseEvent): void => {
-        const expandButton: HTMLElement | null = this.expandCollapseButton;
-        const isButtonAnHTMLElement: boolean = isHTMLElement(expandButton);
+    public handleClick = (e: MouseEvent): void => {
         if (
-            (!isButtonAnHTMLElement ||
-                (isButtonAnHTMLElement && expandButton !== e.target)) &&
-            !this.disabled
+            !this.disabled &&
+            !e.defaultPrevented
         ) {
             this.handleSelected(e);
+            e.preventDefault();
         }
     };
 

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -162,12 +162,10 @@ export class TreeItem extends FASTElement {
 
         switch (e.keyCode) {
             case keyCodeArrowLeft:
-                e.preventDefault();
-                this.handleArrowLeft();
+                this.handleArrowLeft(e);
                 break;
             case keyCodeArrowRight:
-                e.preventDefault();
-                this.handleArrowRight();
+                this.handleArrowRight(e);
                 break;
             case keyCodeArrowDown:
                 e.preventDefault();
@@ -182,8 +180,7 @@ export class TreeItem extends FASTElement {
                 this.handleSelected(e);
                 break;
             case keyCodeSpace:
-                e.preventDefault();
-                this.handleSpaceBar();
+                this.handleSpaceBar(e);
                 break;
         }
 
@@ -198,10 +195,7 @@ export class TreeItem extends FASTElement {
     };
 
     public handleClick = (e: MouseEvent): void => {
-        if (
-            !this.disabled &&
-            !e.defaultPrevented
-        ) {
+        if (!this.disabled && !e.defaultPrevented) {
             this.handleSelected(e);
             e.preventDefault();
         }
@@ -220,8 +214,9 @@ export class TreeItem extends FASTElement {
         return isTreeItemElement(this.parentElement as Element);
     };
 
-    private handleArrowLeft(): void {
+    private handleArrowLeft(e: KeyboardEvent): void {
         if (this.expanded) {
+            e.preventDefault();
             this.setExpanded(false);
         } else if (isHTMLElement(this.parentElement)) {
             const parentTreeItemNode:
@@ -230,29 +225,33 @@ export class TreeItem extends FASTElement {
                 | undefined = this.parentElement!.closest("[role='treeitem']");
 
             if (isHTMLElement(parentTreeItemNode)) {
+                e.preventDefault();
                 (parentTreeItemNode as HTMLElement).focus();
             }
         }
     }
 
-    private handleArrowRight(): void {
+    private handleArrowRight(e: KeyboardEvent): void {
         if (typeof this.expanded !== "boolean") {
             return;
         }
-
+        e.preventDefault();
         if (!this.expanded && this.childItemLength() > 0) {
+            e.preventDefault();
             this.setExpanded(true);
         } else {
             if (this.enabledChildTreeItems.length > 0) {
+                e.preventDefault();
                 this.enabledChildTreeItems[0].focus();
             }
         }
     }
 
-    private handleSpaceBar(): void {
+    private handleSpaceBar(e: KeyboardEvent): void {
         if (typeof this.expanded !== "boolean") {
             return;
         }
+        e.preventDefault();
         this.setExpanded(!this.expanded);
     }
 

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -196,7 +196,7 @@ export class TreeItem extends FASTElement {
     };
 
     public handleClick = (e: MouseEvent): void => {
-        if (!e.defaultPrevented) {
+        if (!e.defaultPrevented && !this.disabled) {
             this.handleSelected(e);
         }
     };

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -162,25 +162,26 @@ export class TreeItem extends FASTElement {
 
         switch (e.keyCode) {
             case keyCodeArrowLeft:
-                this.handleArrowLeft(e);
+                this.handleArrowLeft();
                 break;
             case keyCodeArrowRight:
-                this.handleArrowRight(e);
+                this.handleArrowRight();
                 break;
             case keyCodeArrowDown:
+                // preventDefault to ensure we don't scroll the page
                 e.preventDefault();
                 this.focusNextNode(1);
                 break;
             case keyCodeArrowUp:
+                // preventDefault to ensure we don't scroll the page
                 e.preventDefault();
                 this.focusNextNode(-1);
                 break;
             case keyCodeEnter:
-                e.preventDefault();
                 this.handleSelected(e);
                 break;
             case keyCodeSpace:
-                this.handleSpaceBar(e);
+                this.handleSpaceBar();
                 break;
         }
 
@@ -195,9 +196,8 @@ export class TreeItem extends FASTElement {
     };
 
     public handleClick = (e: MouseEvent): void => {
-        if (!this.disabled && !e.defaultPrevented) {
+        if (!e.defaultPrevented) {
             this.handleSelected(e);
-            e.preventDefault();
         }
     };
 
@@ -214,9 +214,8 @@ export class TreeItem extends FASTElement {
         return isTreeItemElement(this.parentElement as Element);
     };
 
-    private handleArrowLeft(e: KeyboardEvent): void {
+    private handleArrowLeft(): void {
         if (this.expanded) {
-            e.preventDefault();
             this.setExpanded(false);
         } else if (isHTMLElement(this.parentElement)) {
             const parentTreeItemNode:
@@ -225,33 +224,29 @@ export class TreeItem extends FASTElement {
                 | undefined = this.parentElement!.closest("[role='treeitem']");
 
             if (isHTMLElement(parentTreeItemNode)) {
-                e.preventDefault();
                 (parentTreeItemNode as HTMLElement).focus();
             }
         }
     }
 
-    private handleArrowRight(e: KeyboardEvent): void {
+    private handleArrowRight(): void {
         if (typeof this.expanded !== "boolean") {
             return;
         }
-        e.preventDefault();
+
         if (!this.expanded && this.childItemLength() > 0) {
-            e.preventDefault();
             this.setExpanded(true);
         } else {
             if (this.enabledChildTreeItems.length > 0) {
-                e.preventDefault();
                 this.enabledChildTreeItems[0].focus();
             }
         }
     }
 
-    private handleSpaceBar(e: KeyboardEvent): void {
+    private handleSpaceBar(): void {
         if (typeof this.expanded !== "boolean") {
             return;
         }
-        e.preventDefault();
         this.setExpanded(!this.expanded);
     }
 


### PR DESCRIPTION
# Description
In order to comply with https://www.w3.org/TR/core-aam-1.2/#mapping_actions. and enable some accessibility scenarios tree view items must be able to react to click events sent to the root of the component.  

Additionally this fix marks some handled key events with prevent default so that they don't trigger additional actions (I noticed space bar was triggering scrolls when I tested)

## Motivation & context
Fixes https://github.com/microsoft/fast/issues/3914

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
