### PR TITLE
fix: update high contrast colors in button and anchor components

### DIFF
--- a/packages/web-components/fast-components/src/button/button.styles.ts
+++ b/packages/web-components/fast-components/src/button/button.styles.ts
@@ -1,11 +1,5 @@
 import { css } from "@microsoft/fast-element";
 import {
-    disabledCursor,
-    focusVisible,
-    forcedColorsStylesheetBehavior,
-} from "@microsoft/fast-foundation";
-import { SystemColors } from "@microsoft/fast-web-utilities";
-import {
     AccentButtonStyles,
     BaseButtonStyles,
     LightweightButtonStyles,
@@ -19,79 +13,4 @@ export const ButtonStyles = css`
     ${LightweightButtonStyles}
     ${OutlineButtonStyles}
     ${StealthButtonStyles}
-`.withBehaviors(
-    forcedColorsStylesheetBehavior(
-        css`
-            :host([disabled]),
-            :host([disabled]) .control {
-                forced-color-adjust: none;
-                background: ${SystemColors.ButtonFace};
-                border-color: ${SystemColors.GrayText};
-                color: ${SystemColors.GrayText};
-                cursor: ${disabledCursor};
-                opacity: 1;
-            }
-            :host([appearance="accent"]) .control {
-                forced-color-adjust: none;
-                background: ${SystemColors.Highlight};
-                color: ${SystemColors.HighlightText};
-            }
-    
-            :host([appearance="accent"]) .control:hover {
-                background: ${SystemColors.HighlightText};
-                border-color: ${SystemColors.Highlight};
-                color: ${SystemColors.Highlight};
-            }
-    
-            :host([appearance="accent"]:${focusVisible}) .control {
-                border-color: ${SystemColors.ButtonText};
-                box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
-            }
-    
-            :host([appearance="accent"][disabled]) .control,
-            :host([appearance="accent"][disabled]) .control:hover {
-                background: ${SystemColors.ButtonFace};
-                border-color: ${SystemColors.GrayText};
-                color: ${SystemColors.GrayText};
-            }
-            :host([appearance="lightweight"]) .control:hover {
-                forced-color-adjust: none;
-                color: ${SystemColors.Highlight};
-            }
-    
-            :host([appearance="lightweight"]) .control:hover .content::before {
-                background: ${SystemColors.Highlight};
-            }
-    
-            :host([appearance="lightweight"][disabled]) .control {
-                forced-color-adjust: none;
-                color: ${SystemColors.GrayText};
-            }
-        
-            :host([appearance="lightweight"][disabled]) .control:hover .content::before {
-                background: none;
-            }
-            :host([appearance="outline"][disabled]) .control {
-                border-color: ${SystemColors.GrayText};
-            }
-            :host([appearance="stealth"]) .control {
-                forced-color-adjust: none;
-                background: none;
-                border-color: transparent;
-                color: ${SystemColors.ButtonText};
-                fill: currentcolor;
-            }
-            :host([appearance="stealth"]) .control:hover,
-            :host([appearance="stealth"]:${focusVisible}) .control {
-                background: ${SystemColors.Highlight};
-                border-color: ${SystemColors.Highlight};
-                color: ${SystemColors.HighlightText};
-            }
-            :host([appearance="stealth"][disabled]) .control {
-                background: none;
-                border-color: transparent;
-                color: ${SystemColors.GrayText};
-            }
-        `
-    )
-);
+`;

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -113,7 +113,61 @@ export const BaseButtonStyles = css`
     neutralFillRestBehavior,
     neutralForegroundRestBehavior,
     neutralFillHoverBehavior,
-    neutralFillActiveBehavior
+    neutralFillActiveBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            :host {
+              background-color: ${SystemColors.ButtonFace};
+              border-color: ${SystemColors.ButtonText};
+              color: ${SystemColors.ButtonText};
+              fill: currentColor;
+            }
+    
+            :host(:hover) {
+              forced-color-adjust: none;
+              background-color: ${SystemColors.Highlight};
+              color: ${SystemColors.HighlightText};
+            }
+    
+            .control:${focusVisible} {
+              forced-color-adjust: none;
+              background-color: ${SystemColors.Highlight};
+              border-color: ${SystemColors.ButtonText};
+              box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${SystemColors.ButtonText};
+              color: ${SystemColors.HighlightText};
+            }
+    
+            .control:hover,
+            :host([appearance="outline"]) .control:hover {
+              border-color: ${SystemColors.ButtonText};
+            }
+    
+            :host([disabled]),
+            :host([disabled]) .control {
+                forced-color-adjust: none;
+                background-color: ${SystemColors.ButtonFace};
+                border-color: ${SystemColors.GrayText};
+                color: ${SystemColors.GrayText};
+                cursor: ${disabledCursor};
+                opacity: 1;
+            }
+    
+            :host([href]) {
+              color: ${SystemColors.LinkText};
+            }
+    
+            :host([href]) .control:hover,
+            :host(:hover[href]),
+            :host([href]) .control:${focusVisible}{
+              forced-color-adjust: none;
+              background: ${SystemColors.ButtonFace};
+              border-color: ${SystemColors.LinkText};
+              box-shadow: 0 0 0 1px ${SystemColors.LinkText} inset;
+              color: ${SystemColors.LinkText};
+              fill: currentColor;
+            }
+        `
+    )
 );
 
 /**
@@ -145,7 +199,52 @@ export const AccentButtonStyles = css`
     accentForegroundCutRestBehavior,
     accentFillHoverBehavior,
     accentFillActiveBehavior,
-    neutralFocusInnerAccentBehavior
+    neutralFocusInnerAccentBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            :host([appearance="accent"]) .control {
+                forced-color-adjust: none;
+                background: ${SystemColors.Highlight};
+                color: ${SystemColors.HighlightText};
+            }
+
+            :host([appearance="accent"]) .control:hover {
+                background: ${SystemColors.HighlightText};
+                border-color: ${SystemColors.Highlight};
+                color: ${SystemColors.Highlight};
+            }
+
+            :host([appearance="accent"]) .control:${focusVisible} {
+                border-color: ${SystemColors.ButtonText};
+                box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
+            }
+
+            :host([appearance="accent"][disabled]) .control,
+            :host([appearance="accent"][disabled]) .control:hover {
+                background: ${SystemColors.ButtonFace};
+                border-color: ${SystemColors.GrayText};
+                color: ${SystemColors.GrayText};
+            }
+
+            :host([appearance="accent"][href]) .control{
+                background: ${SystemColors.LinkText};
+                color: ${SystemColors.HighlightText};
+            }
+
+            :host([appearance="accent"][href]) .control:hover {
+                background: ${SystemColors.ButtonFace};
+                border-color: ${SystemColors.LinkText};
+                box-shadow: none;
+                color: ${SystemColors.LinkText};
+                fill: currentColor;
+            }
+
+            :host([appearance="accent"][href]) .control:${focusVisible} {
+                border-color: ${SystemColors.LinkText};
+                box-shadow: 0 0 0 2px ${SystemColors.HighlightText} inset;
+            }
+        `
+    )
 );
 
 /**
@@ -168,6 +267,7 @@ export const HypertextStyles = css`
         border-radius: 0;
         line-height: 1;
     }
