### PR TITLE
feat: add loaded event to anchored region

### DIFF
--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -200,15 +200,11 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 - default slot for content
 
 *functions:*
-- default slot for content
+- update() - forces the anchored region to recalculate positioning.
 
 *Events:*
-- updateAnchorOffset = (
-    horizontalOffsetDelta: number,
-    verticalOffsetDelta: number
-) 
-
-Enables developers to update the offset between the anchor and the region as it changes,  for example to promt layout recalculations as a result of scrolling so a scaling region tracks the viewport boundary.  
+- loaded - the region and its contents have been added to the DOM and positioned
+- change - the positioning of the anchored region has changed
 
 
 

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -854,7 +854,10 @@ export class AnchoredRegion extends FASTElement {
 
         this.updateRegionStyle();
 
-        this.initialLayoutComplete = true;
+        if (!this.initialLayoutComplete) {
+            this.initialLayoutComplete = true;
+            DOM.queueUpdate(() => this.$emit("loaded", this, { bubbles: false }));
+        }
 
         if (positionChanged) {
             this.$emit("change");


### PR DESCRIPTION
# Description
Anchored region now emits a "loaded" event when it has been positioned and children rendered.

## Motivation & context
Make it easier for developers to know when child elements are available in the DOM

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.


**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
