### PR TITLE
feat: convert FormAssociated to a constructable function

### DIFF
--- a/packages/web-components/fast-components/package.json
+++ b/packages/web-components/fast-components/package.json
@@ -75,7 +75,7 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.2",
     "karma-coverage-istanbul-reporter": "^3.0.0",
-    "karma-firefox-launcher": "^1.3.0",
+    "karma-firefox-launcher": "^2.1.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-source-map-support": "^1.4.0",

--- a/packages/web-components/fast-components/src/slider-label/index.ts
+++ b/packages/web-components/fast-components/src/slider-label/index.ts
@@ -1,14 +1,14 @@
 import { customElement } from "@microsoft/fast-element";
 import { SliderLabel, SliderLabelTemplate as template } from "@microsoft/fast-foundation";
+import { Orientation } from "@microsoft/fast-web-utilities";
 import {
-    SliderLabelStyles as styles,
     horizontalSliderStyles,
+    SliderLabelStyles as styles,
     verticalSliderStyles,
 } from "./slider-label.styles";
-import { Orientation } from "@microsoft/fast-web-utilities";
 
 /**
- * The FAST Slider Label Custom Element. Implements {@link @microsoft/fast-foundation#SliderLabel},
+ * The FAST Slider Label Custom Element. Implements {@link @microsoft/fast-foundation#(SliderLabel:class)},
  * {@link @microsoft/fast-foundation#SliderLabelTemplate}
  *
  *

--- a/packages/web-components/fast-components/src/slider/index.ts
+++ b/packages/web-components/fast-components/src/slider/index.ts
@@ -3,7 +3,7 @@ import { Slider, SliderTemplate as template } from "@microsoft/fast-foundation";
 import { SliderStyles as styles } from "./slider.styles";
 
 /**
- * The FAST Slider Custom Element. Implements {@link @microsoft/fast-foundation#Slider},
+ * The FAST Slider Custom Element. Implements {@link @microsoft/fast-foundation#(Slider:class)},
  * {@link @microsoft/fast-foundation#SliderTemplate}
  *
  *

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -173,6 +173,11 @@ export function compileTemplate(template: HTMLTemplateElement, directives: Reado
 export type ComposableStyles = string | ElementStyles | CSSStyleSheet;
 
 // @public
+export type Constructable<T = {}> = {
+    new (...args: any[]): T;
+};
+
+// @public
 export class Controller extends PropertyChangeNotifier {
     // @internal
     constructor(element: HTMLElement, definition: FASTElementDefinition);

--- a/packages/web-components/fast-element/package.json
+++ b/packages/web-components/fast-element/package.json
@@ -61,7 +61,7 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.2",
     "karma-coverage-istanbul-reporter": "^3.0.0",
-    "karma-firefox-launcher": "^1.3.0",
+    "karma-firefox-launcher": "^2.1.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-source-map-support": "^1.4.0",

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -5,6 +5,15 @@
 export type Callable = typeof Function.prototype.call | { call(): void };
 
 /**
+ * Allows for the creation of Constructable mixin classes.
+ *
+ * @public
+ */
+export type Constructable<T = {}> = {
+    new (...args: any[]): T;
+};
+
+/**
  * Reverses all readonly members, making them mutable.
  * @internal
  */

--- a/packages/web-components/fast-foundation/.eslintrc.js
+++ b/packages/web-components/fast-foundation/.eslintrc.js
@@ -6,5 +6,17 @@ module.exports = {
         "@typescript-eslint/typedef": "off",
         "@typescript-eslint/explicit-function-return-type": "off",
         "@typescript-eslint/no-non-null-assertion": "off",
+        "@typescript-eslint/class-name-casing": [
+            "error",
+            {
+                allowUnderscorePrefix: true,
+            },
+        ],
+        "@typescript-eslint/no-empty-interface": [
+            "error",
+            {
+                allowSingleExtends: true,
+            },
+        ],
     },
 };

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -148,6 +148,7 @@ export const BreadcrumbItemTemplate: import("@microsoft/fast-element").ViewTempl
 export const BreadcrumbTemplate: import("@microsoft/fast-element").ViewTemplate<Breadcrumb, any>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedButton" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Button" because one of its declarations is marked as @internal
 //
 // @public
