### PR TITLE
fix: active indicator losing track if double click

### DIFF
--- a/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
@@ -293,11 +293,46 @@ describe("Tabs", () => {
 
             await connect();
 
-            element.setAttribute("activeId", "03")
+            element.setAttribute("activeId", "03");
 
             expect(
                 element.querySelectorAll("fast-tab")[2]?.getAttribute("aria-selected")
             ).to.equal("true");
+
+            await disconnect();
+        });
+
+        it("should skip updating the active indicator if click twice on the same tab", async () => {
+            const { element, connect, disconnect } = await fixture(html<FASTTabs>`
+                <fast-tabs>
+                    <fast-tab id="01">Tab one</fast-tab>
+                    <fast-tab id="02">Tab two</fast-tab>
+                    <fast-tab id="03">Tab three</fast-tab>
+                    <fast-tab-panel id="panel01">
+                        Tab one content. This is for testing.
+                    </fast-tab-panel>
+                    <fast-tab-panel id="panel02">
+                        Tab two content. This is for testing.
+                    </fast-tab-panel>
+                    <fast-tab-panel id="panel03">
+                        Tab three content. This is for testing.
+                    </fast-tab-panel>
+                </fast-tabs>
+            `);
+
+            await connect();
+
+            const secondTab = element.querySelectorAll("fast-tab")[1] as HTMLElement;
+            expect(secondTab).not.to.be.undefined;
+            [0, 1].forEach(() => {
+                secondTab.click();
+                expect(element.shadowRoot).not.to.be.undefined;
+                expect(
+                    element.shadowRoot
+                        ?.querySelector('[part="activeIndicator"]')
+                        ?.classList.contains("activeIndicatorTransition")
+                ).to.be.false;
+            });
 
             await disconnect();
         });

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -271,7 +271,8 @@ export class Tabs extends FASTElement {
     };
 
     private handleActiveIndicatorPosition() {
-        if (this.activeindicator) {
+        // Ignore if we click twice on the same tab
+        if (this.activeindicator && this.activeTabIndex !== this.prevActiveTabIndex) {
             if (this.ticking) {
                 this.activeIndicatorRef.style.transform = "translateX(0px)";
                 this.activeIndicatorRef.classList.remove("activeIndicatorTransition");


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

If you would click twice on a same tab, the active indicator would lose track of the active tab, until you click twice again on another tab.

## Motivation & context

Have the active indicator always in sync with the actual active tab

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->