### PR TITLE
fix: fix type error in custom property manager running on safari

### DIFF
--- a/packages/web-components/fast-foundation/src/custom-properties/manager.ts
+++ b/packages/web-components/fast-foundation/src/custom-properties/manager.ts
@@ -327,9 +327,8 @@ export class StyleElementCustomPropertyManager extends CustomPropertyManagerBase
         handleChange: () => {
             this._sheet = this.styles.sheet!;
 
-            this.customPropertyTarget = (this.sheet!.rules[
-                this.sheet!.insertRule(hostSelector)
-            ] as CSSStyleRule).style;
+            const key = this.sheet!.insertRule(hostSelector);
+            this.customPropertyTarget = (this.sheet!.rules[key] as CSSStyleRule).style;
 
             Observable.getNotifier(this._owner?.$fastController).unsubscribe(
                 this.handleConnection,


### PR DESCRIPTION
After upgrading the package version from 1.11.1 to 1.12.0 I found my website styles didn't work in Safari running on iPadOS (works fine on Desktop Firefox and Firefox/Chrome on Android). Found I was getting the following error:

```
TypeError: undefined is not an object (evaluating 'this.sheet.rules[this.sheet.insertRule(hostSelector)].style')
```

If I change the following line in fast-foundation/dist/esm/custom-properties/manager.js:

```javascript
this.customPropertyTarget = this.sheet.rules[this.sheet.insertRule(hostSelector)].style;
```

to:

```javascript
const key = this.sheet.insertRule(hostSelector);
this.customPropertyTarget = this.sheet.rules[key].style;
```

Then the styles are working again.

# Description

Call insertRule before using it as an object key. Although by my understanding this should happen anyway, so this may just be a workaround for a Safari bug.

## Motivation & context

Could be related to https://github.com/microsoft/fast/issues/4138, it's possible they're also experiencing this style bug

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

I'm not sure whether there are tests I can add for this, after making the change I've run `lerna run test` and checked the behaviour is correct on: iPadOS Safari/Firefox/Chrome, Android Firefox/Chrome, Linux Firefox/Chrome