### PR TITLE
refactor(fast-element): clean up compilation context concept in compiler

### DIFF
--- a/packages/web-components/fast-element/src/template-compiler.ts
+++ b/packages/web-components/fast-element/src/template-compiler.ts
@@ -15,7 +15,7 @@ class CompilationContext {
     public behaviorFactories!: BehaviorFactory[];
     public directives: ReadonlyArray<Directive>;
 
-    public addFactory(factory: BehaviorFactory) {
+    public addFactory(factory: BehaviorFactory): void {
         factory.targetIndex = this.targetIndex;
         this.behaviorFactories.push(factory);
     }
@@ -25,16 +25,16 @@ class CompilationContext {
         this.addFactory(directive);
     }
 
-    public reset() {
+    public reset(): void {
         this.behaviorFactories = [];
         this.targetIndex = -1;
     }
 
-    public release() {
+    public release(): void {
         sharedContext = this;
     }
 
-    public static borrow(directives: ReadonlyArray<Directive>) {
+    public static borrow(directives: ReadonlyArray<Directive>): CompilationContext {
         const shareable = sharedContext || new CompilationContext();
         shareable.directives = directives;
         shareable.reset();


### PR DESCRIPTION
# Description

This is an internal refactoring of the template compiler to make the compilation context more explicit, reduce some duplication, and enable future nested calls to the compile function without messing up global state.

## Issue type checklist

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.