### PR TITLE
fix: getDirection utility should not throw

### DIFF
--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -1,5 +1,6 @@
 import { attr, DOM, FASTElement, observable } from "@microsoft/fast-element";
 import { Direction } from "@microsoft/fast-web-utilities";
+import { getDirection } from "../utilities";
 
 // TODO: the Resize Observer related files are a temporary stopgap measure until
 // Resize Observer types are pulled into TypeScript, which seems imminent
@@ -63,8 +64,6 @@ enum Location {
 }
 
 export class AnchoredRegion extends FASTElement {
-    private static DirectionAttributeName: string = "dir";
-
     /**
      * The HTML id of the anchor element this region is positioned relative to
      *
@@ -722,7 +721,7 @@ export class AnchoredRegion extends FASTElement {
             this.viewportElement = this.getViewport();
         }
 
-        this.currentDirection = this.getDirection();
+        this.currentDirection = getDirection(this);
         this.startObservers();
     };
 
@@ -753,7 +752,7 @@ export class AnchoredRegion extends FASTElement {
                     dirCorrectedHorizontalDefaultPosition === "end"
                 ) {
                     // if direction changes we reset the layout
-                    const newDirection: Direction = this.getDirection();
+                    const newDirection: Direction = getDirection(this);
                     if (newDirection !== this.currentDirection) {
                         this.currentDirection = newDirection;
                         this.initialize();
@@ -1209,19 +1208,5 @@ export class AnchoredRegion extends FASTElement {
         }
 
         return newRegionDimension;
-    };
-
-    /**
-     *  gets the current direction
-     */
-    private getDirection = (): Direction => {
-        const closest: Element | null = this.closest(
-            `[${AnchoredRegion.DirectionAttributeName}]`
-        );
-
-        return closest === null ||
-            closest.getAttribute(AnchoredRegion.DirectionAttributeName) === Direction.ltr
-            ? Direction.ltr
-            : Direction.rtl;
     };
 }

--- a/packages/web-components/fast-foundation/src/utilities/direction.ts
+++ b/packages/web-components/fast-foundation/src/utilities/direction.ts
@@ -7,6 +7,6 @@ import { Direction } from "@microsoft/fast-web-utilities";
  */
 
 export const getDirection = (rootNode: HTMLElement): Direction => {
-    const dirNode: HTMLElement | null = rootNode.parentElement!.closest("[dir]");
+    const dirNode: HTMLElement | null = rootNode.closest("[dir]");
     return dirNode !== null && dirNode.dir === "rtl" ? Direction.rtl : Direction.ltr;
 };


### PR DESCRIPTION
# Description
The getDirection utility function would call .closest() on the parent node of the element node passed in.  This would throw an exception when .parent is null which happens when the node is a child of a shadow root (there may be other cases too).  Since I'm not sure why we call this on the .parent rather than the node itself I changed the function to use the param directly.

I also removed the local version of getDirection from the AnchoredRegion element and pointed at the utility code instead.  

## Motivation & context
The function should not throw, and should work correctly even if the element passed to the function is at the root of a shadow dom.  

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
