### PR TITLE
fix: clamp fast-select height and set its box sizing

### DIFF
--- a/packages/web-components/fast-components/src/select/select.styles.ts
+++ b/packages/web-components/fast-components/src/select/select.styles.ts
@@ -32,8 +32,10 @@ export const SelectStyles = css`
         background: ${neutralFillInputRestBehavior.var};
         border-radius: calc(var(--corner-radius) * 1px);
         border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
+        box-sizing: border-box;
         color: ${neutralForegroundRestBehavior.var};
         contain: contents;
+        height: calc(${heightNumber} * 1px);
         position: relative;
         user-select: none;
         min-width: 250px;
@@ -69,7 +71,7 @@ export const SelectStyles = css`
         font: inherit;
         line-height: var(--type-ramp-base-line-height);
         min-height: calc(${heightNumber} * 1px);
-        padding: calc(var(--design-unit) * 2.25px);
+        padding: 0 calc(var(--design-unit) * 2.25px);
         width: 100%;
     }
 


### PR DESCRIPTION
# Description
Sets the `fast-select` height to use `heightNumber` instead of allowing it to use intrinsic sizing.

Closes #4145.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.