### PR TITLE
fix: update react-dnd package to 9.5.1

### DIFF
--- a/packages/tooling/fast-tooling-react/package.json
+++ b/packages/tooling/fast-tooling-react/package.json
@@ -91,7 +91,7 @@
     "lodash-es": "^4.0.0",
     "prettier": "2.0.2",
     "react": "^16.8.0",
-    "react-dnd-html5-backend": "^9.0.0",
+    "react-dnd-html5-backend": "^9.5.1",
     "react-dom": "^16.8.0",
     "react-redux": "^5.0.7",
     "react-router-dom": "^4.2.2",

--- a/packages/tooling/fast-tooling-react/package.json
+++ b/packages/tooling/fast-tooling-react/package.json
@@ -120,6 +120,6 @@
     "@microsoft/fast-web-utilities": "^4.6.1",
     "exenv-es6": "^1.0.0",
     "raf-throttle": "^2.0.3",
-    "react-dnd": "^9.0.0"
+    "react-dnd": "^9.5.1"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -22635,7 +22635,7 @@ react-dev-utils@^9.0.0:
     strip-ansi "5.2.0"
     text-table "0.2.0"
 
-react-dnd-html5-backend@^9.0.0:
+react-dnd-html5-backend@^9.0.0, react-dnd-html5-backend@^9.5.1:
   version "9.5.1"
   resolved "https://registry.yarnpkg.com/react-dnd-html5-backend/-/react-dnd-html5-backend-9.5.1.tgz#e6a0aed3ece800c1abe004f9ed9991513e2e644c"
   integrity sha512-wUdzjREwLqHxFkA6E+XDVL5IFjRDbBI3SHVKil9n3qrGT5dm2tA2oi1aIALdfMKsu00c+OXA9lz/LuKZCE9KXg==

--- a/yarn.lock
+++ b/yarn.lock
@@ -22642,7 +22642,7 @@ react-dnd-html5-backend@^9.0.0:
   dependencies:
     dnd-core "^9.5.1"
 
-react-dnd@^9.0.0:
+react-dnd@^9.0.0, react-dnd@^9.5.1:
   version "9.5.1"
   resolved "https://registry.yarnpkg.com/react-dnd/-/react-dnd-9.5.1.tgz#907e55c791d6c50cbed1a4021c14b989b86ac467"
   integrity sha512-j2MvziPNLsxXkb3kIJzLvvOv/TQ4sysp6U4CmxAXd4C884dXm/9UGdB7K1wkTW3ZxVpI1K7XhKbX0JgNlPfLcA==


### PR DESCRIPTION
# Description
When using TypeScript version 3.7 or higher and importing the `fast-tooling-react` package, users will encounter a build error with the message:
```ts
node_modules/dnd-core/lib/cjs/interfaces.d.ts:1:10 - error TS2440: Import declaration conflicts with local declaration of 'Unsubscribe'.

1 import { Unsubscribe } from 'redux'
```

Updating the react-dnd dependency to 9.3.1 or higher resolves this issue. See more information here: https://github.com/react-dnd/react-dnd/issues/1560

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
