### PR TITLE
fix: allow child radio buttons to be changed multiple times from javascript

### DIFF
--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -1,6 +1,22 @@
 <fast-design-system-provider use-defaults>
     <h1>Radio Group</h1>
 
+    <button
+        onclick="const rg = document.getElementById('vertical'); rg.setAttribute('value', 'juniper' );"
+    >
+        Set Juniper
+    </button>
+    <button
+        onclick="const rg = document.getElementById('vertical'); rg.setAttribute('value', 'hemlock' );"
+    >
+        Set Hemlock
+    </button>
+    <button
+        onclick="const rg = document.getElementById('vertical'); rg.setAttribute('value', 'fir' );"
+    >
+        Set fir
+    </button>
+
     <h4>Defaults</h4>
     <div>
         <fast-radio-group name="numbers">
@@ -13,7 +29,7 @@
     </div>
 
     <div>
-        <fast-radio-group orientation="vertical" name="trees">
+        <fast-radio-group id="vertical" orientation="vertical" name="trees">
             <label style="color: --var(neutral-foreground-rest);" slot="label">
                 Trees
             </label>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -2,21 +2,31 @@
     <h1>Radio Group</h1>
 
     <button
-        onclick="const rg = document.getElementById('vertical'); rg.setAttribute('value', 'juniper' );"
+        onclick="const rg1 = document.getElementById('vertical'); rg1.setAttribute('value', 'juniper' );"
     >
         Set Juniper
     </button>
     <button
-        onclick="const rg = document.getElementById('vertical'); rg.setAttribute('value', 'hemlock' );"
+        onclick="const rg2 = document.getElementById('vertical'); rg2.setAttribute('value', 'hemlock' );"
     >
         Set Hemlock
     </button>
     <button
-        onclick="const rg = document.getElementById('vertical'); rg.setAttribute('value', 'fir' );"
+        onclick="const rg3 = document.getElementById('vertical'); rg3.setAttribute('value', 'fir' );"
     >
         Set fir
     </button>
 
+    <button
+        onclick="const rg4 = document.getElementById('hemlock'); rg4.setAttribute('checked', '' );"
+    >
+        Set Hemlock
+    </button>
+    <button
+        onclick="const rg5 = document.getElementById('fir'); rg5.setAttribute('checked', '' );"
+    >
+        Set fir
+    </button>
     <h4>Defaults</h4>
     <div>
         <fast-radio-group name="numbers">
@@ -33,9 +43,9 @@
             <label style="color: --var(neutral-foreground-rest);" slot="label">
                 Trees
             </label>
-            <fast-radio value="fir">Fir</fast-radio>
+            <fast-radio id="fir" value="fir">Fir</fast-radio>
             <fast-radio value="juniper">Juniper</fast-radio>
-            <fast-radio value="hemlock">Hemlock</fast-radio>
+            <fast-radio id="hemlock" value="hemlock">Hemlock</fast-radio>
             <fast-radio value="pine">Pine</fast-radio>
         </fast-radio-group>
     </div>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -9,7 +9,7 @@
     <button
         onclick="const rg2 = document.getElementById('vertical'); rg2.setAttribute('value', 'hemlock' );"
     >
-        Set Hemlock
+        Set Hemlock attr
     </button>
     <button
         onclick="const rg3 = document.getElementById('vertical'); rg3.setAttribute('value', 'fir' );"
@@ -18,15 +18,23 @@
     </button>
 
     <button
-        onclick="const rg4 = document.getElementById('hemlock'); rg4.setAttribute('checked', '' );"
+        onclick="const rg4 = document.getElementById('hemlock'); rg4.checked = !rg4.checked;"
     >
         Set Hemlock
     </button>
     <button
-        onclick="const rg5 = document.getElementById('fir'); rg5.setAttribute('checked', '' );"
+        onclick="const rg5 = document.getElementById('fir'); rg5.checked = !rg5.checked;"
     >
         Set fir
     </button>
+    <h4>native</h4>
+    <input type="radio" name="foo" value="blue" id="blue-radio" />
+    <label for="blue-radio">blue</label>
+    <input type="radio" name="foo" value="red" checked id="red-radio" />
+    <label for="red-radio">red</label>
+    <input type="radio" name="foo" value="white" checked id="white-radio" />
+    <label for="white-radio">white</label>
+
     <h4>Defaults</h4>
     <div>
         <fast-radio-group name="numbers">
