### PR TITLE
fix: updated the background on attribute dropdown in fast tooling used in component explorer

### DIFF
--- a/packages/tooling/fast-tooling-react/app/pages/form.tsx
+++ b/packages/tooling/fast-tooling-react/app/pages/form.tsx
@@ -21,6 +21,7 @@ import {
     textColorName,
     L3FillColorName,
     errorColorName,
+    FloatingColorName,
 } from "../../src/style";
 
 export type componentDataOnChange = (e: React.ChangeEvent<HTMLFormElement>) => void;
@@ -84,6 +85,7 @@ const CSSpropertyOverrides = {
     [textColorName]: "black",
     [L3FillColorName]: "white",
     [errorColorName]: "green",
+    [FloatingColorName]: "purple",
 };
 
 let fastMessageSystem: MessageSystem;

--- a/packages/tooling/fast-tooling-react/src/form/controls/control.select.style.ts
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.select.style.ts
@@ -1,5 +1,10 @@
 import { ComponentStyles } from "@microsoft/fast-jss-manager-react";
-import { defaultFontStyle, selectInputStyle, selectSpanStyle } from "../../style";
+import {
+    defaultFontStyle,
+    selectInputStyle,
+    selectSpanStyle,
+    FloatingCSSProperty,
+} from "../../style";
 
 /**
  * Select class name contract
@@ -21,6 +26,9 @@ const styles: ComponentStyles<SelectControlClassNameContract, {}> = {
     selectControl__disabled: {},
     selectControl_input: {
         ...selectInputStyle,
+        "& option": {
+            background: FloatingCSSProperty,
+        },
     },
     selectControl__default: {},
 };

--- a/packages/tooling/fast-tooling-react/src/form/controls/control.select.style.ts
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.select.style.ts
@@ -1,9 +1,9 @@
 import { ComponentStyles } from "@microsoft/fast-jss-manager-react";
 import {
     defaultFontStyle,
+    FloatingCSSProperty,
     selectInputStyle,
     selectSpanStyle,
-    FloatingCSSProperty,
 } from "../../style";
 
 /**

--- a/packages/tooling/fast-tooling-react/src/style/css-properties.ts
+++ b/packages/tooling/fast-tooling-react/src/style/css-properties.ts
@@ -44,6 +44,13 @@ export const L4ColorName = `${propertyNamePrefix}l4-color`;
 const L4ColorValue = "#1B1B1B";
 export const L4CSSProperty = assignCSSCustomProperty(L4ColorName, L4ColorValue);
 
+export const FloatingColorName = `${propertyNamePrefix}floating-color`;
+const FloatingColorValue = "#3B3B3B";
+export const FloatingCSSProperty = assignCSSCustomProperty(
+    FloatingColorName,
+    FloatingColorValue
+);
+
 /**
  * Accent color
  */


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Created a new css property called `FloatingCSSProperty` with the color of #3b3b3b. This is applied to the option in the select input dropdown. This fixes the issue where the background in the dropdown blends into the background of the pane. 

closes #3979 

before
![image](https://user-images.githubusercontent.com/37851220/98075328-07e2f300-1e21-11eb-9450-f6fb28ffc019.png)
after
![image](https://user-images.githubusercontent.com/37851220/98075315-03b6d580-1e21-11eb-85a1-bf6cfacedddb.png)


## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->