### PR TITLE
fix: tooltip does not position correctly in documentation sample

### DIFF
--- a/packages/web-components/fast-foundation/src/tooltip/README.md
+++ b/packages/web-components/fast-foundation/src/tooltip/README.md
@@ -11,10 +11,10 @@ The `fast-tooltip` component is used provide extra information about another ele
 
 ```html live
 <fast-design-system-provider use-defaults>
-    <button id="mybutton">
+    <fast-button id="mybutton">
        Hover me for more info
-    </button>
-    <fast-tooltip anchor="mybutton">
+    </fast-button>
+    <fast-tooltip anchor="mybutton" position="right">
       helpful text
     </fast-tooltip>
 </fast-design-system-provider>

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
@@ -10,17 +10,17 @@ export const TooltipTemplate = html<Tooltip>`
         x => x.tooltipVisible,
         html<Tooltip>`
             <fast-anchored-region
-                ${ref("region")}
-                dir=${x => x.currentDirection}
-                vertical-positioning-mode=${x => x.verticalPositioningMode}
-                vertical-default-position=${x => x.verticalDefaultPosition}
-                vertical-inset=${x => x.verticalInset}
-                vertical-scaling=${x => x.verticalScaling}
-                horizontal-positioning-mode=${x => x.horizontalPositioningMode}
-                horizontal-default-position=${x => x.horizontalDefaultPosition}
-                horizontal-scaling=${x => x.horizontalScaling}
-                horizontal-inset=${x => x.horizontalInset}
                 fixed-placement="true"
+                vertical-positioning-mode="${x => x.verticalPositioningMode}"
+                vertical-default-position="${x => x.verticalDefaultPosition}"
+                vertical-inset="${x => x.verticalInset}"
+                vertical-scaling="${x => x.verticalScaling}"
+                horizontal-positioning-mode="${x => x.horizontalPositioningMode}"
+                horizontal-default-position="${x => x.horizontalDefaultPosition}"
+                horizontal-scaling="${x => x.horizontalScaling}"
+                horizontal-inset="${x => x.horizontalInset}"
+                dir="${x => x.currentDirection}"
+                ${ref("region")}
             >
                 <div class="tooltip" part="tooltip" role="tooltip">
                     <slot></slot>


### PR DESCRIPTION
# Description
I noticed that tooltip was not positioning itself properly in our documentation sample at https://www.fast.design/docs/components/tooltip.

After some investigation I found that the component's internal attibute bindings were getting munged into a big string with no spaces:

![tooltipbinding](https://user-images.githubusercontent.com/7649425/94603451-231f7900-024b-11eb-9364-b2080374bd70.png)

After much poking around I was able to resolve the issue for tooltip by modifying the template to wrap all attribute value bindings in quotes:

```ts
vertical-positioning-mode="${x => x.verticalPositioningMode}"
```

instead of 

```ts
vertical-positioning-mode=${x => x.verticalPositioningMode}
```
I will open a tracking bug to investigate the issue further as technically we don't require the quotes and it isn't clear what is causing the tooltip template to break without them in our document environment.

## Motivation & context
Tooltip should position properly.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
