### PR TITLE
fix: display active indicator when tab is disabled

### DIFF
--- a/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
@@ -354,4 +354,60 @@ describe("Tabs", () => {
             await disconnect();
         });
     });
+
+    describe("disabled tab", () => {
+        it("should not display an active indicator if every tabs are disabled", async () => {
+            const { element, connect, disconnect } = await fixture<FASTTabs>(html<
+                FASTTabs
+            >`
+                <fast-tabs>
+                    <fast-tab disabled>Tab one</fast-tab>
+                    <fast-tab disabled>Tab two</fast-tab>
+                    <fast-tab disabled>Tab three</fast-tab>
+                    <fast-tab-panel>
+                        Tab one content. This is for testing.
+                    </fast-tab-panel>
+                    <fast-tab-panel>
+                        Tab two content. This is for testing.
+                    </fast-tab-panel>
+                    <fast-tab-panel>
+                        Tab three content. This is for testing.
+                    </fast-tab-panel>
+                </fast-tabs>
+            `);
+
+            await connect();
+
+            expect(element.showActiveIndicator).to.be.false;
+
+            await disconnect();
+        });
+
+        it("should display an active indicator if the last tab is disabled", async () => {
+            const { element, connect, disconnect } = await fixture<FASTTabs>(html<
+                FASTTabs
+            >`
+                <fast-tabs>
+                    <fast-tab>Tab one</fast-tab>
+                    <fast-tab>Tab two</fast-tab>
+                    <fast-tab disabled>Tab three</fast-tab>
+                    <fast-tab-panel>
+                        Tab one content. This is for testing.
+                    </fast-tab-panel>
+                    <fast-tab-panel>
+                        Tab two content. This is for testing.
+                    </fast-tab-panel>
+                    <fast-tab-panel>
+                        Tab three content. This is for testing.
+                    </fast-tab-panel>
+                </fast-tabs>
+            `);
+
+            await connect();
+
+            expect(element.showActiveIndicator).to.be.true;
+
+            await disconnect();
+        });
+    });
 });

--- a/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
@@ -356,7 +356,7 @@ describe("Tabs", () => {
     });
 
     describe("disabled tab", () => {
-        it("should not display an active indicator if every tabs are disabled", async () => {
+        it("should not display an active indicator if all tabs are disabled", async () => {
             const { element, connect, disconnect } = await fixture<FASTTabs>(html<
                 FASTTabs
             >`

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -183,13 +183,14 @@ export class Tabs extends FASTElement {
                 if (this.activeTabIndex === index) {
                     this.activetab = tab;
                 }
-            } else {
-                this.showActiveIndicator = false;
             }
             tab.style[gridProperty] = `${index + 1}`;
             !this.isHorizontal()
                 ? tab.classList.add("vertical")
                 : tab.classList.remove("vertical");
+            this.showActiveIndicator = !!this.tabs.find(
+                tab => tab.slot === "tab" && this.isFocusableElement(tab)
+            );
         });
     };
 

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -158,6 +158,7 @@ export class Tabs extends FASTElement {
         this.tabIds = this.getTabIds();
         this.tabpanelIds = this.getTabPanelIds();
         this.activeTabIndex = this.getActiveIndex();
+        this.showActiveIndicator = false;
         this.tabs.forEach((tab: HTMLElement, index: number) => {
             if (tab.slot === "tab" && this.isFocusableElement(tab)) {
                 if (this.activeindicator) {
@@ -188,9 +189,6 @@ export class Tabs extends FASTElement {
             !this.isHorizontal()
                 ? tab.classList.add("vertical")
                 : tab.classList.remove("vertical");
-            this.showActiveIndicator = !!this.tabs.find(
-                tab => tab.slot === "tab" && this.isFocusableElement(tab)
-            );
         });
     };
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

When setting the _last_ tab to `disabled`, the active indicator would not show up at all. This PR is to fix that

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->