### PR TITLE
fix: anchored region default viewport

### DIFF
--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -269,7 +269,6 @@ export class FASTButton extends Button {
     appearance: ButtonAppearance;
     // (undocumented)
     connectedCallback(): void;
-    // (undocumented)
     defaultSlottedContentChanged(oldValue: any, newValue: any): void;
 }
 

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -206,7 +206,8 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 ) 
 
 *Events:*
-- positionchange
+- loaded - The contents of the anchored region are loaded into the DOM.
+- positionchange - The positioning of the anchored region has changed.
 
 
 Enables developers to update the offset between the anchor and the region as it changes,  for example to promt layout recalculations as a result of scrolling so a scaling region tracks the viewport boundary.  

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -200,11 +200,16 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 - default slot for content
 
 *functions:*
-- update() - forces the anchored region to recalculate positioning.
+- updateAnchorOffset = (
+    horizontalOffsetDelta: number,
+    verticalOffsetDelta: number
+) 
 
 *Events:*
-- loaded - the region and its contents have been added to the DOM and positioned
-- change - the positioning of the anchored region has changed
+- positionchange
+
+
+Enables developers to update the offset between the anchor and the region as it changes,  for example to promt layout recalculations as a result of scrolling so a scaling region tracks the viewport boundary.  
 
 
 

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -727,18 +727,13 @@ export class AnchoredRegion extends FASTElement {
 
         this.pendingLayoutUpdate = false;
 
+        let desiredVerticalPosition: AnchoredRegionVerticalPositionLabel =
+            AnchoredRegionVerticalPositionLabel.undefined;
         let desiredHorizontalPosition: AnchoredRegionHorizontalPositionLabel =
             AnchoredRegionHorizontalPositionLabel.undefined;
 
         if (this.horizontalPositioningMode !== "uncontrolled") {
-            // identify possible placements
             const horizontalOptions: AnchoredRegionHorizontalPositionLabel[] = this.getHorizontalPositioningOptions();
-
-            // get the available space of each possible placement
-            const horizontalOptionHeights: number[] = [
-                this.getAvailableWidth(horizontalOptions[0]),
-                this.getAvailableWidth(horizontalOptions[1]),
-            ];
 
             if (this.horizontalDefaultPosition !== "unset") {
                 let dirCorrectedHorizontalDefaultPosition: string = this
@@ -782,49 +777,30 @@ export class AnchoredRegion extends FASTElement {
                             : AnchoredRegionHorizontalPositionLabel.right;
                         break;
                 }
+            }
 
-                // if not locked to default position check to see if default "fits"
-                if (this.horizontalPositioningMode !== "locktodefault") {
-                    // minimum required space
-                    const horizontalThreshold: number =
-                        this.horizontalThreshold !== undefined
-                            ? Number(this.horizontalThreshold)
-                            : this.regionDimension.width;
+            const horizontalThreshold: number =
+                this.horizontalThreshold !== undefined
+                    ? Number(this.horizontalThreshold)
+                    : this.regionDimension.width;
 
-                    // if the preferred placement doesn't fit pick the one with the most space
-                    if (
-                        horizontalOptionHeights[
-                            horizontalOptions.indexOf(desiredHorizontalPosition)
-                        ] < horizontalThreshold
-                    ) {
-                        desiredHorizontalPosition =
-                            horizontalOptionHeights[0] > horizontalOptionHeights[1]
-                                ? horizontalOptions[0]
-                                : horizontalOptions[1];
-                    }
-                }
-            } else {
-                // no preference, pick the option with the most space
+            if (
+                desiredHorizontalPosition ===
+                    AnchoredRegionHorizontalPositionLabel.undefined ||
+                (!(this.horizontalPositioningMode === "locktodefault") &&
+                    this.getAvailableWidth(desiredHorizontalPosition) <
+                        horizontalThreshold)
+            ) {
                 desiredHorizontalPosition =
-                    horizontalOptionHeights[0] > horizontalOptionHeights[1]
+                    this.getAvailableWidth(horizontalOptions[0]) >
+                    this.getAvailableWidth(horizontalOptions[1])
                         ? horizontalOptions[0]
                         : horizontalOptions[1];
             }
         }
 
-        let desiredVerticalPosition: AnchoredRegionVerticalPositionLabel =
-            AnchoredRegionVerticalPositionLabel.undefined;
-
         if (this.verticalPositioningMode !== "uncontrolled") {
-            // identify possible placements
             const verticalOptions: AnchoredRegionVerticalPositionLabel[] = this.getVerticalPositioningOptions();
-
-            // get the available space of each possible placement
-            const verticalOptionHeights: number[] = [
-                this.getAvailableHeight(verticalOptions[0]),
-                this.getAvailableHeight(verticalOptions[1]),
-            ];
-
             if (this.verticalDefaultPosition !== "unset") {
                 switch (this.verticalDefaultPosition) {
                     case "top":
@@ -839,31 +815,22 @@ export class AnchoredRegion extends FASTElement {
                             : AnchoredRegionVerticalPositionLabel.bottom;
                         break;
                 }
+            }
 
-                // if not locked to default position check to see if default "fits"
-                if (this.verticalPositioningMode !== "locktodefault") {
-                    // minimum required space
-                    const verticalThreshold: number =
-                        this.verticalThreshold !== undefined
-                            ? Number(this.verticalThreshold)
-                            : this.regionDimension.height;
+            const verticalThreshold: number =
+                this.verticalThreshold !== undefined
+                    ? Number(this.verticalThreshold)
+                    : this.regionDimension.height;
 
-                    // if the preferred placement doesn't fit pick the one with the most space
-                    if (
-                        verticalOptionHeights[
-                            verticalOptions.indexOf(desiredVerticalPosition)
-                        ] < verticalThreshold
-                    ) {
-                        desiredVerticalPosition =
-                            verticalOptionHeights[0] > verticalOptionHeights[1]
-                                ? verticalOptions[0]
-                                : verticalOptions[1];
-                    }
-                }
-            } else {
-                // no preference, pick the option with the most space
+            if (
+                desiredVerticalPosition ===
+                    AnchoredRegionVerticalPositionLabel.undefined ||
+                (!(this.verticalPositioningMode === "locktodefault") &&
+                    this.getAvailableHeight(desiredVerticalPosition) < verticalThreshold)
+            ) {
                 desiredVerticalPosition =
-                    verticalOptionHeights[0] > verticalOptionHeights[1]
+                    this.getAvailableHeight(verticalOptions[0]) >
+                    this.getAvailableHeight(verticalOptions[1])
                         ? verticalOptions[0]
                         : verticalOptions[1];
             }
@@ -889,7 +856,7 @@ export class AnchoredRegion extends FASTElement {
         }
 
         if (positionChanged) {
-            this.$emit("change", this, { bubbles: false });
+            this.$emit("positionchange", this, { bubbles: false });
         }
     };
 

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -417,7 +417,10 @@ export class Tooltip extends FASTElement {
             return;
         }
         if (this.region !== null && this.region !== undefined) {
-            (this.region as any).removeEventListener("change", this.handlePositionChange);
+            (this.region as any).removeEventListener(
+                "positionchange",
+                this.handlePositionChange
+            );
             this.region.viewportElement = null;
             this.region.anchorElement = null;
         }
@@ -436,6 +439,9 @@ export class Tooltip extends FASTElement {
         this.viewportElement = document.body;
         this.region.viewportElement = this.viewportElement;
         this.region.anchorElement = this.anchorElement;
-        (this.region as any).addEventListener("change", this.handlePositionChange);
+        (this.region as any).addEventListener(
+            "positionchange",
+            this.handlePositionChange
+        );
     };
 }


### PR DESCRIPTION
# Description

Minor fixes to anchored region that came to light while putting [nested menus](https://github.com/microsoft/fast/pull/4142) together. 

- use document root element to calculate default viewport as intersection event rootbounds prop doesn't take things like toolbars into account.
- "change" event becomes "positionchange" and no longer bubbles
- threshold attributes default to undefined

## Motivation & context
bug fixes

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.