### PR TITLE
feat(fast-element): introduce NamedTargetDirective for extensibility

### DIFF
--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -108,12 +108,11 @@ export class BindingBehavior implements Behavior {
 }
 
 // @public
-export class BindingDirective extends Directive {
+export class BindingDirective extends NamedTargetDirective {
     constructor(binding: Binding);
     // (undocumented)
     binding: Binding;
     createBehavior(target: Node): BindingBehavior;
-    createPlaceholder: (index: number) => string;
     targetAtContent(): void;
     get targetName(): string | undefined;
     set targetName(value: string | undefined);
@@ -350,6 +349,12 @@ export class HTMLView implements ElementView, SyntheticView {
 export type Mutable<T> = {
     -readonly [P in keyof T]: T[P];
 };
+
+// @public
+export abstract class NamedTargetDirective extends Directive {
+    createPlaceholder: (index: number) => string;
+    abstract targetName: string | undefined;
+}
 
 // @public
 export interface NodeBehaviorOptions<T = any> {

--- a/packages/web-components/fast-element/src/directives/binding.ts
+++ b/packages/web-components/fast-element/src/directives/binding.ts
@@ -201,7 +201,7 @@ export class BindingDirective extends NamedTargetDirective {
      */
     public constructor(public binding: Binding) {
         super();
-        this.isBindingVolatile = Observable.isVolatileBinding(this.bind);
+        this.isBindingVolatile = Observable.isVolatileBinding(this.binding);
     }
 
     /**

--- a/packages/web-components/fast-element/src/directives/binding.ts
+++ b/packages/web-components/fast-element/src/directives/binding.ts
@@ -7,7 +7,7 @@ import {
 import { Observable } from "../observation/observable";
 import { DOM } from "../dom";
 import { SyntheticView } from "../view";
-import { Directive } from "./directive";
+import { NamedTargetDirective } from "./directive";
 import { Behavior } from "./behavior";
 
 function normalBind(
@@ -187,20 +187,13 @@ function updateClassTarget(this: BindingBehavior, value: string): void {
  * A directive that configures data binding to element content and attributes.
  * @public
  */
-export class BindingDirective extends Directive {
+export class BindingDirective extends NamedTargetDirective {
     private cleanedTargetName?: string;
     private originalTargetName?: string;
     private bind: typeof normalBind = normalBind;
     private unbind: typeof normalUnbind = normalUnbind;
     private updateTarget: typeof updateAttributeTarget = updateAttributeTarget;
     private isBindingVolatile: boolean;
-
-    /**
-     * Creates a placeholder string based on the directive's index within the template.
-     * @param index - The index of the directive within the template.
-     */
-    public createPlaceholder: (index: number) => string =
-        DOM.createInterpolationPlaceholder;
 
     /**
      * Creates an instance of BindingDirective.

--- a/packages/web-components/fast-element/src/directives/directive.ts
+++ b/packages/web-components/fast-element/src/directives/directive.ts
@@ -25,6 +25,25 @@ export abstract class Directive implements BehaviorFactory {
 }
 
 /**
+ * A {@link Directive} that targets a named attribute or property on a node or object.
+ * @public
+ */
+export abstract class NamedTargetDirective extends Directive {
+    /**
+     * Gets/sets the name of the attribute or property that this
+     * directive is targeting on the associated node or object.
+     */
+    public abstract targetName: string | undefined;
+
+    /**
+     * Creates a placeholder string based on the directive's index within the template.
+     * @param index - The index of the directive within the template.
+     */
+    public createPlaceholder: (index: number) => string =
+        DOM.createInterpolationPlaceholder;
+}
+
+/**
  * Describes the shape of a behavior constructor that can be created by
  * an {@link AttachedBehaviorDirective}.
  * @public

--- a/packages/web-components/fast-element/src/template.spec.ts
+++ b/packages/web-components/fast-element/src/template.spec.ts
@@ -6,9 +6,7 @@ import { Directive, NamedTargetDirective } from "./directives/directive";
 
 describe(`The html tag template helper`, () => {
     it(`transforms a string into a ViewTemplate.`, () => {
-        const template = html`
-            This is a test HTML string.
-        `;
+        const template = html`This is a test HTML string.`;
         expect(template).instanceOf(ViewTemplate);
     });
 
@@ -32,77 +30,59 @@ describe(`The html tag template helper`, () => {
         {
             type: "string",
             location: "at the beginning",
-            template: html`
-                ${stringValue} end
-            `,
+            template: html`${stringValue} end`,
             result: `${stringValue} end`,
         },
         {
             type: "string",
             location: "in the middle",
-            template: html`
-                beginning ${stringValue} end
-            `,
+            template: html`beginning ${stringValue} end`,
             result: `beginning ${stringValue} end`,
         },
         {
             type: "string",
             location: "at the end",
-            template: html`
-                beginning ${stringValue}
-            `,
+            template: html`beginning ${stringValue}`,
             result: `beginning ${stringValue}`,
         },
         // number interpolation
         {
             type: "number",
             location: "at the beginning",
-            template: html`
-                ${numberValue} end
-            `,
+            template: html`${numberValue} end`,
             result: `${numberValue} end`,
         },
         {
             type: "number",
             location: "in the middle",
-            template: html`
-                beginning ${numberValue} end
-            `,
+            template: html`beginning ${numberValue} end`,
             result: `beginning ${numberValue} end`,
         },
         {
             type: "number",
             location: "at the end",
-            template: html`
-                beginning ${numberValue}
-            `,
+            template: html`beginning ${numberValue}`,
             result: `beginning ${numberValue}`,
         },
         // expression interpolation
         {
             type: "expression",
             location: "at the beginning",
-            template: html<Model>`
-                ${x => x.value} end
-            `,
+            template: html<Model>`${x => x.value} end`,
             result: `${DOM.createInterpolationPlaceholder(0)} end`,
             expectDirectives: [BindingDirective],
         },
         {
             type: "expression",
             location: "in the middle",
-            template: html<Model>`
-                beginning ${x => x.value} end
-            `,
+            template: html<Model>`beginning ${x => x.value} end`,
             result: `beginning ${DOM.createInterpolationPlaceholder(0)} end`,
             expectDirectives: [BindingDirective],
         },
         {
             type: "expression",
             location: "at the end",
-            template: html<Model>`
-                beginning ${x => x.value}
-            `,
+            template: html<Model>`beginning ${x => x.value}`,
             result: `beginning ${DOM.createInterpolationPlaceholder(0)}`,
             expectDirectives: [BindingDirective],
         },
@@ -110,27 +90,21 @@ describe(`The html tag template helper`, () => {
         {
             type: "directive",
             location: "at the beginning",
-            template: html`
-                ${new TestDirective()} end
-            `,
+            template: html`${new TestDirective()} end`,
             result: `${DOM.createBlockPlaceholder(0)} end`,
             expectDirectives: [TestDirective],
         },
         {
             type: "directive",
             location: "in the middle",
-            template: html`
-                beginning ${new TestDirective()} end
-            `,
+            template: html`beginning ${new TestDirective()} end`,
             result: `beginning ${DOM.createBlockPlaceholder(0)} end`,
             expectDirectives: [TestDirective],
         },
         {
             type: "directive",
             location: "at the end",
-            template: html`
-                beginning ${new TestDirective()}
-            `,
+            template: html`beginning ${new TestDirective()}`,
             result: `beginning ${DOM.createBlockPlaceholder(0)}`,
             expectDirectives: [TestDirective],
         },
@@ -138,37 +112,21 @@ describe(`The html tag template helper`, () => {
         {
             type: "template",
             location: "at the beginning",
-            template: html`
-                ${html`
-                    sub-template
-                `}
-                end
-            `,
+            template: html`${html`sub-template`} end`,
             result: `${DOM.createInterpolationPlaceholder(0)} end`,
             expectDirectives: [BindingDirective],
         },
         {
             type: "template",
             location: "in the middle",
-            template: html`
-                beginning
-                ${html`
-                    sub-template
-                `}
-                end
-            `,
+            template: html`beginning ${html`sub-template`} end`,
             result: `beginning ${DOM.createInterpolationPlaceholder(0)} end`,
             expectDirectives: [BindingDirective],
         },
         {
             type: "template",
             location: "at the end",
-            template: html`
-                beginning
-                ${html`
-                    sub-template
-                `}
-            `,
+            template: html`beginning ${html`sub-template`}`,
             result: `beginning ${DOM.createInterpolationPlaceholder(0)}`,
             expectDirectives: [BindingDirective],
         },
@@ -176,9 +134,7 @@ describe(`The html tag template helper`, () => {
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the beginning",
-            template: html<Model>`
-                ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end
-            `,
+            template: html<Model>`${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
             result: `${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
                 0
             )}${DOM.createBlockPlaceholder(1)} end`,
@@ -187,10 +143,7 @@ describe(`The html tag template helper`, () => {
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "in the middle",
-            template: html<Model>`
-                beginning
-                ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end
-            `,
+            template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
             result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
                 0
             )}${DOM.createBlockPlaceholder(1)} end`,
@@ -199,10 +152,7 @@ describe(`The html tag template helper`, () => {
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the end",
-            template: html<Model>`
-                beginning
-                ${stringValue}${numberValue}${x => x.value}${new TestDirective()}
-            `,
+            template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()}`,
             result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
                 0
             )}${DOM.createBlockPlaceholder(1)}`,
@@ -211,11 +161,8 @@ describe(`The html tag template helper`, () => {
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "at the beginning",
-            template: html<Model>`
-                ${stringValue}separator${numberValue}separator${x =>
-                    x.value}separator${new TestDirective()}
-                end
-            `,
+            template: html<Model>`${stringValue}separator${numberValue}separator${x =>
+                    x.value}separator${new TestDirective()} end`,
             result: `${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
                 0
             )}separator${DOM.createBlockPlaceholder(1)} end`,
@@ -224,12 +171,8 @@ describe(`The html tag template helper`, () => {
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "in the middle",
-            template: html<Model>`
-                beginning
-                ${stringValue}separator${numberValue}separator${x =>
-                    x.value}separator${new TestDirective()}
-                end
-            `,
+            template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x =>
+                    x.value}separator${new TestDirective()} end`,
             result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
                 0
             )}separator${DOM.createBlockPlaceholder(1)} end`,
@@ -238,11 +181,8 @@ describe(`The html tag template helper`, () => {
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "at the end",
-            template: html<Model>`
-                beginning
-                ${stringValue}separator${numberValue}separator${x =>
-                    x.value}separator${new TestDirective()}
-            `,
+            template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x =>
+                    x.value}separator${new TestDirective()}`,
             result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
                 0
             )}separator${DOM.createBlockPlaceholder(1)}`,
@@ -264,9 +204,7 @@ describe(`The html tag template helper`, () => {
     });
 
     it(`captures a case-sensitive property name when used with an expression`, () => {
-        const template = html<Model>`
-            <my-element :someAttribute=${x => x.value}></my-element>
-        `;
+        const template = html<Model>`<my-element :someAttribute=${x => x.value}></my-element>`;
         const placeholder = DOM.createInterpolationPlaceholder(0);
 
         expect(template.html).to.equal(
@@ -278,9 +216,7 @@ describe(`The html tag template helper`, () => {
     });
 
     it(`captures a case-sensitive property name when used with a binding`, () => {
-        const template = html<Model>`
-            <my-element :someAttribute=${new BindingDirective(x => x.value)}></my-element>
-        `;
+        const template = html<Model>`<my-element :someAttribute=${new BindingDirective(x => x.value)}></my-element>`;
         const placeholder = DOM.createInterpolationPlaceholder(0);
 
         expect(template.html).to.equal(
@@ -299,9 +235,7 @@ describe(`The html tag template helper`, () => {
             }
         }
 
-        const template = html<Model>`
-            <my-element :someAttribute=${new TestDirective()}></my-element>
-        `;
+        const template = html<Model>`<my-element :someAttribute=${new TestDirective()}></my-element>`;
         const placeholder = DOM.createInterpolationPlaceholder(0);
 
         expect(template.html).to.equal(

--- a/packages/web-components/fast-element/src/template.spec.ts
+++ b/packages/web-components/fast-element/src/template.spec.ts
@@ -2,11 +2,13 @@ import { expect } from "chai";
 import { html, ViewTemplate } from "./template";
 import { DOM } from "./dom";
 import { BindingDirective } from "./directives/binding";
-import { Directive } from "./directives/directive";
+import { Directive, NamedTargetDirective } from "./directives/directive";
 
 describe(`The html tag template helper`, () => {
     it(`transforms a string into a ViewTemplate.`, () => {
-        const template = html`This is a test HTML string.`;
+        const template = html`
+            This is a test HTML string.
+        `;
         expect(template).instanceOf(ViewTemplate);
     });
 
@@ -30,59 +32,77 @@ describe(`The html tag template helper`, () => {
         {
             type: "string",
             location: "at the beginning",
-            template: html`${stringValue} end`,
+            template: html`
+                ${stringValue} end
+            `,
             result: `${stringValue} end`,
         },
         {
             type: "string",
             location: "in the middle",
-            template: html`beginning ${stringValue} end`,
+            template: html`
+                beginning ${stringValue} end
+            `,
             result: `beginning ${stringValue} end`,
         },
         {
             type: "string",
             location: "at the end",
-            template: html`beginning ${stringValue}`,
+            template: html`
+                beginning ${stringValue}
+            `,
             result: `beginning ${stringValue}`,
         },
         // number interpolation
         {
             type: "number",
             location: "at the beginning",
-            template: html`${numberValue} end`,
+            template: html`
+                ${numberValue} end
+            `,
             result: `${numberValue} end`,
         },
         {
             type: "number",
             location: "in the middle",
-            template: html`beginning ${numberValue} end`,
+            template: html`
+                beginning ${numberValue} end
+            `,
             result: `beginning ${numberValue} end`,
         },
         {
             type: "number",
             location: "at the end",
-            template: html`beginning ${numberValue}`,
+            template: html`
+                beginning ${numberValue}
+            `,
             result: `beginning ${numberValue}`,
         },
         // expression interpolation
         {
             type: "expression",
             location: "at the beginning",
-            template: html<Model>`${x => x.value} end`,
+            template: html<Model>`
+                ${x => x.value} end
+            `,
             result: `${DOM.createInterpolationPlaceholder(0)} end`,
             expectDirectives: [BindingDirective],
         },
         {
             type: "expression",
             location: "in the middle",
-            template: html<Model>`beginning ${x => x.value} end`,
+            template: html<Model>`
+                beginning ${x => x.value} end
+            `,
             result: `beginning ${DOM.createInterpolationPlaceholder(0)} end`,
             expectDirectives: [BindingDirective],
         },
         {
             type: "expression",
             location: "at the end",
-            template: html<Model>`beginning ${x => x.value}`,
+            template: html<Model>`
+                beginning ${x => x.value}
+            `,
             result: `beginning ${DOM.createInterpolationPlaceholder(0)}`,
             expectDirectives: [BindingDirective],
         },
@@ -90,21 +110,27 @@ describe(`The html tag template helper`, () => {
         {
             type: "directive",
             location: "at the beginning",
-            template: html`${new TestDirective()} end`,
+            template: html`
+                ${new TestDirective()} end
+            `,
             result: `${DOM.createBlockPlaceholder(0)} end`,
             expectDirectives: [TestDirective],
         },
         {
             type: "directive",
             location: "in the middle",
-            template: html`beginning ${new TestDirective()} end`,
+            template: html`
+                beginning ${new TestDirective()} end
+            `,
             result: `beginning ${DOM.createBlockPlaceholder(0)} end`,
             expectDirectives: [TestDirective],
         },
         {
             type: "directive",
             location: "at the end",
-            template: html`beginning ${new TestDirective()}`,
+            template: html`
+                beginning ${new TestDirective()}
+            `,
             result: `beginning ${DOM.createBlockPlaceholder(0)}`,
             expectDirectives: [TestDirective],
         },
@@ -112,21 +138,37 @@ describe(`The html tag template helper`, () => {
         {
             type: "template",
             location: "at the beginning",
-            template: html`${html`sub-template`} end`,
+            template: html`
+                ${html`
+                    sub-template
+                `}
+                end
+            `,
             result: `${DOM.createInterpolationPlaceholder(0)} end`,
             expectDirectives: [BindingDirective],
         },
         {
             type: "template",
             location: "in the middle",
-            template: html`beginning ${html`sub-template`} end`,
+            template: html`
+                beginning
+                ${html`
+                    sub-template
+                `}
+                end
+            `,
             result: `beginning ${DOM.createInterpolationPlaceholder(0)} end`,
             expectDirectives: [BindingDirective],
         },
         {
             type: "template",
             location: "at the end",
-            template: html`beginning ${html`sub-template`}`,
+            template: html`
+                beginning
+                ${html`
+                    sub-template
+                `}
+            `,
             result: `beginning ${DOM.createInterpolationPlaceholder(0)}`,
             expectDirectives: [BindingDirective],
         },
@@ -134,43 +176,76 @@ describe(`The html tag template helper`, () => {
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the beginning",
-            template: html<Model>`${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
-            result: `${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(0)}${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`
+                ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end
+            `,
+            result: `${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
+                0
+            )}${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "in the middle",
-            template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
-            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(0)}${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`
+                beginning
+                ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end
+            `,
+            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
+                0
+            )}${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the end",
-            template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()}`,
-            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(0)}${DOM.createBlockPlaceholder(1)}`,
+            template: html<Model>`
+                beginning
+                ${stringValue}${numberValue}${x => x.value}${new TestDirective()}
+            `,
+            result: `beginning ${stringValue}${numberValue}${DOM.createInterpolationPlaceholder(
+                0
+            )}${DOM.createBlockPlaceholder(1)}`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "at the beginning",
-            template: html<Model>`${stringValue}separator${numberValue}separator${x => x.value}separator${new TestDirective()} end`,
-            result: `${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(0)}separator${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`
+                ${stringValue}separator${numberValue}separator${x =>
+                    x.value}separator${new TestDirective()}
+                end
+            `,
+            result: `${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
+                0
+            )}separator${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "in the middle",
-            template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x => x.value}separator${new TestDirective()} end`,
-            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(0)}separator${DOM.createBlockPlaceholder(1)} end`,
+            template: html<Model>`
+                beginning
+                ${stringValue}separator${numberValue}separator${x =>
+                    x.value}separator${new TestDirective()}
+                end
+            `,
+            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
+                0
+            )}separator${DOM.createBlockPlaceholder(1)} end`,
             expectDirectives: [BindingDirective, TestDirective],
         },
         {
             type: "mixed, separated string, number, expression, and directive",
             location: "at the end",
-            template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x => x.value}separator${new TestDirective()}`,
-            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(0)}separator${DOM.createBlockPlaceholder(1)}`,
+            template: html<Model>`
+                beginning
+                ${stringValue}separator${numberValue}separator${x =>
+                    x.value}separator${new TestDirective()}
+            `,
+            result: `beginning ${stringValue}separator${numberValue}separator${DOM.createInterpolationPlaceholder(
+                0
+            )}separator${DOM.createBlockPlaceholder(1)}`,
             expectDirectives: [BindingDirective, TestDirective],
         },
     ];
@@ -189,13 +264,50 @@ describe(`The html tag template helper`, () => {
     });
 
     it(`captures a case-sensitive property name when used with an expression`, () => {
-        const template = html<Model>`<my-element :someAttribute=${x => x.value}></my-element>`;
+        const template = html<Model>`
+            <my-element :someAttribute=${x => x.value}></my-element>
+        `;
         const placeholder = DOM.createInterpolationPlaceholder(0);
 
         expect(template.html).to.equal(
             `<my-element :someAttribute=${placeholder}></my-element>`
         );
         expect((template.directives[0] as BindingDirective).targetName).to.equal(
+            ":someAttribute"
+        );
+    });
+
+    it(`captures a case-sensitive property name when used with a binding`, () => {
+        const template = html<Model>`
+            <my-element :someAttribute=${new BindingDirective(x => x.value)}></my-element>
+        `;
+        const placeholder = DOM.createInterpolationPlaceholder(0);
+
+        expect(template.html).to.equal(
+            `<my-element :someAttribute=${placeholder}></my-element>`
+        );
+        expect((template.directives[0] as NamedTargetDirective).targetName).to.equal(
+            ":someAttribute"
+        );
+    });
+
+    it(`captures a case-sensitive property name when used with a named target directive`, () => {
+        class TestDirective extends NamedTargetDirective {
+            targetName: string | undefined;
+            createBehavior(target: Node) {
+                return { bind() {}, unbind() {} };
+            }
+        }
+
+        const template = html<Model>`
+            <my-element :someAttribute=${new TestDirective()}></my-element>
+        `;
+        const placeholder = DOM.createInterpolationPlaceholder(0);
+
+        expect(template.html).to.equal(
+            `<my-element :someAttribute=${placeholder}></my-element>`
+        );
+        expect((template.directives[0] as NamedTargetDirective).targetName).to.equal(
             ":someAttribute"
         );
     });

--- a/packages/web-components/fast-element/src/template.ts
+++ b/packages/web-components/fast-element/src/template.ts
@@ -2,7 +2,7 @@ import { compileTemplate } from "./template-compiler";
 import { ElementView, HTMLView, SyntheticView } from "./view";
 import { DOM } from "./dom";
 import { Behavior, BehaviorFactory } from "./directives/behavior";
-import { Directive } from "./directives/directive";
+import { Directive, NamedTargetDirective } from "./directives/directive";
 import { BindingDirective } from "./directives/binding";
 import { defaultExecutionContext, Binding } from "./observation/observable";
 
@@ -226,10 +226,12 @@ export function html<TSource = any, TParent = any>(
 
         if (typeof value === "function") {
             value = new BindingDirective(value as Binding);
+        }
 
+        if (value instanceof NamedTargetDirective) {
             const match = lastAttributeNameRegex.exec(currentString);
             if (match !== null) {
-                (value as BindingDirective).targetName = match[2];
+                value.targetName = match[2];
             }
         }
 


### PR DESCRIPTION
# Description

Prior to this PR, the `html` tagged template helper was hard-coded to only capture attribute and property names if the interpolated value was a function. This PR changes the behavior so that the target name is captured for any directive that inherits from `NamedTargetDirective` of which `BindingDirective` is the only out-of-the-box example.

Note that `BindindDirective`s are created for function interpolated values, so there is no change in behavior for built-ins. However, this opens up the system for more extensibility. In particular, it enables the possibility of creating a two-way binding systems as a plugin.

In addition to this change, a typo was found in the `BindingDirective` which causes bindings to always be interpreted as non-volatile, regardless of the nature of the expression.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.