@@ -178,6 +179,8 @@ export class Card extends FASTElement {
 // @public
 export const CardTemplate: import("@microsoft/fast-element").ViewTemplate<Card, any>;
 
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedCheckbox" needs to be exported by the entry point index.d.ts
+//
 // @public
 export class Checkbox extends FormAssociatedCheckbox {
     constructor();
@@ -485,90 +488,6 @@ export interface FormAssociated extends Omit<ElementInternals, "labels"> {
     valueChanged(previous: any, next: any): void;
 }
 
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociatedButton_base" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedButton" because one of its declarations is marked as @internal
-//
-// @public
-export class FormAssociatedButton extends FormAssociatedButton_base {
-}
-
-// @internal
-export interface FormAssociatedButton extends FormAssociated {
-}
-
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociatedCheckbox_base" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedCheckbox" because one of its declarations is marked as @internal
-//
-// @public
-export class FormAssociatedCheckbox extends FormAssociatedCheckbox_base {
-}
-
-// @internal
-export interface FormAssociatedCheckbox extends FormAssociated {
-}
-
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociatedRadio_base" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedRadio" because one of its declarations is marked as @internal
-//
-// @public
-export class FormAssociatedRadio extends FormAssociatedRadio_base {
-}
-
-// @internal
-export interface FormAssociatedRadio extends FormAssociated {
-}
-
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociatedSlider_base" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedSlider" because one of its declarations is marked as @internal
-//
-// @public
-export class FormAssociatedSlider extends FormAssociatedSlider_base {
-}
-
-// @internal
-export interface FormAssociatedSlider extends FormAssociated {
-}
-
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociatedSwitch_base" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedSwitch" because one of its declarations is marked as @internal
-//
-// @public
-export class FormAssociatedSwitch extends FormAssociatedSwitch_base {
-}
-
-// @internal
-export interface FormAssociatedSwitch extends FormAssociated {
-}
-
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociatedTextArea_base" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedTextArea" because one of its declarations is marked as @internal
-//
-// @public
-export class FormAssociatedTextArea extends FormAssociatedTextArea_base {
-}
-
-// @internal
-export interface FormAssociatedTextArea extends FormAssociated {
-}
-
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociatedTextField_base" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedTextField" because one of its declarations is marked as @internal
-//
-// @public
-export class FormAssociatedTextField extends FormAssociatedTextField_base {
-}
-
-// @internal
-export interface FormAssociatedTextField extends FormAssociated {
-}
-
 // @public
 export const getDirection: (rootNode: HTMLElement) => Direction;
 
@@ -661,6 +580,8 @@ export const ProgressRingTemplate: import("@microsoft/fast-element").ViewTemplat
 // @public
 export const ProgressTemplate: import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
 
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedRadio" needs to be exported by the entry point index.d.ts
+//
 // @public
 export class Radio extends FormAssociatedRadio implements RadioControl {
     checked: boolean;
@@ -732,6 +653,10 @@ export type SkeletonShape = "rect" | "circle";
 // @public
 export const SkeletonTemplate: import("@microsoft/fast-element").ViewTemplate<Skeleton, any>;
 
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedSlider" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Slider" because one of its declarations is marked as @internal
+//
 // @public
 export class Slider extends FormAssociatedSlider implements SliderConfiguration {
     // @internal (undocumented)
@@ -746,7 +671,7 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     initialValue: string;
     // @internal (undocumented)
     isDragging: boolean;
-    // @internal (undocumented)
+    // (undocumented)
     protected keypressHandler: (e: KeyboardEvent) => void;
     max: number;
     min: number;
@@ -773,6 +698,10 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     // @internal (undocumented)
     valueChanged(previous: any, next: any): void;
     valueTextFormatter: (value: string) => string | null;
+}
+
+// @internal (undocumented)
+export interface Slider extends FormAssociatedSlider {
 }
 
 // @public
@@ -812,7 +741,7 @@ export class SliderLabel extends FASTElement {
     sliderMinPosition: number;
     // @internal (undocumented)
     sliderOrientation: Orientation;
-    // (undocumented)
+    // @internal (undocumented)
     protected sliderOrientationChanged(): void;
 }
 
@@ -861,6 +790,8 @@ export class StyleElementCustomPropertyManager extends CustomPropertyManagerBase
 // @alpha (undocumented)
 export const supportsElementInternals: boolean;
 
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedSwitch" needs to be exported by the entry point index.d.ts
+//
 // @public
 export class Switch extends FormAssociatedSwitch {
     checked: boolean;
@@ -872,7 +803,7 @@ export class Switch extends FormAssociatedSwitch {
     defaultChecked: boolean;
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
-    // (undocumented)
+    // @internal (undocumented)
     formResetCallback(): void;
     // @internal
     initialValue: string;
@@ -941,6 +872,7 @@ export const TabsTemplate: import("@microsoft/fast-element").ViewTemplate<Tabs, 
 export const TabTemplate: import("@microsoft/fast-element").ViewTemplate<Tab, any>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedTextArea" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "TextArea" because one of its declarations is marked as @internal
 //
 // @public
@@ -983,6 +915,7 @@ export enum TextAreaResize {
 export const TextAreaTemplate: import("@microsoft/fast-element").ViewTemplate<TextArea, any>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedTextField" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "TextField" because one of its declarations is marked as @internal
 //
 // @public

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -147,11 +147,11 @@ export const BreadcrumbItemTemplate: import("@microsoft/fast-element").ViewTempl
 export const BreadcrumbTemplate: import("@microsoft/fast-element").ViewTemplate<Breadcrumb, any>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-incompatible-release-tags) The symbol "Button" is marked as @public, but its signature references "FormAssociated" which is marked as @alpha
+// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Button" because one of its declarations is marked as @internal
 //
 // @public
-export class Button extends FormAssociated<HTMLInputElement> {
+export class Button extends FormAssociated_2 {
     autofocus: boolean;
     // @internal (undocumented)
     connectedCallback(): void;
@@ -161,13 +161,11 @@ export class Button extends FormAssociated<HTMLInputElement> {
     formmethod: string;
     formnovalidate: boolean;
     formtarget: "_self" | "_blank" | "_parent" | "_top";
-    // (undocumented)
-    protected proxy: HTMLInputElement;
     type: "submit" | "reset" | "button";
     }
 
 // @internal
-export interface Button extends StartEnd, DelegatesARIAButton {
+export interface Button extends FormAssociated, StartEnd, DelegatesARIAButton {
 }
 
 // @public
@@ -180,10 +178,12 @@ export class Card extends FASTElement {
 // @public
 export const CardTemplate: import("@microsoft/fast-element").ViewTemplate<Card, any>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "Checkbox" is marked as @public, but its signature references "FormAssociated" which is marked as @alpha
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Checkbox" because one of its declarations is marked as @internal
 //
 // @public
-export class Checkbox extends FormAssociated<HTMLInputElement> {
+export class Checkbox extends FormAssociated_3 {
     constructor();
     checked: boolean;
     checkedAttribute: boolean;
@@ -194,17 +194,17 @@ export class Checkbox extends FormAssociated<HTMLInputElement> {
     defaultChecked: boolean;
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
-    // (undocumented)
-    formResetCallback(): void;
     indeterminate: boolean;
     // @internal
-    protected initialValue: string;
+    initialValue: string;
     // @internal (undocumented)
     keypressHandler: (e: KeyboardEvent) => void;
-    // (undocumented)
-    protected proxy: HTMLInputElement;
     readOnly: boolean;
     }
+
+// @internal
+export interface Checkbox extends FormAssociated {
+}
 
 // @public
 export const CheckboxTemplate: import("@microsoft/fast-element").ViewTemplate<Checkbox, any>;
@@ -436,47 +436,75 @@ export const focusVisible: string;
 // @public
 export const forcedColorsStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
+// Warning: (ae-forgotten-export) The symbol "Constructable" needs to be exported by the entry point index.d.ts
+//
 // @alpha
-export abstract class FormAssociated<T extends HTMLInputElement | HTMLTextAreaElement | HTMLSelectElement> extends FASTElement {
-    constructor();
-    protected attachProxy(): void;
+export function FormAssociated<T extends Constructable<FASTElement & HTMLElement & {
+    proxy: HTMLSelectElement | HTMLTextAreaElement | HTMLInputElement;
+    initialValueChanged?(previous: any, next: any): void;
+    valueChanged?(previous: any, next: any): void;
+    formResetCallback?(): void;
+    formDisabledCallback?(disabled: boolean): void;
+}>>(BaseCtor: T): T;
+
+// @alpha
+export interface FormAssociated {
+    // (undocumented)
+    attachProxy(): void;
+    // (undocumented)
     checkValidity(): boolean;
-    // @internal (undocumented)
+    // (undocumented)
     connectedCallback(): void;
-    protected detachProxy(): void;
+    // (undocumented)
+    detachProxy(): void;
+    // (undocumented)
+    dirtyValue: boolean;
+    // (undocumented)
     disabled: boolean;
-    protected disabledChanged(previous: boolean, next: boolean): void;
-    // @internal (undocumented)
+    // (undocumented)
+    disabledChanged(previous: boolean, next: boolean): void;
+    // (undocumented)
     disconnectedCallback(): void;
-    // Warning: (ae-forgotten-export) The symbol "ElementInternals" needs to be exported by the entry point index.d.ts
-    protected elementInternals: ElementInternals;
-    get form(): HTMLFormElement | null;
-    // @internal
-    static get formAssociated(): boolean;
-    formDisabledCallback(disabled: boolean): void;
     // (undocumented)
-    formResetCallback(): void;
-    protected initialValue: string;
-    protected initialValueChanged(previous: string, next: string): void;
+    readonly form: HTMLFormElement | null;
     // (undocumented)
-    protected keypressHandler(e: KeyboardEvent): void;
-    get labels(): ReadonlyArray<Node>;
+    formAssociated(): boolean;
+    // (undocumented)
+    initialValueChanged?(previous: string, next: string): void;
+    // (undocumented)
+    readonly labels: ReadonlyArray<Node>;
+    // (undocumented)
     name: string;
-    protected nameChanged(): void;
-    protected abstract proxy: T;
+    // (undocumented)
+    nameChanged(): void;
+    // (undocumented)
+    proxyEventsToBlock: string[];
+    // (undocumented)
+    proxyInitialized: boolean;
+    // (undocumented)
     reportValidity(): boolean;
+    // (undocumented)
     required: boolean;
-    protected requiredChanged(prev: boolean, next: boolean): void;
-    protected setFormValue(value: File | string | FormData | null, state?: File | string | FormData | null): void;
+    // (undocumented)
+    requiredChanged(prev: boolean, next: boolean): void;
+    // (undocumented)
+    setFormValue(value: File | string | FormData | null, state?: File | string | FormData | null): void;
     // Warning: (ae-forgotten-export) The symbol "ValidityStateFlags" needs to be exported by the entry point index.d.ts
-    // Warning: (ae-forgotten-export) The symbol "HTMLElement" needs to be exported by the entry point index.d.ts
-    setValidity(flags: ValidityStateFlags, message?: string, anchor?: HTMLElement_2): void;
-    protected validate(): void;
-    get validationMessage(): string;
-    get validity(): ValidityState;
+    //
+    // (undocumented)
+    setValidity(flags: ValidityStateFlags, message?: string, anchor?: HTMLElement): void;
+    // (undocumented)
+    stopPropagation(e: Event): void;
+    // (undocumented)
+    validate(): void;
+    // (undocumented)
+    readonly validationMessage: string;
+    // (undocumented)
+    readonly validity: ValidityState;
+    // (undocumented)
     value: string;
-    protected valueChanged(previous: string, next: string): void;
-    get willValidate(): boolean;
+    // (undocumented)
+    readonly willValidate: boolean;
 }
 
 // @public
@@ -571,10 +599,12 @@ export const ProgressRingTemplate: import("@microsoft/fast-element").ViewTemplat
 // @public
 export const ProgressTemplate: import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "Radio" is marked as @public, but its signature references "FormAssociated" which is marked as @alpha
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Radio" because one of its declarations is marked as @internal
 //
 // @public
-export class Radio extends FormAssociated<HTMLInputElement> implements RadioControl {
+export class Radio extends FormAssociated_4 implements RadioControl {
     checked: boolean;
     checkedAttribute: boolean;
     // @internal (undocumented)
@@ -587,16 +617,15 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
     // (undocumented)
     formResetCallback(): void;
     // @internal
-    protected initialValue: string;
+    initialValue: string;
     // @internal (undocumented)
     keypressHandler: (e: KeyboardEvent) => void;
-    name: string;
-    // (undocumented)
-    protected nameChanged(): void;
-    // (undocumented)
-    protected proxy: HTMLInputElement;
     readOnly: boolean;
     }
+
+// @internal
+export interface Radio extends FormAssociated {
+}
 
 // @public
 export type RadioControl = Pick<HTMLInputElement, "checked" | "disabled" | "readOnly" | "focus" | "setAttribute" | "getAttribute">;
@@ -605,14 +634,14 @@ export type RadioControl = Pick<HTMLInputElement, "checked" | "disabled" | "read
 export class RadioGroup extends FASTElement {
     // (undocumented)
     childItems: HTMLElement[];
-    // (undocumented)
+    // @internal (undocumented)
     clickHandler: (e: MouseEvent) => void;
     // @internal (undocumented)
     connectedCallback(): void;
     disabled: boolean;
     // (undocumented)
     disconnectedCallback(): void;
-    // (undocumented)
+    // @internal (undocumented)
     focusOutHandler: (e: FocusEvent) => boolean | void;
     // @internal
     keydownHandler: (e: KeyboardEvent) => boolean | void;
@@ -648,10 +677,12 @@ export type SkeletonShape = "rect" | "circle";
 // @public
 export const SkeletonTemplate: import("@microsoft/fast-element").ViewTemplate<Skeleton, any>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "Slider" is marked as @public, but its signature references "FormAssociated" which is marked as @alpha
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Slider" because one of its declarations is marked as @internal
 //
 // @public
-export class Slider extends FormAssociated<HTMLInputElement> implements SliderConfiguration {
+export class Slider extends FormAssociated_5 implements SliderConfiguration {
     // @internal (undocumented)
     connectedCallback(): void;
     decrement: () => void;
@@ -660,6 +691,8 @@ export class Slider extends FormAssociated<HTMLInputElement> implements SliderCo
     // @internal (undocumented)
     disconnectedCallback(): void;
     increment: () => void;
+    // (undocumented)
+    initialValue: string;
     // @internal (undocumented)
     isDragging: boolean;
     // (undocumented)
@@ -670,8 +703,6 @@ export class Slider extends FormAssociated<HTMLInputElement> implements SliderCo
     orientation: Orientation;
     // @internal (undocumented)
     position: string;
-    // (undocumented)
-    protected proxy: HTMLInputElement;
     readOnly: boolean;
     step: number;
     // @internal (undocumented)
@@ -688,9 +719,13 @@ export class Slider extends FormAssociated<HTMLInputElement> implements SliderCo
     trackMinWidth: number;
     // @internal (undocumented)
     trackWidth: number;
-    // @internal
-    protected valueChanged(previous: string, next: string): void;
+    // @internal (undocumented)
+    valueChanged(previous: any, next: any): void;
     valueTextFormatter: (value: string) => string | null;
+}
+
+// @internal
+export interface Slider extends FormAssociated {
 }
 
 // @public
@@ -779,10 +814,12 @@ export class StyleElementCustomPropertyManager extends CustomPropertyManagerBase
 // @alpha (undocumented)
 export const supportsElementInternals: boolean;
 
-// Warning: (ae-incompatible-release-tags) The symbol "Switch" is marked as @public, but its signature references "FormAssociated" which is marked as @alpha
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Switch" because one of its declarations is marked as @internal
 //
 // @public
-export class Switch extends FormAssociated<HTMLInputElement> {
+export class Switch extends FormAssociated_6 {
     checked: boolean;
     checkedAttribute: boolean;
     // @internal (undocumented)
@@ -795,13 +832,15 @@ export class Switch extends FormAssociated<HTMLInputElement> {
     // (undocumented)
     formResetCallback(): void;
     // @internal
-    protected initialValue: string;
+    initialValue: string;
     // @internal (undocumented)
     keypressHandler: (e: KeyboardEvent) => void;
-    // (undocumented)
-    protected proxy: HTMLInputElement;
     readOnly: boolean;
     }
+
+// @internal
+export interface Switch extends FormAssociated {
+}
 
 // @public
 export const SwitchTemplate: import("@microsoft/fast-element").ViewTemplate<Switch, any>;
@@ -863,11 +902,11 @@ export const TabsTemplate: import("@microsoft/fast-element").ViewTemplate<Tabs, 
 export const TabTemplate: import("@microsoft/fast-element").ViewTemplate<Tab, any>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-incompatible-release-tags) The symbol "TextArea" is marked as @public, but its signature references "FormAssociated" which is marked as @alpha
+// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "TextArea" because one of its declarations is marked as @internal
 //
 // @public
-export class TextArea extends FormAssociated<HTMLTextAreaElement> {
+export class TextArea extends FormAssociated_7 {
     autofocus: boolean;
     cols: number;
     // @internal
@@ -884,8 +923,6 @@ export class TextArea extends FormAssociated<HTMLTextAreaElement> {
     minlength: number;
     name: string;
     placeholder: string;
-    // (undocumented)
-    protected proxy: HTMLTextAreaElement;
     readOnly: boolean;
     resize: TextAreaResize;
     rows: number;
@@ -893,7 +930,7 @@ export class TextArea extends FormAssociated<HTMLTextAreaElement> {
     }
 
 // @internal
-export interface TextArea extends DelegatesARIATextbox {
+export interface TextArea extends FormAssociated, DelegatesARIATextbox {
 }
 
 // @public
@@ -908,11 +945,11 @@ export enum TextAreaResize {
 export const TextAreaTemplate: import("@microsoft/fast-element").ViewTemplate<TextArea, any>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-incompatible-release-tags) The symbol "TextField" is marked as @public, but its signature references "FormAssociated" which is marked as @alpha
+// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "TextField" because one of its declarations is marked as @internal
 //
 // @public
-export class TextField extends FormAssociated<HTMLInputElement> {
+export class TextField extends FormAssociated_8 {
     autofocus: boolean;
     // @internal (undocumented)
     connectedCallback(): void;
@@ -924,15 +961,11 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     handleChange(): void;
     // @internal
     handleTextInput(): void;
-    // @internal (undocumented)
-    keypressHandler: (e: KeyboardEvent) => boolean;
     list: string;
     maxlength: number;
     minlength: number;
     pattern: string;
     placeholder: string;
-    // (undocumented)
-    protected proxy: HTMLInputElement;
     readOnly: boolean;
     size: number;
     spellcheck: boolean;
@@ -940,7 +973,7 @@ export class TextField extends FormAssociated<HTMLInputElement> {
     }
 
 // @internal
-export interface TextField extends StartEnd, DelegatesARIATextbox {
+export interface TextField extends FormAssociated, StartEnd, DelegatesARIATextbox {
 }
 
 // @public

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -5,6 +5,7 @@
 ```ts
 
 import { Behavior } from '@microsoft/fast-element';
+import { Constructable } from '@microsoft/fast-element';
 import { DecoratorAttributeConfiguration } from '@microsoft/fast-element';
 import { Direction } from '@microsoft/fast-web-utilities';
 import { ElementStyles } from '@microsoft/fast-element';
@@ -147,11 +148,10 @@ export const BreadcrumbItemTemplate: import("@microsoft/fast-element").ViewTempl
 export const BreadcrumbTemplate: import("@microsoft/fast-element").ViewTemplate<Breadcrumb, any>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Button" because one of its declarations is marked as @internal
 //
 // @public
-export class Button extends FormAssociated_2 {
+export class Button extends FormAssociatedButton {
     autofocus: boolean;
     // @internal (undocumented)
     connectedCallback(): void;
@@ -165,7 +165,7 @@ export class Button extends FormAssociated_2 {
     }
 
 // @internal
-export interface Button extends FormAssociated, StartEnd, DelegatesARIAButton {
+export interface Button extends StartEnd, DelegatesARIAButton {
 }
 
 // @public
@@ -178,12 +178,8 @@ export class Card extends FASTElement {
 // @public
 export const CardTemplate: import("@microsoft/fast-element").ViewTemplate<Card, any>;
 
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Checkbox" because one of its declarations is marked as @internal
-//
 // @public
-export class Checkbox extends FormAssociated_3 {
+export class Checkbox extends FormAssociatedCheckbox {
     constructor();
     checked: boolean;
     checkedAttribute: boolean;
@@ -194,6 +190,8 @@ export class Checkbox extends FormAssociated_3 {
     defaultChecked: boolean;
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
+    // @internal (undocumented)
+    formResetCallback(): void;
     indeterminate: boolean;
     // @internal
     initialValue: string;
@@ -201,10 +199,6 @@ export class Checkbox extends FormAssociated_3 {
     keypressHandler: (e: KeyboardEvent) => void;
     readOnly: boolean;
     }
-
-// @internal
-export interface Checkbox extends FormAssociated {
-}
 
 // @public
 export const CheckboxTemplate: import("@microsoft/fast-element").ViewTemplate<Checkbox, any>;
@@ -436,25 +430,23 @@ export const focusVisible: string;
 // @public
 export const forcedColorsStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
-// Warning: (ae-forgotten-export) The symbol "Constructable" needs to be exported by the entry point index.d.ts
-//
 // @alpha
 export function FormAssociated<T extends Constructable<FASTElement & HTMLElement & {
     proxy: HTMLSelectElement | HTMLTextAreaElement | HTMLInputElement;
+    disabledChanged?(previous: boolean, next: boolean): void;
+    formDisabledCallback?(disabled: boolean): void;
+    formResetCallback?(): void;
     initialValueChanged?(previous: any, next: any): void;
     valueChanged?(previous: any, next: any): void;
-    formResetCallback?(): void;
-    formDisabledCallback?(disabled: boolean): void;
+    nameChanged?(previous: any, next: any): void;
 }>>(BaseCtor: T): T;
 
+// Warning: (ae-forgotten-export) The symbol "ElementInternals" needs to be exported by the entry point index.d.ts
+//
 // @alpha
-export interface FormAssociated {
+export interface FormAssociated extends Omit<ElementInternals, "labels"> {
     // (undocumented)
     attachProxy(): void;
-    // (undocumented)
-    checkValidity(): boolean;
-    // (undocumented)
-    connectedCallback(): void;
     // (undocumented)
     detachProxy(): void;
     // (undocumented)
@@ -462,49 +454,119 @@ export interface FormAssociated {
     // (undocumented)
     disabled: boolean;
     // (undocumented)
-    disabledChanged(previous: boolean, next: boolean): void;
+    disabledChanged?(previous: boolean, next: boolean): void;
     // (undocumented)
-    disconnectedCallback(): void;
+    readonly elementInternals: ElementInternals | null;
     // (undocumented)
-    readonly form: HTMLFormElement | null;
+    readonly formAssociated: boolean;
     // (undocumented)
-    formAssociated(): boolean;
+    formDisabledCallback?(disabled: boolean): void;
     // (undocumented)
-    initialValueChanged?(previous: string, next: string): void;
+    formResetCallback(): void;
     // (undocumented)
-    readonly labels: ReadonlyArray<Node>;
+    initialValueChanged?(previous: any, next: any): void;
+    // (undocumented)
+    readonly labels: ReadonlyArray<Node[]>;
     // (undocumented)
     name: string;
     // (undocumented)
-    nameChanged(): void;
-    // (undocumented)
-    proxyEventsToBlock: string[];
-    // (undocumented)
-    proxyInitialized: boolean;
-    // (undocumented)
-    reportValidity(): boolean;
+    nameChanged?(previous: any, next: any): void;
     // (undocumented)
     required: boolean;
     // (undocumented)
     requiredChanged(prev: boolean, next: boolean): void;
     // (undocumented)
-    setFormValue(value: File | string | FormData | null, state?: File | string | FormData | null): void;
-    // Warning: (ae-forgotten-export) The symbol "ValidityStateFlags" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    setValidity(flags: ValidityStateFlags, message?: string, anchor?: HTMLElement): void;
-    // (undocumented)
     stopPropagation(e: Event): void;
     // (undocumented)
     validate(): void;
     // (undocumented)
-    readonly validationMessage: string;
-    // (undocumented)
-    readonly validity: ValidityState;
-    // (undocumented)
     value: string;
     // (undocumented)
-    readonly willValidate: boolean;
+    valueChanged(previous: any, next: any): void;
+}
+
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedButton_base" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedButton" because one of its declarations is marked as @internal
+//
+// @public
+export class FormAssociatedButton extends FormAssociatedButton_base {
+}
+
+// @internal
+export interface FormAssociatedButton extends FormAssociated {
+}
+
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedCheckbox_base" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedCheckbox" because one of its declarations is marked as @internal
+//
+// @public
+export class FormAssociatedCheckbox extends FormAssociatedCheckbox_base {
+}
+
+// @internal
+export interface FormAssociatedCheckbox extends FormAssociated {
+}
+
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedRadio_base" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedRadio" because one of its declarations is marked as @internal
+//
+// @public
+export class FormAssociatedRadio extends FormAssociatedRadio_base {
+}
+
+// @internal
+export interface FormAssociatedRadio extends FormAssociated {
+}
+
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedSlider_base" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedSlider" because one of its declarations is marked as @internal
+//
+// @public
+export class FormAssociatedSlider extends FormAssociatedSlider_base {
+}
+
+// @internal
+export interface FormAssociatedSlider extends FormAssociated {
+}
+
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedSwitch_base" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedSwitch" because one of its declarations is marked as @internal
+//
+// @public
+export class FormAssociatedSwitch extends FormAssociatedSwitch_base {
+}
+
+// @internal
+export interface FormAssociatedSwitch extends FormAssociated {
+}
+
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedTextArea_base" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedTextArea" because one of its declarations is marked as @internal
+//
+// @public
+export class FormAssociatedTextArea extends FormAssociatedTextArea_base {
+}
+
+// @internal
+export interface FormAssociatedTextArea extends FormAssociated {
+}
+
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-forgotten-export) The symbol "FormAssociatedTextField_base" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "FormAssociatedTextField" because one of its declarations is marked as @internal
+//
+// @public
+export class FormAssociatedTextField extends FormAssociatedTextField_base {
+}
+
+// @internal
+export interface FormAssociatedTextField extends FormAssociated {
 }
 
 // @public
@@ -599,12 +661,8 @@ export const ProgressRingTemplate: import("@microsoft/fast-element").ViewTemplat
 // @public
 export const ProgressTemplate: import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
 
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Radio" because one of its declarations is marked as @internal
-//
 // @public
-export class Radio extends FormAssociated_4 implements RadioControl {
+export class Radio extends FormAssociatedRadio implements RadioControl {
     checked: boolean;
     checkedAttribute: boolean;
     // @internal (undocumented)
@@ -614,18 +672,15 @@ export class Radio extends FormAssociated_4 implements RadioControl {
     defaultChecked: boolean | undefined;
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
-    // (undocumented)
+    // @internal (undocumented)
     formResetCallback(): void;
     // @internal
     initialValue: string;
     // @internal (undocumented)
     keypressHandler: (e: KeyboardEvent) => void;
+    name: string;
     readOnly: boolean;
     }
-
-// @internal
-export interface Radio extends FormAssociated {
-}
 
 // @public
 export type RadioControl = Pick<HTMLInputElement, "checked" | "disabled" | "readOnly" | "focus" | "setAttribute" | "getAttribute">;
@@ -677,25 +732,21 @@ export type SkeletonShape = "rect" | "circle";
 // @public
 export const SkeletonTemplate: import("@microsoft/fast-element").ViewTemplate<Skeleton, any>;
 
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Slider" because one of its declarations is marked as @internal
-//
 // @public
-export class Slider extends FormAssociated_5 implements SliderConfiguration {
+export class Slider extends FormAssociatedSlider implements SliderConfiguration {
     // @internal (undocumented)
     connectedCallback(): void;
-    decrement: () => void;
+    decrement(): void;
     // @internal (undocumented)
     direction: Direction;
     // @internal (undocumented)
     disconnectedCallback(): void;
-    increment: () => void;
-    // (undocumented)
+    increment(): void;
+    // @internal (undocumented)
     initialValue: string;
     // @internal (undocumented)
     isDragging: boolean;
-    // (undocumented)
+    // @internal (undocumented)
     protected keypressHandler: (e: KeyboardEvent) => void;
     max: number;
     min: number;
@@ -722,10 +773,6 @@ export class Slider extends FormAssociated_5 implements SliderConfiguration {
     // @internal (undocumented)
     valueChanged(previous: any, next: any): void;
     valueTextFormatter: (value: string) => string | null;
-}
-
-// @internal
-export interface Slider extends FormAssociated {
 }
 
 // @public
@@ -814,12 +861,8 @@ export class StyleElementCustomPropertyManager extends CustomPropertyManagerBase
 // @alpha (undocumented)
 export const supportsElementInternals: boolean;
 
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Switch" because one of its declarations is marked as @internal
-//
 // @public
-export class Switch extends FormAssociated_6 {
+export class Switch extends FormAssociatedSwitch {
     checked: boolean;
     checkedAttribute: boolean;
     // @internal (undocumented)
@@ -837,10 +880,6 @@ export class Switch extends FormAssociated_6 {
     keypressHandler: (e: KeyboardEvent) => void;
     readOnly: boolean;
     }
-
-// @internal
-export interface Switch extends FormAssociated {
-}
 
 // @public
 export const SwitchTemplate: import("@microsoft/fast-element").ViewTemplate<Switch, any>;
@@ -902,11 +941,10 @@ export const TabsTemplate: import("@microsoft/fast-element").ViewTemplate<Tabs, 
 export const TabTemplate: import("@microsoft/fast-element").ViewTemplate<Tab, any>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "TextArea" because one of its declarations is marked as @internal
 //
 // @public
-export class TextArea extends FormAssociated_7 {
+export class TextArea extends FormAssociatedTextArea {
     autofocus: boolean;
     cols: number;
     // @internal
@@ -930,7 +968,7 @@ export class TextArea extends FormAssociated_7 {
     }
 
 // @internal
-export interface TextArea extends FormAssociated, DelegatesARIATextbox {
+export interface TextArea extends DelegatesARIATextbox {
 }
 
 // @public
@@ -945,11 +983,10 @@ export enum TextAreaResize {
 export const TextAreaTemplate: import("@microsoft/fast-element").ViewTemplate<TextArea, any>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-forgotten-export) The symbol "FormAssociated" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "TextField" because one of its declarations is marked as @internal
 //
 // @public
-export class TextField extends FormAssociated_8 {
+export class TextField extends FormAssociatedTextField {
     autofocus: boolean;
     // @internal (undocumented)
     connectedCallback(): void;
@@ -973,7 +1010,7 @@ export class TextField extends FormAssociated_8 {
     }
 
 // @internal
-export interface TextField extends FormAssociated, StartEnd, DelegatesARIATextbox {
+export interface TextField extends StartEnd, DelegatesARIATextbox {
 }
 
 // @public

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -61,7 +61,7 @@
     "karma-chrome-launcher": "^3.1.0",
     "karma-coverage": "^2.0.2",
     "karma-coverage-istanbul-reporter": "^3.0.0",
-    "karma-firefox-launcher": "^1.3.0",
+    "karma-firefox-launcher": "^2.1.0",
     "karma-mocha": "^2.0.1",
     "karma-mocha-reporter": "^2.2.5",
     "karma-source-map-support": "^1.4.0",

--- a/packages/web-components/fast-foundation/rollup.config.js
+++ b/packages/web-components/fast-foundation/rollup.config.js
@@ -15,6 +15,7 @@ const parserOptions = {
 
 export default [
     {
+        context: "this",
         input: "src/index-rollup.ts",
         output: [
             {

--- a/packages/web-components/fast-foundation/src/button/button.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/button/button.form-associated.ts
@@ -1,0 +1,18 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { FormAssociated } from "../form-associated/form-associated";
+
+/**
+ * A form-associated base class for the {@link (Button:class)} component.
+ *
+ * @internal
+ */
+export class FormAssociatedButton extends FormAssociated(
+    class extends FASTElement {
+        public proxy: HTMLInputElement = document.createElement("input");
+    }
+) {}
+
+/**
+ * @internal
+ */
+export interface FormAssociatedButton extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -1,15 +1,26 @@
-import { attr } from "@microsoft/fast-element";
-import { FormAssociated } from "../form-associated/form-associated";
+import { attr, FASTElement } from "@microsoft/fast-element";
+import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
 
 /**
- * An Button Custom HTML Element.
+ * A form-associated base class for the {@link (Button:class)} component.
+ *
+ * @public
+ */
+const FormAssociated = _FormAssociated(
+    class extends FASTElement {
+        proxy: HTMLInputElement = document.createElement("input");
+    }
+);
+
+/**
+ * A Button Custom HTML Element.
  * Based largely on the {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/button | <button> element }.
  *
  * @public
  */
-export class Button extends FormAssociated<HTMLInputElement> {
+export class Button extends FormAssociated {
     /**
      * Determines if the element should receive document focus on page load.
      *
@@ -128,8 +139,6 @@ export class Button extends FormAssociated<HTMLInputElement> {
         previous === "reset" && this.removeEventListener("click", this.handleFormReset);
     }
 
-    protected proxy: HTMLInputElement = document.createElement("input");
-
     /**
      * @internal
      */
@@ -150,7 +159,7 @@ export class Button extends FormAssociated<HTMLInputElement> {
         const attached = this.proxy.isConnected;
 
         if (!attached) {
-            super.attachProxy();
+            this.attachProxy();
         }
 
         // Browser support for requestSubmit is not comprehensive
@@ -160,7 +169,7 @@ export class Button extends FormAssociated<HTMLInputElement> {
             : this.proxy.click();
 
         if (!attached) {
-            super.detachProxy();
+            this.detachProxy();
         }
     };
 
@@ -203,6 +212,5 @@ export class DelegatesARIAButton extends ARIAGlobalStatesAndProperties {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-/* eslint-disable-next-line */
-export interface Button extends StartEnd, DelegatesARIAButton {}
+export interface Button extends _FormAssociated, StartEnd, DelegatesARIAButton {}
 applyMixins(Button, StartEnd, DelegatesARIAButton);

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -1,5 +1,5 @@
 import { attr, FASTElement } from "@microsoft/fast-element";
-import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated } from "../form-associated/form-associated";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
 
@@ -8,11 +8,11 @@ import { applyMixins } from "../utilities/apply-mixins";
  *
  * @public
  */
-const FormAssociated = _FormAssociated(
+export class FormAssociatedButton extends FormAssociated(
     class extends FASTElement {
         proxy: HTMLInputElement = document.createElement("input");
     }
-);
+) {}
 
 /**
  * A Button Custom HTML Element.
@@ -20,7 +20,7 @@ const FormAssociated = _FormAssociated(
  *
  * @public
  */
-export class Button extends FormAssociated {
+export class Button extends FormAssociatedButton {
     /**
      * Determines if the element should receive document focus on page load.
      *
@@ -212,5 +212,13 @@ export class DelegatesARIAButton extends ARIAGlobalStatesAndProperties {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface Button extends _FormAssociated, StartEnd, DelegatesARIAButton {}
+export interface FormAssociatedButton extends FormAssociated {}
+
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+export interface Button extends StartEnd, DelegatesARIAButton {}
 applyMixins(Button, StartEnd, DelegatesARIAButton);

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -1,18 +1,7 @@
-import { attr, FASTElement } from "@microsoft/fast-element";
-import { FormAssociated } from "../form-associated/form-associated";
+import { attr } from "@microsoft/fast-element";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
-
-/**
- * A form-associated base class for the {@link (Button:class)} component.
- *
- * @public
- */
-export class FormAssociatedButton extends FormAssociated(
-    class extends FASTElement {
-        proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
+import { FormAssociatedButton } from "./button.form-associated";
 
 /**
  * A Button Custom HTML Element.
@@ -205,14 +194,6 @@ export class DelegatesARIAButton extends ARIAGlobalStatesAndProperties {
     @attr({ attribute: "aria-pressed", mode: "fromView" })
     public ariaPressed: "true" | "false" | "mixed" | undefined;
 }
-
-/**
- * Mark internal because exporting class and interface of the same name
- * confuses API documenter.
- * TODO: https://github.com/microsoft/fast/issues/3317
- * @internal
- */
-export interface FormAssociatedButton extends FormAssociated {}
 
 /**
  * Mark internal because exporting class and interface of the same name

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.form-associated.ts
@@ -1,0 +1,18 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { FormAssociated } from "../form-associated/form-associated";
+
+/**
+ * A form-associated base class for the {@link (Checkbox:class)} component.
+ *
+ * @internal
+ */
+export class FormAssociatedCheckbox extends FormAssociated(
+    class extends FASTElement {
+        public proxy: HTMLInputElement = document.createElement("input");
+    }
+) {}
+
+/**
+ * @internal
+ */
+export interface FormAssociatedCheckbox extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
@@ -355,11 +355,11 @@ describe("Checkbox", () => {
             form.appendChild(element);
             element.checked = true;
 
-            assert(element.getAttribute("checked") === null);
-            assert(element.checked);
+            assert.isNull(element.getAttribute("checked"));
+            assert.isTrue(element.checked);
             form.reset();
 
-            assert(!element.checked);
+            assert.isFalse(!!element.checked);
             await disconnect();
         });
 

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
@@ -1,7 +1,7 @@
 import { assert, expect } from "chai";
 import { Checkbox, CheckboxTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement, html } from "@microsoft/fast-element";
+import { DOM, customElement } from "@microsoft/fast-element";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 
 @customElement({
@@ -345,8 +345,8 @@ describe("Checkbox", () => {
         });
     });
 
-    describe("who's parent form has it's reset() method invoked", () => {
-        it("should set it's checked property to false if the checked attribute is unset", async () => {
+    describe("whose parent form has its reset() method invoked", () => {
+        it("should set its checked property to false if the checked attribute is unset", async () => {
             const { element, connect, disconnect } = await setup();
             await connect();
 
@@ -360,9 +360,10 @@ describe("Checkbox", () => {
             form.reset();
 
             assert(!element.checked);
+            await disconnect();
         });
 
-        it("should set it's checked property to true if the checked attribute is set", async () => {
+        it("should set its checked property to true if the checked attribute is set", async () => {
             const { element, connect, disconnect } = await setup();
             await connect();
 
@@ -379,6 +380,7 @@ describe("Checkbox", () => {
             form.reset();
 
             assert(element.checked);
+            await disconnect();
         });
         it("should put the control into a clean state, where checked attribute changes change the checked property prior to user or programmatic interaction", () => {
             const element = document.createElement("fast-checkbox") as FASTCheckbox;

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
@@ -2,7 +2,7 @@ import { html, slotted } from "@microsoft/fast-element";
 import { Checkbox } from "./checkbox";
 
 /**
- * The template for the {@link @microsoft/fast-foundation#Checkbox} component.
+ * The template for the {@link @microsoft/fast-foundation#(Checkbox:class)} component.
  * @public
  */
 export const CheckboxTemplate = html<Checkbox>`

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -1,14 +1,20 @@
-import { attr, observable } from "@microsoft/fast-element";
+import { attr, FASTElement, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
-import { FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
+
+const FormAssociated = _FormAssociated(
+    class extends FASTElement {
+        proxy: HTMLInputElement = document.createElement("input");
+    }
+);
 
 /**
- * A Switch Custom HTML Element.
+ * A Checkbox Custom HTML Element.
  * Implements the {@link https://www.w3.org/TR/wai-aria-1.1/#checkbox | ARIA checkbox }.
  *
  * @public
  */
-export class Checkbox extends FormAssociated<HTMLInputElement> {
+export class Checkbox extends FormAssociated {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -29,7 +35,7 @@ export class Checkbox extends FormAssociated<HTMLInputElement> {
      *
      * @internal
      */
-    protected initialValue: string = "on"; // Map to proxy element.
+    public initialValue: string = "on";
 
     /**
      * Provides the default checkedness of the input element
@@ -94,8 +100,6 @@ export class Checkbox extends FormAssociated<HTMLInputElement> {
         this.validate();
     }
 
-    protected proxy: HTMLInputElement = document.createElement("input");
-
     /**
      * The indeterminate state of the control
      */
@@ -131,7 +135,7 @@ export class Checkbox extends FormAssociated<HTMLInputElement> {
         this.updateForm();
     }
 
-    public formResetCallback() {
+    private formResetCallback(): void {
         this.checked = this.checkedAttribute;
         this.dirtyChecked = false;
     }
@@ -145,8 +149,6 @@ export class Checkbox extends FormAssociated<HTMLInputElement> {
      * @internal
      */
     public keypressHandler = (e: KeyboardEvent): void => {
-        super.keypressHandler(e);
-
         switch (e.keyCode) {
             case keyCodeSpace:
                 this.checked = !this.checked;
@@ -163,3 +165,11 @@ export class Checkbox extends FormAssociated<HTMLInputElement> {
         }
     };
 }
+
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+export interface Checkbox extends _FormAssociated {}

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -1,17 +1,6 @@
-import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
-import { FormAssociated } from "../form-associated/form-associated";
-
-/**
- * A form-associated base class for the {@link (Checkbox:class)} component.
- *
- * @public
- */
-export class FormAssociatedCheckbox extends FormAssociated(
-    class extends FASTElement {
-        proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
+import { FormAssociatedCheckbox } from "./checkbox.form-associated";
 
 /**
  * A Checkbox Custom HTML Element.
@@ -174,11 +163,3 @@ export class Checkbox extends FormAssociatedCheckbox {
         }
     };
 }
-
-/**
- * Mark internal because exporting class and interface of the same name
- * confuses API documenter.
- * TODO: https://github.com/microsoft/fast/issues/3317
- * @internal
- */
-export interface FormAssociatedCheckbox extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -1,12 +1,17 @@
 import { attr, FASTElement, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
-import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated } from "../form-associated/form-associated";
 
-const FormAssociated = _FormAssociated(
+/**
+ * A form-associated base class for the {@link (Checkbox:class)} component.
+ *
+ * @public
+ */
+export class FormAssociatedCheckbox extends FormAssociated(
     class extends FASTElement {
         proxy: HTMLInputElement = document.createElement("input");
     }
-);
+) {}
 
 /**
  * A Checkbox Custom HTML Element.
@@ -14,7 +19,7 @@ const FormAssociated = _FormAssociated(
  *
  * @public
  */
-export class Checkbox extends FormAssociated {
+export class Checkbox extends FormAssociatedCheckbox {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -135,9 +140,13 @@ export class Checkbox extends FormAssociated {
         this.updateForm();
     }
 
-    private formResetCallback(): void {
+    /**
+     * @internal
+     */
+    public formResetCallback(): void {
         this.checked = this.checkedAttribute;
         this.dirtyChecked = false;
+        super.formResetCallback();
     }
 
     private updateForm(): void {
@@ -172,4 +181,4 @@ export class Checkbox extends FormAssociated {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface Checkbox extends _FormAssociated {}
+export interface FormAssociatedCheckbox extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.spec.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.spec.ts
@@ -46,9 +46,9 @@ interface CustomInitialValue extends FormAssociated {}
 
 describe("FormAssociated:", () => {
     describe("construction and connection:", () => {
-        it("should have an undefined value prior to connectedCallback", () => {
+        it("should have an empty string value prior to connectedCallback", () => {
             const el: TestElement = document.createElement("test-element") as TestElement;
-            expect(el.value).to.equal(undefined);
+            expect(el.value).to.equal("");
         });
 
         it("should initialize to the initial value if no value property is set", () => {

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.spec.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.spec.ts
@@ -1,8 +1,6 @@
 import { FormAssociated } from "./form-associated";
 import { assert, expect } from "chai";
-import { customElement, html, DOM } from "@microsoft/fast-element";
-import { classNames } from "@microsoft/fast-web-utilities";
-import { values } from "lodash-es";
+import { customElement, FASTElement, html } from "@microsoft/fast-element";
 
 @customElement({
     name: "test-element",
@@ -10,15 +8,19 @@ import { values } from "lodash-es";
         <slot></slot>
     `,
 })
-class TestElement extends FormAssociated<HTMLInputElement> {
-    protected proxy = document.createElement("input");
+class TestElement extends FormAssociated(
+    class extends FASTElement {
+        proxy = document.createElement("input");
 
-    constructor() {
-        super();
+        constructor() {
+            super();
 
-        this.proxy.setAttribute("type", "text");
+            this.proxy.setAttribute("type", "text");
+        }
     }
-}
+) {}
+
+interface TestElement extends FormAssociated {}
 
 @customElement({
     name: "custom-initial-value",
@@ -26,17 +28,21 @@ class TestElement extends FormAssociated<HTMLInputElement> {
         <slot></slot>
     `,
 })
-class CustomInitialValue extends FormAssociated<HTMLInputElement> {
-    protected proxy = document.createElement("input");
+class CustomInitialValue extends FormAssociated(
+    class extends FASTElement {
+        proxy = document.createElement("input");
 
-    constructor() {
-        super();
+        constructor() {
+            super();
 
-        this.proxy.setAttribute("type", "text");
+            this.proxy.setAttribute("type", "text");
+        }
+
+        protected initialValue: string = "foobar";
     }
+) {}
 
-    protected initialValue: string = "foobar";
-}
+interface CustomInitialValue extends FormAssociated {}
 
 describe("FormAssociated:", () => {
     describe("construction and connection:", () => {

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -255,7 +255,9 @@ export class RadioGroup extends FASTElement {
         (this.previousElementSibling as HTMLInputElement).focus();
     };
 
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+    /**
+     * @internal
+     */
     public focusOutHandler = (e: FocusEvent): boolean | void => {
         const group: HTMLElement[] = this.slottedRadioButtons;
         const radio: HTMLInputElement | null = e.target as HTMLInputElement;
@@ -289,6 +291,9 @@ export class RadioGroup extends FASTElement {
         return true;
     };
 
+    /**
+     * @internal
+     */
     public clickHandler = (e: MouseEvent): void => {
         const radio: HTMLInputElement | null = e.target as HTMLInputElement;
         if (radio) {

--- a/packages/web-components/fast-foundation/src/radio/radio.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.form-associated.ts
@@ -1,0 +1,18 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { FormAssociated } from "../form-associated/form-associated";
+
+/**
+ * A form-associated base class for the {@link (Radio:class)} component.
+ *
+ * @internal
+ */
+export class FormAssociatedRadio extends FormAssociated(
+    class extends FASTElement {
+        public proxy: HTMLInputElement = document.createElement("input");
+    }
+) {}
+
+/**
+ * @internal
+ */
+export interface FormAssociatedRadio extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/radio/radio.template.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.template.ts
@@ -2,7 +2,7 @@ import { html, slotted } from "@microsoft/fast-element";
 import { Radio } from "./radio";
 
 /**
- * The template for the {@link @microsoft/fast-foundation#Radio} component.
+ * The template for the {@link @microsoft/fast-foundation#(Radio:class)} component.
  * @public
  */
 export const RadioTemplate = html<Radio>`

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -1,6 +1,6 @@
-import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
-import { FormAssociated } from "../form-associated/form-associated";
+import { FormAssociatedRadio } from "./radio.form-associated";
 
 /**
  * A structure representing a {@link @microsoft/fast-foundation#(Radio:class)} element
@@ -10,17 +10,6 @@ export type RadioControl = Pick<
     HTMLInputElement,
     "checked" | "disabled" | "readOnly" | "focus" | "setAttribute" | "getAttribute"
 >;
-
-/**
- * A form-associated base class for the {@link (Radio:class)} component.
- *
- * @public
- */
-export class FormAssociatedRadio extends FormAssociated(
-    class extends FASTElement {
-        proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
 
 /**
  * A Radio Custom HTML Element.
@@ -205,11 +194,3 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
         }
     };
 }
-
-/**
- * Mark internal because exporting class and interface of the same name
- * confuses API documenter.
- * TODO: https://github.com/microsoft/fast/issues/3317
- * @internal
- */
-export interface FormAssociatedRadio extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -1,9 +1,9 @@
-import { attr, observable } from "@microsoft/fast-element";
+import { attr, FASTElement, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
-import { FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
 
 /**
- * A structure representing a Radio element
+ * A structure representing a {@link @microsoft/fast-foundation#(Radio:class)} element
  * @public
  */
 export type RadioControl = Pick<
@@ -11,13 +11,19 @@ export type RadioControl = Pick<
     "checked" | "disabled" | "readOnly" | "focus" | "setAttribute" | "getAttribute"
 >;
 
+const FormAssociated = _FormAssociated(
+    class extends FASTElement {
+        proxy: HTMLInputElement = document.createElement("input");
+    }
+);
+
 /**
- * An Switch Custom HTML Element.
- * Implements the {@link https://www.w3.org/TR/wai-aria-1.1/#switch | ARIA switch }.
+ * A Radio Custom HTML Element.
+ * Implements the {@link https://www.w3.org/TR/wai-aria-1.1/#radio | ARIA radio }.
  *
  * @public
  */
-export class Radio extends FormAssociated<HTMLInputElement> implements RadioControl {
+export class Radio extends FormAssociated implements RadioControl {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -33,27 +39,12 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
     }
 
     /**
-     * The name of the radio. See {@link https://developer.mozilla.org/en-US/docs/Web/API/Element/name | name attribute} for more info.
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: name
-     */
-    @attr
-    public name: string; // Map to proxy element
-    protected nameChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
-            this.proxy.name = this.name;
-        }
-    }
-
-    /**
      * The element's value to be included in form submission when checked.
      * Default to "on" to reach parity with input[type="radio"]
      *
      * @internal
      */
-    protected initialValue: string = "on"; // Map to proxy element.
+    public initialValue: string = "on";
 
     /**
      * Provides the default checkedness of the input element
@@ -121,8 +112,6 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
         }
     }
 
-    protected proxy: HTMLInputElement = document.createElement("input");
-
     /**
      * Tracks whether the "checked" property has been changed.
      * This is necessary to provide consistent behavior with
@@ -184,7 +173,6 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
      * @internal
      */
     public keypressHandler = (e: KeyboardEvent): void => {
-        super.keypressHandler(e);
         switch (e.keyCode) {
             case keyCodeSpace:
                 if (!this.checked && !this.readOnly) {
@@ -203,3 +191,11 @@ export class Radio extends FormAssociated<HTMLInputElement> implements RadioCont
         }
     };
 }
+
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+export interface Radio extends _FormAssociated {}

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -1,6 +1,6 @@
 import { attr, FASTElement, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
-import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated } from "../form-associated/form-associated";
 
 /**
  * A structure representing a {@link @microsoft/fast-foundation#(Radio:class)} element
@@ -11,11 +11,16 @@ export type RadioControl = Pick<
     "checked" | "disabled" | "readOnly" | "focus" | "setAttribute" | "getAttribute"
 >;
 
-const FormAssociated = _FormAssociated(
+/**
+ * A form-associated base class for the {@link (Radio:class)} component.
+ *
+ * @public
+ */
+export class FormAssociatedRadio extends FormAssociated(
     class extends FASTElement {
         proxy: HTMLInputElement = document.createElement("input");
     }
-);
+) {}
 
 /**
  * A Radio Custom HTML Element.
@@ -23,7 +28,7 @@ const FormAssociated = _FormAssociated(
  *
  * @public
  */
-export class Radio extends FormAssociated implements RadioControl {
+export class Radio extends FormAssociatedRadio implements RadioControl {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -37,6 +42,12 @@ export class Radio extends FormAssociated implements RadioControl {
             this.proxy.readOnly = this.readOnly;
         }
     }
+
+    /**
+     * The name of the radio. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefname | name attribute} for more info.
+     */
+    @observable
+    public name: string;
 
     /**
      * The element's value to be included in form submission when checked.
@@ -152,6 +163,9 @@ export class Radio extends FormAssociated implements RadioControl {
         }
     }
 
+    /**
+     * @internal
+     */
     public formResetCallback() {
         this.checked = !!this.defaultChecked;
         this.dirtyChecked = false;
@@ -198,4 +212,4 @@ export class Radio extends FormAssociated implements RadioControl {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface Radio extends _FormAssociated {}
+export interface FormAssociatedRadio extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
@@ -3,7 +3,7 @@ import { Orientation } from "@microsoft/fast-web-utilities";
 import { SliderLabel } from "./slider-label";
 
 /**
- * The template for the {@link @microsoft/fast-foundation#SliderLabel} component.
+ * The template for the {@link @microsoft/fast-foundation#(SliderLabel:class)} component.
  * @public
  */
 export const SliderLabelTemplate = html<SliderLabel>`

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
@@ -36,7 +36,9 @@ export class SliderLabel extends FASTElement {
 
     /**
      * The position of the label relative to the min and max value of the parent {@link @microsoft/fast-foundation#(Slider:class)}.
+     *
      * @public
+     * @remarks
      * HTML Attribute: position
      */
     @attr
@@ -49,6 +51,7 @@ export class SliderLabel extends FASTElement {
      * Hides the tick mark.
      *
      * @public
+     * @remarks
      * HTML Attribute: hide-mark
      */
     @attr({ attribute: "hide-mark", mode: "boolean" })
@@ -58,6 +61,7 @@ export class SliderLabel extends FASTElement {
      * The disabled state of the label. This is generally controlled by the parent {@link @microsoft/fast-foundation#(Slider:class)}.
      *
      * @public
+     * @remarks
      * HTML Attribute: disabled
      */
     @attr({ attribute: "disabled", mode: "boolean" })
@@ -68,6 +72,10 @@ export class SliderLabel extends FASTElement {
      */
     @observable
     public sliderOrientation: Orientation;
+
+    /**
+     * @internal
+     */
     protected sliderOrientationChanged(): void {
         void 0;
     }

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
@@ -18,7 +18,7 @@ const defaultConfig: SliderConfiguration = {
 };
 
 /**
- * A label element intended to be used with the {@link @microsoft/fast-foundation#Slider} component.
+ * A label element intended to be used with the {@link @microsoft/fast-foundation#(Slider:class)} component.
  *
  * @public
  */
@@ -35,7 +35,7 @@ export class SliderLabel extends FASTElement {
     public root: HTMLDivElement;
 
     /**
-     * The position of the label relative to the min and max value of the parent {@link @microsoft/fast-foundation#Slider}.
+     * The position of the label relative to the min and max value of the parent {@link @microsoft/fast-foundation#(Slider:class)}.
      * @public
      * HTML Attribute: position
      */
@@ -55,7 +55,7 @@ export class SliderLabel extends FASTElement {
     public hideMark: boolean = false;
 
     /**
-     * The disabled state of the label. This is generally controlled by the parent {@link @microsoft/fast-foundation#Slider}.
+     * The disabled state of the label. This is generally controlled by the parent {@link @microsoft/fast-foundation#(Slider:class)}.
      *
      * @public
      * HTML Attribute: disabled
@@ -68,7 +68,9 @@ export class SliderLabel extends FASTElement {
      */
     @observable
     public sliderOrientation: Orientation;
-    protected sliderOrientationChanged(): void {}
+    protected sliderOrientationChanged(): void {
+        void 0;
+    }
 
     /**
      * @internal

--- a/packages/web-components/fast-foundation/src/slider/slider.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.form-associated.ts
@@ -1,0 +1,18 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { FormAssociated } from "../form-associated/form-associated";
+
+/**
+ * A form-associated base class for the {@link (Slider:class)} component.
+ *
+ * @internal
+ */
+export class FormAssociatedSlider extends FormAssociated(
+    class extends FASTElement {
+        public proxy: HTMLInputElement = document.createElement("input");
+    }
+) {}
+
+/**
+ * @internal
+ */
+export interface FormAssociatedSlider extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/slider/slider.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.spec.ts
@@ -351,22 +351,22 @@ describe("Slider", () => {
     });
 
     describe("when the owning form's reset() method is invoked", () => {
-        it("should reset it's value property to an empty string if no value attribute is set", () => {
+        it("should reset its value property to an empty string if no value attribute is set", () => {
             const element = document.createElement("fast-slider") as FASTSlider;
             const form = document.createElement("form");
             form.appendChild(element);
             document.body.appendChild(form);
             element.value = "3";
 
-            assert(element.getAttribute("value") === null);
-            assert(element.value === "3");
+            assert.strictEqual(element.getAttribute("value"), null);
+            assert.strictEqual(element.value, "3");
 
             form.reset();
 
-            assert(element.value === "5");
+            assert.strictEqual(element.value, "5");
         });
 
-        it("should reset it's value property to the value of the value attribute if it is set", () => {
+        it("should reset its value property to the value of the value attribute if it is set", () => {
             const element = document.createElement("fast-slider") as FASTSlider;
             const form = document.createElement("form");
             form.appendChild(element);
@@ -374,15 +374,15 @@ describe("Slider", () => {
             element.setAttribute("value", "7");
             element.value = "8";
 
-            assert(element.getAttribute("value") === "7");
-            assert(element.value === "8");
+            assert.strictEqual(element.getAttribute("value"), "7");
+            assert.strictEqual(element.value, "8");
 
             form.reset();
 
-            assert(element.value === "7");
+            assert.strictEqual(element.value, "7");
         });
 
-        it("should put the control into a clean state, where value attribute changes change the property value prior to user or programmatic interaction", () => {
+        it("should put the control into a clean state, where the value attribute changes the value property prior to user or programmatic interaction", () => {
             const element = document.createElement("fast-slider") as FASTSlider;
             const form = document.createElement("form");
             form.appendChild(element);
@@ -390,15 +390,15 @@ describe("Slider", () => {
             element.value = "7";
             element.setAttribute("value", "8");
 
-            assert(element.value === "7");
+            assert.strictEqual(element.value, "7");
 
             form.reset();
 
-            assert(element.value === "8");
+            assert.strictEqual(element.value, "8");
 
             element.setAttribute("value", "3");
 
-            assert(element.value === "3");
+            assert.strictEqual(element.value, "3");
         });
     });
 });

--- a/packages/web-components/fast-foundation/src/slider/slider.template.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.template.ts
@@ -4,13 +4,13 @@ import { Orientation } from "@microsoft/fast-web-utilities";
 import { Slider } from "./slider";
 
 /**
- * The template for the {@link @microsoft/fast-foundation#Slider} component.
+ * The template for the {@link @microsoft/fast-foundation#(Slider:class)} component.
  * @public
  */
 export const SliderTemplate = html<Slider>`
     <template
         role="slider"
-        class="${x => (x.readOnly ? "readonly" : "")} 
+        class="${x => (x.readOnly ? "readonly" : "")}
         ${x => x.orientation || Orientation.horizontal}"
         tabindex="${x => (x.disabled ? null : 0)}"
         aria-valuetext="${x => x.valueTextFormatter(x.value)}"

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -1,4 +1,9 @@
-import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
+import {
+    attr,
+    FASTElement,
+    nullableNumberConverter,
+    observable,
+} from "@microsoft/fast-element";
 import {
     Direction,
     keyCodeArrowDown,
@@ -10,12 +15,12 @@ import {
     keyCodeTab,
     Orientation,
 } from "@microsoft/fast-web-utilities";
-import { FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
 import { getDirection } from "../utilities/";
 import { convertPixelToPercent } from "./slider-utilities";
 
 /**
- * The selection modes of a {@link Slider}
+ * The selection modes of a {@link @microsoft/fast-foundation#(Slider:class)}.
  * @public
  */
 export enum SliderMode {
@@ -23,7 +28,7 @@ export enum SliderMode {
 }
 
 /**
- * The configuration structure of {@link Slider}.
+ * The configuration structure of {@link @microsoft/fast-foundation#(Slider:class)}.
  * @public
  */
 export interface SliderConfiguration {
@@ -34,14 +39,24 @@ export interface SliderConfiguration {
     disabled?: boolean;
 }
 
+const FormAssociated = _FormAssociated(
+    class extends FASTElement {
+        /**
+         * Proxy input element for {@link @microsoft/fast-foundation#(FormAssociated:function)}.
+         *
+         * @internal
+         */
+        public proxy: HTMLInputElement = document.createElement("input");
+    }
+);
+
 /**
- * An Switch Custom HTML Element.
+ * A Slider Custom HTML Element.
  * Implements the {@link https://www.w3.org/TR/wai-aria-1.1/#slider | ARIA slider }.
  *
  * @public
  */
-export class Slider extends FormAssociated<HTMLInputElement>
-    implements SliderConfiguration {
+export class Slider extends FormAssociated implements SliderConfiguration {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -123,11 +138,9 @@ export class Slider extends FormAssociated<HTMLInputElement>
     public valueTextFormatter: (value: string) => string | null = () => null;
 
     /**
-     * The element's value to be included in form submission changed.
      * @internal
      */
-    protected valueChanged(previous: string, next: string): void {
-        super.valueChanged(previous, next);
+    public valueChanged(previous, next) {
         if (this.$fastController.isConnected) {
             this.setThumbPositionForOrientation(this.direction);
         }
@@ -206,8 +219,6 @@ export class Slider extends FormAssociated<HTMLInputElement>
     @attr
     public mode: SliderMode = SliderMode.singleValue;
 
-    protected proxy = document.createElement("input");
-
     /**
      * @internal
      */
@@ -266,7 +277,6 @@ export class Slider extends FormAssociated<HTMLInputElement>
     };
 
     protected keypressHandler = (e: KeyboardEvent) => {
-        super.keypressHandler(e);
         if (e.keyCode !== keyCodeTab) {
             e.preventDefault();
         }
@@ -327,23 +337,25 @@ export class Slider extends FormAssociated<HTMLInputElement>
         this.thumb.addEventListener("touchstart", this.handleThumbMouseDown);
     };
 
-    private setupDefaultValue = (): void => {
-        if (typeof this.value === "string") {
-            const midpoint = `${this.convertToConstrainedValue(
-                (this.max + this.min) / 2
-            )}`;
+    public initialValue: string = "";
 
+    private get midpoint(): string {
+        return `${this.convertToConstrainedValue((this.max + this.min) / 2)}`;
+    }
+
+    private setupDefaultValue(): void {
+        if (typeof this.value === "string") {
             if (this.value.length === 0) {
-                this.initialValue = midpoint;
+                this.initialValue = this.midpoint;
             } else {
                 const value = parseFloat(this.value);
 
                 if (!Number.isNaN(value) && (value < this.min || value > this.max)) {
-                    this.value = midpoint;
+                    this.value = this.midpoint;
                 }
             }
         }
-    };
+    }
 
     /**
      *  Handle mouse moves during a thumb drag operation
@@ -444,3 +456,11 @@ export class Slider extends FormAssociated<HTMLInputElement>
         return constrainedValue + this.min;
     };
 }
+
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+export interface Slider extends _FormAssociated {}

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -1,9 +1,4 @@
-import {
-    attr,
-    FASTElement,
-    nullableNumberConverter,
-    observable,
-} from "@microsoft/fast-element";
+import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
 import {
     Direction,
     keyCodeArrowDown,
@@ -15,9 +10,9 @@ import {
     keyCodeTab,
     Orientation,
 } from "@microsoft/fast-web-utilities";
-import { FormAssociated } from "../form-associated/form-associated";
-import { getDirection } from "../utilities/";
+import { getDirection } from "../utilities/direction";
 import { convertPixelToPercent } from "./slider-utilities";
+import { FormAssociatedSlider } from "./slider.form-associated";
 
 /**
  * The selection modes of a {@link @microsoft/fast-foundation#(Slider:class)}.
@@ -40,17 +35,6 @@ export interface SliderConfiguration {
 }
 
 /**
- * A form-associated base class for the {@link (Slider:class)} component.
- *
- * @public
- */
-export class FormAssociatedSlider extends FormAssociated(
-    class extends FASTElement {
-        public proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
-
-/**
  * A Slider Custom HTML Element.
  * Implements the {@link https://www.w3.org/TR/wai-aria-1.1/#slider | ARIA slider }.
  *
@@ -59,6 +43,7 @@ export class FormAssociatedSlider extends FormAssociated(
 export class Slider extends FormAssociatedSlider implements SliderConfiguration {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
+     *
      * @public
      * @remarks
      * HTML Attribute: readonly
@@ -150,10 +135,11 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     }
 
     /**
-     * The minimum allowed value
+     * The minimum allowed value.
      *
      * @defaultValue - 0
      * @public
+     * @remarks
      * HTML Attribute: min
      */
     @attr({ converter: nullableNumberConverter })
@@ -167,10 +153,11 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     }
 
     /**
-     * The maximum allowed value
+     * The maximum allowed value.
      *
      * @defaultValue - 10
      * @public
+     * @remarks
      * HTML Attribute: max
      */
     @attr({ converter: nullableNumberConverter })
@@ -183,9 +170,10 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     }
 
     /**
-     * Value to increment or decrement via arrow keys, mouse click or drag
+     * Value to increment or decrement via arrow keys, mouse click or drag.
      *
      * @public
+     * @remarks
      * HTML Attribute: step
      */
     @attr({ converter: nullableNumberConverter })
@@ -199,7 +187,7 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     }
 
     /**
-     * Orientation of the slider
+     * The orientation of the slider.
      *
      * @public
      * @remarks
@@ -214,7 +202,7 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     }
 
     /**
-     * The selection mode
+     * The selection mode.
      *
      * @public
      * @remarks
@@ -280,9 +268,6 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
         this.value = decrementedValString;
     }
 
-    /**
-     * @internal
-     */
     protected keypressHandler = (e: KeyboardEvent) => {
         if (e.keyCode !== keyCodeTab) {
             e.preventDefault();
@@ -429,7 +414,6 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     /**
      * Handle a window mouse up during a drag operation
      */
-    /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
     private handleWindowMouseUp = (event: MouseEvent): void => {
         this.stopDragging();
     };
@@ -474,9 +458,6 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
 }
 
 /**
- * Mark internal because exporting class and interface of the same name
- * confuses API documenter.
- * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface FormAssociatedSlider extends FormAssociated {}
+export interface Slider extends FormAssociatedSlider {}

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -15,7 +15,7 @@ import {
     keyCodeTab,
     Orientation,
 } from "@microsoft/fast-web-utilities";
-import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated } from "../form-associated/form-associated";
 import { getDirection } from "../utilities/";
 import { convertPixelToPercent } from "./slider-utilities";
 
@@ -39,16 +39,16 @@ export interface SliderConfiguration {
     disabled?: boolean;
 }
 
-const FormAssociated = _FormAssociated(
+/**
+ * A form-associated base class for the {@link (Slider:class)} component.
+ *
+ * @public
+ */
+export class FormAssociatedSlider extends FormAssociated(
     class extends FASTElement {
-        /**
-         * Proxy input element for {@link @microsoft/fast-foundation#(FormAssociated:function)}.
-         *
-         * @internal
-         */
         public proxy: HTMLInputElement = document.createElement("input");
     }
-);
+) {}
 
 /**
  * A Slider Custom HTML Element.
@@ -56,7 +56,7 @@ const FormAssociated = _FormAssociated(
  *
  * @public
  */
-export class Slider extends FormAssociated implements SliderConfiguration {
+export class Slider extends FormAssociatedSlider implements SliderConfiguration {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -140,7 +140,9 @@ export class Slider extends FormAssociated implements SliderConfiguration {
     /**
      * @internal
      */
-    public valueChanged(previous, next) {
+    public valueChanged(previous, next): void {
+        super.valueChanged(previous, next);
+
         if (this.$fastController.isConnected) {
             this.setThumbPositionForOrientation(this.direction);
         }
@@ -200,6 +202,7 @@ export class Slider extends FormAssociated implements SliderConfiguration {
      * Orientation of the slider
      *
      * @public
+     * @remarks
      * HTML Attribute: orientation
      */
     @attr
@@ -214,6 +217,7 @@ export class Slider extends FormAssociated implements SliderConfiguration {
      * The selection mode
      *
      * @public
+     * @remarks
      * HTML Attribute: mode
      */
     @attr
@@ -249,7 +253,7 @@ export class Slider extends FormAssociated implements SliderConfiguration {
      *
      * @public
      */
-    public increment = (): void => {
+    public increment(): void {
         const newVal: number =
             this.direction !== Direction.rtl && this.orientation !== Orientation.vertical
                 ? Number(this.value) + Number(this.step)
@@ -258,14 +262,14 @@ export class Slider extends FormAssociated implements SliderConfiguration {
         const incrementedValString: string =
             incrementedVal < Number(this.max) ? `${incrementedVal}` : `${this.max}`;
         this.value = incrementedValString;
-    };
+    }
 
     /**
      * Decrement the value by the step
      *
      * @public
      */
-    public decrement = (): void => {
+    public decrement(): void {
         const newVal =
             this.direction !== Direction.rtl && this.orientation !== Orientation.vertical
                 ? Number(this.value) - Number(this.step)
@@ -274,8 +278,11 @@ export class Slider extends FormAssociated implements SliderConfiguration {
         const decrementedValString: string =
             decrementedVal > Number(this.min) ? `${decrementedVal}` : `${this.min}`;
         this.value = decrementedValString;
-    };
+    }
 
+    /**
+     * @internal
+     */
     protected keypressHandler = (e: KeyboardEvent) => {
         if (e.keyCode !== keyCodeTab) {
             e.preventDefault();
@@ -299,7 +306,13 @@ export class Slider extends FormAssociated implements SliderConfiguration {
         }
     };
 
-    private setThumbPositionForOrientation = (direction: Direction): void => {
+    /**
+     * Places the thumb based on the current value
+     *
+     * @public
+     * @param direction - writing mode
+     */
+    private setThumbPositionForOrientation(direction: Direction): void {
         const newPct: number = convertPixelToPercent(
             Number(this.value),
             Number(this.min),
@@ -316,7 +329,7 @@ export class Slider extends FormAssociated implements SliderConfiguration {
                 ? `bottom: ${percentage}%; transition: none;`
                 : `bottom: ${percentage}%; transition: all 0.2s ease;`;
         }
-    };
+    }
 
     private setupTrackConstraints = (): void => {
         const clientRect: DOMRect = this.track.getBoundingClientRect();
@@ -337,6 +350,9 @@ export class Slider extends FormAssociated implements SliderConfiguration {
         this.thumb.addEventListener("touchstart", this.handleThumbMouseDown);
     };
 
+    /**
+     * @internal
+     */
     public initialValue: string = "";
 
     private get midpoint(): string {
@@ -463,4 +479,4 @@ export class Slider extends FormAssociated implements SliderConfiguration {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface Slider extends _FormAssociated {}
+export interface FormAssociatedSlider extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/switch/switch.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.form-associated.ts
@@ -1,0 +1,18 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { FormAssociated } from "../form-associated/form-associated";
+
+/**
+ * A form-associated base class for the {@link (Switch:class)} component.
+ *
+ * @internal
+ */
+export class FormAssociatedSwitch extends FormAssociated(
+    class extends FASTElement {
+        public proxy: HTMLInputElement = document.createElement("input");
+    }
+) {}
+
+/**
+ * @internal
+ */
+export interface FormAssociatedSwitch extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/switch/switch.template.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.template.ts
@@ -2,7 +2,7 @@ import { html, slotted } from "@microsoft/fast-element";
 import { Switch } from "./switch";
 
 /**
- * The template for the {@link @microsoft/fast-foundation#Switch} component.
+ * The template for the {@link @microsoft/fast-foundation#(Switch:class)} component.
  * @public
  */
 export const SwitchTemplate = html<Switch>`

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -1,17 +1,6 @@
-import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
-import { FormAssociated } from "../form-associated/form-associated";
-
-/**
- * A form-associated base class for the {@link (Switch:class)} component.
- *
- * @public
- */
-export class FormAssociatedSwitch extends FormAssociated(
-    class extends FASTElement {
-        proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
+import { FormAssociatedSwitch } from "./switch.form-associated";
 
 /**
  * A Switch Custom HTML Element.
@@ -125,6 +114,9 @@ export class Switch extends FormAssociatedSwitch {
         this.updateForm();
     }
 
+    /**
+     * @internal
+     */
     public formResetCallback() {
         this.checked = this.checkedAttribute;
         this.dirtyChecked = false;
@@ -155,11 +147,3 @@ export class Switch extends FormAssociatedSwitch {
         }
     };
 }
-
-/**
- * Mark internal because exporting class and interface of the same name
- * confuses API documenter.
- * TODO: https://github.com/microsoft/fast/issues/3317
- * @internal
- */
-export interface FormAssociatedSwitch extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -1,6 +1,12 @@
-import { attr, observable } from "@microsoft/fast-element";
+import { attr, FASTElement, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
-import { FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
+
+const FormAssociated = _FormAssociated(
+    class extends FASTElement {
+        proxy: HTMLInputElement = document.createElement("input");
+    }
+);
 
 /**
  * A Switch Custom HTML Element.
@@ -8,7 +14,7 @@ import { FormAssociated } from "../form-associated/form-associated";
  *
  * @public
  */
-export class Switch extends FormAssociated<HTMLInputElement> {
+export class Switch extends FormAssociated {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -33,7 +39,7 @@ export class Switch extends FormAssociated<HTMLInputElement> {
      *
      * @internal
      */
-    protected initialValue: string = "on";
+    public initialValue: string = "on";
 
     /**
      * The checked attribute value. This sets the initial checked value.
@@ -96,8 +102,6 @@ export class Switch extends FormAssociated<HTMLInputElement> {
         this.validate();
     }
 
-    protected proxy = document.createElement("input");
-
     /**
      * Tracks whether the "checked" property has been changed.
      * This is necessary to provide consistent behavior with
@@ -130,8 +134,6 @@ export class Switch extends FormAssociated<HTMLInputElement> {
      * @internal
      */
     public keypressHandler = (e: KeyboardEvent) => {
-        super.keypressHandler(e);
-
         switch (e.keyCode) {
             case keyCodeSpace:
                 this.checked = !this.checked;
@@ -148,3 +150,11 @@ export class Switch extends FormAssociated<HTMLInputElement> {
         }
     };
 }
+
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+export interface Switch extends _FormAssociated {}

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -1,12 +1,17 @@
 import { attr, FASTElement, observable } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
-import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated } from "../form-associated/form-associated";
 
-const FormAssociated = _FormAssociated(
+/**
+ * A form-associated base class for the {@link (Switch:class)} component.
+ *
+ * @public
+ */
+export class FormAssociatedSwitch extends FormAssociated(
     class extends FASTElement {
         proxy: HTMLInputElement = document.createElement("input");
     }
-);
+) {}
 
 /**
  * A Switch Custom HTML Element.
@@ -14,7 +19,7 @@ const FormAssociated = _FormAssociated(
  *
  * @public
  */
-export class Switch extends FormAssociated {
+export class Switch extends FormAssociatedSwitch {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -157,4 +162,4 @@ export class Switch extends FormAssociated {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface Switch extends _FormAssociated {}
+export interface FormAssociatedSwitch extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/text-area/text-area.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.form-associated.ts
@@ -1,0 +1,18 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { FormAssociated } from "../form-associated/form-associated";
+
+/**
+ * A form-associated base class for the {@link (TextArea:class)} component.
+ *
+ * @internal
+ */
+export class FormAssociatedTextArea extends FormAssociated(
+    class extends FASTElement {
+        public proxy: HTMLTextAreaElement = document.createElement("textarea");
+    }
+) {}
+
+/**
+ * @internal
+ */
+export interface FormAssociatedTextArea extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -1,18 +1,29 @@
-import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
-import { FormAssociated } from "../form-associated/form-associated";
+import {
+    attr,
+    FASTElement,
+    nullableNumberConverter,
+    observable,
+} from "@microsoft/fast-element";
+import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
 import { DelegatesARIATextbox } from "../text-field/index";
 import { applyMixins } from "../utilities";
 import { TextAreaResize } from "./text-area.options";
 
 export { TextAreaResize };
 
+const FormAssociated = _FormAssociated(
+    class extends FASTElement {
+        proxy: HTMLTextAreaElement = document.createElement("textarea");
+    }
+);
+
 /**
- * An Text Area Custom HTML Element.
+ * A Text Area Custom HTML Element.
  * Based largely on the {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea | <textarea> element }.
  *
  * @public
  */
-export class TextArea extends FormAssociated<HTMLTextAreaElement> {
+export class TextArea extends FormAssociated {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -165,8 +176,6 @@ export class TextArea extends FormAssociated<HTMLTextAreaElement> {
     @observable
     public defaultSlottedNodes: Node[];
 
-    protected proxy: HTMLTextAreaElement = document.createElement("textarea");
-
     /**
      * @internal
      */
@@ -194,6 +203,5 @@ export class TextArea extends FormAssociated<HTMLTextAreaElement> {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-/* eslint-disable-next-line */
-export interface TextArea extends DelegatesARIATextbox {}
+export interface TextArea extends _FormAssociated, DelegatesARIATextbox {}
 applyMixins(TextArea, DelegatesARIATextbox);

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -4,18 +4,23 @@ import {
     nullableNumberConverter,
     observable,
 } from "@microsoft/fast-element";
-import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated } from "../form-associated/form-associated";
 import { DelegatesARIATextbox } from "../text-field/index";
 import { applyMixins } from "../utilities";
 import { TextAreaResize } from "./text-area.options";
 
 export { TextAreaResize };
 
-const FormAssociated = _FormAssociated(
+/**
+ * A form-associated base class for the {@link (TextArea:class)} component.
+ *
+ * @public
+ */
+export class FormAssociatedTextArea extends FormAssociated(
     class extends FASTElement {
         proxy: HTMLTextAreaElement = document.createElement("textarea");
     }
-);
+) {}
 
 /**
  * A Text Area Custom HTML Element.
@@ -23,7 +28,7 @@ const FormAssociated = _FormAssociated(
  *
  * @public
  */
-export class TextArea extends FormAssociated {
+export class TextArea extends FormAssociatedTextArea {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -203,5 +208,13 @@ export class TextArea extends FormAssociated {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface TextArea extends _FormAssociated, DelegatesARIATextbox {}
+export interface FormAssociatedTextArea extends FormAssociated {}
+
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+export interface TextArea extends DelegatesARIATextbox {}
 applyMixins(TextArea, DelegatesARIATextbox);

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -1,26 +1,10 @@
-import {
-    attr,
-    FASTElement,
-    nullableNumberConverter,
-    observable,
-} from "@microsoft/fast-element";
-import { FormAssociated } from "../form-associated/form-associated";
+import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
 import { DelegatesARIATextbox } from "../text-field/index";
 import { applyMixins } from "../utilities";
+import { FormAssociatedTextArea } from "./text-area.form-associated";
 import { TextAreaResize } from "./text-area.options";
 
 export { TextAreaResize };
-
-/**
- * A form-associated base class for the {@link (TextArea:class)} component.
- *
- * @public
- */
-export class FormAssociatedTextArea extends FormAssociated(
-    class extends FASTElement {
-        proxy: HTMLTextAreaElement = document.createElement("textarea");
-    }
-) {}
 
 /**
  * A Text Area Custom HTML Element.
@@ -201,14 +185,6 @@ export class TextArea extends FormAssociatedTextArea {
         this.$emit("change");
     }
 }
-
-/**
- * Mark internal because exporting class and interface of the same name
- * confuses API documenter.
- * TODO: https://github.com/microsoft/fast/issues/3317
- * @internal
- */
-export interface FormAssociatedTextArea extends FormAssociated {}
 
 /**
  * Mark internal because exporting class and interface of the same name

--- a/packages/web-components/fast-foundation/src/text-field/text-field.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.form-associated.ts
@@ -1,0 +1,18 @@
+import { FASTElement } from "@microsoft/fast-element";
+import { FormAssociated } from "../form-associated/form-associated";
+
+/**
+ * A form-associated base class for the {@link (TextField:class)} component.
+ *
+ * @internal
+ */
+export class FormAssociatedTextField extends FormAssociated(
+    class extends FASTElement {
+        public proxy: HTMLInputElement = document.createElement("input");
+    }
+) {}
+
+/**
+ * @internal
+ */
+export interface FormAssociatedTextField extends FormAssociated {}

--- a/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
@@ -28,7 +28,6 @@ export const TextFieldTemplate = html<TextField>`
                 class="control"
                 part="control"
                 id="control"
-                @keypress="${(x, c) => x.keypressHandler(c.event as KeyboardEvent)}"
                 @input="${x => x.handleTextInput()}"
                 @change="${x => x.handleChange()}"
                 ?autofocus="${x => x.autofocus}"

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -5,18 +5,23 @@ import {
     nullableNumberConverter,
     observable,
 } from "@microsoft/fast-element";
-import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
+import { FormAssociated } from "../form-associated/form-associated";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/index";
 import { TextFieldType } from "./text-field.options";
 
 export { TextFieldType };
 
-const FormAssociated = _FormAssociated(
+/**
+ * A form-associated base class for the {@link (TextField:class)} component.
+ *
+ * @public
+ */
+export class FormAssociatedTextField extends FormAssociated(
     class extends FASTElement {
         proxy: HTMLInputElement = document.createElement("input");
     }
-);
+) {}
 
 /**
  * A Text Field Custom HTML Element.
@@ -24,7 +29,7 @@ const FormAssociated = _FormAssociated(
  *
  * @public
  */
-export class TextField extends FormAssociated {
+export class TextField extends FormAssociatedTextField {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -236,5 +241,13 @@ export class DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {}
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface TextField extends _FormAssociated, StartEnd, DelegatesARIATextbox {}
+export interface FormAssociatedTextField extends FormAssociated {}
+
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+export interface TextField extends StartEnd, DelegatesARIATextbox {}
 applyMixins(TextField, StartEnd, DelegatesARIATextbox);

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -1,27 +1,10 @@
-import {
-    attr,
-    DOM,
-    FASTElement,
-    nullableNumberConverter,
-    observable,
-} from "@microsoft/fast-element";
-import { FormAssociated } from "../form-associated/form-associated";
+import { attr, DOM, nullableNumberConverter, observable } from "@microsoft/fast-element";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/index";
+import { FormAssociatedTextField } from "./text-field.form-associated";
 import { TextFieldType } from "./text-field.options";
 
 export { TextFieldType };
-
-/**
- * A form-associated base class for the {@link (TextField:class)} component.
- *
- * @public
- */
-export class FormAssociatedTextField extends FormAssociated(
-    class extends FASTElement {
-        proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
 
 /**
  * A Text Field Custom HTML Element.
@@ -234,14 +217,6 @@ export class TextField extends FormAssociatedTextField {
  * @public
  */
 export class DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {}
-
-/**
- * Mark internal because exporting class and interface of the same name
- * confuses API documenter.
- * TODO: https://github.com/microsoft/fast/issues/3317
- * @internal
- */
-export interface FormAssociatedTextField extends FormAssociated {}
 
 /**
  * Mark internal because exporting class and interface of the same name

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -1,18 +1,30 @@
-import { attr, DOM, nullableNumberConverter, observable } from "@microsoft/fast-element";
-import { FormAssociated } from "../form-associated/form-associated";
+import {
+    attr,
+    DOM,
+    FASTElement,
+    nullableNumberConverter,
+    observable,
+} from "@microsoft/fast-element";
+import { FormAssociated as _FormAssociated } from "../form-associated/form-associated";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/index";
 import { TextFieldType } from "./text-field.options";
 
 export { TextFieldType };
 
+const FormAssociated = _FormAssociated(
+    class extends FASTElement {
+        proxy: HTMLInputElement = document.createElement("input");
+    }
+);
+
 /**
- * An Text Field Custom HTML Element.
+ * A Text Field Custom HTML Element.
  * Based largely on the {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input/text | <input type="text" /> element }.
  *
  * @public
  */
-export class TextField extends FormAssociated<HTMLInputElement> {
+export class TextField extends FormAssociated {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -173,8 +185,6 @@ export class TextField extends FormAssociated<HTMLInputElement> {
      */
     public control: HTMLInputElement;
 
-    protected proxy = document.createElement("input");
-
     /**
      * @internal
      */
@@ -190,14 +200,6 @@ export class TextField extends FormAssociated<HTMLInputElement> {
             });
         }
     }
-
-    /**
-     * @internal
-     */
-    public keypressHandler = (e: KeyboardEvent): boolean => {
-        super.keypressHandler(e);
-        return true;
-    };
 
     /**
      * Handles the internal control's `input` event
@@ -222,11 +224,10 @@ export class TextField extends FormAssociated<HTMLInputElement> {
 }
 
 /**
- * Includes ARIA states and properties relating to the ARIA link role
+ * Includes ARIA states and properties relating to the ARIA textbox role
  *
  * @public
  */
-/* eslint-disable-next-line */
 export class DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {}
 
 /**
@@ -235,6 +236,5 @@ export class DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {}
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-/* eslint-disable-next-line */
-export interface TextField extends StartEnd, DelegatesARIATextbox {}
+export interface TextField extends _FormAssociated, StartEnd, DelegatesARIATextbox {}
 applyMixins(TextField, StartEnd, DelegatesARIATextbox);

--- a/packages/web-components/fast-foundation/src/utilities/constructable.ts
+++ b/packages/web-components/fast-foundation/src/utilities/constructable.ts
@@ -1,6 +1,0 @@
-/**
- * @internal
- */
-export type Constructable<T = {}> = {
-    new (...args: any[]): T;
-};

--- a/packages/web-components/fast-foundation/src/utilities/constructable.ts
+++ b/packages/web-components/fast-foundation/src/utilities/constructable.ts
@@ -1,0 +1,6 @@
+/**
+ * @internal
+ */
+export type Constructable<T = {}> = {
+    new (...args: any[]): T;
+};

--- a/yarn.lock
+++ b/yarn.lock
@@ -6789,13 +6789,21 @@
   dependencies:
     "@types/react" "*"
 
-"@types/react@*", "@types/react@^16.3.0", "@types/react@^16.7.17", "@types/react@^16.8.0", "@types/react@^16.9.17":
+"@types/react@*", "@types/react@^16.3.0", "@types/react@^16.7.17", "@types/react@^16.8.0":
   version "16.9.11"
   resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.11.tgz#70e0b7ad79058a7842f25ccf2999807076ada120"
   integrity sha512-UBT4GZ3PokTXSWmdgC/GeCGEJXE5ofWyibCcecRLUVN2ZBpXQGVgQGtG2foS7CrTKFKlQVVswLvf7Js6XA/CVQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^2.2.0"
+
+"@types/react@^16.9.17":
+  version "16.9.56"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.56.tgz#ea25847b53c5bec064933095fc366b1462e2adf0"
+  integrity sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==
+  dependencies:
+    "@types/prop-types" "*"
+    csstype "^3.0.2"
 
 "@types/resolve@0.0.8":
   version "0.0.8"
@@ -11631,6 +11639,11 @@ csstype@^2.2.0, csstype@^2.3.0, csstype@^2.5.7, csstype@^2.5.8:
   resolved "https://registry.yarnpkg.com/csstype/-/csstype-2.6.7.tgz#20b0024c20b6718f4eda3853a1f5a1cce7f5e4a5"
   integrity sha512-9Mcn9sFbGBAdmimWb2gLVDtFJzeKtDGIr76TUqmjZrw9LFXBMSU70lcs+C0/7fyCd6iBDqmksUcCOUIkisPHsQ==
 
+csstype@^3.0.2:
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.4.tgz#b156d7be03b84ff425c9a0a4b1e5f4da9c5ca888"
+  integrity sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA==
+
 currently-unhandled@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/currently-unhandled/-/currently-unhandled-0.4.1.tgz#988df33feab191ef799a61369dd76c17adf957ea"
@@ -16261,17 +16274,17 @@ is-wsl@^1.1.0:
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-1.1.0.tgz#1f16e4aa22b04d1336b66188a66af3c600c3a66d"
   integrity sha1-HxbkqiKwTRM2tmGIpmrzxgDDpm0=
 
-is-wsl@^2.1.0:
+is-wsl@^2.1.1:
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
+  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
+
+is-wsl@^2.2.0:
   version "2.2.0"
   resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.2.0.tgz#74a4c76e77ca9fd3f932f290c17ea326cd157271"
   integrity sha512-fKzAra0rGJUUBwGBgNkHZuToZcn+TtXHpeCgmkMJMMYx1sQDYaCSyjJBSCa2nH1DGm7s3n1oBnohoVTBaN7Lww==
   dependencies:
     is-docker "^2.0.0"
-
-is-wsl@^2.1.1:
-  version "2.1.1"
-  resolved "https://registry.yarnpkg.com/is-wsl/-/is-wsl-2.1.1.tgz#4a1c152d429df3d441669498e2486d3596ebaf1d"
-  integrity sha512-umZHcSrwlDHo2TGMXv0DZ8dIUGunZ2Iv68YZnrmCiBPkZ4aaOhtv7pXJKeki9k3qJ3RJr0cDyitcl5wEH3AYog==
 
 is-yarn-global@^0.3.0:
   version "0.3.0"
@@ -17468,12 +17481,13 @@ karma-coverage@^2.0.2:
     istanbul-reports "^3.0.0"
     minimatch "^3.0.4"
 
-karma-firefox-launcher@^1.3.0:
-  version "1.3.0"
-  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-1.3.0.tgz#ebcbb1d1ddfada6be900eb8fae25bcf2dcdc8171"
-  integrity sha512-Fi7xPhwrRgr+94BnHX0F5dCl1miIW4RHnzjIGxF8GaIEp7rNqX7LSi7ok63VXs3PS/5MQaQMhGxw+bvD+pibBQ==
+karma-firefox-launcher@^2.1.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/karma-firefox-launcher/-/karma-firefox-launcher-2.1.0.tgz#d0d328c93dfcf9b46f1ac83b4bb32f43aadb2050"
+  integrity sha512-dkiyqN2R6fCWt78rciOXJLFDWcQ7QEQi++HgebPJlw1y0ycDjGNDHuSrhdh48QG02fzZKK20WHFWVyBZ6CPngg==
   dependencies:
-    is-wsl "^2.1.0"
+    is-wsl "^2.2.0"
+    which "^2.0.1"
 
 karma-mocha-reporter@^2.2.5:
   version "2.2.5"


### PR DESCRIPTION
# Description
Converts `FormAssociated` to be a "constructable" function call that returns a mixin class.

## Motivation & context
Allows for easier control when working with mixin classes and `FormAssociated`.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
This modifies all `FormAssociated`-based components:
- Button
- Checkbox
- Radio
- Slider
- Text Area
- Text Field

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.