### PR TITLE
fix: fixes runtime error in StyleElementCustomPropertyManager during construction in Safari

### DIFF
--- a/packages/web-components/fast-foundation/src/custom-properties/manager.ts
+++ b/packages/web-components/fast-foundation/src/custom-properties/manager.ts
@@ -326,9 +326,9 @@ export class StyleElementCustomPropertyManager extends CustomPropertyManagerBase
     private handleConnection = {
         handleChange: () => {
             this._sheet = this.styles.sheet!;
-
+            const ruleIndex = this.sheet!.insertRule(hostSelector);
             this.customPropertyTarget = (this.sheet!.rules[
-                this.sheet!.insertRule(hostSelector)
+                ruleIndex
             ] as CSSStyleRule).style;
 
             Observable.getNotifier(this._owner?.$fastController).unsubscribe(


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
This PR fixes a runtime error in Safari when the `DesignSystemProvider` constructs.

Safari does not seem to be able to successfully reference a `CSSRule` from a `CSSStyleSheet.rules` list by index when the index value is the direct product of `CSSStyleSheet.insertRule()`.

Moving `CSSStyleSheet.insertRule()` to it's own expression and *then* using the returned value to index the rule resolves the issue.

fixes #4151 
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->