### PR TITLE
fix: corrects ElementInternals feature detection

### DIFF
--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -1,3 +1,4 @@
+import { ElementStyles } from "@microsoft/fast-element";
 import { attr, DOM, emptyArray, FASTElement, observable } from "@microsoft/fast-element";
 import { keyCodeEnter } from "@microsoft/fast-web-utilities";
 
@@ -88,10 +89,12 @@ interface HTMLElement {
 
 const proxySlotName = "form-associated-proxy";
 
+const ElementInternalsKey = "ElementInternals";
 /**
  * @alpha
  */
-export const supportsElementInternals = "ElementInternals" in window;
+export const supportsElementInternals =
+    ElementInternalsKey in window && "setFormData" in window[ElementInternalsKey];
 
 /**
  * Base class for providing Custom Element Form Association.

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -93,7 +93,8 @@ const ElementInternalsKey = "ElementInternals";
  * @alpha
  */
 export const supportsElementInternals =
-    ElementInternalsKey in window && "setFormData" in window[ElementInternalsKey];
+    ElementInternalsKey in window &&
+    "setFormValue" in window[ElementInternalsKey].prototype;
 
 /**
  * Base class for providing Custom Element Form Association.

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -1,4 +1,3 @@
-import { ElementStyles } from "@microsoft/fast-element";
 import { attr, DOM, emptyArray, FASTElement, observable } from "@microsoft/fast-element";
 import { keyCodeEnter } from "@microsoft/fast-web-utilities";
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
This change updates the feature-detection algo to check for an implementation of `ElementInternals` in the window, not just for the existence of the `ElementInternals` object. This is because Firefox nightly's window contains the `ElementInternals` object but does not contain an implementation of the `ElementInternals` API, causing invocations of API methods to throw at runtime.

Fixes #4086
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->