### PR TITLE
fix: update high contrast light theme foreground color on pivot

### DIFF
--- a/sites/fast-component-explorer/app/explorer.style.ts
+++ b/sites/fast-component-explorer/app/explorer.style.ts
@@ -1,6 +1,7 @@
 import { ComponentStyles, CSSRules } from "@microsoft/fast-jss-manager-react";
 import {
     DesignSystem,
+    highContrastForeground,
     neutralLayerL1,
     neutralLayerL3,
 } from "@microsoft/fast-components-styles-msft";
@@ -30,6 +31,7 @@ export const pivotStyleSheetOverrides: ComponentStyles<
 > = {
     pivot: {
         height: "100%",
+        ...highContrastForeground,
     },
     pivot_tabList: {
         padding: "0 16px",
@@ -46,6 +48,9 @@ export const pivotStyleSheetOverrides: ComponentStyles<
     },
     pivot_tabPanel: {
         height: "100%",
+    },
+    pivot_tabContent: {
+        ...highContrastForeground,
     },
 };
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Added the high contrast foreground color on the pivot tab and the content panel to fix the text in high contrast white theme.

closes #3965 

After
![image](https://user-images.githubusercontent.com/37851220/94190221-acf0d000-fe60-11ea-98e7-07e30ad8e098.png)
![image](https://user-images.githubusercontent.com/37851220/94190240-b24e1a80-fe60-11ea-85ab-f33f6a1973d8.png)
![image](https://user-images.githubusercontent.com/37851220/94190250-b5490b00-fe60-11ea-82c7-e2bd44a5fc35.png)


## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->