### PR TITLE
fix: designSystem property resolution behavior correction

### DIFF
--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.spec.ts
@@ -100,20 +100,15 @@ describe("A DesignSystemProvider", () => {
 
             expect(aAccessors.length).to.equal(2);
 
-            console.log(dspA.designSystem, dspB.designSystem);
-
             window.setTimeout(() => {
-                // console.log("Starting tests", dspB.designSystem)
                 Observable.getAccessors(dspA.designSystem).forEach(x => {
-                    // console.log("testing", x.name, dspB.designSystem[x.name])
-                    // expect(dspB.designSystem[x.name]).not.to.equal(undefined)
                     expect(dspA.designSystem[x.name]).to.equal(dspB.designSystem[x.name]);
                 });
                 done();
             }, 0);
         });
 
-        xit("should update it's local design system when a parent DesignSystemProperty is changed and the local property is unset", done => {
+        it("should update it's local design system when a parent DesignSystemProperty is changed and the local property is unset", done => {
             const dspA = document.createElement("dsp-a") as DSPA;
             const dspB = document.createElement("dsp-a") as DSPA;
             dspA.useDefaults = true;
@@ -133,7 +128,7 @@ describe("A DesignSystemProvider", () => {
     });
 
     describe("that is nested inside an instance of a different DesignSystemProvider definition", () => {
-        xit("should have a design system that is the union of ancestor's and descendant's design system properties", async () => {
+        it("should have a design system that is the union of ancestor's and descendant's design system properties", async () => {
             const { dspA, dspB, connect, disconnect } = await setup();
             await connect();
 
@@ -154,7 +149,7 @@ describe("A DesignSystemProvider", () => {
             await disconnect();
         });
 
-        xit("should have a design system that is the union of ancestor's when deeply nested", done => {
+        it("should have a design system that is the union of ancestor's when deeply nested", done => {
             const dspA = document.createElement("dsp-a") as DSPA;
             const dspB = document.createElement("dsp-b") as DSPB;
             const dspC = document.createElement("dsp-c") as DSPC;
@@ -167,19 +162,16 @@ describe("A DesignSystemProvider", () => {
             document.body.appendChild(dspA);
 
             window.setTimeout(() => {
-                // expect(dspC.designSystem['a']).not.to.equal(undefined);
-                // expect(dspC.designSystem['b']).not.to.equal(undefined);
+                expect(dspC.designSystem["a"]).not.to.equal(undefined);
+                expect(dspC.designSystem["b"]).not.to.equal(undefined);
                 expect(dspC.designSystem["c"]).not.to.equal(undefined);
                 expect(dspC.designSystem["d"]).not.to.equal(undefined);
 
                 expect(dspC.designSystem["a"]).to.equal(dspA.designSystem["a"]);
-                expect(dspC.designSystem["b"]).to.equal(dspA.designSystem["b"]);
-                expect(dspC.designSystem["c"]).to.equal(dspA.designSystem["c"]);
+                expect(dspC.designSystem["b"]).to.equal(dspB.designSystem["b"]);
+                expect(dspC.designSystem["c"]).to.equal(dspC.c);
+                expect(dspC.designSystem["d"]).to.equal(dspC.d);
 
-                // Observable.getAccessors(dspA.designSystem).forEach(x => {
-                //     expect(dspB.designSystem[x.name]).not.to.equal(undefined)
-                //     expect(dspA.designSystem[x.name]).to.equal(dspB.designSystem[x.name])
-                // })
                 done();
             });
         });

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.spec.ts
@@ -8,10 +8,6 @@ import {
     DesignSystemProviderTemplate as template,
 } from "./index";
 
-const a = Symbol();
-const b = Symbol();
-const c = Symbol();
-
 @defineDesignSystemProvider({
     name: "dsp-a",
     template,
@@ -25,7 +21,7 @@ class DSPA extends DesignSystemProvider {
     public a: symbol;
 
     @designSystemProperty({
-        default: b,
+        default: Symbol(),
         cssCustomProperty: false,
         attribute: false,
     })
@@ -73,16 +69,16 @@ class DSPC extends DesignSystemProvider {
 }
 
 async function setup() {
-    const { element: dspA, connect: connectA, disconnect: disconnectA } = await fixture<
+    const { element: a, connect: connectA, disconnect: disconnectA } = await fixture<
         DSPA
     >("dsp-a");
-    const { element: dspB, connect: connectB, disconnect: disconnectB } = await fixture<
+    const { element: b, connect: connectB, disconnect: disconnectB } = await fixture<
         DSPB
     >("dsp-b");
 
     return {
-        dspA,
-        dspB,
+        a,
+        b,
         connect: async () => Promise.all([connectA(), connectB()]),
         disconnect: async () => Promise.all([disconnectA(), disconnectB()]),
     };
@@ -91,35 +87,35 @@ async function setup() {
 describe("A DesignSystemProvider", () => {
     describe("that is nested inside an instance of the same DesignSystemProvider definition", () => {
         it("should sync all unset design system properties from the parent provider", done => {
-            const dspA = document.createElement("dsp-a") as DSPA;
-            const dspB = document.createElement("dsp-a") as DSPA;
-            dspA.useDefaults = true;
-            dspA.appendChild(dspB);
-            document.body.appendChild(dspA);
-            const aAccessors = Observable.getAccessors(dspA.designSystem);
+            const a = document.createElement("dsp-a") as DSPA;
+            const n = document.createElement("dsp-a") as DSPA;
+            a.useDefaults = true;
+            a.appendChild(n);
+            document.body.appendChild(a);
+            const aAccessors = Observable.getAccessors(a.designSystem);
 
             expect(aAccessors.length).to.equal(2);
 
             window.setTimeout(() => {
-                Observable.getAccessors(dspA.designSystem).forEach(x => {
-                    expect(dspA.designSystem[x.name]).to.equal(dspB.designSystem[x.name]);
+                Observable.getAccessors(a.designSystem).forEach(x => {
+                    expect(a.designSystem[x.name]).to.equal(n.designSystem[x.name]);
                 });
                 done();
             }, 0);
         });
 
         it("should update it's local design system when a parent DesignSystemProperty is changed and the local property is unset", done => {
-            const dspA = document.createElement("dsp-a") as DSPA;
-            const dspB = document.createElement("dsp-a") as DSPA;
-            dspA.useDefaults = true;
-            dspA.appendChild(dspB);
-            document.body.appendChild(dspA);
+            const a = document.createElement("dsp-a") as DSPA;
+            const b = document.createElement("dsp-a") as DSPA;
+            a.useDefaults = true;
+            a.appendChild(b);
+            document.body.appendChild(a);
 
             window.setTimeout(() => {
-                dspA.a = Symbol();
-                Observable.getAccessors(dspA.designSystem).forEach(x => {
-                    expect(dspB.designSystem[x.name]).not.to.equal(undefined);
-                    expect(dspA.designSystem[x.name]).to.equal(dspB.designSystem[x.name]);
+                a.a = Symbol();
+                Observable.getAccessors(a.designSystem).forEach(x => {
+                    expect(b.designSystem[x.name]).not.to.equal(undefined);
+                    expect(a.designSystem[x.name]).to.equal(b.designSystem[x.name]);
                 });
 
                 done();
@@ -129,49 +125,75 @@ describe("A DesignSystemProvider", () => {
 
     describe("that is nested inside an instance of a different DesignSystemProvider definition", () => {
         it("should have a design system that is the union of ancestor's and descendant's design system properties", async () => {
-            const { dspA, dspB, connect, disconnect } = await setup();
+            const { a, b, connect, disconnect } = await setup();
             await connect();
 
-            dspA.a = a;
-            dspA.b = b;
+            const _a = Symbol();
+            const _b = Symbol();
+            const _c = Symbol();
+            a.a = _a;
+            a.b = _b;
 
-            dspB.b = b;
-            dspB.c = c;
+            b.b = _b;
+            b.c = _c;
 
-            dspA.appendChild(dspB);
+            a.appendChild(b);
 
             await Promise.resolve();
 
-            expect((dspB.designSystem as any).a).to.equal(a);
-            expect((dspB.designSystem as any).b).to.equal(b);
-            expect((dspB.designSystem as any).c).to.equal(c);
+            expect((b.designSystem as any).a).to.equal(_a);
+            expect((b.designSystem as any).b).to.equal(_b);
+            expect((b.designSystem as any).c).to.equal(_c);
 
             await disconnect();
         });
 
         it("should have a design system that is the union of ancestor's when deeply nested", done => {
-            const dspA = document.createElement("dsp-a") as DSPA;
-            const dspB = document.createElement("dsp-b") as DSPB;
-            const dspC = document.createElement("dsp-c") as DSPC;
+            const a = document.createElement("dsp-a") as DSPA;
+            const b = document.createElement("dsp-b") as DSPB;
+            const c = document.createElement("dsp-c") as DSPC;
 
-            dspA.useDefaults = true;
-            dspB.useDefaults = true;
-            dspC.useDefaults = true;
-            dspB.appendChild(dspC);
-            dspA.appendChild(dspB);
-            document.body.appendChild(dspA);
+            a.useDefaults = true;
+            b.useDefaults = true;
+            c.useDefaults = true;
+            b.appendChild(c);
+            a.appendChild(b);
+            document.body.appendChild(a);
 
             window.setTimeout(() => {
-                expect(dspC.designSystem["a"]).not.to.equal(undefined);
-                expect(dspC.designSystem["b"]).not.to.equal(undefined);
-                expect(dspC.designSystem["c"]).not.to.equal(undefined);
-                expect(dspC.designSystem["d"]).not.to.equal(undefined);
+                expect(c.designSystem["a"]).not.to.equal(undefined);
+                expect(c.designSystem["b"]).not.to.equal(undefined);
+                expect(c.designSystem["c"]).not.to.equal(undefined);
+                expect(c.designSystem["d"]).not.to.equal(undefined);
 
-                expect(dspC.designSystem["a"]).to.equal(dspA.designSystem["a"]);
-                expect(dspC.designSystem["b"]).to.equal(dspB.designSystem["b"]);
-                expect(dspC.designSystem["c"]).to.equal(dspC.c);
-                expect(dspC.designSystem["d"]).to.equal(dspC.d);
+                expect(c.designSystem["a"]).to.equal(a.designSystem["a"]);
+                expect(c.designSystem["b"]).to.equal(b.designSystem["b"]);
+                expect(c.designSystem["c"]).to.equal(c.c);
+                expect(c.designSystem["d"]).to.equal(c.d);
 
+                done();
+            });
+        });
+
+        it("should propagate property updates through providers where a parent provider doesn't declare the property as a designSystemProperty", done => {
+            const a = document.createElement("dsp-a") as DSPA;
+            const b = document.createElement("dsp-b") as DSPB;
+            const c = document.createElement("dsp-c") as DSPC;
+
+            a.useDefaults = true;
+            b.useDefaults = true;
+            c.useDefaults = true;
+            b.appendChild(c);
+            a.appendChild(b);
+            document.body.appendChild(a);
+
+            window.setTimeout(() => {
+                expect(c.designSystem["a"]).to.equal(a.designSystem["a"]);
+                const symbol = Symbol();
+                a.a = symbol;
+
+                expect(a.designSystem["a"]).to.equal(symbol);
+                expect(c.designSystem["a"]).to.equal(symbol);
                 done();
             });
         });

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.spec.ts
@@ -1,3 +1,4 @@
+import { Observable } from "@microsoft/fast-element";
 import { expect } from "chai";
 import { fixture } from "../fixture";
 import {
@@ -21,14 +22,14 @@ class DSPA extends DesignSystemProvider {
         cssCustomProperty: false,
         attribute: false,
     })
-    public a: Symbol;
+    public a: symbol;
 
     @designSystemProperty({
         default: b,
         cssCustomProperty: false,
         attribute: false,
     })
-    public b: Symbol;
+    public b: symbol;
 }
 
 @defineDesignSystemProvider({
@@ -41,14 +42,34 @@ class DSPB extends DesignSystemProvider {
         cssCustomProperty: false,
         attribute: false,
     })
-    public b: Symbol;
+    public b: symbol;
 
     @designSystemProperty({
         default: Symbol(),
         cssCustomProperty: false,
         attribute: false,
     })
-    public c: Symbol;
+    public c: symbol;
+}
+
+@defineDesignSystemProvider({
+    name: "dsp-c",
+    template,
+})
+class DSPC extends DesignSystemProvider {
+    @designSystemProperty({
+        default: Symbol(),
+        cssCustomProperty: false,
+        attribute: false,
+    })
+    public c: symbol;
+
+    @designSystemProperty({
+        default: Symbol(),
+        cssCustomProperty: false,
+        attribute: false,
+    })
+    public d: symbol;
 }
 
 async function setup() {
@@ -68,8 +89,51 @@ async function setup() {
 }
 
 describe("A DesignSystemProvider", () => {
+    describe("that is nested inside an instance of the same DesignSystemProvider definition", () => {
+        it("should sync all unset design system properties from the parent provider", done => {
+            const dspA = document.createElement("dsp-a") as DSPA;
+            const dspB = document.createElement("dsp-a") as DSPA;
+            dspA.useDefaults = true;
+            dspA.appendChild(dspB);
+            document.body.appendChild(dspA);
+            const aAccessors = Observable.getAccessors(dspA.designSystem);
+
+            expect(aAccessors.length).to.equal(2);
+
+            console.log(dspA.designSystem, dspB.designSystem);
+
+            window.setTimeout(() => {
+                // console.log("Starting tests", dspB.designSystem)
+                Observable.getAccessors(dspA.designSystem).forEach(x => {
+                    // console.log("testing", x.name, dspB.designSystem[x.name])
+                    // expect(dspB.designSystem[x.name]).not.to.equal(undefined)
+                    expect(dspA.designSystem[x.name]).to.equal(dspB.designSystem[x.name]);
+                });
+                done();
+            }, 0);
+        });
+
+        xit("should update it's local design system when a parent DesignSystemProperty is changed and the local property is unset", done => {
+            const dspA = document.createElement("dsp-a") as DSPA;
+            const dspB = document.createElement("dsp-a") as DSPA;
+            dspA.useDefaults = true;
+            dspA.appendChild(dspB);
+            document.body.appendChild(dspA);
+
+            window.setTimeout(() => {
+                dspA.a = Symbol();
+                Observable.getAccessors(dspA.designSystem).forEach(x => {
+                    expect(dspB.designSystem[x.name]).not.to.equal(undefined);
+                    expect(dspA.designSystem[x.name]).to.equal(dspB.designSystem[x.name]);
+                });
+
+                done();
+            });
+        });
+    });
+
     describe("that is nested inside an instance of a different DesignSystemProvider definition", () => {
-        it("should have a design system that is the union of ancestor's and descendant's design system properties", async () => {
+        xit("should have a design system that is the union of ancestor's and descendant's design system properties", async () => {
             const { dspA, dspB, connect, disconnect } = await setup();
             await connect();
 
@@ -88,6 +152,36 @@ describe("A DesignSystemProvider", () => {
             expect((dspB.designSystem as any).c).to.equal(c);
 
             await disconnect();
+        });
+
+        xit("should have a design system that is the union of ancestor's when deeply nested", done => {
+            const dspA = document.createElement("dsp-a") as DSPA;
+            const dspB = document.createElement("dsp-b") as DSPB;
+            const dspC = document.createElement("dsp-c") as DSPC;
+
+            dspA.useDefaults = true;
+            dspB.useDefaults = true;
+            dspC.useDefaults = true;
+            dspB.appendChild(dspC);
+            dspA.appendChild(dspB);
+            document.body.appendChild(dspA);
+
+            window.setTimeout(() => {
+                // expect(dspC.designSystem['a']).not.to.equal(undefined);
+                // expect(dspC.designSystem['b']).not.to.equal(undefined);
+                expect(dspC.designSystem["c"]).not.to.equal(undefined);
+                expect(dspC.designSystem["d"]).not.to.equal(undefined);
+
+                expect(dspC.designSystem["a"]).to.equal(dspA.designSystem["a"]);
+                expect(dspC.designSystem["b"]).to.equal(dspA.designSystem["b"]);
+                expect(dspC.designSystem["c"]).to.equal(dspA.designSystem["c"]);
+
+                // Observable.getAccessors(dspA.designSystem).forEach(x => {
+                //     expect(dspB.designSystem[x.name]).not.to.equal(undefined)
+                //     expect(dspA.designSystem[x.name]).to.equal(dspB.designSystem[x.name])
+                // })
+                done();
+            });
         });
     });
 });

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
@@ -489,24 +489,10 @@ export class DesignSystemProvider extends FASTElement
                 }
 
                 if (sync) {
-                    if (!localDSAccessors.findIndex(y => y.name === x.name)) {
+                    if (localDSAccessors.findIndex(y => y.name === x.name) === -1) {
                         Observable.defineProperty(this.designSystem, x.name);
                     }
-
-                    // this.designSystem[x.name] = this.provider?.designSystem[x.name]
-                    console.log(
-                        this,
-                        this.provider,
-                        this.designSystem,
-                        this.provider?.designSystem
-                    );
                     this.designSystem[x.name] = this.provider?.designSystem[x.name];
-                    console.log(
-                        this,
-                        this.provider,
-                        this.designSystem,
-                        this.provider?.designSystem
-                    );
                 }
             });
         }

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
@@ -190,11 +190,9 @@ export class DesignSystemProvider extends FASTElement
         next: DesignSystemProvider | null
     ): void {
         if (prev instanceof HTMLElement) {
-            Object.keys(prev.designSystemProperties).forEach(key => {
-                Observable.getNotifier(prev.designSystem).unsubscribe(
-                    this.providerDesignSystemChangeHandler,
-                    key
-                );
+            const notifier = Observable.getNotifier(prev.designSystem);
+            Observable.getAccessors(prev.designSystem).forEach(x => {
+                notifier.unsubscribe(this.providerDesignSystemChangeHandler, x.name);
             });
         }
 
@@ -202,12 +200,13 @@ export class DesignSystemProvider extends FASTElement
             next instanceof HTMLElement &&
             DesignSystemProvider.isDesignSystemProvider(next)
         ) {
-            Object.keys(next.designSystemProperties).forEach(key => {
-                Observable.getNotifier(next.designSystem).subscribe(
-                    this.providerDesignSystemChangeHandler,
-                    key
-                );
+            const notifier = Observable.getNotifier(next.designSystem);
+            Observable.getAccessors(next.designSystem).forEach(x => {
+                notifier.subscribe(this.providerDesignSystemChangeHandler, x.name);
             });
+            // Object.keys(next.designSystemProperties).forEach(key => {
+
+            // });
 
             this.syncDesignSystemWithProvider();
         }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
This PR addresses several issues surrounding nested DesignSystemProviders where the nested provider's `designSystem` object did not contain all of the non-overriden information that the parent provider's `designSystem` contained. 

**Providers that only declared a sub-set of the parent providers DesignSystemProperties would only have the declared properties mirrored to the `designSystem` object.**
```html
<provider-a>
  <provider-b></provider-b>
</provider-a>
```

where `<provider-a>` declares designSystemProperties of `a` and `b` and `<provider-b>` declares only `b`, instances of `<provider-b>` would only have `designSystem.b` availible.

Only declared properties of the parent provider were synced down in other cases, meaning multiple nesting of providers dissimilar declared properties would lose data after two layers of nesting.

```html
<provider-a>
  <provider-b>
      <provider-c></provider-c>
  </provider-b>
</provider-a>
```
where `<provider-a>` declares `a`, `<provider-b>` declares `b`, and `<provider-c>` declares `c`, `<provider-c>.designSystem` would only have available properties `b` and `c` (`a` is omitted).

These lead to issues where code would try to register with these nested providers but not have the information available to work correctly.
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->