### PR TITLE
fix: formassociated and async tests on firefox

### DIFF
--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -196,7 +196,7 @@ export class Checkbox extends FormAssociatedCheckbox {
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
     // @internal (undocumented)
-    formResetCallback(): void;
+    formResetCallback: () => void;
     indeterminate: boolean;
     // @internal
     initialValue: string;
@@ -568,6 +568,8 @@ export class Listbox extends FASTElement {
     selectNextOption(): void;
     // @internal
     selectPreviousOption(): void;
+    // @internal (undocumented)
+    protected setDefaultSelectedOption(): void;
     setSelectedOption(index?: number): void;
     static slottedOptionFilter: (n: ListboxOption) => boolean;
     // @internal
@@ -724,7 +726,7 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
     // @internal (undocumented)
-    formResetCallback(): void;
+    formResetCallback: () => void;
     // @internal
     initialValue: string;
     // @internal (undocumented)
@@ -783,6 +785,8 @@ export class Select extends FormAssociatedSelect {
     get displayValue(): string;
     // (undocumented)
     focusoutHandler(e: FocusEvent): boolean | void;
+    // @internal (undocumented)
+    formResetCallback: () => void;
     // (undocumented)
     keydownHandler(e: KeyboardEvent): boolean | void;
     // @internal
@@ -987,7 +991,7 @@ export class Switch extends FormAssociatedSwitch {
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
     // @internal (undocumented)
-    formResetCallback(): void;
+    formResetCallback: () => void;
     // @internal
     initialValue: string;
     // @internal (undocumented)

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -27,6 +27,7 @@
     "build": "yarn build:tsc && yarn build:rollup && yarn doc",
     "dev": "tsc -p ./tsconfig.json -w",
     "tdd": "yarn dev & yarn test-chrome:watch",
+    "tdd:firefox": "yarn dev & yarn test-firefox:watch",
     "prepare": "yarn clean:dist && yarn build",
     "prettier": "prettier --config ../../../.prettierrc --write \"**/*.ts\"",
     "prettier:diff": "prettier --config ../../../.prettierrc \"**/*.ts\" --list-different",
@@ -42,7 +43,8 @@
     "test-chrome:verbose:watch": "karma start karma.conf.js --browsers=ChromeHeadlessOpt --coverage --watch-extensions js --reporter=mocha",
     "test-chrome:verbose:debugger": "karma start karma.conf.js --browsers=ChromeDebugging --reporter=mocha",
     "test-firefox": "karma start karma.conf.js --browsers=FirefoxHeadless --single-run --coverage",
-    "test-firefox:verbose": "karma start karma.conf.js --browsers=FirefoxHeadless --single-run --coverage --reporter=mocha"
+    "test-firefox:verbose": "karma start karma.conf.js --browsers=FirefoxHeadless --single-run --coverage --reporter=mocha",
+    "test-firefox:watch": "karma start karma.conf.js --browsers=FirefoxHeadless   --coverage --watch-extensions js"
   },
   "devDependencies": {
     "@microsoft/api-extractor": "^7.7.13",

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -132,11 +132,10 @@ export class Checkbox extends FormAssociatedCheckbox {
     /**
      * @internal
      */
-    public formResetCallback(): void {
+    public formResetCallback = (): void => {
         this.checked = this.checkedAttribute;
         this.dirtyChecked = false;
-        super.formResetCallback();
-    }
+    };
 
     private updateForm(): void {
         const value = this.checked ? this.value : null;

--- a/packages/web-components/fast-foundation/src/custom-properties/manager.spec.ts
+++ b/packages/web-components/fast-foundation/src/custom-properties/manager.spec.ts
@@ -20,12 +20,13 @@ class Client extends FASTElement implements CustomPropertyManagerClient {
 }
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<Client>("fast-client");
+    const { connect, disconnect, element, parent } = await fixture<Client>("fast-client");
 
     return {
         element,
         connect,
         disconnect,
+        parent,
     };
 }
 
@@ -48,18 +49,23 @@ describe("ConstructableStylesCustomPropertyManager", () => {
             await disconnect();
         });
         it("should keep the first subscriber as the owner after multiple subscribers", async () => {
-            const { element, connect, disconnect } = await setup();
+            const { connect, disconnect, element, parent } = await setup();
+
             const clone = element.cloneNode() as Client;
-            document.body.appendChild(clone);
+
+            parent.appendChild(clone);
+
             const manager = new ConstructableStylesCustomPropertyManager(
                 new CSSStyleSheet()
             );
 
             await connect();
+
             manager.subscribe(element);
             manager.subscribe(clone);
 
             expect(manager.owner).to.equal(element);
+
             await disconnect();
         });
         it("should evaluate and write the value of all CSSCustomPropertyDefinitions in the client", async () => {
@@ -69,6 +75,7 @@ describe("ConstructableStylesCustomPropertyManager", () => {
             );
 
             await connect();
+
             element.cssCustomPropertyDefinitions.set("my-property", {
                 name: "my-property",
                 value: "value",
@@ -79,6 +86,7 @@ describe("ConstructableStylesCustomPropertyManager", () => {
             expect(
                 window.getComputedStyle(element).getPropertyValue("--my-property")
             ).to.equal("value");
+
             await disconnect();
         });
     });
@@ -90,28 +98,34 @@ describe("ConstructableStylesCustomPropertyManager", () => {
             );
 
             await connect();
+
             manager.subscribe(element);
             manager.unsubscribe(element);
 
             expect(manager.owner).to.equal(null);
+
             await disconnect();
         });
         it("of the owner should set the owner to the subsequent subscriber", async () => {
-            const { element, connect, disconnect } = await setup();
+            const { connect, disconnect, element, parent } = await setup();
             const b = element.cloneNode() as Client;
             const c = element.cloneNode() as Client;
-            document.body.appendChild(b);
-            document.body.appendChild(c);
+
+            parent.appendChild(b);
+            parent.appendChild(c);
+
             const manager = new ConstructableStylesCustomPropertyManager(
                 new CSSStyleSheet()
             );
 
             await connect();
+
             manager.subscribe(element);
             manager.subscribe(b);
             manager.subscribe(c);
 
             manager.unsubscribe(element);
+
             expect(manager.owner).to.equal(b);
 
             await disconnect();
@@ -134,6 +148,7 @@ describe("ConstructableStylesCustomPropertyManager", () => {
             expect(
                 window.getComputedStyle(element).getPropertyValue("--my-property")
             ).to.equal("");
+
             await disconnect();
         });
     });
@@ -168,10 +183,12 @@ describe("StyleElementCustomPropertyManager", () => {
 
     it("should queue and apply properties set prior to connection once connected", () => {
         const element = document.createElement("fast-client") as Client;
+
         element.cssCustomPropertyDefinitions.set("my-property", {
             name: "my-property",
             value: "value",
         });
+
         const client = new StyleElementCustomPropertyManager(
             document.createElement("style"),
             element
@@ -181,11 +198,15 @@ describe("StyleElementCustomPropertyManager", () => {
             window.getComputedStyle(element).getPropertyValue("--my-property"),
             ""
         );
+
         document.body.appendChild(element);
+
         assert.equal(
             window.getComputedStyle(element).getPropertyValue("--my-property"),
             "value"
         );
+
+        element.remove();
     });
 
     it("should connect the style element to the DOM during construction", async () => {

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.spec.ts
@@ -1,4 +1,4 @@
-import { Observable } from "@microsoft/fast-element";
+import { DOM, Observable } from "@microsoft/fast-element";
 import { assert, expect } from "chai";
 import { ConstructableStylesCustomPropertyManager } from "../custom-properties";
 import { fixture } from "../fixture";
@@ -175,6 +175,8 @@ describe("A DesignSystemProvider", () => {
                     expect(
                         window.getComputedStyle(p).getPropertyValue("--color")
                     ).to.equal("blue");
+
+                    p.remove();
                 });
 
                 it("should not write the default value when the use-defaults attribute is applied but the property is also assigned", () => {
@@ -188,6 +190,8 @@ describe("A DesignSystemProvider", () => {
                     expect(
                         window.getComputedStyle(p).getPropertyValue("--color")
                     ).to.equal("pink");
+
+                    p.remove();
                 });
 
                 it("should not create a CSS custom property when the value is unassigned", () => {
@@ -199,6 +203,8 @@ describe("A DesignSystemProvider", () => {
                     expect(
                         window.getComputedStyle(p).getPropertyValue("--color")
                     ).to.equal("");
+
+                    p.remove();
                 });
 
                 it("should create a CSS custom property equal to the property value when the value is assigned", () => {
@@ -212,6 +218,8 @@ describe("A DesignSystemProvider", () => {
                     expect(
                         window.getComputedStyle(p).getPropertyValue("--color")
                     ).to.equal("red");
+
+                    p.remove();
                 });
 
                 it("should update a CSS custom property equal to the property value when the value is re-assigned", () => {
@@ -235,6 +243,8 @@ describe("A DesignSystemProvider", () => {
                     expect(
                         window.getComputedStyle(p).getPropertyValue("--color")
                     ).to.equal("blue");
+
+                    p.remove();
                 });
             });
         });
@@ -251,12 +261,14 @@ describe("A DesignSystemProvider", () => {
 
             expect(aAccessors.length).to.equal(2);
 
-            window.setTimeout(() => {
+            DOM.queueUpdate(() => {
                 Observable.getAccessors(a.designSystem).forEach(x => {
                     expect(a.designSystem[x.name]).to.equal(n.designSystem[x.name]);
                 });
                 done();
-            }, 0);
+            });
+
+            a.remove();
         });
 
         it("should update it's local design system when a parent DesignSystemProperty is changed and the local property is unset", done => {
@@ -266,7 +278,7 @@ describe("A DesignSystemProvider", () => {
             a.appendChild(b);
             document.body.appendChild(a);
 
-            window.setTimeout(() => {
+            DOM.queueUpdate(() => {
                 a.a = Symbol();
                 Observable.getAccessors(a.designSystem).forEach(x => {
                     expect(b.designSystem[x.name]).not.to.equal(undefined);
@@ -275,6 +287,8 @@ describe("A DesignSystemProvider", () => {
 
                 done();
             });
+
+            a.remove();
         });
 
         it("should update it's local design system when a local DesignSystemProperty is changed", done => {
@@ -285,13 +299,15 @@ describe("A DesignSystemProvider", () => {
             document.body.appendChild(a);
             const value = Symbol();
 
-            window.setTimeout(() => {
+            DOM.queueUpdate(() => {
                 b.a = value;
                 expect(b.designSystem["a"]).to.equal(value);
                 expect(a.designSystem["a"]).equal(a.a);
 
                 done();
             });
+
+            a.remove();
         });
     });
 
@@ -319,6 +335,7 @@ describe("A DesignSystemProvider", () => {
 
             await disconnect();
         });
+
         it("should have a design system that is the union of ancestor's when deeply nested", done => {
             const a = document.createElement("dsp-a") as DSPA;
             const b = document.createElement("dsp-b") as DSPB;
@@ -331,7 +348,7 @@ describe("A DesignSystemProvider", () => {
             a.appendChild(b);
             document.body.appendChild(a);
 
-            window.setTimeout(() => {
+            DOM.queueUpdate(() => {
                 expect(c.designSystem["a"]).not.to.equal(undefined);
                 expect(c.designSystem["b"]).not.to.equal(undefined);
                 expect(c.designSystem["c"]).not.to.equal(undefined);
@@ -344,6 +361,8 @@ describe("A DesignSystemProvider", () => {
 
                 done();
             });
+
+            a.remove();
         });
         it("should propagate property updates through providers where a parent provider doesn't declare the property as a designSystemProperty", done => {
             const a = document.createElement("dsp-a") as DSPA;
@@ -357,7 +376,7 @@ describe("A DesignSystemProvider", () => {
             a.appendChild(b);
             document.body.appendChild(a);
 
-            window.setTimeout(() => {
+            DOM.queueUpdate(() => {
                 expect(c.designSystem["a"]).to.equal(a.designSystem["a"]);
                 const symbol = Symbol();
                 a.a = symbol;
@@ -366,6 +385,8 @@ describe("A DesignSystemProvider", () => {
                 expect(c.designSystem["a"]).to.equal(symbol);
                 done();
             });
+
+            a.remove();
         });
     });
 
@@ -384,6 +405,7 @@ describe("A DesignSystemProvider", () => {
             );
             await disconnect();
         });
+
         it("should write the product of a function value to a CSS custom property after registration", async () => {
             const { a, connect, disconnect } = await setup();
             await connect();
@@ -399,6 +421,7 @@ describe("A DesignSystemProvider", () => {
 
             await disconnect();
         });
+
         it("should evaluate function values with the current designSystem object", async () => {
             const { a, connect, disconnect } = await setup();
             let arg: any;
@@ -419,6 +442,7 @@ describe("A DesignSystemProvider", () => {
 
             await disconnect();
         });
+
         it("should remove the CSSCustomProperty after registration if it has only be registered once", async () => {
             const { a, connect, disconnect } = await setup();
             await connect();
@@ -436,6 +460,7 @@ describe("A DesignSystemProvider", () => {
             );
             await disconnect();
         });
+
         it("should only remove a custom property after it has been unregistered the same number of times it has been registered", async () => {
             const { a, connect, disconnect } = await setup();
             await connect();

--- a/packages/web-components/fast-foundation/src/fixture.spec.ts
+++ b/packages/web-components/fast-foundation/src/fixture.spec.ts
@@ -11,7 +11,10 @@ import { uniqueElementName, fixture } from "./fixture";
 
 describe("The fixture helper", () => {
     const name = uniqueElementName();
-    const template = html<MyElement>`${x => x.value}<slot></slot>`;
+    const template = html<MyElement>`
+        ${x => x.value}
+        <slot></slot>
+    `;
 
     @customElement({
         name,
@@ -49,6 +52,8 @@ describe("The fixture helper", () => {
         await connect();
 
         expect(element.isConnected).to.equal(true);
+
+        document.body.removeChild(element.parentElement!);
     });
 
     it("can disconnect an element", async () => {
@@ -67,7 +72,7 @@ describe("The fixture helper", () => {
 
     it("can bind an element to data", async () => {
         const source = new MyModel();
-        const { element } = await fixture<MyElement>(
+        const { element, disconnect } = await fixture<MyElement>(
             html<MyModel>`
       <${name} value=${x => x.value}></${name}>
     `,
@@ -81,5 +86,7 @@ describe("The fixture helper", () => {
         await DOM.nextUpdate();
 
         expect(element.value).to.equal(source.value);
+
+        await disconnect();
     });
 });

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -106,7 +106,11 @@ export class Listbox extends FASTElement {
      * @internal
      */
     protected focusAndScrollOptionIntoView(): void {
-        if (this.contains(document.activeElement)) {
+        if (
+            this.$fastController.isConnected &&
+            this.contains(document.activeElement) &&
+            this.firstSelectedOption
+        ) {
             this.firstSelectedOption.focus();
             this.firstSelectedOption.scrollIntoView({ block: "nearest" });
         }
@@ -125,7 +129,7 @@ export class Listbox extends FASTElement {
     /**
      * @internal
      */
-    private setDefaultSelectedOption(): void {
+    protected setDefaultSelectedOption(): void {
         let selectedIndex = this.options.findIndex(el => el.selected);
         selectedIndex = selectedIndex !== -1 ? selectedIndex : 0;
         this.setSelectedOption(selectedIndex);

--- a/packages/web-components/fast-foundation/src/radio/radio.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.spec.ts
@@ -11,9 +11,11 @@ import { KeyCodes } from "@microsoft/fast-web-utilities";
 class FASTRadio extends Radio {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTRadio>("fast-radio");
+    const { connect, disconnect, element, parent } = await fixture<FASTRadio>(
+        "fast-radio"
+    );
 
-    return { element, connect, disconnect };
+    return { element, connect, disconnect, parent };
 }
 
 describe("Radio", () => {
@@ -337,16 +339,20 @@ describe("Radio", () => {
 
     describe("who's parent form has it's reset() method invoked", () => {
         it("should set it's checked property to false if the checked attribute is unset", async () => {
-            const { element, connect, disconnect } = await setup();
-            await connect();
+            const { connect, disconnect, element, parent } = await setup();
 
             const form = document.createElement("form");
-            document.body.appendChild(form);
             form.appendChild(element);
+            parent.appendChild(form);
+
+            await connect();
+
             element.checked = true;
 
             assert(element.getAttribute("checked") === null);
+
             assert(element.checked);
+
             form.reset();
 
             assert(!element.checked);
@@ -355,12 +361,14 @@ describe("Radio", () => {
         });
 
         it("should set it's checked property to true if the checked attribute is set", async () => {
-            const { element, connect, disconnect } = await setup();
-            await connect();
+            const { connect, disconnect, element, parent } = await setup();
 
             const form = document.createElement("form");
-            document.body.appendChild(form);
             form.appendChild(element);
+            parent.appendChild(form);
+
+            await connect();
+
             element.setAttribute("checked", "");
 
             assert(element.getAttribute("checked") === "");
@@ -375,12 +383,17 @@ describe("Radio", () => {
             await disconnect();
         });
 
-        it("should put the control into a clean state, where checked attribute changes change the checked property prior to user or programmatic interaction", () => {
-            const element = document.createElement("fast-radio") as FASTRadio;
+        it("should put the control into a clean state, where checked attribute changes change the checked property prior to user or programmatic interaction", async () => {
+            const { connect, disconnect, element, parent } = await setup();
+
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+
+            await connect();
+
             element.checked = true;
+
             element.removeAttribute("checked");
 
             assert(element.checked);
@@ -392,6 +405,8 @@ describe("Radio", () => {
             element.setAttribute("checked", "");
 
             assert(element.value);
+
+            await disconnect();
         });
     });
 });

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -155,10 +155,10 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     /**
      * @internal
      */
-    public formResetCallback() {
+    public formResetCallback = (): void => {
         this.checked = !!this.defaultChecked;
         this.dirtyChecked = false;
-    }
+    };
 
     private isInsideRadioGroup(): boolean {
         const parent: HTMLElement | null = (this as HTMLElement).closest(

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -108,6 +108,13 @@ export class Select extends FormAssociatedSelect {
     }
 
     /**
+     * @internal
+     */
+    public formResetCallback = (): void => {
+        this.setDefaultSelectedOption();
+    };
+
+    /**
      * Sets the value when the options are changed.
      *
      * @param prev - The previous value

--- a/packages/web-components/fast-foundation/src/slider/slider.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.spec.ts
@@ -18,9 +18,11 @@ class FASTSlider extends Slider {}
 class FASTSliderLabel extends SliderLabel {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTSlider>("fast-slider");
+    const { element, connect, disconnect, parent } = await fixture<FASTSlider>(
+        "fast-slider"
+    );
 
-    return { element, connect, disconnect };
+    return { element, connect, disconnect, parent };
 }
 
 // TODO: Need to add tests for keyboard handling, position, and focus management
@@ -351,11 +353,15 @@ describe("Slider", () => {
     });
 
     describe("when the owning form's reset() method is invoked", () => {
-        it("should reset its value property to an empty string if no value attribute is set", () => {
-            const element = document.createElement("fast-slider") as FASTSlider;
+        it("should reset its value property to an empty string if no value attribute is set", async () => {
+            const { connect, disconnect, element, parent } = await setup();
+
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+
+            await connect();
+
             element.value = "3";
 
             assert.strictEqual(element.getAttribute("value"), null);
@@ -364,13 +370,19 @@ describe("Slider", () => {
             form.reset();
 
             assert.strictEqual(element.value, "5");
+
+            await disconnect();
         });
 
-        it("should reset its value property to the value of the value attribute if it is set", () => {
-            const element = document.createElement("fast-slider") as FASTSlider;
+        it("should reset its value property to the value of the value attribute if it is set", async () => {
+            const { connect, disconnect, element, parent } = await setup();
+
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+
+            await connect();
+
             element.setAttribute("value", "7");
             element.value = "8";
 
@@ -380,14 +392,21 @@ describe("Slider", () => {
             form.reset();
 
             assert.strictEqual(element.value, "7");
+
+            await disconnect();
         });
 
-        it("should put the control into a clean state, where the value attribute changes the value property prior to user or programmatic interaction", () => {
-            const element = document.createElement("fast-slider") as FASTSlider;
+        it("should put the control into a clean state, where the value attribute changes the value property prior to user or programmatic interaction", async () => {
+            const { connect, disconnect, element, parent } = await setup();
+
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+
+            await connect();
+
             element.value = "7";
+
             element.setAttribute("value", "8");
 
             assert.strictEqual(element.value, "7");
@@ -399,6 +418,8 @@ describe("Slider", () => {
             element.setAttribute("value", "3");
 
             assert.strictEqual(element.value, "3");
+
+            await disconnect();
         });
     });
 });

--- a/packages/web-components/fast-foundation/src/switch/switch.spec.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.spec.ts
@@ -11,9 +11,11 @@ import { KeyCodes } from "@microsoft/fast-web-utilities";
 class FASTSwitch extends Switch {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTSwitch>("fast-switch");
+    const { element, connect, disconnect, parent } = await fixture<FASTSwitch>(
+        "fast-switch"
+    );
 
-    return { element, connect, disconnect };
+    return { element, connect, disconnect, parent };
 }
 
 describe("Switch", () => {
@@ -299,11 +301,11 @@ describe("Switch", () => {
 
     describe("who's parent form has it's reset() method invoked", () => {
         it("should set it's checked property to false if the checked attribute is unset", async () => {
-            const { element, connect, disconnect } = await setup();
+            const { element, connect, disconnect, parent } = await setup();
             await connect();
 
             const form = document.createElement("form");
-            document.body.appendChild(form);
+            parent.appendChild(form);
             form.appendChild(element);
             element.checked = true;
 
@@ -311,17 +313,17 @@ describe("Switch", () => {
             assert(element.checked);
             form.reset();
 
-            assert(!element.checked);
+            assert.isFalse(!!element.checked);
 
             await disconnect();
         });
 
         it("should set it's checked property to true if the checked attribute is set", async () => {
-            const { element, connect, disconnect } = await setup();
+            const { element, connect, disconnect, parent } = await setup();
             await connect();
 
             const form = document.createElement("form");
-            document.body.appendChild(form);
+            parent.appendChild(form);
             form.appendChild(element);
             element.setAttribute("checked", "");
 
@@ -337,11 +339,13 @@ describe("Switch", () => {
             await disconnect();
         });
 
-        it("should put the control into a clean state, where checked attribute changes change the checked property prior to user or programmatic interaction", () => {
-            const element = document.createElement("fast-switch") as FASTSwitch;
+        it("should put the control into a clean state, where checked attribute changes change the checked property prior to user or programmatic interaction", async () => {
+            const { element, connect, disconnect, parent } = await setup();
+            await connect();
+
             const form = document.createElement("form");
+            parent.appendChild(form);
             form.appendChild(element);
-            document.body.appendChild(form);
             element.checked = true;
             element.removeAttribute("checked");
 
@@ -349,11 +353,13 @@ describe("Switch", () => {
 
             form.reset();
 
-            assert(!element.checked);
+            assert.isFalse(!!element.checked);
 
             element.setAttribute("checked", "");
 
-            assert(element.value);
+            assert(element.checked);
+
+            await disconnect();
         });
     });
 });

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -117,10 +117,10 @@ export class Switch extends FormAssociatedSwitch {
     /**
      * @internal
      */
-    public formResetCallback() {
+    public formResetCallback = (): void => {
         this.checked = this.checkedAttribute;
         this.dirtyChecked = false;
-    }
+    };
 
     private updateForm(): void {
         const value = this.checked ? this.value : null;

--- a/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
@@ -1,14 +1,28 @@
-import { expect } from "chai";
-import { TabsOrientation, Tabs, TabsTemplate as template } from "./index";
-import { fixture } from "../fixture";
+import { assert, expect } from "chai";
 import { css, DOM, customElement, html } from "@microsoft/fast-element";
+import { fixture } from "../fixture";
+import { Tab, TabTemplate } from "../tab";
+import { TabPanel, TabPanelTemplate } from "../tab-panel";
+import { TabsOrientation, Tabs, TabsTemplate as template } from "./index";
+
+@customElement({
+    name: "fast-tab",
+    template: TabTemplate,
+})
+class FASTTab extends Tab {}
+
+@customElement({
+    name: "fast-tab-panel",
+    template: TabPanelTemplate,
+})
+class FASTTabPanel extends TabPanel {}
 
 @customElement({
     name: "fast-tabs",
     template,
     styles: css`
         .activeIndicatorTransition {
-            transition: transform 0.2s ease-in-out;
+            transition: transform 1ms;
         }
     `,
 })
@@ -17,10 +31,35 @@ class FASTTabs extends Tabs {}
 async function setup() {
     const { element, connect, disconnect } = await fixture<FASTTabs>("fast-tabs");
 
-    return { element, connect, disconnect };
+    for (let i = 1; i < 4; i++) {
+        const tab = document.createElement("fast-tab") as FASTTab;
+        tab.id = `tab${i}`;
+
+        const panel = document.createElement("fast-tab-panel") as FASTTabPanel;
+        panel.id = `panel${i}`;
+        element.appendChild(panel);
+        element.insertBefore(tab, element.querySelector("fast-tab-panel"));
+    }
+
+    const [tabPanel1, tabPanel2, tabPanel3] = Array.from(
+        element.querySelectorAll("fast-tab-panel")
+    );
+    const [tab1, tab2, tab3] = Array.from(element.querySelectorAll("fast-tab"));
+
+    return {
+        element,
+        connect,
+        disconnect,
+        tab1,
+        tab2,
+        tab3,
+        tabPanel1,
+        tabPanel2,
+        tabPanel3,
+    };
 }
 
-// TODO: Need to add tests for keyboard handling, activeIndicator position, and focus managemen
+// TODO: Need to add tests for keyboard handling, activeIndicator position, and focus management
 describe("Tabs", () => {
     it("should have an internal element with a role of `tablist`", async () => {
         const { element, connect, disconnect } = await setup();
@@ -37,7 +76,7 @@ describe("Tabs", () => {
         const { element, connect, disconnect } = await setup();
         await connect();
 
-        expect(element.orientation).to.equal(`${TabsOrientation.horizontal}`);
+        expect(element.orientation).to.equal(TabsOrientation.horizontal);
 
         await disconnect();
     });
@@ -48,15 +87,13 @@ describe("Tabs", () => {
 
         await connect();
 
-        expect(element.classList.contains(`${TabsOrientation.horizontal}`)).to.equal(
-            true
-        );
+        expect(element.classList.contains(TabsOrientation.horizontal)).to.equal(true);
 
         element.orientation = TabsOrientation.vertical;
 
         await DOM.nextUpdate();
 
-        expect(element.classList.contains(`${TabsOrientation.vertical}`)).to.equal(true);
+        expect(element.classList.contains(TabsOrientation.vertical)).to.equal(true);
         await disconnect();
     });
 
@@ -198,253 +235,121 @@ describe("Tabs", () => {
 
     describe("active tab", () => {
         it("should set an `aria-selected` attribute on the active tab when `activeId` is provided", async () => {
-            const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-                <fast-tabs activeId="02">
-                    <fast-tab id="01">Tab one</fast-tab>
-                    <fast-tab id="02">Tab two</fast-tab>
-                    <fast-tab id="03">Tab three</fast-tab>
-                    <fast-tab-panel>
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+            const { element, connect, disconnect, tab2 } = await setup();
 
             await connect();
 
-            expect(
-                element.querySelectorAll("fast-tab")[1]?.getAttribute("aria-selected")
-            ).to.equal("true");
+            element.activeid = "tab2";
+
+            expect(tab2.getAttribute("aria-selected")).to.equal("true");
 
             await disconnect();
         });
 
         it("should default the first tab as the active index if `activeId` is NOT provided", async () => {
-            const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-                <fast-tabs>
-                    <fast-tab id="01">Tab one</fast-tab>
-                    <fast-tab id="02">Tab two</fast-tab>
-                    <fast-tab id="03">Tab three</fast-tab>
-                    <fast-tab-panel>
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+            const { connect, disconnect, tab1 } = await setup();
 
             await connect();
 
-            expect(
-                element.querySelector("fast-tab")?.getAttribute("aria-selected")
-            ).to.equal("true");
+            expect(tab1.getAttribute("aria-selected")).to.equal("true");
 
             await disconnect();
         });
 
         it("should set an `aria-selected` attribute on the active tab when `activeId` is provided", async () => {
-            const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-                <fast-tabs activeId="02">
-                    <fast-tab id="01">Tab one</fast-tab>
-                    <fast-tab id="02">Tab two</fast-tab>
-                    <fast-tab id="03">Tab three</fast-tab>
-                    <fast-tab-panel>
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+            const { element, connect, disconnect, tab2 } = await setup();
+
+            element.activeid = "tab2";
 
             await connect();
 
-            expect(
-                element.querySelectorAll("fast-tab")[1]?.getAttribute("aria-selected")
-            ).to.equal("true");
+            expect(tab2.getAttribute("aria-selected")).to.equal("true");
 
             await disconnect();
         });
 
         it("should update `aria-selected` attribute on the active tab when `activeId` is updated", async () => {
-            const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-                <fast-tabs activeId="02">
-                    <fast-tab id="01">Tab one</fast-tab>
-                    <fast-tab id="02">Tab two</fast-tab>
-                    <fast-tab id="03">Tab three</fast-tab>
-                    <fast-tab-panel id="panel01">
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel02">
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel03">
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+            const { element, connect, disconnect, tab2, tab3 } = await setup();
+
+            element.setAttribute("activeId", "tab2");
 
             await connect();
 
-            element.setAttribute("activeId", "03");
+            expect(tab2.getAttribute("aria-selected")).to.equal("true");
 
-            expect(
-                element.querySelectorAll("fast-tab")[2]?.getAttribute("aria-selected")
-            ).to.equal("true");
+            element.setAttribute("activeId", "tab3");
+
+            expect(tab3.getAttribute("aria-selected")).to.equal("true");
 
             await disconnect();
         });
 
         it("should skip updating the active indicator if click twice on the same tab", async () => {
-            const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-                <fast-tabs>
-                    <fast-tab id="01">Tab one</fast-tab>
-                    <fast-tab id="02">Tab two</fast-tab>
-                    <fast-tab id="03">Tab three</fast-tab>
-                    <fast-tab-panel id="panel01">
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel02">
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel03">
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+            const { element, connect, disconnect, tab2 } = await setup();
 
             await connect();
 
-            const activeIndicator = element.shadowRoot?.querySelector(
+            const activeIndicator = element.shadowRoot!.querySelector(
                 '[part="activeIndicator"]'
-            );
-            const secondTab = element.querySelectorAll("fast-tab")[1] as HTMLElement;
-            expect(secondTab).not.to.be.undefined;
-            await new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    secondTab.click();
-                    resolve();
-                }, 1000);
+            )!;
+
+            await new Promise(resolve => {
+                activeIndicator.addEventListener("transitionend", resolve, {
+                    once: true,
+                });
+
+                tab2.click();
+
+                expect(activeIndicator.classList.contains("activeIndicatorTransition")).to
+                    .be.true;
             });
 
-            expect(
-                element.shadowRoot
-                    ?.querySelector('[part="activeIndicator"]')
-                    ?.classList.contains("activeIndicatorTransition")
-            ).to.be.true;
+            await DOM.nextUpdate();
 
-            await new Promise((resolve, reject) => {
-                setTimeout(() => {
-                    secondTab.click();
-                    resolve();
-                }, 1000);
-            });
-            expect(element.shadowRoot).not.to.be.undefined;
-            expect(
-                element.shadowRoot
-                    ?.querySelector('[part="activeIndicator"]')
-                    ?.classList.contains("activeIndicatorTransition")
-            ).to.be.false;
+            tab2.click();
+
+            expect(activeIndicator.classList.contains("activeIndicatorTransition")).to.be
+                .false;
 
             await disconnect();
         });
     });
 
     describe("active tabpanel", () => {
-        it("should set an `aria-labelledby` attribute on the tabpanel with a value of the tab id when `activeId` is provided", async () => {
-            const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-                <fast-tabs activeId="02">
-                    <fast-tab id="01">Tab one</fast-tab>
-                    <fast-tab id="02">Tab two</fast-tab>
-                    <fast-tab id="03">Tab three</fast-tab>
-                    <fast-tab-panel id="panel01">
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel02">
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel03">
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+        it("should set an `aria-labelledby` attribute on the tabpanel with a value of the tab id when `activeid` is provided", async () => {
+            const { element, connect, disconnect, tabPanel2 } = await setup();
 
             await connect();
 
-            expect(
-                element
-                    .querySelectorAll("fast-tab-panel")[1]
-                    ?.getAttribute("aria-labelledby")
-            ).to.equal("02");
+            element.activeid = "tab2";
+
+            expect(tabPanel2.getAttribute("aria-labelledby")).to.equal("tab2");
 
             await disconnect();
         });
 
         it("should set an attribute of hidden if the tabpanel is not active", async () => {
-            const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-                <fast-tabs activeId="02">
-                    <fast-tab id="01">Tab one</fast-tab>
-                    <fast-tab id="02">Tab two</fast-tab>
-                    <fast-tab id="03">Tab three</fast-tab>
-                    <fast-tab-panel id="panel01">
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel02">
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel03">
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+            const { element, connect, disconnect, tabPanel1, tabPanel3 } = await setup();
 
             await connect();
 
-            expect(
-                element.querySelectorAll("fast-tab-panel")[0]?.hasAttribute("hidden")
-            ).to.equal(true);
-            expect(
-                element.querySelectorAll("fast-tab-panel")[2]?.hasAttribute("hidden")
-            ).to.equal(true);
+            element.activeid = "tab2";
+
+            expect(tabPanel1.hasAttribute("hidden")).to.equal(true);
+
+            expect(tabPanel3.hasAttribute("hidden")).to.equal(true);
 
             await disconnect();
         });
 
         it("should NOT set an attribute of hidden if the tabpanel is active", async () => {
-            const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-                <fast-tabs activeId="02">
-                    <fast-tab id="01">Tab one</fast-tab>
-                    <fast-tab id="02">Tab two</fast-tab>
-                    <fast-tab id="03">Tab three</fast-tab>
-                    <fast-tab-panel id="panel01">
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel02">
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel id="panel03">
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+            const { element, connect, disconnect, tabPanel2 } = await setup();
 
             await connect();
 
-            expect(
-                element.querySelectorAll("fast-tab-panel")[1]?.hasAttribute("hidden")
-            ).to.equal(false);
+            element.activeid = "tab2";
+
+            expect(tabPanel2.hasAttribute("hidden")).to.equal(false);
 
             await disconnect();
         });

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -21,7 +21,7 @@ export enum TabsOrientation {
 }
 
 /**
- * An Tabs Custom HTML Element.
+ * A Tabs Custom HTML Element.
  * Implements the {@link https://www.w3.org/TR/wai-aria-1.1/#tablist | ARIA tablist }.
  *
  * @public

--- a/packages/web-components/fast-foundation/src/text-area/text-area.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.spec.ts
@@ -10,11 +10,11 @@ import { customElement } from "@microsoft/fast-element";
 class FASTTextArea extends TextArea {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTTextArea>(
+    const { element, connect, disconnect, parent } = await fixture<FASTTextArea>(
         "fast-text-area"
     );
 
-    return { element, connect, disconnect };
+    return { element, connect, disconnect, parent };
 }
 
 describe("TextArea", () => {
@@ -564,11 +564,15 @@ describe("TextArea", () => {
     });
 
     describe("when the owning form's reset() method is invoked", () => {
-        it("should reset it's value property to an empty string if no value attribute is set", () => {
-            const element = document.createElement("fast-text-area") as FASTTextArea;
+        it("should reset it's value property to an empty string if no value attribute is set", async () => {
+            const { element, connect, disconnect, parent } = await setup();
+
+            await connect();
+
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+
             element.value = "test-value";
 
             assert(element.getAttribute("value") === null);
@@ -577,30 +581,45 @@ describe("TextArea", () => {
             form.reset();
 
             assert(element.value === "");
+
+            await disconnect();
         });
 
-        it("should reset it's value property to the value of the value attribute if it is set", () => {
-            const element = document.createElement("fast-text-area") as FASTTextArea;
+        it("should reset it's value property to the value of the value attribute if it is set", async () => {
+            const { element, connect, disconnect, parent } = await setup();
+
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+
+            await connect();
+
             element.setAttribute("value", "attr-value");
+
             element.value = "test-value";
 
             assert(element.getAttribute("value") === "attr-value");
+
             assert(element.value === "test-value");
 
             form.reset();
 
             assert(element.value === "attr-value");
+
+            await disconnect();
         });
 
-        it("should put the control into a clean state, where value attribute changes change the property value prior to user or programmatic interaction", () => {
-            const element = document.createElement("fast-text-area") as FASTTextArea;
+        it("should put the control into a clean state, where value attribute changes change the property value prior to user or programmatic interaction", async () => {
+            const { element, connect, disconnect, parent } = await setup();
+
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+
+            await connect();
+
             element.value = "test-value";
+
             element.setAttribute("value", "attr-value");
 
             assert(element.value === "test-value");
@@ -612,6 +631,8 @@ describe("TextArea", () => {
             element.setAttribute("value", "new-attr-value");
 
             assert(element.value === "new-attr-value");
+
+            await disconnect();
         });
     });
 });

--- a/packages/web-components/fast-foundation/src/text-field/text-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.spec.ts
@@ -11,11 +11,11 @@ import { TextFieldType } from "./text-field";
 class FASTTextField extends TextField {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTTextField>(
+    const { element, connect, disconnect, parent } = await fixture<FASTTextField>(
         "fast-text-field"
     );
 
-    return { element, connect, disconnect };
+    return { element, connect, disconnect, parent };
 }
 
 describe("TextField", () => {
@@ -573,27 +573,23 @@ describe("TextField", () => {
                             const { element, connect, disconnect } = await setup();
                             await connect();
                             const value = "";
-                            const el = document.createElement(
-                                "fast-text-field"
-                            ) as TextField;
-                            el.type = type;
-                            el.value = value;
-                            el.minlength = value.length + 1;
+                            element.type = type;
+                            element.value = value;
+                            element.minlength = value.length + 1;
 
-                            expect(el.validity.tooShort).to.equal(false);
+                            expect(element.validity.tooShort).to.equal(false);
+                            await disconnect();
                         });
                         it("should be valid if the value has a length less than the minlength", async () => {
                             const { element, connect, disconnect } = await setup();
                             await connect();
                             const value = "value";
-                            const el = document.createElement(
-                                "fast-text-field"
-                            ) as TextField;
-                            el.type = type;
-                            el.value = value;
-                            el.minlength = value.length + 1;
+                            element.type = type;
+                            element.value = value;
+                            element.minlength = value.length + 1;
 
-                            expect(el.validity.tooShort).to.equal(false);
+                            expect(element.validity.tooShort).to.equal(false);
+                            await disconnect();
                         });
                     });
 
@@ -603,14 +599,13 @@ describe("TextField", () => {
                             await connect();
 
                             const value = "";
-                            const el = document.createElement(
-                                "fast-text-field"
-                            ) as TextField;
-                            el.type = type;
-                            el.value = value;
-                            el.maxlength = value.length;
+                            element.type = type;
+                            element.value = value;
+                            element.maxlength = value.length;
 
-                            expect(el.validity.tooLong).to.equal(false);
+                            expect(element.validity.tooLong).to.equal(false);
+
+                            await disconnect();
                         });
                         it("should be valid if the value has a exceeding the maxlength", async () => {
                             const { element, connect, disconnect } = await setup();
@@ -621,6 +616,7 @@ describe("TextField", () => {
                             element.maxlength = value.length - 1;
 
                             expect(element.validity.tooLong).to.equal(false);
+                            await disconnect();
                         });
                         it("should be valid if the value has a length shorter than maxlength and the element is [required]", async () => {
                             const { element, connect, disconnect } = await setup();
@@ -632,6 +628,7 @@ describe("TextField", () => {
                             element.maxlength = value.length + 1;
 
                             expect(element.validity.tooLong).to.equal(false);
+                            await disconnect();
                         });
                     });
 
@@ -646,6 +643,7 @@ describe("TextField", () => {
                             element.value = value;
 
                             expect(element.validity.patternMismatch).to.equal(false);
+                            await disconnect();
                         });
 
                         it("should be invalid if the value does not match a pattern", async () => {
@@ -658,6 +656,7 @@ describe("TextField", () => {
                             element.value = "foo";
 
                             expect(element.validity.patternMismatch).to.equal(true);
+                            await disconnect();
                         });
                     });
                 });
@@ -671,6 +670,8 @@ describe("TextField", () => {
                 element.value = "";
 
                 expect(element.validity.typeMismatch).to.equal(false);
+
+                await disconnect();
             });
             it("should be a typeMismatch when value is not a valid email", async () => {
                 const { element, connect, disconnect } = await setup();
@@ -680,6 +681,8 @@ describe("TextField", () => {
                 element.value = "foobar";
 
                 expect(element.validity.typeMismatch).to.equal(true);
+
+                await disconnect();
             });
         });
         describe('of [type="url"]', () => {
@@ -691,6 +694,8 @@ describe("TextField", () => {
                 element.value = "";
 
                 expect(element.validity.typeMismatch).to.equal(false);
+
+                await disconnect();
             });
             it("should be a typeMismatch when value is not a valid URL", async () => {
                 const { element, connect, disconnect } = await setup();
@@ -700,16 +705,22 @@ describe("TextField", () => {
                 element.value = "foobar";
 
                 expect(element.validity.typeMismatch).to.equal(true);
+
+                await disconnect();
             });
         });
     });
 
     describe("when the owning form's reset() method is invoked", () => {
-        it("should reset it's value property to an empty string if no value attribute is set", () => {
-            const element = document.createElement("fast-text-field") as FASTTextField;
+        it("should reset it's value property to an empty string if no value attribute is set", async () => {
+            const { element, connect, disconnect, parent } = await setup();
+
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+
+            await connect();
+
             element.value = "test-value";
 
             assert(element.getAttribute("value") === null);
@@ -718,29 +729,41 @@ describe("TextField", () => {
             form.reset();
 
             assert(element.value === "");
+
+            await disconnect();
         });
 
-        it("should reset it's value property to the value of the value attribute if it is set", () => {
-            const element = document.createElement("fast-text-field") as FASTTextField;
+        it("should reset it's value property to the value of the value attribute if it is set", async () => {
+            const { element, connect, disconnect, parent } = await setup();
+
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+            await connect();
+
             element.setAttribute("value", "attr-value");
+
             element.value = "test-value";
 
             assert(element.getAttribute("value") === "attr-value");
+
             assert(element.value === "test-value");
 
             form.reset();
 
             assert(element.value === "attr-value");
+
+            await disconnect();
         });
 
-        it("should put the control into a clean state, where value attribute changes change the property value prior to user or programmatic interaction", () => {
-            const element = document.createElement("fast-text-field") as FASTTextField;
+        it("should put the control into a clean state, where value attribute changes change the property value prior to user or programmatic interaction", async () => {
+            const { element, connect, disconnect, parent } = await setup();
             const form = document.createElement("form");
             form.appendChild(element);
-            document.body.appendChild(form);
+            parent.appendChild(form);
+
+            await connect();
+
             element.value = "test-value";
             element.setAttribute("value", "attr-value");
 
@@ -753,6 +776,7 @@ describe("TextField", () => {
             element.setAttribute("value", "new-attr-value");
 
             assert(element.value === "new-attr-value");
+            await disconnect();
         });
     });
 });


### PR DESCRIPTION
# Description
* fix broken `FormAssociated` tests on Firefox
* make sure tests are asynchronous and that each scenario cleans up after itself
* fix a `select` test that was incorrectly using native browser elements

## Motivation & context
All of the `FormAssociated` tests were working in Chromium but failing in Firefox. There were also some tests that used timeouts and others that didn't utilize async fixture methods. Tests can use the fixture's `parent` and `document` to attach elements like forms when needed, and all fixture-based tests should call `disconnect()` or remove any attached elements at the end of each scenario.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
