### PR TITLE
chore: remove elevated-corner-radius which was not in use

### DIFF
--- a/packages/web-components/fast-components/src/design-system-provider/README.md
+++ b/packages/web-components/fast-components/src/design-system-provider/README.md
@@ -13,7 +13,6 @@ For more information view the [design system provider readme](../../../fast-foun
 |baseHeightMultiplier|number| base-height-multiplier | base-height-multiplier |
 |baseHorizontalSpacingMultiplier|number| base-horizontal-spacing-multiplier | base-horizontal-spacing-multiplier |
 |cornerRadius|number| corner-radius | corner-radius |
-|elevatedCornerRadius|number| elevated-corner-radius | elevated-corner-radius |
 |outlineWidth|number| outline-width | outline-width |
 |focusOutlineWidth|number| focus-outline-width | focus-outline-width |
 |disabledOpacity|number| disabled-opacity | disabled-opacity |

--- a/packages/web-components/fast-components/src/menu/menu.styles.ts
+++ b/packages/web-components/fast-components/src/menu/menu.styles.ts
@@ -11,7 +11,6 @@ export const MenuStyles = css`
         --elevation: 11;
         background: ${neutralLayerFloatingBehavior.var};
         border: calc(var(--outline-width) * 1px) solid transparent;
-        border-radius: var(--elevated-corner-radius);
         ${elevation}
         margin: 0;
         border-radius: calc(var(--corner-radius) * 1px);


### PR DESCRIPTION
# Description

Removed a couple of references to `elevated-corner-radius` which was never implemented in the new FAST design system provider.

## Motivation & context

Our default component styling does not rely on two different corner radius values. Perhaps this will change, but currently this is misleading.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->
