### PR TITLE
fix: update high contrast outline color on progress bar

### DIFF
--- a/packages/web-components/fast-components/src/progress/progress.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress.styles.ts
@@ -115,21 +115,20 @@ export const ProgressStyles = css`
     neutralForegroundHintBehavior,
     forcedColorsStylesheetBehavior(
         css`
+            .progress {
+                forced-color-adjust: none;
+                background-color: ${SystemColors.Field};
+                box-shadow: 0 0 0 1px inset ${SystemColors.FieldText};
+            }
+            .determinate,
             .indeterminate-indicator-1,
-            .indeterminate-indicator-2,
-            .determinate {
+            .indeterminate-indicator-2 {
                 forced-color-adjust: none;
                 background-color: ${SystemColors.FieldText};
             }
-            .progress {
-                background-color: ${SystemColors.Field};
-                border: calc(var(--outline-width) * 1px) solid ${SystemColors.FieldText};
-            }
+            :host(.paused) .determinate,
             :host(.paused) .indeterminate-indicator-1,
-            .indeterminate-indicator-2 {
-                background-color: ${SystemColors.Field};
-            }
-            :host(.paused) .determinate {
+            :host(.paused) .indeterminate-indicator-2 {
                 background-color: ${SystemColors.GrayText};
             }
         `


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

The progress bar was shifting the determinate and indeterminate element. To fix this, I use a box-shadow instead of a border.
Additional work was cleaning up the pause state, combining all the selectors into one rule.

closes #3966 

## Motivation & context

It's hard to tell, but if you zoom into the component, you can see the difference.

Before
![image](https://user-images.githubusercontent.com/37851220/95798132-ff761d00-0ca5-11eb-9aed-2e01bb8f826b.png)

After
![image](https://user-images.githubusercontent.com/37851220/95798141-069d2b00-0ca6-11eb-801a-c9bc3f8364cf.png)


## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->