### PR TITLE
fix: flipper icon and menu item text in high contrast mode

### DIFF
--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -111,8 +111,8 @@ export const FlipperStyles = css`
             :host {
                 background: ${SystemColors.Canvas};
             }
-            :host [direction="next"],
-            :host [direction="previous"] {
+            :host .next,
+            :host .previous {
                 color: ${SystemColors.ButtonText};
                 fill: currentcolor;
             }
@@ -126,8 +126,8 @@ export const FlipperStyles = css`
                 border-color: ${SystemColors.ButtonText};
                 opacity: 1;
             }
-            :host(:hover) [direction="next"],
-            :host(:hover) [direction="previous"] {
+            :host(:hover) .next,
+            :host(:hover) .previous  {
                 forced-color-adjust: none;
                 color: ${SystemColors.HighlightText};
                 fill: currentcolor;
@@ -137,10 +137,8 @@ export const FlipperStyles = css`
             }
             :host([disabled])::before,
             :host([disabled]:hover)::before,
-            :host([disabled]) [direction="next"],
-            :host([disabled]) [direction="previous"],
-            :host([disabled]:hover) [direction="next"],
-            :host([disabled]:hover) [direction="previous"] {
+            :host([disabled]) .next,
+            :host([disabled]) .previous {
                 forced-color-adjust: none;
                 background: ${SystemColors.Canvas};
                 border-color: ${SystemColors.GrayText};

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -119,6 +119,7 @@ export const MenuItemStyles = css`
         css`
             :host {
                 border-color: transparent;
+                color: ${SystemColors.ButtonText};
                 forced-color-adjust: none;
             }
             :host(:hover) {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Added color to the host selector in menu-item to fix high contrast white. Updated the high contrast selector in the flipper style to be set on a class instead of the attribute.

menu-item
before
![image](https://user-images.githubusercontent.com/37851220/98699182-b6a89700-232b-11eb-8362-ab149d2ae5ac.png)
after
![image](https://user-images.githubusercontent.com/37851220/98699347-e5bf0880-232b-11eb-9b6d-e83d1e2c932d.png)


flipper
before
![image](https://user-images.githubusercontent.com/37851220/98698763-44d04d80-232b-11eb-8f5e-641c3dd8b2cc.png)
![image](https://user-images.githubusercontent.com/37851220/98698795-4d288880-232b-11eb-8ad3-fca65a8f2555.png)
![image](https://user-images.githubusercontent.com/37851220/98698837-56195a00-232b-11eb-8e0d-2f1f6b285418.png)
![image](https://user-images.githubusercontent.com/37851220/98698856-5c0f3b00-232b-11eb-8f39-42a27769f3d0.png)
after
![image](https://user-images.githubusercontent.com/37851220/98698995-7cd79080-232b-11eb-99e0-547142d0c60e.png)
![image](https://user-images.githubusercontent.com/37851220/98699015-852fcb80-232b-11eb-989e-f22f8e213c66.png)
![image](https://user-images.githubusercontent.com/37851220/98699031-8a8d1600-232b-11eb-8258-863138cf759c.png)
![image](https://user-images.githubusercontent.com/37851220/98699051-9082f700-232b-11eb-96e6-fdb29fad36a6.png)

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->