### PR TITLE
chore: add listbox scenario

### DIFF
--- a/packages/web-components/fast-components/src/listbox/listbox.definition.ts
+++ b/packages/web-components/fast-components/src/listbox/listbox.definition.ts
@@ -15,6 +15,7 @@ export const fastListboxDefinition: WebComponentDefinition = {
                     type: DataType.string,
                     default: ListboxRole.listbox,
                     required: true,
+                    values: Object.keys(ListboxRole).map(e => ({ name: `${e}` })),
                 },
                 {
                     name: "disabled",

--- a/packages/web-components/fast-components/src/listbox/scenarios/index.html
+++ b/packages/web-components/fast-components/src/listbox/scenarios/index.html
@@ -1,0 +1,7 @@
+<template title="Default">
+    <fast-listbox>
+        <fast-option value="1">Option 1</fast-option>
+        <fast-option value="2">Option 2</fast-option>
+        <fast-option value="3">Option 3</fast-option>
+    </fast-listbox>
+</template>

--- a/sites/fast-component-explorer/app/fast-components/configs/fast-listbox.ts
+++ b/sites/fast-component-explorer/app/fast-components/configs/fast-listbox.ts
@@ -1,0 +1,20 @@
+import {
+    fastComponentDefinitions,
+    fastComponentSchemas,
+} from "@microsoft/site-utilities";
+import { camelCase } from "lodash-es";
+import Guidance from "../../.tmp/listbox/guidance";
+import Scenarios from "../../.tmp/listbox/scenario";
+import { mapScenarios } from "../utilities/mapping";
+import { ComponentViewConfig } from "./data.props";
+
+export const fastOptionId = "fast-option";
+export const fastListboxId = "fast-listbox";
+const fastListboxConfig: ComponentViewConfig = {
+    schema: fastComponentSchemas[fastListboxId],
+    definition: fastComponentDefinitions[`${camelCase(fastListboxId)}Definition`],
+    guidance: Guidance,
+    scenarios: mapScenarios(Scenarios),
+};
+
+export default fastListboxConfig;

--- a/sites/fast-component-explorer/app/fast-components/configs/index.ts
+++ b/sites/fast-component-explorer/app/fast-components/configs/index.ts
@@ -28,6 +28,9 @@ export { fastDividerConfig };
 import fastFlipperConfig from "./fast-flipper";
 export { fastFlipperConfig };
 
+import fastListboxConfig from "./fast-listbox";
+export { fastListboxConfig };
+
 import fastMenuConfig from "./fast-menu";
 export { fastMenuConfig };
 


### PR DESCRIPTION
# Description
Adds a scenario for the `<fast-listbox>` element.

## Issue type checklist
- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [ ] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->