### PR TITLE
fix: leverage FASTController.addStyles to attach css custom property target sheet

### DIFF
--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
@@ -325,9 +325,9 @@ export class DesignSystemProvider extends FASTElement
 
         if (supportsAdoptedStylesheets) {
             const sheet = new CSSStyleSheet();
-            sheet.insertRule(":host{}");
+            const index = sheet.insertRule(":host{}");
             this.$fastController.addStyles(ElementStyles.create([sheet]));
-            this.customPropertyTarget = (sheet.rules[0] as CSSStyleRule).style;
+            this.customPropertyTarget = (sheet.rules[index] as CSSStyleRule).style;
         } else {
             this.customPropertyTarget = this.style;
         }

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
@@ -2,6 +2,7 @@ import {
     attr,
     Behavior,
     customElement,
+    ElementStyles,
     FASTElement,
     observable,
     Observable,
@@ -322,14 +323,10 @@ export class DesignSystemProvider extends FASTElement
     constructor() {
         super();
 
-        if (supportsAdoptedStylesheets && this.shadowRoot !== null) {
+        if (supportsAdoptedStylesheets) {
             const sheet = new CSSStyleSheet();
             sheet.insertRule(":host{}");
-            (this.shadowRoot as any).adoptedStyleSheets = [
-                ...(this.shadowRoot as any).adoptedStyleSheets,
-                sheet,
-            ];
-
+            this.$fastController.addStyles(ElementStyles.create([sheet]));
             this.customPropertyTarget = (sheet.rules[0] as CSSStyleRule).style;
         } else {
             this.customPropertyTarget = this.style;


### PR DESCRIPTION


# Description
This change adjusts the way the DesignSystemProvider's CSSCustomPropetyTarget is determined, expanding the usage of constructible stylesheets and unifying behavior between open and closed shadow roots.

The existing approach of directly manipulating the `adoptedStyleSheets` of the `shadowRoot` to append a CSSCustomProperty target relies on an open shadow root. When the shadowRoot is closed, CSS custom properties are applied via the `HTMLElement.style.setProperty()` API. We can improve this by utilizing the Controller's `addStyles()` API to perform the style attachment for us so that we don't require access to the shadowRoot. The DSP will still use the `HTMLElement.style.setProperty()` API in cases where constructible styles are not supported.
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->