### PR TITLE
fix: revert radio to using class selector instead of attr, update slider-label to use internal styles for orientation

### DIFF
--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -266,8 +266,6 @@ export class FASTBreadcrumbItem extends BreadcrumbItem {
 export class FASTButton extends Button {
     appearance: ButtonAppearance;
     // (undocumented)
-    appearanceChanged(oldValue: ButtonAppearance, newValue: ButtonAppearance): void;
-    // (undocumented)
     connectedCallback(): void;
 }
 
@@ -517,6 +515,8 @@ export class FASTSlider extends Slider {
 
 // @public
 export class FASTSliderLabel extends SliderLabel {
+    // (undocumented)
+    protected sliderOrientationChanged(): void;
 }
 
 // @public
@@ -539,16 +539,12 @@ export class FASTTabs extends Tabs {
 export class FASTTextArea extends TextArea {
     appearance: TextAreaAppearance;
     // @internal (undocumented)
-    appearanceChanged(oldValue: TextAreaAppearance, newValue: TextAreaAppearance): void;
-    // @internal (undocumented)
     connectedCallback(): void;
 }
 
 // @public
 export class FASTTextField extends TextField {
     appearance: TextFieldAppearance;
-    // @internal (undocumented)
-    appearanceChanged(oldValue: TextFieldAppearance, newValue: TextFieldAppearance): void;
     // @internal (undocumented)
     connectedCallback(): void;
 }

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -103,22 +103,22 @@ export const RadioStyles = css`
         border-color: ${neutralFocusBehavior.var};
     }
 
-    :host(.checked) .control {
+    :host([aria-checked="true"]) .control {
         background: ${accentFillRestBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
     }
 
-    :host(.checked:not([disabled])) .control:hover {
+    :host([aria-checked="true"]:not([disabled])) .control:hover {
         background: ${accentFillHoverBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillHoverBehavior.var};
     }
 
-    :host(.checked:not([disabled])) .control:active {
+    :host([aria-checked="true"]:not([disabled])) .control:active {
         background: ${accentFillActiveBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillActiveBehavior.var};
     }
 
-    :host(.checked:${focusVisible}:not([disabled])) .control {
+    :host([aria-checked="true"]:${focusVisible}:not([disabled])) .control {
         box-shadow: 0 0 0 2px var(--background-color), 0 0 0 4px ${
             neutralFocusBehavior.var
         };
@@ -132,7 +132,7 @@ export const RadioStyles = css`
         cursor: ${disabledCursor};
     }
 
-    :host(.checked) .checked-indicator {
+    :host([aria-checked="true"]) .checked-indicator {
         opacity: 1;
     }
 

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -103,22 +103,22 @@ export const RadioStyles = css`
         border-color: ${neutralFocusBehavior.var};
     }
 
-    :host([checked]) .control {
+    :host(.checked) .control {
         background: ${accentFillRestBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
     }
 
-    :host([checked]:not([disabled])) .control:hover {
+    :host(.checked:not([disabled])) .control:hover {
         background: ${accentFillHoverBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillHoverBehavior.var};
     }
 
-    :host([checked]:not([disabled])) .control:active {
+    :host(.checked:not([disabled])) .control:active {
         background: ${accentFillActiveBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${accentFillActiveBehavior.var};
     }
 
-    :host([checked]:${focusVisible}:not([disabled])) .control {
+    :host(.checked:${focusVisible}:not([disabled])) .control {
         box-shadow: 0 0 0 2px var(--background-color), 0 0 0 4px ${
             neutralFocusBehavior.var
         };
@@ -132,7 +132,7 @@ export const RadioStyles = css`
         cursor: ${disabledCursor};
     }
 
-    :host([checked]) .checked-indicator {
+    :host(.checked) .checked-indicator {
         opacity: 1;
     }
 

--- a/packages/web-components/fast-components/src/slider-label/index.ts
+++ b/packages/web-components/fast-components/src/slider-label/index.ts
@@ -1,6 +1,11 @@
 import { customElement } from "@microsoft/fast-element";
 import { SliderLabel, SliderLabelTemplate as template } from "@microsoft/fast-foundation";
-import { SliderLabelStyles as styles } from "./slider-label.styles";
+import {
+    SliderLabelStyles as styles,
+    horizontalSliderStyles,
+    verticalSliderStyles,
+} from "./slider-label.styles";
+import { Orientation } from "@microsoft/fast-web-utilities";
 
 /**
  * The FAST Slider Label Custom Element. Implements {@link @microsoft/fast-foundation#SliderLabel},
@@ -16,7 +21,17 @@ import { SliderLabelStyles as styles } from "./slider-label.styles";
     template,
     styles,
 })
-export class FASTSliderLabel extends SliderLabel {}
+export class FASTSliderLabel extends SliderLabel {
+    protected sliderOrientationChanged(): void {
+        if (this.sliderOrientation === Orientation.horizontal) {
+            this.$fastController.addStyles(horizontalSliderStyles);
+            this.$fastController.removeStyles(verticalSliderStyles);
+        } else {
+            this.$fastController.addStyles(verticalSliderStyles);
+            this.$fastController.removeStyles(horizontalSliderStyles);
+        }
+    }
+}
 
 /**
  * Styles for SliderLabel

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -16,33 +16,9 @@ export const SliderLabelStyles = css`
         position: absolute;
         display: grid;
     }
-    :host([orientation="horizontal"]) {
-        align-self: start;
-        grid-row: 2;
-        margin-top: -2px;
-        height: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
-        width: auto;
-    }
-    :host([orientation="vertical"]) {
-        justify-self: start;
-        grid-column: 2;
-        margin-left: 2px;
-        height: auto;
-        width: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
-    }
     .container {
         display: grid;
         justify-self: center;
-    }
-    :host([orientation="horizontal"]) .container {
-        grid-template-rows: auto auto;
-        grid-template-columns: 0;
-    }
-    :host([orientation="vertical"]) .container {
-        grid-template-columns: auto auto;
-        grid-template-rows: 0;
-        min-width: calc(var(--thumb-size) * 1px);
-        height: calc(var(--thumb-size) * 1px);
     }
     .label {
         justify-self: center;
@@ -56,14 +32,6 @@ export const SliderLabelStyles = css`
         height: calc(${heightNumber} * 0.25 * 1px);
         background: ${neutralOutlineRestBehavior.var};
         justify-self: center;
-    }
-    :host([orientation="vertical"]) .mark {
-        transform: rotate(90deg);
-        align-self: center;
-    }
-    :host([orientation="vertical"]) .label {
-        margin-left: calc((var(--design-unit) / 2) * 2px);
-        align-self: center;
     }
     :host(.disabled) {
         opacity: var(--disabled-opacity);

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -7,6 +7,44 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
+export const horizontalSliderStyles = css`
+    :host {
+        align-self: start;
+        grid-row: 2;
+        margin-top: -2px;
+        height: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
+        width: auto;
+    }
+    .container {
+        grid-template-rows: auto auto;
+        grid-template-columns: 0;
+    }
+`;
+
+export const verticalSliderStyles = css`
+    :host {
+        justify-self: start;
+        grid-column: 2;
+        margin-left: 2px;
+        height: auto;
+        width: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
+    }
+    .container {
+        grid-template-columns: auto auto;
+        grid-template-rows: 0;
+        min-width: calc(var(--thumb-size) * 1px);
+        height: calc(var(--thumb-size) * 1px);
+    }
+    .mark {
+        transform: rotate(90deg);
+        align-self: center;
+    }
+    .label {
+        margin-left: calc((var(--design-unit) / 2) * 2px);
+        align-self: center;
+    }
+`;
+
 export const SliderLabelStyles = css`
     ${display("block")} :host {
         color: ${neutralForegroundRestBehavior.var};

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -19,6 +19,9 @@ export const horizontalSliderStyles = css`
         grid-template-rows: auto auto;
         grid-template-columns: 0;
     }
+    .label {
+        margin: 2px 0;
+    }
 `;
 
 export const verticalSliderStyles = css`
@@ -40,7 +43,7 @@ export const verticalSliderStyles = css`
         align-self: center;
     }
     .label {
-        margin-left: calc((var(--design-unit) / 2) * 2px);
+        margin-left: calc((var(--design-unit) / 2) * 3px);
         align-self: center;
     }
 `;
@@ -63,7 +66,6 @@ export const SliderLabelStyles = css`
         align-self: center;
         white-space: nowrap;
         max-width: 30px;
-        margin: 2px 0;
     }
     .mark {
         width: calc((var(--design-unit) / 4) * 1px);

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -717,8 +717,6 @@ export class SliderLabel extends FASTElement {
     // @internal (undocumented)
     handleChange(source: any, propertyName: string): void;
     hideMark: boolean;
-    // (undocumented)
-    protected horizontalStyles: import("@microsoft/fast-element").ElementStyles;
     position: string;
     // @internal (undocumented)
     positionStyle: string;
@@ -733,7 +731,7 @@ export class SliderLabel extends FASTElement {
     // @internal (undocumented)
     sliderOrientation: Orientation;
     // (undocumented)
-    protected verticalStyles: import("@microsoft/fast-element").ElementStyles;
+    protected sliderOrientationChanged(): void;
 }
 
 // @public

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -581,7 +581,7 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
     clickHandler: (e: MouseEvent) => void;
     // @internal (undocumented)
     connectedCallback(): void;
-    defaultChecked: boolean;
+    defaultChecked: boolean | undefined;
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
     // (undocumented)
@@ -717,6 +717,8 @@ export class SliderLabel extends FASTElement {
     // @internal (undocumented)
     handleChange(source: any, propertyName: string): void;
     hideMark: boolean;
+    // (undocumented)
+    protected horizontalStyles: import("@microsoft/fast-element").ElementStyles;
     position: string;
     // @internal (undocumented)
     positionStyle: string;
@@ -730,6 +732,8 @@ export class SliderLabel extends FASTElement {
     sliderMinPosition: number;
     // @internal (undocumented)
     sliderOrientation: Orientation;
+    // (undocumented)
+    protected verticalStyles: import("@microsoft/fast-element").ElementStyles;
 }
 
 // @public
@@ -790,6 +794,8 @@ export class Switch extends FormAssociated<HTMLInputElement> {
     defaultChecked: boolean;
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
+    // (undocumented)
+    formResetCallback(): void;
     // @internal
     protected initialValue: string;
     // @internal (undocumented)

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -82,7 +82,7 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
      * @public
      */
     @observable
-    public defaultChecked: boolean | undefined = undefined;
+    public defaultChecked: boolean | undefined;
     private defaultCheckedChanged(): void {
         if (this.$fastController.isConnected && !this.dirtyChecked) {
             // Setting this.checked will cause us to enter a dirty state,

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -82,14 +82,14 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
      * @public
      */
     @observable
-    public defaultChecked: boolean;
+    public defaultChecked: boolean | undefined = undefined;
     private defaultCheckedChanged(): void {
         if (this.$fastController.isConnected && !this.dirtyChecked) {
             // Setting this.checked will cause us to enter a dirty state,
             // but if we are clean when defaultChecked is changed, we want to stay
             // in a clean state, so reset this.dirtyChecked
             if (!this.isInsideRadioGroup()) {
-                this.checked = this.defaultChecked;
+                this.checked = this.defaultChecked ?? false;
                 this.dirtyChecked = false;
             }
         }
@@ -104,7 +104,6 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
     public checked: boolean = this.defaultChecked ?? false;
     private checkedChanged(): void {
         if (this.$fastController.isConnected) {
-            // TODO: temporarily removed as it's causing issues with
             // changing the value via code and from radio-group
             if (!this.dirtyChecked) {
                 this.dirtyChecked = true;
@@ -157,7 +156,7 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
                 // but if we are clean when defaultChecked is changed, we want to stay
                 // in a clean state, so reset this.dirtyChecked
                 if (!this.isInsideRadioGroup()) {
-                    this.checked = this.defaultChecked;
+                    this.checked = this.defaultChecked ?? false;
                     this.dirtyChecked = false;
                 }
             }
@@ -170,18 +169,10 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
     }
 
     private isInsideRadioGroup(): boolean {
-        //return this.name !== undefined && this.name !== null && this.name.length > 0;
         const parent: HTMLElement | null = (this as HTMLElement).closest(
             "[role=radiogroup]"
         );
         return parent !== null;
-    }
-
-    private getParentNode(): HTMLElement | null | undefined {
-        const parentNode: Element | null | undefined = this.parentElement!.closest(
-            "[role='tree']"
-        );
-        return parentNode as HTMLElement;
     }
 
     private updateForm(): void {

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
@@ -1,6 +1,5 @@
 import {
     attr,
-    css,
     FASTElement,
     Notifier,
     Observable,
@@ -27,43 +26,6 @@ const heightNumber =
  * @public
  */
 export class SliderLabel extends FASTElement {
-    protected horizontalStyles = css`
-        :host {
-            align-self: start;
-            grid-row: 2;
-            margin-top: -2px;
-            height: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
-            width: auto;
-        }
-        .container {
-            grid-template-rows: auto auto;
-            grid-template-columns: 0;
-        }
-    `;
-
-    protected verticalStyles = css`
-        :host {
-            justify-self: start;
-            grid-column: 2;
-            margin-left: 2px;
-            height: auto;
-            width: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
-        }
-        .container {
-            grid-template-columns: auto auto;
-            grid-template-rows: 0;
-            min-width: calc(var(--thumb-size) * 1px);
-            height: calc(var(--thumb-size) * 1px);
-        }
-        .mark {
-            transform: rotate(90deg);
-            align-self: center;
-        }
-        .label {
-            margin-left: calc((var(--design-unit) / 2) * 2px);
-            align-self: center;
-        }
-    `;
     /**
      * @internal
      */
@@ -109,15 +71,7 @@ export class SliderLabel extends FASTElement {
      */
     @observable
     public sliderOrientation: Orientation;
-    private sliderOrientationChanged(): void {
-        if (this.sliderOrientation === Orientation.horizontal) {
-            this.$fastController.addStyles(this.horizontalStyles);
-            this.$fastController.removeStyles(this.verticalStyles);
-        } else {
-            this.$fastController.addStyles(this.verticalStyles);
-            this.$fastController.removeStyles(this.horizontalStyles);
-        }
-    }
+    protected sliderOrientationChanged(): void {}
 
     /**
      * @internal

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
@@ -17,9 +17,6 @@ const defaultConfig: SliderConfiguration = {
     disabled: false,
 };
 
-const heightNumber =
-    "(var(--base-height-multiplier) + var(--density)) * var(--design-unit)";
-
 /**
  * A label element intended to be used with the {@link @microsoft/fast-foundation#Slider} component.
  *

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
@@ -1,5 +1,6 @@
 import {
     attr,
+    css,
     FASTElement,
     Notifier,
     Observable,
@@ -17,12 +18,52 @@ const defaultConfig: SliderConfiguration = {
     disabled: false,
 };
 
+const heightNumber =
+    "(var(--base-height-multiplier) + var(--density)) * var(--design-unit)";
+
 /**
  * A label element intended to be used with the {@link @microsoft/fast-foundation#Slider} component.
  *
  * @public
  */
 export class SliderLabel extends FASTElement {
+    protected horizontalStyles = css`
+        :host {
+            align-self: start;
+            grid-row: 2;
+            margin-top: -2px;
+            height: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
+            width: auto;
+        }
+        .container {
+            grid-template-rows: auto auto;
+            grid-template-columns: 0;
+        }
+    `;
+
+    protected verticalStyles = css`
+        :host {
+            justify-self: start;
+            grid-column: 2;
+            margin-left: 2px;
+            height: auto;
+            width: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
+        }
+        .container {
+            grid-template-columns: auto auto;
+            grid-template-rows: 0;
+            min-width: calc(var(--thumb-size) * 1px);
+            height: calc(var(--thumb-size) * 1px);
+        }
+        .mark {
+            transform: rotate(90deg);
+            align-self: center;
+        }
+        .label {
+            margin-left: calc((var(--design-unit) / 2) * 2px);
+            align-self: center;
+        }
+    `;
     /**
      * @internal
      */
@@ -68,6 +109,15 @@ export class SliderLabel extends FASTElement {
      */
     @observable
     public sliderOrientation: Orientation;
+    private sliderOrientationChanged(): void {
+        if (this.sliderOrientation === Orientation.horizontal) {
+            this.$fastController.addStyles(this.horizontalStyles);
+            this.$fastController.removeStyles(this.verticalStyles);
+        } else {
+            this.$fastController.addStyles(this.verticalStyles);
+            this.$fastController.removeStyles(this.horizontalStyles);
+        }
+    }
 
     /**
      * @internal


### PR DESCRIPTION
# Description
This change fixes visual bugs in **radio**, **radio-group** and **slider-label**
A recent update changed all style selectors to be attribute based, this was problematic for radio as the checked attribute is on the internal proxy input element and checked styling was broken. Slider-label also suffered from the style attribute selector change, that has been updated to use internal but protected (so fluent-ui components can utilize them) styles, **horizontalStyles** and **verticalStyles**.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
