### PR TITLE
fix(fast-foundation): ensure global aria attrs are applied

### DIFF
--- a/packages/web-components/fast-foundation/src/anchor/anchor.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.ts
@@ -87,7 +87,7 @@ export class Anchor extends FASTElement {
  *
  * @public
  */
-export class DelegatesARIALink extends ARIAGlobalStatesAndProperties {
+export class DelegatesARIALink {
     /**
      * See {@link https://www.w3.org/WAI/PF/aria/roles#link} for more information
      * @public
@@ -98,6 +98,8 @@ export class DelegatesARIALink extends ARIAGlobalStatesAndProperties {
     public ariaExpanded: "true" | "false" | undefined;
 }
 
+applyMixins(DelegatesARIALink, ARIAGlobalStatesAndProperties);
+
 /**
  * Mark internal because exporting class and interface of the same name
  * confuses API documenter.
@@ -105,5 +107,8 @@ export class DelegatesARIALink extends ARIAGlobalStatesAndProperties {
  * @internal
  */
 /* eslint-disable-next-line */
-export interface Anchor extends StartEnd, DelegatesARIALink {}
+export interface Anchor
+    extends StartEnd,
+        DelegatesARIALink,
+        ARIAGlobalStatesAndProperties {}
 applyMixins(Anchor, StartEnd, DelegatesARIALink);

--- a/packages/web-components/fast-foundation/src/anchor/anchor.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.ts
@@ -98,6 +98,14 @@ export class DelegatesARIALink {
     public ariaExpanded: "true" | "false" | undefined;
 }
 
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+/* eslint-disable-next-line */
+export interface DelegatesARIALink extends ARIAGlobalStatesAndProperties {}
 applyMixins(DelegatesARIALink, ARIAGlobalStatesAndProperties);
 
 /**
@@ -107,8 +115,5 @@ applyMixins(DelegatesARIALink, ARIAGlobalStatesAndProperties);
  * @internal
  */
 /* eslint-disable-next-line */
-export interface Anchor
-    extends StartEnd,
-        DelegatesARIALink,
-        ARIAGlobalStatesAndProperties {}
+export interface Anchor extends StartEnd, DelegatesARIALink {}
 applyMixins(Anchor, StartEnd, DelegatesARIALink);

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -210,6 +210,14 @@ export class DelegatesARIAButton {
     public ariaPressed: "true" | "false" | "mixed" | undefined;
 }
 
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+/* eslint-disable-next-line */
+export interface DelegatesARIAButton extends ARIAGlobalStatesAndProperties {}
 applyMixins(DelegatesARIAButton, ARIAGlobalStatesAndProperties);
 
 /**
@@ -218,8 +226,5 @@ applyMixins(DelegatesARIAButton, ARIAGlobalStatesAndProperties);
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface Button
-    extends StartEnd,
-        DelegatesARIAButton,
-        ARIAGlobalStatesAndProperties {}
+export interface Button extends StartEnd, DelegatesARIAButton {}
 applyMixins(Button, StartEnd, DelegatesARIAButton);

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -190,7 +190,7 @@ export class Button extends FormAssociatedButton {
  *
  * @public
  */
-export class DelegatesARIAButton extends ARIAGlobalStatesAndProperties {
+export class DelegatesARIAButton {
     /**
      * See {@link https://www.w3.org/WAI/PF/aria/roles#button} for more information
      * @public
@@ -210,11 +210,16 @@ export class DelegatesARIAButton extends ARIAGlobalStatesAndProperties {
     public ariaPressed: "true" | "false" | "mixed" | undefined;
 }
 
+applyMixins(DelegatesARIAButton, ARIAGlobalStatesAndProperties);
+
 /**
  * Mark internal because exporting class and interface of the same name
  * confuses API documenter.
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface Button extends StartEnd, DelegatesARIAButton {}
+export interface Button
+    extends StartEnd,
+        DelegatesARIAButton,
+        ARIAGlobalStatesAndProperties {}
 applyMixins(Button, StartEnd, DelegatesARIAButton);

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -344,7 +344,7 @@ export class Listbox extends FASTElement {
  *
  * @public
  */
-export class DelegatesARIAListbox extends ARIAGlobalStatesAndProperties {
+export class DelegatesARIAListbox {
     /**
      * See {@link https://www.w3.org/WAI/PF/aria/roles#button} for more information
      * @public
@@ -367,8 +367,10 @@ export class DelegatesARIAListbox extends ARIAGlobalStatesAndProperties {
     public ariaExpanded: "true" | "false" | undefined;
 }
 
+applyMixins(DelegatesARIAListbox, ARIAGlobalStatesAndProperties);
+
 /**
  * @internal
  */
-export interface Listbox extends DelegatesARIAListbox {}
+export interface Listbox extends DelegatesARIAListbox, ARIAGlobalStatesAndProperties {}
 applyMixins(Listbox, DelegatesARIAListbox);

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -367,10 +367,18 @@ export class DelegatesARIAListbox {
     public ariaExpanded: "true" | "false" | undefined;
 }
 
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+/* eslint-disable-next-line */
+export interface DelegatesARIAListbox extends ARIAGlobalStatesAndProperties {}
 applyMixins(DelegatesARIAListbox, ARIAGlobalStatesAndProperties);
 
 /**
  * @internal
  */
-export interface Listbox extends DelegatesARIAListbox, ARIAGlobalStatesAndProperties {}
+export interface Listbox extends DelegatesARIAListbox {}
 applyMixins(Listbox, DelegatesARIAListbox);

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -247,13 +247,18 @@ export class DelegatesARIASelect {
     public ariaExpanded: "true" | "false" | undefined;
 }
 
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+/* eslint-disable-next-line */
+export interface DelegatesARIASelect extends ARIAGlobalStatesAndProperties {}
 applyMixins(DelegatesARIASelect, ARIAGlobalStatesAndProperties);
 
 /**
  * @internal
  */
-export interface Select
-    extends StartEnd,
-        DelegatesARIASelect,
-        ARIAGlobalStatesAndProperties {}
+export interface Select extends StartEnd, DelegatesARIASelect {}
 applyMixins(Select, StartEnd, DelegatesARIASelect);

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -236,7 +236,7 @@ export class Select extends FormAssociatedSelect {
  *
  * @public
  */
-export class DelegatesARIASelect extends ARIAGlobalStatesAndProperties {
+export class DelegatesARIASelect {
     /**
      * See {@link https://www.w3.org/WAI/PF/aria/roles#button} for more information
      * @public
@@ -247,8 +247,13 @@ export class DelegatesARIASelect extends ARIAGlobalStatesAndProperties {
     public ariaExpanded: "true" | "false" | undefined;
 }
 
+applyMixins(DelegatesARIASelect, ARIAGlobalStatesAndProperties);
+
 /**
  * @internal
  */
-export interface Select extends StartEnd, DelegatesARIASelect {}
+export interface Select
+    extends StartEnd,
+        DelegatesARIASelect,
+        ARIAGlobalStatesAndProperties {}
 applyMixins(Select, StartEnd, DelegatesARIASelect);

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -216,7 +216,9 @@ export class TextField extends FormAssociatedTextField {
  *
  * @public
  */
-export class DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {}
+export class DelegatesARIATextbox {}
+
+applyMixins(DelegatesARIATextbox, ARIAGlobalStatesAndProperties);
 
 /**
  * Mark internal because exporting class and interface of the same name
@@ -224,5 +226,8 @@ export class DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {}
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface TextField extends StartEnd, DelegatesARIATextbox {}
+export interface TextField
+    extends StartEnd,
+        DelegatesARIATextbox,
+        ARIAGlobalStatesAndProperties {}
 applyMixins(TextField, StartEnd, DelegatesARIATextbox);

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -218,6 +218,14 @@ export class TextField extends FormAssociatedTextField {
  */
 export class DelegatesARIATextbox {}
 
+/**
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ * @internal
+ */
+/* eslint-disable-next-line */
+export interface DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {}
 applyMixins(DelegatesARIATextbox, ARIAGlobalStatesAndProperties);
 
 /**
@@ -226,8 +234,5 @@ applyMixins(DelegatesARIATextbox, ARIAGlobalStatesAndProperties);
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface TextField
-    extends StartEnd,
-        DelegatesARIATextbox,
-        ARIAGlobalStatesAndProperties {}
+export interface TextField extends StartEnd, DelegatesARIATextbox {}
 applyMixins(TextField, StartEnd, DelegatesARIATextbox);


### PR DESCRIPTION
# Description

This PR fixes an issue where global aria attributes are not syncing state.
Fixes https://github.com/microsoft/fluentui/issues/16121

Several of the attribute mixins were applied through mixin inheritance. However, the `applyMixins` helper only copies own properties of the prototype. After some discussion @nicholasrice and I decided the best course of action was to not change the `applyMixins` function (could have some unexpected consequence for consumers) but to use it to apply the base mixins instead of using inheritance. This should provide for the highest compatibility with existing code.

Note: This is a temporary fix. We hope to provide a new feature in fast-element to allow templates to hook into observation of built-in attribute changes without re-defining the aria properties like this.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**

The mixed class no longer inherits from the global base. However, all the same properties will be present. The only issue that could arise is if someone, through TypeScript, were somehow dependent on those properties being statically defined on the mixin itself, rather than applied through the mixin helper.

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.