### PR TITLE
fix(dialog): accidental improperly bound this in callback

### DIFF
--- a/packages/web-components/fast-foundation/src/dialog/dialog.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.ts
@@ -116,7 +116,7 @@ export class Dialog extends FASTElement {
         document.addEventListener("keydown", this.handleDocumentKeydown);
 
         // Ensure the DOM is updated
-        // This helps avoid a delay with `autofocus` elements recieving focus
+        // This helps avoid a delay with `autofocus` elements receiving focus
         DOM.queueUpdate(this.trapFocusChanged);
     }
 
@@ -138,15 +138,11 @@ export class Dialog extends FASTElement {
         }
     }
 
-    private onChildListChange(
-        mutations: MutationRecord[],
-        /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-        observer: MutationObserver
-    ): void {
-        if (mutations!.length) {
-            this.tabbableElements = tabbable(this as Element);
+    private onChildListChange = (mutations: MutationRecord[]): void => {
+        if (mutations.length) {
+            this.tabbableElements = tabbable(this);
         }
-    }
+    };
 
     private trapFocusChanged = (): void => {
         if (this.trapFocus) {


### PR DESCRIPTION
# Description

This PR corrects a common JS "oopsie" with an event handler in the `dialog` implementation.
Fixes #4105 

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

I didn't add more tests for dialog. I'm wondering whether we should and what those might look like. Given the nature of this bug, I'm not sure that tabbable was working correctly with the dialog ever. Though, I don't know how tabbable works so I may not be the best person to make that assessment.

## Next Steps

Reviewing the code while fixing this bug, I wonder that the mutation observer and `tabbable` functionality should not be hooked up in connect/disconnect, but rather on show/hide of the dialog. I don't know much about how `tabbable` work though.

I also noticed the use of `KeyboardEvent#keyCode` which is deprecated. We might want to make a survey of our components and update anything that uses `keyCode` to a more modern approach.