### PR TITLE
fix: update text on adaptive fast frame component to use high contrast foreground color

### DIFF
--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.styles.ts
@@ -1,5 +1,5 @@
 import { css } from "@microsoft/fast-element";
-import { display } from "@microsoft/fast-foundation";
+import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import {
     accentFillRestBehavior,
     accentForegroundCutRestBehavior,
@@ -9,6 +9,7 @@ import {
     neutralFillCardRestBehavior,
 } from "@microsoft/fast-components";
 import { drawerBreakpoint } from "./fast-frame";
+import { SystemColors } from "@microsoft/fast-web-utilities";
 
 export const FastFrameStyles = css`
     ${display("block")} :host {
@@ -371,5 +372,12 @@ export const FastFrameStyles = css`
     accentForegroundRestBehavior,
     neutralForegroundHintBehavior,
     neutralForegroundRestBehavior,
-    neutralFillCardRestBehavior
+    neutralFillCardRestBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            .text-container {
+                color: ${SystemColors.ButtonText};
+            }
+        `
+    )
 );


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

The text color was not changing when in high contrast white theme. Added forced-color query to set the color on text container to use `ButtonText`.

before
![image](https://user-images.githubusercontent.com/37851220/94202217-27761b80-fe72-11ea-9b3c-ef400bb4da62.png)


after
![image](https://user-images.githubusercontent.com/37851220/94202230-2b09a280-fe72-11ea-9a85-6a4b3f4ae822.png)

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->