### PR TITLE
fix: remove anchored region "contains" test 

### DIFF
--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -515,11 +515,7 @@ export class AnchoredRegion extends FASTElement {
     private startObservers = (): void => {
         this.stopObservers();
 
-        if (
-            this.anchorElement === null ||
-            (this.viewportElement !== null &&
-                !this.viewportElement.contains(this.anchorElement))
-        ) {
+        if (this.anchorElement === null) {
             return;
         }
 


### PR DESCRIPTION
# Description
Before anchored region starts up observers it would check to see if the anchor was actually a child of the viewport, but the "contains()" call it was using to verify this did not work with elements within a shadow dom and always returned false which prevented initialization in some scenarios.  Since anchored region now uses the document root as the intersection observer viewport this test isn't actually necessary, so took it out.

## Motivation & context
Anchored region should work for elements in a shadow dom

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.