### PR TITLE
fix: tabbing disabled for when linkedDataControl used in form

### DIFF
--- a/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
@@ -238,7 +238,7 @@ class LinkedDataControl extends React.Component<
                         searchTerm: "",
                     });
                 }
-                // Tab performs an autocompete if there is a single schema it can match to
+                // Tab performs an auto-complete if there is a single schema it can match to
             } else if (e.keyCode === keyCodeTab) {
                 const normalizedValue = e.currentTarget.value.toLowerCase();
                 const matchedSchema = this.lazyMatchValueWithASingleSchema(
@@ -246,6 +246,8 @@ class LinkedDataControl extends React.Component<
                 );
 
                 if (typeof matchedSchema === "string") {
+                    // prevent normal tabbing when single schema matched
+                    e.preventDefault();
                     this.setState({
                         searchTerm: this.props.schemaDictionary[matchedSchema].title,
                     });

--- a/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
@@ -240,8 +240,6 @@ class LinkedDataControl extends React.Component<
                 }
                 // Tab performs an autocompete if there is a single schema it can match to
             } else if (e.keyCode === keyCodeTab) {
-                e.preventDefault();
-
                 const normalizedValue = e.currentTarget.value.toLowerCase();
                 const matchedSchema = this.lazyMatchValueWithASingleSchema(
                     normalizedValue

--- a/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
@@ -246,7 +246,7 @@ class LinkedDataControl extends React.Component<
                 );
 
                 if (typeof matchedSchema === "string") {
-                    // prevent normal tabbing when single schema matched
+                    // prevent navigating away by tab when single schema matched
                     e.preventDefault();
                     this.setState({
                         searchTerm: this.props.schemaDictionary[matchedSchema].title,

--- a/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
@@ -248,6 +248,7 @@ class LinkedDataControl extends React.Component<
                 if (typeof matchedSchema === "string") {
                     // prevent navigating away by tab when single schema matched
                     e.preventDefault();
+
                     this.setState({
                         searchTerm: this.props.schemaDictionary[matchedSchema].title,
                     });


### PR DESCRIPTION
# Description

Removed preventDefault() call in keydownHandler in linkedDataControl when key is tab, this prevented normal tabbing from occurring.
closes #3885 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