@@ -43,9 +51,9 @@
             <label style="color: --var(neutral-foreground-rest);" slot="label">
                 Trees
             </label>
-            <fast-radio id="fir" value="fir" checked>Fir</fast-radio>
+            <fast-radio id="fir" value="fir">Fir</fast-radio>
             <fast-radio value="juniper">Juniper</fast-radio>
-            <fast-radio id="hemlock" value="hemlock">Hemlock</fast-radio>
+            <fast-radio id="hemlock" value="hemlock" checked>Hemlock</fast-radio>
             <fast-radio value="pine">Pine</fast-radio>
         </fast-radio-group>
     </div>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -4,36 +4,29 @@
     <button
         onclick="const rg1 = document.getElementById('vertical'); rg1.setAttribute('value', 'juniper' );"
     >
-        Set Juniper
+        Set value to Juniper
     </button>
     <button
         onclick="const rg2 = document.getElementById('vertical'); rg2.setAttribute('value', 'hemlock' );"
     >
-        Set Hemlock attr
+        Set value to hemlock
     </button>
     <button
         onclick="const rg3 = document.getElementById('vertical'); rg3.setAttribute('value', 'fir' );"
     >
-        Set fir
+        Set value to fir
     </button>
 
     <button
         onclick="const rg4 = document.getElementById('hemlock'); rg4.checked = !rg4.checked;"
     >
-        Set Hemlock
+        Set Hemlock radio
     </button>
     <button
         onclick="const rg5 = document.getElementById('fir'); rg5.checked = !rg5.checked;"
     >
-        Set fir
+        Set fir radio
     </button>
-    <h4>native</h4>
-    <input type="radio" name="foo" value="blue" id="blue-radio" />
-    <label for="blue-radio">blue</label>
-    <input type="radio" name="foo" value="red" checked id="red-radio" />
-    <label for="red-radio">red</label>
-    <input type="radio" name="foo" value="white" checked id="white-radio" />
-    <label for="white-radio">white</label>
 
     <h4>Defaults</h4>
     <div>
@@ -54,7 +47,7 @@
             <fast-radio id="fir" value="fir">Fir</fast-radio>
             <fast-radio value="juniper">Juniper</fast-radio>
             <fast-radio id="hemlock" value="hemlock" checked>Hemlock</fast-radio>
-            <fast-radio value="pine">Pine</fast-radio>
+            <fast-radio value="pine" checked>Pine</fast-radio>
         </fast-radio-group>
     </div>
 

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -43,7 +43,7 @@
             <label style="color: --var(neutral-foreground-rest);" slot="label">
                 Trees
             </label>
-            <fast-radio id="fir" value="fir">Fir</fast-radio>
+            <fast-radio id="fir" value="fir" checked>Fir</fast-radio>
             <fast-radio value="juniper">Juniper</fast-radio>
             <fast-radio id="hemlock" value="hemlock">Hemlock</fast-radio>
             <fast-radio value="pine">Pine</fast-radio>

--- a/packages/web-components/fast-components/src/radio-group/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio-group/fixtures/base.html
@@ -20,12 +20,12 @@
     <button
         onclick="const rg4 = document.getElementById('hemlock'); rg4.checked = !rg4.checked;"
     >
-        Set Hemlock radio
+        Toggle Hemlock radio
     </button>
     <button
         onclick="const rg5 = document.getElementById('fir'); rg5.checked = !rg5.checked;"
     >
-        Set fir radio
+        Toggle fir radio
     </button>
 
     <h4>Defaults</h4>

--- a/packages/web-components/fast-components/src/radio/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio/fixtures/base.html
@@ -8,17 +8,17 @@
     </div>
 
     <h4>Checked</h4>
-    <fast-radio value="checked" checked></fast-radio>
+    <fast-radio id="thecheckedone" value="checked" checked></fast-radio>
 
     <!-- Required -->
     <h4>Required</h4>
