### PR TITLE
fix: colorswatch change handler was checking for the wrong type on the event target

### DIFF
--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
@@ -6,6 +6,7 @@ import {
     fastDesignSystemDefaults,
     StandardLuminance,
     neutralLayerCardContainer,
+    FASTRadioGroup,
 } from "@microsoft/fast-components";
 import {
     ColorHSL,
@@ -96,12 +97,10 @@ export class FastFrame extends FASTElement {
     };
 
     public neutralChangeHandler = (e: CustomEvent): void => {
-        if (e.target instanceof SiteColorSwatch) {
-            if (e.target.checked) {
-                const parsedColor = parseColorHexRGB(e.target.value);
-                this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64);
-                this.updateBackgroundColor();
-            }
+        if (e.target instanceof FASTRadioGroup) {
+            const parsedColor = parseColorHexRGB(e.target.value);
+            this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64);
+            this.updateBackgroundColor();
         }
     };
 

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
@@ -83,16 +83,14 @@ export class FastFrame extends FASTElement {
     public isMobile: boolean = this.mql.matches;
 
     public accentChangeHandler = (e: CustomEvent): void => {
-        if (e.target instanceof SiteColorSwatch) {
-            if (e.target.checked) {
-                this.accentColor = e.target.value;
-                const accentColorHSL = rgbToHSL(parseColorHexRGB(this.accentColor)!);
-                this.hue = accentColorHSL.h;
-                this.saturation = accentColorHSL.s;
-                this.lightness = accentColorHSL.l;
-                const parsedColor = parseColorHexRGB(this.accentColor);
-                this.accentPalette = createColorPalette(parsedColor as ColorRGBA64);
-            }
+        if (e.target instanceof FASTRadioGroup) {
+            this.accentColor = e.target.value;
+            const accentColorHSL = rgbToHSL(parseColorHexRGB(this.accentColor)!);
+            this.hue = accentColorHSL.h;
+            this.saturation = accentColorHSL.s;
+            this.lightness = accentColorHSL.l;
+            const parsedColor = parseColorHexRGB(this.accentColor);
+            this.accentPalette = createColorPalette(parsedColor as ColorRGBA64);
         }
     };
 


### PR DESCRIPTION
# Description
Recent `fast-radio-group` changes have caused the handler in fast-frame for the color swatches to be checking for the wrong instanceof type, now checking for FASTRadioGroup which should only get emitted when a change in the child radio components forces a change of the parent radio-group's value.


## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