+
     :host a.control:not(:link) {
         background-color: transparent;
         cursor: default;
@@ -178,12 +278,15 @@ export const HypertextStyles = css`
         color: ${accentForegroundRestBehavior.var};
         border-bottom: calc(var(--outline-width) * 1px) solid ${accentForegroundRestBehavior.var};
     }
+
     :host([appearance="hypertext"]) .control:hover {
         border-bottom-color: ${accentForegroundHoverBehavior.var};
     }
+
     :host([appearance="hypertext"]) .control:active {
         border-bottom-color: ${accentForegroundActiveBehavior.var};
     }
+
     :host([appearance="hypertext"]) .control:${focusVisible} {
         border-bottom: calc(var(--focus-outline-width) * 1px) solid ${neutralFocusBehavior.var};
     }
@@ -191,7 +294,22 @@ export const HypertextStyles = css`
     accentForegroundRestBehavior,
     accentForegroundHoverBehavior,
     accentForegroundActiveBehavior,
-    neutralFocusBehavior
+    neutralFocusBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            :host([appearance="hypertext"]:hover) {
+                background-color: ${SystemColors.ButtonFace};
+                color: ${SystemColors.ButtonText};
+            }
+            :host([appearance="hypertext"][href]) .control:hover,
+            :host([appearance="hypertext"][href]) .control:active,
+            :host([appearance="hypertext"][href]) .control:${focusVisible} {
+                color: ${SystemColors.LinkText};
+                border-bottom-color: ${SystemColors.LinkText};
+                box-shadow: none;
+            }
+        `
+    )
 );
 
 /**
@@ -256,7 +374,35 @@ export const LightweightButtonStyles = css`
     neutralForegroundRestBehavior,
     forcedColorsStylesheetBehavior(
         css`
-            :host([appearance="lightweight"]:hover) .content::before {
+            :host([appearance="lightweight"]) .control:hover,
+            :host([appearance="lightweight"]) .control:${focusVisible} {
+                forced-color-adjust: none;
+                background: ${SystemColors.ButtonFace};
+                color: ${SystemColors.Highlight};
+            }
+            :host([appearance="lightweight"]) .control:hover .content::before,
+            :host([appearance="lightweight"]) .control:${focusVisible} .content::before {
+                background: ${SystemColors.Highlight};
+            }
+
+            :host([appearance="lightweight"].disabled) .control {
+                forced-color-adjust: none;
+                color: ${SystemColors.GrayText};
+            }
+
+            :host([appearance="lightweight"].disabled) .control:hover .content::before {
+                background: none;
+            }
+
+            :host([appearance="lightweight"][href]) .control:hover,
+            :host([appearance="lightweight"][href]) .control:${focusVisible} {
+                background: ${SystemColors.ButtonFace};
+                box-shadow: none;
+                color: ${SystemColors.LinkText};
+            }
+
+            :host([appearance="lightweight"][href]) .control:hover .content::before,
+            :host([appearance="lightweight"][href]) .control:${focusVisible} .content::before {
                 background: ${SystemColors.LinkText};
             }
         `
@@ -296,7 +442,30 @@ export const OutlineButtonStyles = css`
     accentFillRestBehavior,
     accentFillHoverBehavior,
     accentFillActiveBehavior,
-    neutralFocusBehavior
+    neutralFocusBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            :host([appearance="outline"]) .control:${focusVisible} {
+              forced-color-adjust: none;
+              background-color: ${SystemColors.Highlight};
+              border-color: ${SystemColors.ButtonText};
+              box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${SystemColors.ButtonText};
+              color: ${SystemColors.HighlightText};
+              fill: currentColor;
+            }
+            :host([appearance="outline"][href]) .control:hover {
+              forced-color-adjust: none;
+              background: ${SystemColors.ButtonFace};
+              border-color: ${SystemColors.LinkText};
+              box-shadow: 0 0 0 1px ${SystemColors.LinkText} inset;
+              color: ${SystemColors.LinkText};
+              fill: currentColor;
+            }
+            :host([appearance="outline"][disabled]) .control {
+                border-color: ${SystemColors.GrayText};
+            }
+        `
+    )
 );
 
 /**
@@ -321,5 +490,56 @@ export const StealthButtonStyles = css`
 `.withBehaviors(
     neutralFillStealthRestBehavior,
     neutralFillStealthHoverBehavior,
-    neutralFillStealthActiveBehavior
+    neutralFillStealthActiveBehavior,
+    forcedColorsStylesheetBehavior(
+        css`
+            :host([appearance="stealth"]) .control {
+                forced-color-adjust: none;
+                background-color: none;
+                border-color: transparent;
+                color: ${SystemColors.ButtonText};
+                fill: currentColor;
+            }
+
+            :host([appearance="stealth"]:hover) .control {
+                background-color: ${SystemColors.Highlight};
+                border-color: ${SystemColors.Highlight};
+                color: ${SystemColors.HighlightText};
+                fill: currentColor;
+            }
+
+            :host([appearance="stealth"]:${focusVisible}) .control {
+                box-shadow: 0 0 0 1px ${SystemColors.Highlight};
+                color: ${SystemColors.HighlightText};
+                fill: currentColor;
+            }
+
+            :host([appearance="stealth"].disabled) {
+                background-color: ${SystemColors.ButtonFace};
+            }
+
+            :host([appearance="stealth"].disabled) .control {
+                background-color: ${SystemColors.ButtonFace};
+                border-color: transparent;
+                color: ${SystemColors.GrayText};
+            }
+
+            :host([appearance="stealth"][href]) .control {
+                color: ${SystemColors.LinkText};
+            }
+
+            :host([appearance="stealth"]:hover[href]) .control {
+                background-color: ${SystemColors.LinkText};
+                border-color: ${SystemColors.LinkText};
+                color: ${SystemColors.HighlightText};
+                fill: currentColor;
+            }
+
+            :host(.stealth:${focusVisible}[href]) .control {
+                box-shadow: 0 0 0 1px ${SystemColors.LinkText};
+                color: ${SystemColors.LinkText};
+                fill: currentColor;
+            }
+        `
+    )
 );


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Removed the contrast work from the button style and add the high contrast changes to the common button style. Now both button and anchor will get the high contrast changes.

fixes #4133 

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->