### PR TITLE
feat: use the CSSRef component for syntaxes

### DIFF
--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css-ref.props.ts
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css-ref.props.ts
@@ -1,7 +1,9 @@
 import {
     CSSPropertyRef,
     CSSPropertySyntax,
+    CSSSyntaxRef,
 } from "@microsoft/fast-tooling/dist/data-utilities/mapping.mdn-data";
+import { XOR } from "@microsoft/fast-tooling/dist/data-utilities/type.utilities";
 
 export interface CSSRefProps {
     /**
@@ -20,7 +22,7 @@ export interface CSSRefProps {
     /**
      * The syntax or reference used to determine the form element UI
      */
-    syntax: CSSPropertySyntax | CSSPropertyRef;
+    syntax: XOR<CSSPropertySyntax, XOR<CSSPropertyRef, CSSSyntaxRef>>;
 }
 
 export interface CSSRefState {
@@ -29,7 +31,7 @@ export interface CSSRefState {
      * this will be used when multiple form element UI options are available
      * according to the syntax.
      */
-    index: number;
+    index: number | null;
 
     /**
      * The values available, since CSS can comprise of multiple values for example:

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css-ref.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css-ref.tsx
@@ -22,7 +22,7 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
         super(props);
 
         this.state = {
-            index: 0,
+            index: null,
             values: [],
         };
     }
@@ -61,7 +61,7 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
 
     private renderExactlyOne(): React.ReactNode {
         const cssRef: React.ReactNode =
-            this.state.index !== undefined &&
+            this.state.index !== null &&
             (this.props.syntax.ref as CSSPropertyRef[])[this.state.index] &&
             (this.props.syntax.ref as CSSPropertyRef[])[this.state.index].type !==
                 "value" ? (
@@ -109,7 +109,7 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
 
     private renderByType(): React.ReactNode {
         if (typeof this.props.syntax.ref === "string") {
-            switch (this.props.syntax.type) {
+            switch ((this.props.syntax as CSSPropertyRef).type) {
                 case "value":
                     return renderValueControl({
                         ref: this.props.syntax,
@@ -118,13 +118,13 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
                     });
                 case "type":
                     return renderTypeControl({
-                        type: this.props.syntax.ref as Type,
+                        ref: this.props.syntax,
                         key: this.props.syntax.ref,
                         handleChange: this.props.onChange,
                     });
                 case "syntax":
                     return renderSyntaxControl({
-                        syntax: this.props.syntax.ref as Syntax,
+                        ref: this.props.syntax,
                         key: this.props.syntax.ref,
                         handleChange: this.props.onChange,
                     });
@@ -177,7 +177,7 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
         } else if (value === "") {
             this.setState(
                 {
-                    index: 0,
+                    index: null,
                     values: [],
                 },
                 () => {

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.props.ts
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.props.ts
@@ -1,4 +1,8 @@
-import { CSSPropertyRef } from "@microsoft/fast-tooling/dist/data-utilities/mapping.mdn-data";
+import {
+    CSSPropertyRef,
+    CSSSyntaxRef,
+} from "@microsoft/fast-tooling/dist/data-utilities/mapping.mdn-data";
+import { XOR } from "@microsoft/fast-tooling/dist/data-utilities/type.utilities";
 
 export interface RenderControlConfig {
     /**
@@ -16,7 +20,7 @@ export interface RenderControlConfig {
 }
 
 export interface RenderRefControlConfig extends RenderControlConfig {
-    ref: CSSPropertyRef;
+    ref: XOR<CSSPropertyRef, CSSSyntaxRef>;
 }
 
 interface SelectControlOptions {

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.syntax.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.syntax.tsx
@@ -1,11 +1,8 @@
 import React from "react";
 import { Syntax } from "@microsoft/fast-tooling/dist/css-data.syntax";
-import { RenderControlConfig } from "./control.css.utilities.props";
-import { renderDefault } from "./control.css.utilities";
-
-interface RenderSyntaxControlConfig extends RenderControlConfig {
-    syntax: Syntax;
-}
+import { syntaxes } from "@microsoft/fast-tooling/dist/css-data";
+import { RenderRefControlConfig } from "./control.css.utilities.props";
+import { CSSRef } from "@microsoft/fast-tooling-react/src/form/custom-controls/control.css-ref";
 
 /**
  * The syntax control, for a list of syntaxes available refer to:
@@ -14,8 +11,8 @@ interface RenderSyntaxControlConfig extends RenderControlConfig {
  * These are provided from the @microsoft/fast-tooling package
  * as TypeScript type.
  */
-export function renderSyntaxControl(config: RenderSyntaxControlConfig): React.ReactNode {
-    switch (config.syntax) {
+export function renderSyntaxControl(config: RenderRefControlConfig): React.ReactNode {
+    switch (config.ref.ref as Syntax) {
         case "<absolute-size>":
         case "<alpha-value>":
         case "<angular-color-hint>":
@@ -269,6 +266,12 @@ export function renderSyntaxControl(config: RenderSyntaxControlConfig): React.Re
         case "<viewport-length>":
         case "<wq-name>":
         default:
-            return renderDefault(config);
+            return (
+                <CSSRef
+                    key={config.ref.ref as string}
+                    syntax={syntaxes[config.ref.ref.slice(1, -1) as string].value}
+                    onChange={config.handleChange}
+                />
+            );
     }
 }

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.tsx
@@ -3,7 +3,6 @@ import h from "../../utilities/web-components/pragma"; /* Note: Import wrapped c
 
 import React from "react";
 import {
-    RenderControlConfig,
     RenderRefControlConfig,
     RenderSelectControlConfig,
 } from "./control.css.utilities.props";
@@ -39,7 +38,7 @@ function getTextInputChangeHandler(
     };
 }
 
-export function renderDefault(config: RenderControlConfig): React.ReactNode {
+export function renderDefault(config: RenderRefControlConfig): React.ReactNode {
     return (
         <fast-text-field
             key={config.key}

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.type.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.type.tsx
@@ -1,11 +1,7 @@
 import { Type } from "@microsoft/fast-tooling/dist/css-data.types";
 import { renderDefault } from "./control.css.utilities";
-import { RenderControlConfig } from "./control.css.utilities.props";
+import { RenderRefControlConfig } from "./control.css.utilities.props";
 import React from "react";
-
-export interface RenderTypeControlConfig extends RenderControlConfig {
-    type: Type;
-}
 
 /**
  * The type control, for a list of available types refer to:
@@ -14,8 +10,8 @@ export interface RenderTypeControlConfig extends RenderControlConfig {
  * These are provided from the @microsoft/fast-tooling package
  * as TypeScript type.
  */
-export function renderTypeControl(config: RenderTypeControlConfig): React.ReactNode {
-    switch (config.type) {
+export function renderTypeControl(config: RenderRefControlConfig): React.ReactNode {
+    switch (config.ref.ref as Type) {
         case "<an-plus-b>":
         case "<angle-percentage>":
         case "<angle>":

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.value.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.value.tsx
@@ -1,16 +1,11 @@
 import { renderDefault, renderZeroOrOne } from "./control.css.utilities";
-import { RenderControlConfig } from "./control.css.utilities.props";
+import { RenderRefControlConfig } from "./control.css.utilities.props";
 import React from "react";
-import { CSSPropertyRef } from "@microsoft/fast-tooling/dist/data-utilities/mapping.mdn-data";
-
-export interface RenderValueControlConfig extends RenderControlConfig {
-    ref: CSSPropertyRef;
-}
 
 /**
  * The value control, used for when string values are available
  */
-export function renderValueControl(config: RenderValueControlConfig): React.ReactNode {
+export function renderValueControl(config: RenderRefControlConfig): React.ReactNode {
     if (config.ref.multiplier) {
         switch (config.ref.multiplier.type) {
             case "zeroOrOne":

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.mdn-data.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.mdn-data.ts
@@ -244,7 +244,7 @@ export interface CSSSyntaxRef {
     /**
      * The reference
      */
-    ref: XOR<string, CSSSyntaxRef[]>;
+    ref: XOR<string, CSSPropertyRef[]>;
 
     /**
      * The references combinator type


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
Syntaxes are provided in the same reference format as CSS properties and therefore can take advantage of the same `<CSSRef />` component. This change redirects syntax types to use this component.

## Motivation & context

This creates re-usability so that, for example, if the same `refCombinatorType` of `exactlyOne` generates a select for a CSS property, it will generate a select for a referenced CSS syntax.

Works on a list item in the related issue #4174

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->