### PR TITLE
fix: circular references in fast-components

### DIFF
--- a/packages/web-components/fast-components/src/card/card.stories.ts
+++ b/packages/web-components/fast-components/src/card/card.stories.ts
@@ -1,10 +1,6 @@
-import { FASTDesignSystemProvider } from "../design-system-provider";
+import "../design-system-provider";
 import CardTemplate from "./fixtures/card.html";
-import { FASTCard } from "./";
-
-// Prevent tree-shaking
-FASTCard;
-FASTDesignSystemProvider;
+import "./index";
 
 export default {
     title: "Card",

--- a/packages/web-components/fast-components/src/card/card.styles.ts
+++ b/packages/web-components/fast-components/src/card/card.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
-import { elevation } from "../styles/index";
+import { elevation } from "../styles/elevation";
 
 export const CardStyles = css`
     ${display("block")} :host {

--- a/packages/web-components/fast-components/src/card/index.ts
+++ b/packages/web-components/fast-components/src/card/index.ts
@@ -1,14 +1,14 @@
-import { customElement } from "@microsoft/fast-element";
-import { attr, Notifier, Observable } from "@microsoft/fast-element";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
+import { attr, customElement, Notifier, Observable } from "@microsoft/fast-element";
 import {
     designSystemProperty,
     DesignSystemProvider,
-    Card,
     CardTemplate as template,
 } from "@microsoft/fast-foundation";
+import { createColorPalette } from "../color/create-color-palette";
+import { neutralFillCard } from "../color/neutral-fill-card";
+import { FASTDesignSystem } from "../fast-design-system";
 import { CardStyles as styles } from "./card.styles";
-import { parseColorHexRGB } from "@microsoft/fast-colors";
-import { createColorPalette, FASTDesignSystem, neutralFillCard } from "../index";
 
 const paletteCache = new Map();
 


### PR DESCRIPTION
# Description
Fixes circular references in `fast-components`

## Motivation & context
Local modules should be imported directly from their source file to prevent circular reference warnings when building with rollup.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
