### PR TITLE
fix: add enter key handler to dictionary keys

### DIFF
--- a/packages/tooling/fast-tooling-react/src/form/controls/utilities/dictionary.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/utilities/dictionary.tsx
@@ -117,6 +117,7 @@ class Dictionary extends React.Component<
                         }
                         onFocus={this.handleKeyFocus(propertyName)}
                         onBlur={this.handleKeyBlur(propertyName)}
+                        onKeyDown={this.handleKeyPress()}
                         onChange={this.handleKeyChange(propertyName)}
                     />
                     <button
@@ -226,6 +227,15 @@ class Dictionary extends React.Component<
                 dictionaryId: this.props.dictionaryId,
                 value: void 0,
             });
+        };
+    };
+
+    private handleKeyPress = (): ((e: React.KeyboardEvent<HTMLInputElement>) => void) => {
+        return (e: React.KeyboardEvent<HTMLInputElement>): void => {
+            if (e.keyCode === 13) {
+                e.currentTarget.blur();
+                e.preventDefault();
+            }
         };
     };
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Adding a handler for the enter key in dictionary key fields that triggers a blur event instead of the default enter behavior.

## Motivation & context

Fixes: #2287 

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->