-    <fast-radio value="required" required></fast-radio>
+    <fast-radio id="uncheckedone" value="required" required></fast-radio>
 
     <!-- Disabled -->
     <h4>Disabled</h4>
     <fast-radio disabled></fast-radio>
     <fast-radio disabled>label</fast-radio>
-    <fast-radio disabled checked>checked</fast-radio>
+    <fast-radio disabled checked id="anotherCheckedOne">checked</fast-radio>
 
     <h4>Visual vs audio label</h4>
     <fast-radio>

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -537,6 +537,8 @@ export class RadioGroup extends FASTElement {
     // @internal (undocumented)
     connectedCallback(): void;
     disabled: boolean;
+    // (undocumented)
+    disconnectedCallback(): void;
     // @internal
     keydownHandler: (e: KeyboardEvent) => void;
     name: string;
@@ -547,6 +549,8 @@ export class RadioGroup extends FASTElement {
     // @internal (undocumented)
     slottedRadioButtons: HTMLElement[];
     value: string;
+    // (undocumented)
+    protected valueChanged(): void;
 }
 
 // @public

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -543,9 +543,7 @@ export class RadioGroup extends FASTElement {
     // (undocumented)
     focusOutHandler: (e: FocusEvent) => boolean | void;
     // @internal
-    keydownHandler: (e: KeyboardEvent) => void;
-    // (undocumented)
-    keypressHandler: (e: KeyboardEvent) => void;
+    keydownHandler: (e: KeyboardEvent) => boolean | void;
     name: string;
     // (undocumented)
     protected nameChanged(): void;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -531,16 +531,21 @@ export type RadioControl = Pick<HTMLInputElement, "checked" | "disabled" | "read
 
 // @public
 export class RadioGroup extends FASTElement {
-    constructor();
     // (undocumented)
     childItems: HTMLElement[];
+    // (undocumented)
+    clickHandler: (e: MouseEvent) => void;
     // @internal (undocumented)
     connectedCallback(): void;
     disabled: boolean;
     // (undocumented)
     disconnectedCallback(): void;
+    // (undocumented)
+    focusOutHandler: (e: FocusEvent) => boolean | void;
     // @internal
     keydownHandler: (e: KeyboardEvent) => void;
+    // (undocumented)
+    keypressHandler: (e: KeyboardEvent) => void;
     name: string;
     // (undocumented)
     protected nameChanged(): void;

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
@@ -266,6 +266,42 @@ describe("Radio Group", () => {
         await disconnect();
     });
 
+    it("should mark the last radio defaulted to checked as checked, the rest should not be checked", async () => {
+        const { element, connect, disconnect } = await fixture(html<FASTRadioGroup>`
+            <fast-radio-group>
+                <fast-radio value="foo">Foo</fast-radio>
+                <fast-radio value="bar" checked>Bar</fast-radio>
+                <fast-radio value="baz" checked>Baz</fast-radio>
+            </fast-radio-group>
+        `);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        const radios: NodeList = element.querySelectorAll("fast-radio");
+        expect((radios[2] as HTMLInputElement).checked).to.equal(true);
+        expect((radios[1] as HTMLInputElement).checked).to.equal(false);
+    });
+
+    it("should mark radio matching value on radio-group over any checked attributes", async () => {
+        const { element, connect, disconnect } = await fixture(html<FASTRadioGroup>`
+            <fast-radio-group value="bar">
+                <fast-radio value="foo">Foo</fast-radio>
+                <fast-radio value="bar" checked>Bar</fast-radio>
+                <fast-radio value="baz" checked>Baz</fast-radio>
+            </fast-radio-group>
+        `);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        const radios: NodeList = element.querySelectorAll("fast-radio");
+        expect((radios[2] as HTMLInputElement).checked).to.equal(false);
+        expect((radios[1] as HTMLInputElement).checked).to.equal(true);
+        // radio-group explicitly sets non-matching radio's checked to false if a value match was found
+        expect((radios[2] as HTMLInputElement).hasAttribute("checked")).to.equal(false);
+    });
+
     it("should NOT set a child radio to `checked` if its value does not match the radiogroup `value`", async () => {
         const { element, connect, disconnect } = await fixture(html<FASTRadioGroup>`
             <fast-radio-group value="baz">

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
@@ -267,7 +267,7 @@ describe("Radio Group", () => {
     });
 
     it("should mark the last radio defaulted to checked as checked, the rest should not be checked", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTRadioGroup>`
+        const { element, connect, disconnect } = await fixture(html`
             <fast-radio-group>
                 <fast-radio value="foo">Foo</fast-radio>
                 <fast-radio value="bar" checked>Bar</fast-radio>
@@ -284,7 +284,7 @@ describe("Radio Group", () => {
     });
 
     it("should mark radio matching value on radio-group over any checked attributes", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTRadioGroup>`
+        const { element, connect, disconnect } = await fixture(html`
             <fast-radio-group value="bar">
                 <fast-radio value="foo">Foo</fast-radio>
                 <fast-radio value="bar" checked>Bar</fast-radio>

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
@@ -11,6 +11,10 @@ export const RadioGroupTemplate = html<RadioGroup>`
         role="radiogroup"
         aria-disabled="${x => x.disabled}"
         aria-readonly="${x => x.readOnly}"
+        @keypress="${(x, c) => x.keypressHandler(c.event as KeyboardEvent)}"
+        @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
+        @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
+        @focusout="${(x, c) => x.focusOutHandler(c.event as FocusEvent)}"
     >
         <slot name="label"></slot>
         <div

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
@@ -11,7 +11,6 @@ export const RadioGroupTemplate = html<RadioGroup>`
         role="radiogroup"
         aria-disabled="${x => x.disabled}"
         aria-readonly="${x => x.readOnly}"
-        @keypress="${(x, c) => x.keypressHandler(c.event as KeyboardEvent)}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
         @focusout="${(x, c) => x.focusOutHandler(c.event as FocusEvent)}"

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -211,11 +211,6 @@ export class RadioGroup extends FASTElement {
                 lastCheckedRadio.checked = true;
                 this.focusedRadio = lastCheckedRadio;
                 lastCheckedRadio.setAttribute("tabindex", "0");
-                // checkedRadios.forEach((radio: HTMLInputElement) => {
-                //     if (radio !== lastCheckedRadio) {
-                //         radio.removeAttribute("checked");
-                //     }
-                // })
             } else {
                 this.slottedRadioButtons[0].setAttribute("tabindex", "0");
                 this.focusedRadio = this.slottedRadioButtons[0] as HTMLInputElement;

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -195,6 +195,7 @@ export class RadioGroup extends FASTElement {
                 foundMatchingVal = true;
             } else {
                 radio.setAttribute("tabindex", "-1");
+                radio.checked = false;
             }
             radio.addEventListener("change", this.radioChangeHandler);
         });

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -91,6 +91,10 @@ export class RadioGroup extends FASTElement {
         if (this.slottedRadioButtons) {
             this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
                 if (radio.getAttribute("value") === this.value) {
+                    console.log(
+                        "setting checked to true in valueChanged...value:",
+                        radio.value
+                    );
                     radio.checked = true;
                     this.selectedRadio = radio;
                 }
@@ -158,6 +162,20 @@ export class RadioGroup extends FASTElement {
     }
 
     private setupRadioButtons(): void {
+        const checkedRadios: HTMLElement[] = this.slottedRadioButtons.filter(
+            (radio: HTMLInputElement) => {
+                return radio.hasAttribute("checked");
+            }
+        );
+        const numberOfCheckedRadios: number = checkedRadios ? checkedRadios.length : 0;
+        if (numberOfCheckedRadios > 1) {
+            const lastCheckedRadio: HTMLInputElement = checkedRadios[
+                numberOfCheckedRadios - 1
+            ] as HTMLInputElement;
+            lastCheckedRadio.checked = true;
+        }
+        let foundMatchingVal: boolean = false;
+
         this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
             if (this.name !== undefined) {
                 radio.setAttribute("name", this.name);
@@ -176,14 +194,36 @@ export class RadioGroup extends FASTElement {
                 this.focusedRadio = radio;
                 radio.checked = true;
                 radio.setAttribute("tabindex", "0");
+                foundMatchingVal = true;
             } else {
                 radio.setAttribute("tabindex", "-1");
             }
         });
 
         if (this.value === undefined && this.slottedRadioButtons.length > 0) {
-            this.slottedRadioButtons[0].setAttribute("tabindex", "0");
-            this.focusedRadio = this.slottedRadioButtons[0] as HTMLInputElement;
+            const checkedRadios: HTMLElement[] = this.slottedRadioButtons.filter(
+                (radio: HTMLInputElement) => {
+                    return radio.hasAttribute("checked");
+                }
+            );
+            const numberOfCheckedRadios: number =
+                checkedRadios !== null ? checkedRadios.length : 0;
+            if (numberOfCheckedRadios > 0 && !foundMatchingVal) {
+                const lastCheckedRadio: HTMLInputElement = checkedRadios[
+                    numberOfCheckedRadios - 1
+                ] as HTMLInputElement;
+                lastCheckedRadio.checked = true;
+                this.focusedRadio = lastCheckedRadio;
+                lastCheckedRadio.setAttribute("tabindex", "0");
+                // checkedRadios.forEach((radio: HTMLInputElement) => {
+                //     if (radio !== lastCheckedRadio) {
+                //         radio.removeAttribute("checked");
+                //     }
+                // })
+            } else {
+                this.slottedRadioButtons[0].setAttribute("tabindex", "0");
+                this.focusedRadio = this.slottedRadioButtons[0] as HTMLInputElement;
+            }
         }
     }
 
@@ -221,6 +261,7 @@ export class RadioGroup extends FASTElement {
                     }
                 });
             } else {
+                console.log("setting checked to true, moveToRadioIndex...");
                 radio.checked = true;
                 this.selectedRadio = radio;
             }
@@ -312,6 +353,7 @@ export class RadioGroup extends FASTElement {
             !this.focusedRadio.readOnly &&
             !this.focusedRadio.checked
         ) {
+            console.log("settings checked to true in checkFocusedRadio");
             this.focusedRadio.checked = true;
             this.focusedRadio.setAttribute("tabindex", "0");
             this.focusedRadio.focus();

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -87,6 +87,16 @@ export class RadioGroup extends FASTElement {
      */
     @attr
     public value: string;
+    protected valueChanged(): void {
+        if (this.slottedRadioButtons) {
+            this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
+                if (radio.getAttribute("value") === this.value) {
+                    radio.checked = true;
+                    this.selectedRadio = radio;
+                }
+            });
+        }
+    }
 
     /**
      * The orientation of the group
@@ -137,6 +147,14 @@ export class RadioGroup extends FASTElement {
         this.parentToolbar = this.parentElement?.closest('[role="toolbar"]');
         this.isInsideToolbar =
             this.parentToolbar !== undefined && this.parentToolbar !== null;
+    }
+
+    public disconnectedCallback(): void {
+        this.removeEventListener("keydown", this.keydownHandler);
+        this.removeEventListener("change", this.radioChangeHandler);
+        this.removeEventListener("keypress", this.keypressHandler);
+        this.removeEventListener("click", this.clickHandler);
+        this.removeEventListener("focusout", this.focusOutHandler);
     }
 
     private setupRadioButtons(): void {

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -91,10 +91,6 @@ export class RadioGroup extends FASTElement {
         if (this.slottedRadioButtons) {
             this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
                 if (radio.getAttribute("value") === this.value) {
-                    console.log(
-                        "setting checked to true in valueChanged...value:",
-                        radio.value
-                    );
                     radio.checked = true;
                     this.selectedRadio = radio;
                 }
@@ -261,7 +257,6 @@ export class RadioGroup extends FASTElement {
                     }
                 });
             } else {
-                console.log("setting checked to true, moveToRadioIndex...");
                 radio.checked = true;
                 this.selectedRadio = radio;
             }
@@ -353,7 +348,6 @@ export class RadioGroup extends FASTElement {
             !this.focusedRadio.readOnly &&
             !this.focusedRadio.checked
         ) {
-            console.log("settings checked to true in checkFocusedRadio");
             this.focusedRadio.checked = true;
             this.focusedRadio.setAttribute("tabindex", "0");
             this.focusedRadio.focus();

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -96,6 +96,7 @@ export class RadioGroup extends FASTElement {
                 }
             });
         }
+        this.$emit("change");
     }
 
     /**
@@ -131,7 +132,6 @@ export class RadioGroup extends FASTElement {
     constructor() {
         super();
         this.addEventListener("keydown", this.keydownHandler);
-        this.addEventListener("change", this.radioChangeHandler);
         this.addEventListener("keypress", this.keypressHandler);
         this.addEventListener("click", this.clickHandler);
         this.addEventListener("focusout", this.focusOutHandler);
@@ -151,10 +151,12 @@ export class RadioGroup extends FASTElement {
 
     public disconnectedCallback(): void {
         this.removeEventListener("keydown", this.keydownHandler);
-        this.removeEventListener("change", this.radioChangeHandler);
         this.removeEventListener("keypress", this.keypressHandler);
         this.removeEventListener("click", this.clickHandler);
         this.removeEventListener("focusout", this.focusOutHandler);
+        this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
+            radio.removeEventListener("change", this.radioChangeHandler);
+        });
     }
 
     private setupRadioButtons(): void {
@@ -194,6 +196,7 @@ export class RadioGroup extends FASTElement {
             } else {
                 radio.setAttribute("tabindex", "-1");
             }
+            radio.addEventListener("change", this.radioChangeHandler);
         });
 
         if (this.value === undefined && this.slottedRadioButtons.length > 0) {
@@ -225,8 +228,9 @@ export class RadioGroup extends FASTElement {
         }
     };
 
-    private radioChangeHandler = (e: CustomEvent): void => {
+    private radioChangeHandler = (e: CustomEvent): boolean | void => {
         const changedRadio: HTMLInputElement = e.target as HTMLInputElement;
+
         if (changedRadio.checked) {
             this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
                 if (radio !== changedRadio) {
@@ -239,6 +243,7 @@ export class RadioGroup extends FASTElement {
             changedRadio.setAttribute("tabindex", "0");
             this.focusedRadio = changedRadio;
         }
+        e.stopPropagation();
     };
 
     private moveToRadioByIndex = (group: HTMLElement[], index: number) => {

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -129,14 +129,6 @@ export class RadioGroup extends FASTElement {
     private isInsideToolbar: boolean = false;
     private direction: Direction;
 
-    constructor() {
-        super();
-        this.addEventListener("keydown", this.keydownHandler);
-        this.addEventListener("keypress", this.keypressHandler);
-        this.addEventListener("click", this.clickHandler);
-        this.addEventListener("focusout", this.focusOutHandler);
-    }
-
     /**
      * @internal
      */
@@ -150,10 +142,6 @@ export class RadioGroup extends FASTElement {
     }
 
     public disconnectedCallback(): void {
-        this.removeEventListener("keydown", this.keydownHandler);
-        this.removeEventListener("keypress", this.keypressHandler);
-        this.removeEventListener("click", this.clickHandler);
-        this.removeEventListener("focusout", this.focusOutHandler);
         this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
             radio.removeEventListener("change", this.radioChangeHandler);
         });
@@ -222,7 +210,7 @@ export class RadioGroup extends FASTElement {
         }
     }
 
-    private keypressHandler = (e: KeyboardEvent): void => {
+    public keypressHandler = (e: KeyboardEvent): void => {
         const radio: HTMLInputElement | null = e.target as HTMLInputElement;
         if (radio) {
             radio.setAttribute("tabindex", radio.checked ? "0" : "-1");
@@ -275,7 +263,7 @@ export class RadioGroup extends FASTElement {
     };
 
     /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-    private focusOutHandler = (e: FocusEvent) => {
+    public focusOutHandler = (e: FocusEvent): boolean | void => {
         const group: HTMLElement[] = this.slottedRadioButtons;
         const radio: HTMLInputElement | null = e.target as HTMLInputElement;
         const index: number = radio !== null ? group.indexOf(radio) : 0;
@@ -305,9 +293,10 @@ export class RadioGroup extends FASTElement {
                 });
             }
         }
+        return true;
     };
 
-    private clickHandler = (e: MouseEvent): void => {
+    public clickHandler = (e: MouseEvent): void => {
         const radio: HTMLInputElement | null = e.target as HTMLInputElement;
         if (radio) {
             const group: HTMLElement[] = this.slottedRadioButtons;

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -210,13 +210,6 @@ export class RadioGroup extends FASTElement {
         }
     }
 
-    public keypressHandler = (e: KeyboardEvent): void => {
-        const radio: HTMLInputElement | null = e.target as HTMLInputElement;
-        if (radio) {
-            radio.setAttribute("tabindex", radio.checked ? "0" : "-1");
-        }
-    };
-
     private radioChangeHandler = (e: CustomEvent): boolean | void => {
         const changedRadio: HTMLInputElement = e.target as HTMLInputElement;
 
@@ -408,7 +401,7 @@ export class RadioGroup extends FASTElement {
      *
      * @internal
      */
-    public keydownHandler = (e: KeyboardEvent): void => {
+    public keydownHandler = (e: KeyboardEvent): boolean | void => {
         if (e.keyCode !== keyCodeTab && e.keyCode !== keyCodeSpace) {
             e.preventDefault();
         }
@@ -433,5 +426,6 @@ export class RadioGroup extends FASTElement {
                 }
                 break;
         }
+        return true;
     };
 }

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -200,10 +200,13 @@ export class RadioGroup extends FASTElement {
             this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
                 if (radio !== changedRadio) {
                     radio.checked = false;
+                    radio.setAttribute("tabindex", "-1");
                 }
             });
             this.selectedRadio = changedRadio;
             this.value = changedRadio.value;
+            changedRadio.setAttribute("tabindex", "0");
+            this.focusedRadio = changedRadio;
         }
     };
 

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -402,9 +402,6 @@ export class RadioGroup extends FASTElement {
      * @internal
      */
     public keydownHandler = (e: KeyboardEvent): boolean | void => {
-        if (e.keyCode !== keyCodeTab && e.keyCode !== keyCodeSpace) {
-            e.preventDefault();
-        }
         switch (e.keyCode) {
             case keyCodeEnter:
                 this.checkFocusedRadio();
@@ -426,6 +423,7 @@ export class RadioGroup extends FASTElement {
                 }
                 break;
         }
-        return true;
+
+        return e.keyCode === keyCodeTab || e.keyCode === keyCodeSpace;
     };
 }

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -200,7 +200,6 @@ export class RadioGroup extends FASTElement {
             this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
                 if (radio !== changedRadio) {
                     radio.checked = false;
-                    radio.setAttribute("tabindex", "-1");
                 }
             });
             this.selectedRadio = changedRadio;

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -101,7 +101,7 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
      * @public
      */
     @observable
-    public checked: boolean = this.defaultChecked;
+    public checked: boolean = this.defaultChecked ?? false;
     private checkedChanged(): void {
         if (this.$fastController.isConnected) {
             // TODO: temporarily removed as it's causing issues with

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -104,12 +104,6 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
     public checked: boolean = this.defaultChecked;
     private checkedChanged(): void {
         if (this.$fastController.isConnected) {
-            console.log(
-                "checkedChanged for value:",
-                this.value,
-                " checked:",
-                this.checked
-            );
             // TODO: temporarily removed as it's causing issues with
             // changing the value via code and from radio-group
             if (!this.dirtyChecked) {
@@ -126,7 +120,6 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
             this.checkedAttribute = this.checked;
 
             this.validate();
-            console.log("in checkedCHanged this.checked:", this.checked);
         }
     }
 

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -88,8 +88,10 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
             // Setting this.checked will cause us to enter a dirty state,
             // but if we are clean when defaultChecked is changed, we want to stay
             // in a clean state, so reset this.dirtyChecked
-            this.checked = this.defaultChecked;
-            this.dirtyChecked = false;
+            if (!this.isInsideRadioGroup()) {
+                this.checked = this.defaultChecked;
+                this.dirtyChecked = false;
+            }
         }
     }
 
@@ -101,22 +103,31 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
     @observable
     public checked: boolean = this.defaultChecked;
     private checkedChanged(): void {
-        // TODO: temporarily removed as it's causing issues with
-        // changing the value via code and from radio-group
-        // if (!this.dirtyChecked) {
-        //     this.dirtyChecked = true;
-        // }
+        if (this.$fastController.isConnected) {
+            console.log(
+                "checkedChanged for value:",
+                this.value,
+                " checked:",
+                this.checked
+            );
+            // TODO: temporarily removed as it's causing issues with
+            // changing the value via code and from radio-group
+            if (!this.dirtyChecked) {
+                this.dirtyChecked = true;
+            }
 
-        this.updateForm();
+            this.updateForm();
 
-        if (this.proxy instanceof HTMLElement) {
-            this.proxy.checked = this.checked;
+            if (this.proxy instanceof HTMLElement) {
+                this.proxy.checked = this.checked;
+            }
+
+            this.$emit("change");
+            this.checkedAttribute = this.checked;
+
+            this.validate();
+            console.log("in checkedCHanged this.checked:", this.checked);
         }
-
-        this.$emit("change");
-        this.checkedAttribute = this.checked;
-
-        this.validate();
     }
 
     protected proxy: HTMLInputElement = document.createElement("input");
@@ -147,6 +158,10 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
         }
 
         this.updateForm();
+    }
+
+    private isInsideRadioGroup(): boolean {
+        return this.name !== undefined && this.name !== null && this.name.length > 0;
     }
 
     private updateForm(): void {

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -82,9 +82,9 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
      * @public
      */
     @observable
-    public defaultChecked: boolean = !!this.checkedAttribute;
+    public defaultChecked: boolean;
     private defaultCheckedChanged(): void {
-        if (!this.dirtyChecked) {
+        if (this.$fastController.isConnected && !this.dirtyChecked) {
             // Setting this.checked will cause us to enter a dirty state,
             // but if we are clean when defaultChecked is changed, we want to stay
             // in a clean state, so reset this.dirtyChecked
@@ -151,10 +151,33 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
         }
 
         this.updateForm();
+
+        if (this.checkedAttribute) {
+            if (!this.dirtyChecked) {
+                // Setting this.checked will cause us to enter a dirty state,
+                // but if we are clean when defaultChecked is changed, we want to stay
+                // in a clean state, so reset this.dirtyChecked
+                if (!this.isInsideRadioGroup()) {
+                    this.checked = this.defaultChecked;
+                    this.dirtyChecked = false;
+                }
+            }
+        }
     }
 
     private isInsideRadioGroup(): boolean {
-        return this.name !== undefined && this.name !== null && this.name.length > 0;
+        //return this.name !== undefined && this.name !== null && this.name.length > 0;
+        const parent: HTMLElement | null = (this as HTMLElement).closest(
+            "[role=radiogroup]"
+        );
+        return parent !== null;
+    }
+
+    private getParentNode(): HTMLElement | null | undefined {
+        const parentNode: Element | null | undefined = this.parentElement!.closest(
+            "[role='tree']"
+        );
+        return parentNode as HTMLElement;
     }
 
     private updateForm(): void {

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -101,9 +101,11 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
     @observable
     public checked: boolean = this.defaultChecked;
     private checkedChanged(): void {
-        if (!this.dirtyChecked) {
-            this.dirtyChecked = true;
-        }
+        // TODO: temporarily removed as it's causing issues with
+        // changing the value via code and from radio-group
+        // if (!this.dirtyChecked) {
+        //     this.dirtyChecked = true;
+        // }
 
         if (this.proxy instanceof HTMLElement) {
             this.proxy.checked = this.checked;

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -107,13 +107,14 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
         //     this.dirtyChecked = true;
         // }
 
+        this.updateForm();
+
         if (this.proxy instanceof HTMLElement) {
             this.proxy.checked = this.checked;
         }
 
         this.$emit("change");
         this.checkedAttribute = this.checked;
-        this.updateForm();
 
         this.validate();
     }


### PR DESCRIPTION
# Description
If a developer tried to change a particular radio button in a radio group multiple times it would fail to change after the first change.

<!--- Describe your changes. -->
For input type='radio' there is a bit of a disconnect between the property checked and the attribute checked which is different than most of the other components (though Checkbox has this same behavior). 
* initially when radio group loads we need to look at the last radio with checked attribute and set the property to checked on that radio and set the checked property(NOT the attribute) to false on all the others.
* once that checked property is set, it can only be changed through the property and there is a disconnect between the checked attribute and the checked property.

Also fixed tabindexes when values are changed via code, they were not updated appropriately, only when using mouse interaction.

* still need to add specs

closes #3903 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
