### PR TITLE
fix: select should emit change event

### DIFF
--- a/packages/web-components/fast-components/src/select/select.styles.ts
+++ b/packages/web-components/fast-components/src/select/select.styles.ts
@@ -181,7 +181,8 @@ export const SelectStyles = css`
         width: 1em;
     }
 
-    ::slotted([role="option"]) {
+    ::slotted([role="option"]),
+    ::slotted(option) {
         flex: 0 0 auto;
     }
 
@@ -210,7 +211,8 @@ export const SelectStyles = css`
                 border-color: ${SystemColors.GrayText};
             }
 
-            :host(:${focusVisible}) ::slotted([aria-selected="true"][role="option"]) {
+            :host(:${focusVisible}) ::slotted([aria-selected="true"][role="option"]),
+            :host(:${focusVisible}) ::slotted(option[aria-selected="true"]) {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.ButtonText};
                 box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${SystemColors.HighlightText};

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
@@ -80,8 +80,6 @@ export class ListboxOption extends FASTElement {
             if (this.proxy instanceof HTMLOptionElement) {
                 this.proxy.selected = this.selected;
             }
-
-            this.$emit("change");
         }
     }
 

--- a/packages/web-components/fast-foundation/src/select/select.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.spec.ts
@@ -88,6 +88,32 @@ describe("Select", () => {
         await disconnect();
     });
 
+    it("should emit a 'change' event when the value changes", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        element.value = "one";
+
+        await connect();
+
+        expect(element.value).to.equal("one");
+
+        const wasChanged = await new Promise(resolve => {
+            // Resolve true when the event listener is handled
+            element.addEventListener("change", () => resolve(true));
+
+            element.value = "two";
+
+            // Resolve false on the next update in case change hasn't happened
+            DOM.queueUpdate(() => resolve(false));
+        });
+
+        expect(wasChanged).to.be.true;
+
+        expect(element.value).to.equal("two");
+
+        await disconnect();
+    });
+
     describe("when the owning form's reset() function is invoked", () => {
         it("should reset the value property to the first enabled option", async () => {
             const { connect, disconnect, element, parent } = await setup();

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -24,7 +24,18 @@ export class Select extends FormAssociatedSelect {
         this.ariaExpanded = this.open ? "true" : "false";
         if (this.open) {
             this.setPositioning();
-            super.focusAndScrollOptionIntoView();
+            this.focusAndScrollOptionIntoView();
+        }
+    }
+
+    public valueChanged(prev: string, next: string): void {
+        if (this.$fastController.isConnected) {
+            super.valueChanged(prev, next);
+            const selectedIndex = this.options.findIndex(el => el.value === this.value);
+
+            this.setSelectedOption(selectedIndex);
+
+            this.$emit("change");
         }
     }
 
@@ -111,6 +122,7 @@ export class Select extends FormAssociatedSelect {
      * @internal
      */
     public formResetCallback = (): void => {
+        this.value = this.initialValue;
         this.setDefaultSelectedOption();
     };
 
@@ -122,9 +134,9 @@ export class Select extends FormAssociatedSelect {
      * @internal
      */
     public selectedOptionsChanged(prev, next): void {
-        super.selectedOptionsChanged(prev, next);
         if (this.$fastController.isConnected) {
-            this.value = this.firstSelectedOption.value;
+            super.selectedOptionsChanged(prev, next);
+            this.value = this.firstSelectedOption ? this.firstSelectedOption.value : "";
         }
     }
 
@@ -227,6 +239,7 @@ export class Select extends FormAssociatedSelect {
 
         this.setProxyOptions();
 
+        this.initialValue = this.initialValue || this.value || "";
         this.forcedPosition = !!this.positionAttribute;
     }
 
@@ -258,7 +271,6 @@ export class DelegatesARIASelect {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-/* eslint-disable-next-line */
 export interface DelegatesARIASelect extends ARIAGlobalStatesAndProperties {}
 applyMixins(DelegatesARIASelect, ARIAGlobalStatesAndProperties);
 

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -141,8 +141,9 @@ export class Select extends FormAssociatedSelect {
 
         if (this.open) {
             const captured = (e.target as HTMLElement).closest(
-                `[role=option]`
+                `option,[role=option]`
             ) as ListboxOption;
+
             if (captured && captured.disabled) {
                 return;
             }
@@ -183,8 +184,12 @@ export class Select extends FormAssociatedSelect {
         if (this.proxy instanceof HTMLSelectElement) {
             this.proxy.options.length = 0;
             this.options.forEach(option => {
-                if (option.proxy) {
-                    this.proxy.appendChild(option.proxy);
+                const proxyOption =
+                    option.proxy ||
+                    (option instanceof HTMLOptionElement ? option.cloneNode() : null);
+
+                if (proxyOption) {
+                    this.proxy.appendChild(proxyOption);
                 }
             });
         }


### PR DESCRIPTION
# Description
The `change` event was being emitted by the `fast-option` elements as they changed instead of the `fast-select`, which was causing performance issues when adding a lot of `fast-select` elements on the page.

This PR also includes a fix to allow regular `<option>` elements to be used in a listbox or select for compatibility. It's not recommended to use `<option>`s but at least now things won't break if you do.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
