### PR TITLE
feat: makes Controller.isConnected an observable property

### DIFF
--- a/.prettierignore
+++ b/.prettierignore
@@ -1,1 +1,2 @@
 packages/web-components/fast-components/src/default-palette.ts
+packages/web-components/fast-element/src/**/*.spec.ts

--- a/packages/web-components/fast-element/src/controller.spec.ts
+++ b/packages/web-components/fast-element/src/controller.spec.ts
@@ -9,20 +9,12 @@ import { css } from "./styles";
 import { Observable } from "./observation/observable";
 
 describe("The Controller", () => {
-    const templateA = html`
-        a
-    `;
-    const templateB = html`
-        b
-    `;
+    const templateA = html`a`;
+    const templateB = html`b`;
     const cssA = "class-a { color: red; }";
-    const stylesA = css`
-        ${cssA}
-    `;
+    const stylesA = css`${cssA}`;
     const cssB = "class-b { color: blue; }";
-    const stylesB = css`
-        ${cssB}
-    `;
+    const stylesB = css`${cssB}`;
 
     function createController(
         config: Omit<PartialFASTElementDefinition, "name"> = {},

--- a/packages/web-components/fast-element/src/controller.spec.ts
+++ b/packages/web-components/fast-element/src/controller.spec.ts
@@ -6,14 +6,23 @@ import { uniqueElementName, toHTML } from "./__test__/helpers";
 import { html } from "./template";
 import { DOM } from "./dom";
 import { css } from "./styles";
+import { Observable } from "./observation/observable";
 
 describe("The Controller", () => {
-    const templateA = html`a`;
-    const templateB = html`b`;
+    const templateA = html`
+        a
+    `;
+    const templateB = html`
+        b
+    `;
     const cssA = "class-a { color: red; }";
-    const stylesA = css`${cssA}`;
+    const stylesA = css`
+        ${cssA}
+    `;
     const cssB = "class-b { color: blue; }";
-    const stylesB = css`${cssB}`;
+    const stylesB = css`
+        ${cssB}
+    `;
 
     function createController(
         config: Omit<PartialFASTElementDefinition, "name"> = {},
@@ -304,6 +313,19 @@ describe("The Controller", () => {
                 );
             });
         }
+    });
+
+    it("should have an observable isConnected property", () => {
+        const { element, controller } = createController();
+        let attached = controller.isConnected;
+        const handler = { handleChange: () => (attached = !attached) };
+        Observable.getNotifier(controller).subscribe(handler, "isConnected");
+
+        expect(attached).to.equal(false);
+        document.body.appendChild(element);
+        expect(attached).to.equal(true);
+        document.body.removeChild(element);
+        expect(attached).to.equal(false);
     });
 
     it("should attach and detach the HTMLStyleElement supplied to .addStyles() and .removeStyles() to the shadowRoot", () => {

--- a/packages/web-components/fast-element/src/controller.ts
+++ b/packages/web-components/fast-element/src/controller.ts
@@ -1,7 +1,11 @@
 import { FASTElementDefinition } from "./fast-definitions";
 import { ElementView } from "./view";
 import { PropertyChangeNotifier } from "./observation/notifier";
-import { defaultExecutionContext, Observable } from "./observation/observable";
+import {
+    defaultExecutionContext,
+    Observable,
+    observable,
+} from "./observation/observable";
 import { Behavior } from "./directives/behavior";
 import { ElementStyles, StyleTarget } from "./styles";
 import { Mutable } from "./interfaces";
@@ -51,6 +55,7 @@ export class Controller extends PropertyChangeNotifier {
      * Indicates whether or not the custom element has been
      * connected to the document.
      */
+    @observable
     public readonly isConnected: boolean = false;
 
     /**


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
It is currently very difficult to determine when exactly an element is added or removed from the DOM. Custom elements do have `connectedCallback` and `disconnectedCallback` but these are really only useful to the class implementation and not external code. There is no `connected` or `disconnected` events emitted, and it is [using MutationObserver for this case](https://stackoverflow.com/questions/44935865/detect-when-a-node-is-deleted-or-removed-from-the-dom-because-a-parent-was) is very difficult / expensive.

https://github.com/whatwg/dom/issues/533 tracks a proposal to patch `MutationObserver` with `connected` and `disconnected` records, but this feature has not made its way into implementation yet.

We *can* make "connectedness" easy to observe for `FASTElement` instances though, simply by making the existing `Controller.isConnected` property observable.

<!--- Describe your changes. -->

## Motivation & context
**What does this get us?**
- House-keeping of code relative to, but not implemented in, a FASTElement.
  - adding and removing subscriptions and event listeners, cleaning up element caches, etc.
- Dependency Injection value reconciliation, where DI container is based on DOM location.

There are some additional uses cases outlined in https://github.com/whatwg/dom/issues/533.

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->