### PR TITLE
feat: attribute selectors instead of class selectors

### DIFF
--- a/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
@@ -78,7 +78,7 @@ export const AccordionItemStyles = css`
             ${neutralFocusBehavior.var};
     }
 
-    :host(.expanded) .region {
+    :host([expanded]) .region {
         display: flex;
     }
 
@@ -95,7 +95,7 @@ export const AccordionItemStyles = css`
         display: flex;
     }
 
-    :host(.expanded) slot[name="collapsed-icon"] {
+    :host([expanded]) slot[name="collapsed-icon"] {
         display: none;
     }
 
@@ -103,7 +103,7 @@ export const AccordionItemStyles = css`
         display: none;
     }
     
-    :host(.expanded) slot[name="expanded-icon"] {
+    :host([expanded]) slot[name="expanded-icon"] {
         display: flex;
     }
 

--- a/packages/web-components/fast-components/src/badge/badge.styles.ts
+++ b/packages/web-components/fast-components/src/badge/badge.styles.ts
@@ -21,7 +21,7 @@ export const BadgeStyles = css`
         font-weight: 400;
     }
 
-    :host(.circular) .control {
+    :host([circular]) .control {
         border-radius: 100px;
         padding: 0 calc(var(--design-unit) * 1px);
         ${

--- a/packages/web-components/fast-components/src/button/button.styles.ts
+++ b/packages/web-components/fast-components/src/button/button.styles.ts
@@ -22,8 +22,8 @@ export const ButtonStyles = css`
 `.withBehaviors(
     forcedColorsStylesheetBehavior(
         css`
-            :host(.disabled),
-            :host(.disabled) .control {
+            :host([disabled]),
+            :host([disabled]) .control {
                 forced-color-adjust: none;
                 background: ${SystemColors.ButtonFace};
                 border-color: ${SystemColors.GrayText};
@@ -31,63 +31,63 @@ export const ButtonStyles = css`
                 cursor: ${disabledCursor};
                 opacity: 1;
             }
-            :host(.accent) .control {
+            :host([appearance="accent"]) .control {
                 forced-color-adjust: none;
                 background: ${SystemColors.Highlight};
                 color: ${SystemColors.HighlightText};
             }
     
-            :host(.accent) .control:hover {
+            :host([appearance="accent"]) .control:hover {
                 background: ${SystemColors.HighlightText};
                 border-color: ${SystemColors.Highlight};
                 color: ${SystemColors.Highlight};
             }
     
-            :host(.accent:${focusVisible}) .control {
+            :host([appearance="accent"]:${focusVisible}) .control {
                 border-color: ${SystemColors.ButtonText};
                 box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
             }
     
-            :host(.accent.disabled) .control,
-            :host(.accent.disabled) .control:hover {
+            :host([appearance="accent"][disabled]) .control,
+            :host([appearance="accent"][disabled]) .control:hover {
                 background: ${SystemColors.ButtonFace};
                 border-color: ${SystemColors.GrayText};
                 color: ${SystemColors.GrayText};
             }
-            :host(.lightweight) .control:hover {
+            :host([appearance="lightweight"]) .control:hover {
                 forced-color-adjust: none;
                 color: ${SystemColors.Highlight};
             }
     
-            :host(.lightweight) .control:hover .content::before {
+            :host([appearance="lightweight"]) .control:hover .content::before {
                 background: ${SystemColors.Highlight};
             }
     
-            :host(.lightweight.disabled) .control {
+            :host([appearance="lightweight"][disabled]) .control {
                 forced-color-adjust: none;
                 color: ${SystemColors.GrayText};
             }
         
-            :host(.lightweight.disabled) .control:hover .content::before {
+            :host([appearance="lightweight"][disabled]) .control:hover .content::before {
                 background: none;
             }
-            :host(.outline.disabled) .control {
+            :host([appearance="outline"][disabled]) .control {
                 border-color: ${SystemColors.GrayText};
             }
-            :host(.stealth) .control {
+            :host([appearance="stealth"]) .control {
                 forced-color-adjust: none;
                 background: none;
                 border-color: transparent;
                 color: ${SystemColors.ButtonText};
                 fill: currentcolor;
             }
-            :host(.stealth) .control:hover,
-            :host(.stealth:${focusVisible}) .control {
+            :host([appearance="stealth"]) .control:hover,
+            :host([appearance="stealth"]:${focusVisible}) .control {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
                 color: ${SystemColors.HighlightText};
             }
-            :host(.stealth.disabled) .control {
+            :host([appearance="stealth"][disabled]) .control {
                 background: none;
                 border-color: transparent;
                 color: ${SystemColors.GrayText};

--- a/packages/web-components/fast-components/src/button/index.ts
+++ b/packages/web-components/fast-components/src/button/index.ts
@@ -42,15 +42,6 @@ export class FASTButton extends Button {
      */
     @attr
     public appearance: ButtonAppearance;
-    public appearanceChanged(
-        oldValue: ButtonAppearance,
-        newValue: ButtonAppearance
-    ): void {
-        if (oldValue !== newValue) {
-            this.classList.add(newValue);
-            this.classList.remove(oldValue);
-        }
-    }
 
     public connectedCallback() {
         super.connectedCallback();

--- a/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
@@ -103,22 +103,22 @@ export const CheckboxStyles = css`
         border-color: ${neutralFocusBehavior.var};
     }
 
-    :host([checked]) .control {
+    :host([aria-checked="true"]) .control {
         background: ${accentFillRestBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
     }
 
-    :host([checked]:not([disabled])) .control:hover {
+    :host([aria-checked="true"]:not([disabled])) .control:hover {
         background: ${accentFillHoverBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillHoverBehavior.var};
     }
 
-    :host([checked]:not([disabled])) .control:active {
+    :host([aria-checked="true"]:not([disabled])) .control:active {
         background: ${accentFillActiveBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillActiveBehavior.var};
     }
 
-    :host([checked]:${focusVisible}:not([disabled])) .control {
+    :host([aria-checked="true"]:${focusVisible}:not([disabled])) .control {
         box-shadow: 0 0 0 2px var(--background-color), 0 0 0 4px ${
             neutralFocusBehavior.var
         };
@@ -133,7 +133,7 @@ export const CheckboxStyles = css`
         cursor: ${disabledCursor};
     }
 
-    :host([checked]:not(.indeterminate)) .checked-indicator,
+    :host([aria-checked="true"]:not(.indeterminate)) .checked-indicator,
     :host(.indeterminate) .indeterminate-indicator {
         opacity: 1;
     }
@@ -176,27 +176,27 @@ export const CheckboxStyles = css`
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host([checked]:${focusVisible}:not([disabled])) .control {
+            :host([aria-checked="true"]:${focusVisible}:not([disabled])) .control {
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host([checked]) .control {
+            :host([aria-checked="true"]) .control {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
             }
-            :host([checked]:not([disabled])) .control:hover, .control:active {
+            :host([aria-checked="true"]:not([disabled])) .control:hover, .control:active {
                 border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.HighlightText};
             }
-            :host([checked]) .checked-indicator {
+            :host([aria-checked="true"]) .checked-indicator {
                 fill: ${SystemColors.HighlightText};
             }
-            :host([checked]:not([disabled])) .control:hover .checked-indicator {
+            :host([aria-checked="true"]:not([disabled])) .control:hover .checked-indicator {
                 fill: ${SystemColors.Highlight}
             }
-            :host([checked]) .indeterminate-indicator {
+            :host([aria-checked="true"]) .indeterminate-indicator {
                 background: ${SystemColors.HighlightText};
             }
-            :host([checked]) .control:hover .indeterminate-indicator {
+            :host([aria-checked="true"]) .control:hover .indeterminate-indicator {
                 background: ${SystemColors.Highlight}
             }
             :host([disabled]) {
@@ -208,12 +208,12 @@ export const CheckboxStyles = css`
                 background: ${SystemColors.Field};
             }
             :host([disabled]) .indeterminate-indicator,
-            :host([checked][disabled]) .control:hover .indeterminate-indicator {
+            :host([aria-checked="true"][disabled]) .control:hover .indeterminate-indicator {
                 forced-color-adjust: none;
                 background: ${SystemColors.GrayText};
             }
             :host([disabled]) .checked-indicator,
-            :host([checked][disabled]) .control:hover .checked-indicator {
+            :host([aria-checked="true"][disabled]) .control:hover .checked-indicator {
                 forced-color-adjust: none;
                 fill: ${SystemColors.GrayText};
             }

--- a/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
@@ -103,22 +103,22 @@ export const CheckboxStyles = css`
         border-color: ${neutralFocusBehavior.var};
     }
 
-    :host(.checked) .control {
+    :host([checked]) .control {
         background: ${accentFillRestBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
     }
 
-    :host(.checked:not([disabled])) .control:hover {
+    :host([checked]:not([disabled])) .control:hover {
         background: ${accentFillHoverBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillHoverBehavior.var};
     }
 
-    :host(.checked:not([disabled])) .control:active {
+    :host([checked]:not([disabled])) .control:active {
         background: ${accentFillActiveBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillActiveBehavior.var};
     }
 
-    :host(.checked:${focusVisible}:not([disabled])) .control {
+    :host([checked]:${focusVisible}:not([disabled])) .control {
         box-shadow: 0 0 0 2px var(--background-color), 0 0 0 4px ${
             neutralFocusBehavior.var
         };
@@ -126,19 +126,19 @@ export const CheckboxStyles = css`
     }
 
 
-    :host(.disabled) .label,
-    :host(.readonly) .label,
-    :host(.readonly) .control,
-    :host(.disabled) .control {
+    :host([disabled]) .label,
+    :host([readonly]) .label,
+    :host([readonly]) .control,
+    :host([disabled]) .control {
         cursor: ${disabledCursor};
     }
 
-    :host(.checked:not(.indeterminate)) .checked-indicator,
+    :host([checked]:not(.indeterminate)) .checked-indicator,
     :host(.indeterminate) .indeterminate-indicator {
         opacity: 1;
     }
 
-    :host(.disabled) {
+    :host([disabled]) {
         opacity: var(--disabled-opacity);
     }
 `.withBehaviors(
@@ -176,44 +176,44 @@ export const CheckboxStyles = css`
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.checked:${focusVisible}:not([disabled])) .control {
+            :host([checked]:${focusVisible}:not([disabled])) .control {
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.checked) .control {
+            :host([checked]) .control {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
             }
-            :host(.checked:not([disabled])) .control:hover, .control:active {
+            :host([checked]:not([disabled])) .control:hover, .control:active {
                 border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.HighlightText};
             }
-            :host(.checked) .checked-indicator {
+            :host([checked]) .checked-indicator {
                 fill: ${SystemColors.HighlightText};
             }
-            :host(.checked:not([disabled])) .control:hover .checked-indicator {
+            :host([checked]:not([disabled])) .control:hover .checked-indicator {
                 fill: ${SystemColors.Highlight}
             }
-            :host(.checked) .indeterminate-indicator {
+            :host([checked]) .indeterminate-indicator {
                 background: ${SystemColors.HighlightText};
             }
-            :host(.checked) .control:hover .indeterminate-indicator {
+            :host([checked]) .control:hover .indeterminate-indicator {
                 background: ${SystemColors.Highlight}
             }
-            :host(.disabled) {
+            :host([disabled]) {
                 opacity: 1;
             }
-            :host(.disabled) .control {
+            :host([disabled]) .control {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.GrayText};
                 background: ${SystemColors.Field};
             }
-            :host(.disabled) .indeterminate-indicator,
-            :host(.checked.disabled) .control:hover .indeterminate-indicator {
+            :host([disabled]) .indeterminate-indicator,
+            :host([checked][disabled]) .control:hover .indeterminate-indicator {
                 forced-color-adjust: none;
                 background: ${SystemColors.GrayText};
             }
-            :host(.disabled) .checked-indicator,
-            :host(.checked.disabled) .control:hover .checked-indicator {
+            :host([disabled]) .checked-indicator,
+            :host([checked][disabled]) .control:hover .checked-indicator {
                 forced-color-adjust: none;
                 fill: ${SystemColors.GrayText};
             }

--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -48,8 +48,8 @@ export const FlipperStyles = css`
         transition: all 0.1s ease-in-out;
     }
 
-    [direction="next"],
-    [direction="previous"] {
+    .next,
+    .previous {
         position: relative;
         ${
             /* Glyph size and margin-left is temporary - 

--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -48,8 +48,8 @@ export const FlipperStyles = css`
         transition: all 0.1s ease-in-out;
     }
 
-    .next,
-    .previous {
+    [direction="next"],
+    [direction="previous"] {
         position: relative;
         ${
             /* Glyph size and margin-left is temporary - 
@@ -58,16 +58,16 @@ export const FlipperStyles = css`
         height: 16px;
     }
 
-    :host(.disabled) {
+    :host([disabled]) {
         opacity: var(--disabled-opacity);
         cursor: ${disabledCursor};
         fill: currentcolor;
         color: ${neutralForegroundRestBehavior.var};
     }
 
-    :host(.disabled)::before,
-    :host(.disabled:hover)::before,
-    :host(.disabled:active)::before {
+    :host([disabled])::before,
+    :host([disabled]:hover)::before,
+    :host([disabled]:active)::before {
         background: ${neutralFillStealthRestBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
     }
@@ -111,8 +111,8 @@ export const FlipperStyles = css`
             :host {
                 background: ${SystemColors.Canvas};
             }
-            :host .next,
-            :host .previous {
+            :host [direction="next"],
+            :host [direction="previous"] {
                 color: ${SystemColors.ButtonText};
                 fill: currentcolor;
             }
@@ -126,21 +126,21 @@ export const FlipperStyles = css`
                 border-color: ${SystemColors.ButtonText};
                 opacity: 1;
             }
-            :host(:hover) .next,
-            :host(:hover) .previous {
+            :host(:hover) [direction="next"],
+            :host(:hover) [direction="previous"] {
                 forced-color-adjust: none;
                 color: ${SystemColors.HighlightText};
                 fill: currentcolor;
             }
-            :host(.disabled) {
+            :host([disabled]) {
                 opacity: 1;
             }
-            :host(.disabled)::before,
-            :host(.disabled:hover)::before,
-            :host(.disabled) .next,
-            :host(.disabled) .previous,
-            :host(.disabled:hover) .next,
-            :host(.disabled:hover) .previous {
+            :host([disabled])::before,
+            :host([disabled]:hover)::before,
+            :host([disabled]) [direction="next"],
+            :host([disabled]) [direction="previous"],
+            :host([disabled]:hover) [direction="next"],
+            :host([disabled]:hover) [direction="previous"] {
                 forced-color-adjust: none;
                 background: ${SystemColors.Canvas};
                 border-color: ${SystemColors.GrayText};

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -58,20 +58,20 @@ export const MenuItemStyles = css`
         color: ${accentForegroundCutRestBehavior.var};
     }
 
-    :host(.disabled) {
+    :host([disabled]) {
         cursor: ${disabledCursor};
         opacity: var(--disabled-opacity);
     }
 
-    :host(.disabled:hover) {
+    :host([disabled]:hover) {
         color: ${neutralForegroundRestBehavior.var};
         fill: currentcolor;
         background: ${neutralFillStealthRestBehavior.var}
     }
 
-    :host(.disabled:hover) .start,
-    :host(.disabled:hover) .end,
-    :host(.disabled:hover)::slotted(svg) {
+    :host([disabled]:hover) .start,
+    :host([disabled]:hover) .end,
+    :host([disabled]:hover)::slotted(svg) {
         fill: ${neutralForegroundRestBehavior.var};
     }
 
@@ -133,11 +133,11 @@ export const MenuItemStyles = css`
                 color: ${SystemColors.HighlightText};
                 fill: currentcolor;
             }
-            :host(.disabled),
-            :host(.disabled:hover),
-            :host(.disabled:hover) .start,
-            :host(.disabled:hover) .end,
-            :host(.disabled:hover)::slotted(svg) {
+            :host([disabled]),
+            :host([disabled]:hover),
+            :host([disabled]:hover) .start,
+            :host([disabled]:hover) .end,
+            :host([disabled]:hover)::slotted(svg) {
                 background: ${SystemColors.Canvas};
                 color: ${SystemColors.GrayText};
                 fill: currentcolor;

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -52,6 +52,10 @@ export const MenuItemStyles = css`
         background: ${accentFillHoverBehavior.var};
         color: ${accentForegroundCutRestBehavior.var};
     }
+    :host([checked="true"]) {
+        background: ${accentFillHoverBehavior.var};
+        color: ${accentForegroundCutRestBehavior.var};
+    }
 
     :host(:active) {
         background: ${accentFillActiveBehavior.var};

--- a/packages/web-components/fast-components/src/progress-ring/progress-ring.styles.ts
+++ b/packages/web-components/fast-components/src/progress-ring/progress-ring.styles.ts
@@ -49,12 +49,12 @@ export const ProgressRingStyles = css`
         animation: spin-infinite 2s linear infinite;
     }
 
-    :host(.paused) .indeterminate-indicator-1 {
+    :host([paused]) .indeterminate-indicator-1 {
         animation-play-state: paused;
         stroke: ${neutralFillRestBehavior.var};
     }
 
-    :host(.paused) .determinate {
+    :host([paused]) .determinate {
         stroke: ${neutralForegroundHintBehavior.var};
     }
 
@@ -85,10 +85,10 @@ export const ProgressRingStyles = css`
             .background {
                 stroke: ${SystemColors.Field};
             }
-            :host(.paused) .indeterminate-indicator-1 {
+            :host([paused]) .indeterminate-indicator-1 {
                 stroke: ${SystemColors.Field};
             }
-            :host(.paused) .determinate {
+            :host([paused]) .determinate {
                 stroke: ${SystemColors.GrayText};
             }
         `

--- a/packages/web-components/fast-components/src/progress/progress.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress.styles.ts
@@ -64,13 +64,13 @@ export const ProgressStyles = css`
         animation: indeterminate-2 2s infinite;
     }
 
-    :host(.paused) .indeterminate-indicator-1,
-    :host(.paused) .indeterminate-indicator-2 {
+    :host([paused]) .indeterminate-indicator-1,
+    :host([paused]) .indeterminate-indicator-2 {
         animation-play-state: paused;
         background-color: ${neutralFillRestBehavior.var};
     }
 
-    :host(.paused) .determinate {
+    :host([paused]) .determinate {
         background-color: ${neutralForegroundHintBehavior.var};
     }
 
@@ -126,9 +126,9 @@ export const ProgressStyles = css`
                 forced-color-adjust: none;
                 background-color: ${SystemColors.FieldText};
             }
-            :host(.paused) .determinate,
-            :host(.paused) .indeterminate-indicator-1,
-            :host(.paused) .indeterminate-indicator-2 {
+            :host([paused]) .determinate,
+            :host([paused]) .indeterminate-indicator-1,
+            :host([paused]) .indeterminate-indicator-2 {
                 background-color: ${SystemColors.GrayText};
             }
         `

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -11,10 +11,10 @@ export const RadioGroupStyles = css`
         display: flex;
         flex-wrap: wrap;
     }
-    .vertical {
+    [orientation="vertical"] {
         flex-direction: column;
     }
-    .horizontal {
+    [orientation="horizontal"] {
         flex-direction: row;
     }
 `;

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -103,40 +103,40 @@ export const RadioStyles = css`
         border-color: ${neutralFocusBehavior.var};
     }
 
-    :host(.checked) .control {
+    :host([checked]) .control {
         background: ${accentFillRestBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
     }
 
-    :host(.checked:not([disabled])) .control:hover {
+    :host([checked]:not([disabled])) .control:hover {
         background: ${accentFillHoverBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillHoverBehavior.var};
     }
 
-    :host(.checked:not([disabled])) .control:active {
+    :host([checked]:not([disabled])) .control:active {
         background: ${accentFillActiveBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillActiveBehavior.var};
     }
 
-    :host(.checked:${focusVisible}:not([disabled])) .control {
+    :host([checked]:${focusVisible}:not([disabled])) .control {
         box-shadow: 0 0 0 2px var(--background-color), 0 0 0 4px ${
             neutralFocusBehavior.var
         };
         border-color: transparent;
     }
 
-    :host(.disabled) .label,
-    :host(.readonly) .label,
-    :host(.readonly) .control,
-    :host(.disabled) .control {
+    :host([disabled]) .label,
+    :host([readonly]) .label,
+    :host([readonly]) .control,
+    :host([disabled]) .control {
         cursor: ${disabledCursor};
     }
 
-    :host(.checked) .checked-indicator {
+    :host([checked]) .checked-indicator {
         opacity: 1;
     }
 
-    :host(.disabled) {
+    :host([disabled]) {
         opacity: var(--disabled-opacity);
     }
 `.withBehaviors(
@@ -155,7 +155,7 @@ export const RadioStyles = css`
     forcedColorsStylesheetBehavior(
         css`
             .control,
-            :host(.checked:not([disabled])) .control {
+            :host([checked]:not([disabled])) .control {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.FieldText};
                 background: ${SystemColors.Field};
@@ -164,17 +164,17 @@ export const RadioStyles = css`
                 border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.Field};
             }
-            :host(.checked:not([disabled])) .control:hover,
-            :host(.checked:not([disabled])) .control:active {
+            :host([checked]:not([disabled])) .control:hover,
+            :host([checked]:not([disabled])) .control:active {
                 border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.Highlight};
             }
-            :host(.checked) .checked-indicator {
+            :host([checked]) .checked-indicator {
                 background: ${SystemColors.Highlight};
                 fill: ${SystemColors.Highlight};
             }
-            :host(.checked:not([disabled])) .control:hover .checked-indicator,
-            :host(.checked:not([disabled])) .control:active .checked-indicator {
+            :host([checked]:not([disabled])) .control:hover .checked-indicator,
+            :host([checked]:not([disabled])) .control:active .checked-indicator {
                 background: ${SystemColors.HighlightText};
                 fill: ${SystemColors.HighlightText};
             }
@@ -182,24 +182,24 @@ export const RadioStyles = css`
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.checked:${focusVisible}:not([disabled])) .control {
+            :host([checked]:${focusVisible}:not([disabled])) .control {
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.disabled) {
+            :host([disabled]) {
                 forced-color-adjust: none;
                 opacity: 1;
             }
-            :host(.disabled) .label {
+            :host([disabled]) .label {
                 color: ${SystemColors.GrayText};
             }
-            :host(.disabled) .control,
-            :host(.checked.disabled) .control:hover, .control:active {
+            :host([disabled]) .control,
+            :host([checked][disabled]) .control:hover, .control:active {
                 background: ${SystemColors.Field};
                 border-color: ${SystemColors.GrayText};
             }
-            :host(.disabled) .checked-indicator,
-            :host(.checked.disabled) .control:hover .checked-indicator {
+            :host([disabled]) .checked-indicator,
+            :host([checked][disabled]) .control:hover .checked-indicator {
                 fill: ${SystemColors.GrayText};
                 background: ${SystemColors.GrayText};
             }

--- a/packages/web-components/fast-components/src/skeleton/skeleton.styles.ts
+++ b/packages/web-components/fast-components/src/skeleton/skeleton.styles.ts
@@ -18,11 +18,11 @@ export const SkeletonStyles = css`
         --skeleton-animation-timing-default: ease-in-out;
     }
 
-    :host(.rect) {
+    :host([shape="rect"]) {
         border-radius: calc(var(--corner-radius) * 1px);
     }
 
-    :host(.circle) {
+    :host([shape="circle"]) {
         border-radius: 100%;
         overflow: hidden;
     }

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -16,14 +16,14 @@ export const SliderLabelStyles = css`
         position: absolute;
         display: grid;
     }
-    :host(.horizontal) {
+    :host([orientation="horizontal"]) {
         align-self: start;
         grid-row: 2;
         margin-top: -2px;
         height: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
         width: auto;
     }
-    :host(.vertical) {
+    :host([orientation="vertical"]) {
         justify-self: start;
         grid-column: 2;
         margin-left: 2px;
@@ -34,11 +34,11 @@ export const SliderLabelStyles = css`
         display: grid;
         justify-self: center;
     }
-    :host(.horizontal) .container {
+    :host([orientation="horizontal"]) .container {
         grid-template-rows: auto auto;
         grid-template-columns: 0;
     }
-    :host(.vertical) .container {
+    :host([orientation="vertical"]) .container {
         grid-template-columns: auto auto;
         grid-template-rows: 0;
         min-width: calc(var(--thumb-size) * 1px);
@@ -57,11 +57,11 @@ export const SliderLabelStyles = css`
         background: ${neutralOutlineRestBehavior.var};
         justify-self: center;
     }
-    :host(.vertical) .mark {
+    :host([orientation="vertical"]) .mark {
         transform: rotate(90deg);
         align-self: center;
     }
-    :host(.vertical) .label {
+    :host([orientation="vertical"]) .label {
         margin-left: calc((var(--design-unit) / 2) * 2px);
         align-self: center;
     }

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -36,13 +36,13 @@ export const SliderStyles = css`
         outline: none;
         cursor: pointer;
     }
-    :host(.horizontal) .positioning-region {
+    :host([orientation="horizontal"]) .positioning-region {
         position: relative;
         margin: 0 8px;
         display: grid;
         grid-template-rows: calc(var(--thumb-size) * 1px) 1fr;
     }
-    :host(.vertical) .positioning-region {
+    :host([orientation="vertical"]) .positioning-region {
         position: relative;
         margin: 0 8px;
         display: grid;
@@ -76,23 +76,23 @@ export const SliderStyles = css`
     .thumb-cursor:active {
         background: ${neutralForegroundActiveBehavior.var};
     }
-    :host(.horizontal) .thumb-container {
+    :host([orientation="horizontal"]) .thumb-container {
         transform: translateX(calc(var(--thumb-translate) * 1px));
     }
-    :host(.vertical) .thumb-container {
+    :host([orientation="vertical"]) .thumb-container {
         transform: translateY(calc(var(--thumb-translate) * 1px));
     }
-    :host(.horizontal) {
+    :host([orientation="horizontal"]) {
         min-width: calc(var(--thumb-size) * 1px);
     }
-    :host(.horizontal) .track {
+    :host([orientation="horizontal"]) .track {
         right: calc(var(--track-overhang) * 1px);
         left: calc(var(--track-overhang) * 1px);
         align-self: start;
         margin-top: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
         height: calc(var(--track-width) * 1px);
     }
-    :host(.vertical) .track {
+    :host([orientation="vertical"]) .track {
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
         width: calc(var(--track-width) * 1px);
@@ -104,7 +104,7 @@ export const SliderStyles = css`
         position: absolute;
         border-radius: calc(var(--corner-radius) * 1px);
     }
-    :host(.vertical) {
+    :host([orientation="vertical"]) {
         height: calc(var(--fast-slider-height) * 1px);
         min-height: calc(var(--thumb-size) * 1px);
         min-width: calc(var(--design-unit) * 20px);

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -83,7 +83,7 @@ export const BaseButtonStyles = css`
         border: 0;
     }
 
-    :host(.disabled) {
+    :host([disabled]) {
         opacity: var(--disabled-opacity);
         background-color: ${neutralFillRestBehavior.var};
         cursor: ${disabledCursor};
@@ -117,24 +117,24 @@ export const BaseButtonStyles = css`
  * @internal
  */
 export const AccentButtonStyles = css`
-    :host(.accent) {
+    :host([appearance="accent"]) {
         background: ${accentFillRestBehavior.var};
         color: ${accentForegroundCutRestBehavior.var};
     }
 
-    :host(.accent:hover) {
+    :host([appearance="accent"]:hover) {
         background: ${accentFillHoverBehavior.var};
     }
 
-    :host(.accent:active) .control:active {
+    :host([appearance="accent"]:active) .control:active {
         background: ${accentFillActiveBehavior.var};
     }
 
-    :host(.accent) .control:${focusVisible} {
+    :host([appearance="accent"]) .control:${focusVisible} {
         box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${neutralFocusInnerAccentBehavior.var};
     }
 
-    :host(.accent.disabled) {
+    :host([appearance="accent"][disabled]) {
         background: ${accentFillRestBehavior.var};
     }
 `.withBehaviors(
@@ -149,7 +149,7 @@ export const AccentButtonStyles = css`
  * @internal
  */
 export const HypertextStyles = css`
-    :host(.hypertext) {
+    :host([appearance="hypertext"]) {
         font-size: inherit;
         line-height: inherit;
         height: auto;
@@ -157,7 +157,7 @@ export const HypertextStyles = css`
         background: transparent;
     }
 
-    :host(.hypertext) .control {
+    :host([appearance="hypertext"]) .control {
         display: inline;
         padding: 0;
         border: none;
@@ -169,19 +169,19 @@ export const HypertextStyles = css`
         background-color: transparent;
         cursor: default;
     }
-    :host(.hypertext) .control:link,
-    :host(.hypertext) .control:visited {
+    :host([appearance="hypertext"]) .control:link,
+    :host([appearance="hypertext"]) .control:visited {
         background: transparent;
         color: ${accentForegroundRestBehavior.var};
         border-bottom: calc(var(--outline-width) * 1px) solid ${accentForegroundRestBehavior.var};
     }
-    :host(.hypertext) .control:hover {
+    :host([appearance="hypertext"]) .control:hover {
         border-bottom-color: ${accentForegroundHoverBehavior.var};
     }
-    :host(.hypertext) .control:active {
+    :host([appearance="hypertext"]) .control:active {
         border-bottom-color: ${accentForegroundActiveBehavior.var};
     }
-    :host(.hypertext) .control:${focusVisible} {
+    :host([appearance="hypertext"]) .control:${focusVisible} {
         border-bottom: calc(var(--focus-outline-width) * 1px) solid ${neutralFocusBehavior.var};
     }
 `.withBehaviors(
@@ -195,12 +195,12 @@ export const HypertextStyles = css`
  * @internal
  */
 export const LightweightButtonStyles = css`
-    :host(.lightweight) {
+    :host([appearance="lightweight"]) {
         background: transparent;
         color: ${accentForegroundRestBehavior.var};
     }
 
-    :host(.lightweight) .control {
+    :host([appearance="lightweight"]) .control {
         padding: 0;
         height: initial;
         border: none;
@@ -208,19 +208,19 @@ export const LightweightButtonStyles = css`
         border-radius: 0;
     }
 
-    :host(.lightweight:hover) {
+    :host([appearance="lightweight"]:hover) {
         color: ${accentForegroundHoverBehavior.var};
     }
 
-    :host(.lightweight:active) {
+    :host([appearance="lightweight"]:active) {
         color: ${accentForegroundActiveBehavior.var};
     }
 
-    :host(.lightweight) .content {
+    :host([appearance="lightweight"]) .content {
         position: relative;
     }
 
-    :host(.lightweight) .content::before {
+    :host([appearance="lightweight"]) .content::before {
         content: "";
         display: block;
         height: calc(var(--outline-width) * 1px);
@@ -229,20 +229,20 @@ export const LightweightButtonStyles = css`
         width: 100%;
     }
 
-    :host(.lightweight:hover) .content::before {
+    :host([appearance="lightweight"]:hover) .content::before {
         background: ${accentForegroundHoverBehavior.var};
     }
 
-    :host(.lightweight:active) .content::before {
+    :host([appearance="lightweight"]:active) .content::before {
         background: ${accentForegroundActiveBehavior.var};
     }
 
-    :host(.lightweight) .control:${focusVisible} .content::before {
+    :host([appearance="lightweight"]) .control:${focusVisible} .content::before {
         background: ${neutralForegroundRestBehavior.var};
         height: calc(var(--focus-outline-width) * 1px);
     }
 
-    :host(.lightweight.disabled) .content::before {
+    :host([appearance="lightweight"][disabled]) .content::before {
         background: transparent;
     }
 `.withBehaviors(
@@ -253,7 +253,7 @@ export const LightweightButtonStyles = css`
     neutralForegroundRestBehavior,
     forcedColorsStylesheetBehavior(
         css`
-            :host(.lightweight:hover) .content::before {
+            :host([appearance="lightweight"]:hover) .content::before {
                 background: ${SystemColors.LinkText};
             }
         `
@@ -264,29 +264,29 @@ export const LightweightButtonStyles = css`
  * @internal
  */
 export const OutlineButtonStyles = css`
-    :host(.outline) {
+    :host([appearance="outline"]) {
         background: transparent;
         border-color: ${accentFillRestBehavior.var};
     }
 
-    :host(.outline:hover) {
+    :host([appearance="outline"]:hover) {
         border-color: ${accentFillHoverBehavior.var};
     }
 
-    :host(.outline:active) {
+    :host([appearance="outline"]:active) {
         border-color: ${accentFillActiveBehavior.var};
     }
 
-    :host(.outline) .control {
+    :host([appearance="outline"]) .control {
         border-color: inherit;
     }
 
-    :host(.outline) .control:${focusVisible} {
+    :host([appearance="outline"]) .control:${focusVisible} {
         border: calc(var(--outline-width) * 1px) solid ${neutralFocusBehavior.var});
         box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${neutralFocusBehavior.var};
     }
 
-    :host(.outline.disabled) {
+    :host([appearance="outline"][disabled]) {
         border-color: ${accentFillRestBehavior.var};
     }
 `.withBehaviors(
@@ -300,19 +300,19 @@ export const OutlineButtonStyles = css`
  * @internal
  */
 export const StealthButtonStyles = css`
-    :host(.stealth) {
+    :host([appearance="stealth"]) {
         background: ${neutralFillStealthRestBehavior.var};
     }
 
-    :host(.stealth:hover) {
+    :host([appearance="stealth"]:hover) {
         background: ${neutralFillStealthHoverBehavior.var};
     }
 
-    :host(.stealth:active) {
+    :host([appearance="stealth"]:active) {
         background: ${neutralFillStealthActiveBehavior.var};
     }
 
-    :host(.stealth.disabled) {
+    :host([appearance="stealth"][disabled]) {
         background: ${neutralFillStealthRestBehavior.var};
     }
 `.withBehaviors(

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -46,8 +46,8 @@ export const SwitchStyles = css`
     }
 
     :host([disabled]) .label,
-    :host(.readonly) .label,
-    :host(.readonly) .switch,
+    :host([readonly]) .label,
+    :host([readonly]) .switch,
     :host([disabled]) .switch {
         cursor: ${disabledCursor};
     }

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -41,14 +41,14 @@ export const SwitchStyles = css`
         } user-select: none;
     }
 
-    :host(.disabled) {
+    :host([disabled]) {
         opacity: var(--disabled-opacity);
     }
 
-    :host(.disabled) .label,
+    :host([disabled]) .label,
     :host(.readonly) .label,
     :host(.readonly) .switch,
-    :host(.disabled) .switch {
+    :host([disabled]) .switch {
         cursor: ${disabledCursor};
     }
 
@@ -131,26 +131,26 @@ export const SwitchStyles = css`
         } margin-inline-start: calc(var(--design-unit) * 2px + 2px);
     }
 
-    :host(.checked) .checked-indicator {
+    :host([checked]) .checked-indicator {
         background: ${accentForegroundCutRestBehavior.var};
     }
 
-    :host(.checked) .switch {
+    :host([checked]) .switch {
         background: ${accentFillRestBehavior.var};
         border-color: ${accentFillRestBehavior.var};
     }
 
-    :host(.checked:not([disabled])) .switch:hover {
+    :host([checked]:not([disabled])) .switch:hover {
         background: ${accentFillHoverBehavior.var};
         border-color: ${accentFillHoverBehavior.var};
     }
 
-    :host(.checked:not([disabled])) .switch:active {
+    :host([checked]:not([disabled])) .switch:active {
         background: ${accentFillActiveBehavior.var};
         border-color: ${accentFillActiveBehavior.var};
     }
 
-    :host(.checked:${focusVisible}:not([disabled])) .switch {
+    :host([checked]:${focusVisible}:not([disabled])) .switch {
         box-shadow: 0 0 0 2px var(--background-color), 0 0 0 4px ${
             neutralFocusBehavior.var
         };
@@ -165,11 +165,11 @@ export const SwitchStyles = css`
         display: none;
     }
 
-    :host(.checked) .unchecked-message {
+    :host([checked]) .unchecked-message {
         display: none;
     }
 
-    :host(.checked) .checked-message {
+    :host([checked]) .checked-message {
         display: block;
     }
 `.withBehaviors(
@@ -201,35 +201,35 @@ export const SwitchStyles = css`
                 background: ${SystemColors.HighlightText};
                 border-color: ${SystemColors.Highlight};
             }
-            :host(.checked) .switch {
+            :host([checked]) .switch {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
             }
-            :host(.checked:not([disabled])) .switch:hover,
+            :host([checked]:not([disabled])) .switch:hover,
             :host(:not([disabled])) .switch:active {
                 background: ${SystemColors.HighlightText};
                 border-color: ${SystemColors.Highlight};
             }
-            :host(.checked) .checked-indicator {
+            :host([checked]) .checked-indicator {
                 background: ${SystemColors.HighlightText};
             }
-            :host(.checked:not([disabled])) .switch:hover .checked-indicator {
+            :host([checked]:not([disabled])) .switch:hover .checked-indicator {
                 background: ${SystemColors.Highlight};
             }
-            :host(.disabled) {
+            :host([disabled]) {
                 opacity: 1;
             }
             :host(:${focusVisible}) .switch {
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.checked:${focusVisible}:not([disabled])) .switch {
+            :host([checked]:${focusVisible}:not([disabled])) .switch {
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host(.disabled) .checked-indicator {
+            :host([disabled]) .checked-indicator {
                 background: ${SystemColors.GrayText};
             }
-            :host(.disabled) .switch {
+            :host([disabled]) .switch {
                 background: ${SystemColors.Field};
                 border-color: ${SystemColors.GrayText};
             }
@@ -242,7 +242,7 @@ export const SwitchStyles = css`
                 right: calc(((${heightNumber} / 2) + 1) * 1px);
             }
 
-            :host(.checked) .checked-indicator {
+            :host([checked]) .checked-indicator {
                 left: calc(((${heightNumber} / 2) + 1) * 1px);
                 right: 5px;
             }
@@ -253,7 +253,7 @@ export const SwitchStyles = css`
                 left: calc(((${heightNumber} / 2) + 1) * 1px);
             }
 
-            :host(.checked) .checked-indicator {
+            :host([checked]) .checked-indicator {
                 right: calc(((${heightNumber} / 2) + 1) * 1px);
                 left: 5px;
             }

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -131,26 +131,26 @@ export const SwitchStyles = css`
         } margin-inline-start: calc(var(--design-unit) * 2px + 2px);
     }
 
-    :host([checked]) .checked-indicator {
+    :host([aria-checked="true"]) .checked-indicator {
         background: ${accentForegroundCutRestBehavior.var};
     }
 
-    :host([checked]) .switch {
+    :host([aria-checked="true"]) .switch {
         background: ${accentFillRestBehavior.var};
         border-color: ${accentFillRestBehavior.var};
     }
 
-    :host([checked]:not([disabled])) .switch:hover {
+    :host([aria-checked="true"]:not([disabled])) .switch:hover {
         background: ${accentFillHoverBehavior.var};
         border-color: ${accentFillHoverBehavior.var};
     }
 
-    :host([checked]:not([disabled])) .switch:active {
+    :host([aria-checked="true"]:not([disabled])) .switch:active {
         background: ${accentFillActiveBehavior.var};
         border-color: ${accentFillActiveBehavior.var};
     }
 
-    :host([checked]:${focusVisible}:not([disabled])) .switch {
+    :host([aria-checked="true"]:${focusVisible}:not([disabled])) .switch {
         box-shadow: 0 0 0 2px var(--background-color), 0 0 0 4px ${
             neutralFocusBehavior.var
         };
@@ -165,11 +165,11 @@ export const SwitchStyles = css`
         display: none;
     }
 
-    :host([checked]) .unchecked-message {
+    :host([aria-checked="true"]) .unchecked-message {
         display: none;
     }
 
-    :host([checked]) .checked-message {
+    :host([aria-checked="true"]) .checked-message {
         display: block;
     }
 `.withBehaviors(
@@ -201,19 +201,19 @@ export const SwitchStyles = css`
                 background: ${SystemColors.HighlightText};
                 border-color: ${SystemColors.Highlight};
             }
-            :host([checked]) .switch {
+            :host([aria-checked="true"]) .switch {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
             }
-            :host([checked]:not([disabled])) .switch:hover,
+            :host([aria-checked="true"]:not([disabled])) .switch:hover,
             :host(:not([disabled])) .switch:active {
                 background: ${SystemColors.HighlightText};
                 border-color: ${SystemColors.Highlight};
             }
-            :host([checked]) .checked-indicator {
+            :host([aria-checked="true"]) .checked-indicator {
                 background: ${SystemColors.HighlightText};
             }
-            :host([checked]:not([disabled])) .switch:hover .checked-indicator {
+            :host([aria-checked="true"]:not([disabled])) .switch:hover .checked-indicator {
                 background: ${SystemColors.Highlight};
             }
             :host([disabled]) {
@@ -223,7 +223,7 @@ export const SwitchStyles = css`
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host([checked]:${focusVisible}:not([disabled])) .switch {
+            :host([aria-checked="true"]:${focusVisible}:not([disabled])) .switch {
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
             :host([disabled]) .checked-indicator {
@@ -242,7 +242,7 @@ export const SwitchStyles = css`
                 right: calc(((${heightNumber} / 2) + 1) * 1px);
             }
 
-            :host([checked]) .checked-indicator {
+            :host([aria-checked="true"]) .checked-indicator {
                 left: calc(((${heightNumber} / 2) + 1) * 1px);
                 right: 5px;
             }
@@ -253,7 +253,7 @@ export const SwitchStyles = css`
                 left: calc(((${heightNumber} / 2) + 1) * 1px);
             }
 
-            :host([checked]) .checked-indicator {
+            :host([aria-checked="true"]) .checked-indicator {
                 right: calc(((${heightNumber} / 2) + 1) * 1px);
                 left: 5px;
             }

--- a/packages/web-components/fast-components/src/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tab/tab.styles.ts
@@ -80,24 +80,24 @@ export const TabStyles = css`
         outline: none;
     }
 
-    :host([orientation="vertical"]) {
+    :host(.vertical) {
         justify-content: end;
         grid-column: 2;
     }
 
-    :host([orientation="vertical"][aria-selected="true"]) {
+    :host(.vertical[aria-selected="true"]) {
         z-index: 2;
     }
 
-    :host([orientation="vertical"]:hover) {
+    :host(.vertical:hover) {
         color: ${neutralForegroundHoverBehavior.var};
     }
 
-    :host([orientation="vertical"]:active) {
+    :host(.vertical:active) {
         color: ${neutralForegroundActiveBehavior.var};
     }
 
-    :host([orientation="vertical"]:hover[aria-selected="true"]) {
+    :host(.vertical:hover[aria-selected="true"]) {
     }
 `.withBehaviors(
     accentFillActiveBehavior,
@@ -123,7 +123,7 @@ export const TabStyles = css`
                 fill: currentcolor;
             }
             :host(:hover),
-            :host([orientation="vertical"]:hover),
+            :host(.vertical:hover),
             :host([aria-selected="true"]:hover) {
                 background: ${SystemColors.Highlight};
                 color: ${SystemColors.HighlightText};

--- a/packages/web-components/fast-components/src/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tab/tab.styles.ts
@@ -80,24 +80,24 @@ export const TabStyles = css`
         outline: none;
     }
 
-    :host(.vertical) {
+    :host([orientation="vertical"]) {
         justify-content: end;
         grid-column: 2;
     }
 
-    :host(.vertical[aria-selected="true"]) {
+    :host([orientation="vertical"][aria-selected="true"]) {
         z-index: 2;
     }
 
-    :host(.vertical:hover) {
+    :host([orientation="vertical"]:hover) {
         color: ${neutralForegroundHoverBehavior.var};
     }
 
-    :host(.vertical:active) {
+    :host([orientation="vertical"]:active) {
         color: ${neutralForegroundActiveBehavior.var};
     }
 
-    :host(.vertical:hover[aria-selected="true"]) {
+    :host([orientation="vertical"]:hover[aria-selected="true"]) {
     }
 `.withBehaviors(
     accentFillActiveBehavior,
@@ -123,7 +123,7 @@ export const TabStyles = css`
                 fill: currentcolor;
             }
             :host(:hover),
-            :host(.vertical:hover),
+            :host([orientation="vertical"]:hover),
             :host([aria-selected="true"]:hover) {
                 background: ${SystemColors.Highlight};
                 color: ${SystemColors.HighlightText};

--- a/packages/web-components/fast-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tabs.styles.ts
@@ -57,12 +57,12 @@ export const TabsStyles = css`
         position: relative;
     }
 
-    :host(.vertical) {
+    :host([orientation="vertical"]) {
         grid-template-rows: auto 1fr auto;
         grid-template-columns: auto 1fr;
     }
 
-    :host(.vertical) .tablist {
+    :host([orientation="vertical"]) .tablist {
         grid-row-start: 2;
         grid-row-end: 2;
         display: grid;
@@ -77,17 +77,17 @@ export const TabsStyles = css`
             calc((${heightNumber} - var(--design-unit)) * 1px) 0;
     }
 
-    :host(.vertical) .tabpanel {
+    :host([orientation="vertical"]) .tabpanel {
         grid-column: 2;
         grid-row-start: 1;
         grid-row-end: 4;
     }
 
-    :host(.vertical) .end {
+    :host([orientation="vertical"]) .end {
         grid-row: 3;
     }
 
-    :host(.vertical) .activeIndicator {
+    :host([orientation="vertical"]) .activeIndicator {
         grid-column: 1;
         grid-row: 1;
         width: 5px;
@@ -100,7 +100,7 @@ export const TabsStyles = css`
             0;
     }
 
-    :host(.vertical) .activeIndicatorTransition {
+    :host([orientation="vertical"]) .activeIndicatorTransition {
         transition: transform 0.2s linear;
     }
 `.withBehaviors(
@@ -109,7 +109,7 @@ export const TabsStyles = css`
     forcedColorsStylesheetBehavior(
         css`
             .activeIndicator,
-            :host(.vertical) .activeIndicator {
+            :host([orientation="vertical"]) .activeIndicator {
                 forced-color-adjust: none;
                 background: ${SystemColors.Highlight};
             }

--- a/packages/web-components/fast-components/src/text-area/index.ts
+++ b/packages/web-components/fast-components/src/text-area/index.ts
@@ -41,19 +41,6 @@ export class FASTTextArea extends TextArea {
     /**
      * @internal
      */
-    public appearanceChanged(
-        oldValue: TextAreaAppearance,
-        newValue: TextAreaAppearance
-    ): void {
-        if (oldValue !== newValue) {
-            this.classList.add(newValue);
-            this.classList.remove(oldValue);
-        }
-    }
-
-    /**
-     * @internal
-     */
     public connectedCallback() {
         super.connectedCallback();
 

--- a/packages/web-components/fast-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/fast-components/src/text-area/text-area.styles.ts
@@ -65,23 +65,23 @@ export const TextAreaStyles = css`
         box-shadow: 0 0 0 1px ${neutralFocusBehavior.var} inset;
     }
 
-    :host(.filled) .control {
+    :host([appearance="filled"]) .control {
         background: ${neutralFillRestBehavior.var};
     }
 
-    :host(.filled:hover:not([disabled])) .control {
+    :host([appearance="filled"]:hover:not([disabled])) .control {
         background: ${neutralFillHoverBehavior.var};
     }
 
-    :host(.resize-both) .control {
+    :host([resize="both"]) .control {
         resize: both;
     }
 
-    :host(.resize-horizontal) .control {
+    :host([resize="horizontal"]) .control {
         resize: horizontal;
     }
 
-    :host(.resize-vertical) .control {
+    :host([resize="vertical"]) .control {
         resize: vertical;
     }
 

--- a/packages/web-components/fast-components/src/text-field/index.ts
+++ b/packages/web-components/fast-components/src/text-field/index.ts
@@ -41,19 +41,6 @@ export class FASTTextField extends TextField {
     /**
      * @internal
      */
-    public appearanceChanged(
-        oldValue: TextFieldAppearance,
-        newValue: TextFieldAppearance
-    ): void {
-        if (oldValue !== newValue) {
-            this.classList.add(newValue);
-            this.classList.remove(oldValue);
-        }
-    }
-
-    /**
-     * @internal
-     */
     public connectedCallback() {
         super.connectedCallback();
 

--- a/packages/web-components/fast-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.styles.ts
@@ -94,37 +94,37 @@ export const TextFieldStyles = css`
         margin-inline-end: 11px;
     }
 
-    :host(:hover:not(.disabled)) .root {
+    :host(:hover:not([disabled])) .root {
         background: ${neutralFillInputHoverBehavior.var};
         border-color: ${accentFillHoverBehavior.var};
     }
 
-    :host(:active:not(.disabled)) .root {
+    :host(:active:not([disabled])) .root {
         background: ${neutralFillInputHoverBehavior.var};
         border-color: ${accentFillActiveBehavior.var};
     }
 
-    :host(:focus-within:not(.disabled)) .root {
+    :host(:focus-within:not([disabled])) .root {
         border-color: ${neutralFocusBehavior.var};
         box-shadow: 0 0 0 1px ${neutralFocusBehavior.var} inset;
     }
 
-    :host(.filled) .root {
+    :host([appearance="filled"]) .root {
         background: ${neutralFillRestBehavior.var};
     }
 
-    :host(.filled:hover:not(.disabled)) .root {
+    :host([appearance="filled"]:hover:not([disabled])) .root {
         background: ${neutralFillHoverBehavior.var};
     }
 
-    :host(.disabled) .label,
-    :host(.readonly) .label,
-    :host(.readonly) .control,
-    :host(.disabled) .control {
+    :host([disabled]) .label,
+    :host([readonly]) .label,
+    :host([readonly]) .control,
+    :host([disabled]) .control {
         cursor: ${disabledCursor};
     }
 
-    :host(.disabled) {
+    :host([disabled]) {
         opacity: var(--disabled-opacity);
     }
 
@@ -145,14 +145,14 @@ export const TextFieldStyles = css`
     forcedColorsStylesheetBehavior(
         css`
             .root,
-            :host(.filled) .root {
+            :host([appearance="filled"]) .root {
                 forced-color-adjust: none;
                 background: ${SystemColors.Field};
                 border-color: ${SystemColors.FieldText};
             }
-            :host(:hover:not(.disabled)) .root,
-            :host(.filled:hover:not(.disabled)) .root,
-            :host(.filled:hover) .root {
+            :host(:hover:not([disabled])) .root,
+            :host([appearance="filled"]:hover:not([disabled])) .root,
+            :host([appearance="filled"]:hover) .root {
                 background: ${SystemColors.Field};
                 border-color: ${SystemColors.Highlight};
             }
@@ -160,11 +160,11 @@ export const TextFieldStyles = css`
             .end {
                 fill: currentcolor;
             }
-            :host(.disabled) {
+            :host([disabled]) {
                 opacity: 1;
             }
-            :host(.disabled) .root,
-            :host(.filled:hover.disabled) .root {
+            :host([disabled]) .root,
+            :host([appearance="filled"]:hover[disabled]) .root {
                 border-color: ${SystemColors.GrayText};
                 background: ${SystemColors.Field};
             }

--- a/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
@@ -48,29 +48,29 @@ export const TooltipStyles = css`
         overflow: visible;
     }
 
-    :host(.top) fast-anchored-region,
-    :host(.bottom) fast-anchored-region {
+    :host([position="top"]) fast-anchored-region,
+    :host([position="bottom"]) fast-anchored-region {
         flex-direction: row;
     }
 
-    :host(.right) fast-anchored-region,
-    :host(.left) fast-anchored-region {
+    :host([position="right"]) fast-anchored-region,
+    :host([position="left"]) fast-anchored-region {
         flex-direction: column;
     }
 
-    :host(.top) .tooltip {
+    :host([position="top"]) .tooltip {
         margin-bottom: 4px;
     }
 
-    :host(.bottom) .tooltip {
+    :host([position="bottom"]) .tooltip {
         margin-top: 4px;
     }
 
-    :host(.left) .tooltip {
+    :host([position="left"]) .tooltip {
         margin-right: 4px;
     }
 
-    :host(.right) .tooltip {
+    :host([position="right"]) .tooltip {
         margin-left: 4px;
     }
 `.withBehaviors(

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -33,7 +33,7 @@ const ltr = css`
     :host([selected])::after {
         left: calc(var(--focus-outline-width) * 1px);
     }
-    :host(.expanded) > .positioning-region .expand-collapse-glyph {
+    :host([expanded]) > .positioning-region .expand-collapse-glyph {
         transform: rotate(0deg);
     }
 `;
@@ -48,7 +48,7 @@ const rtl = css`
     :host([selected])::after {
         right: calc(var(--focus-outline-width) * 1px);
     }
-    :host(.expanded) > .positioning-region .expand-collapse-glyph {
+    :host([expanded]) > .positioning-region .expand-collapse-glyph {
         transform: rotate(90deg);
     }
 `;
@@ -189,7 +189,7 @@ export const TreeItemStyles = css`
         } margin-inline-start: calc(var(--design-unit) * 2px + 2px);
     }
 
-    :host(.expanded) > .items {
+    :host([expanded]) > .items {
         display: block;
     }
 


### PR DESCRIPTION
# Description
Uses attribute selectors instead of the class selectors since it's not always easy to integrate.
To make the library more open for integration (e.g. React and Blazor) since we don't have to bother with the css classes.

## Motivation & context

- Fixes #4076

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [x] This change causes current functionality to break.
css classes can no longer be used.

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.