### PR TITLE
feat: add radio group functionality to menu items

### DIFF
--- a/packages/web-components/fast-components/src/menu-item/menu-item.definition.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.definition.ts
@@ -25,7 +25,7 @@ export const fastMenuItemDefinition: WebComponentDefinition = {
                 },
                 {
                     name: "role",
-                    type: DataType.boolean,
+                    type: DataType.string,
                     description: "The role attribute",
                     default: MenuItemRole.menuitem,
                     values: [

--- a/packages/web-components/fast-components/src/menu/fixtures/menu.html
+++ b/packages/web-components/fast-components/src/menu/fixtures/menu.html
@@ -54,10 +54,13 @@
         <fast-menu-item>Menu item 2</fast-menu-item>
         <fast-menu-item>Menu item 3</fast-menu-item>
         <fast-divider></fast-divider>
-        <fast-menu-item role="menuitemradio">Menu item 4</fast-menu-item>
-        <fast-menu-item role="menuitemradio">Menu item 5</fast-menu-item>
+        <fast-menu-item role="menuitemcheckbox">Checkbox 1</fast-menu-item>
+        <fast-menu-item role="menuitemcheckbox">Checkbox 2</fast-menu-item>
         <fast-divider></fast-divider>
-        <fast-menu-item role="menuitemcheckbox">Menu item 4</fast-menu-item>
-        <fast-menu-item role="menuitemcheckbox">Menu item 5</fast-menu-item>
+        <fast-menu-item role="menuitemradio">Radio 1.1</fast-menu-item>
+        <fast-menu-item role="menuitemradio">Radio 1.2</fast-menu-item>
+        <fast-divider></fast-divider>
+        <fast-menu-item role="menuitemradio">Radio 2.1</fast-menu-item>
+        <fast-menu-item role="menuitemradio">Radio 2.2</fast-menu-item>
     </fast-menu>
 </fast-design-system-provider>

--- a/packages/web-components/fast-components/src/menu/scenarios/index.html
+++ b/packages/web-components/fast-components/src/menu/scenarios/index.html
@@ -16,6 +16,22 @@
     </fast-menu>
 </template>
 
+<template title="With checkboxes and radios">
+    <fast-menu>
+        <fast-menu-item>Menu item 1</fast-menu-item>
+        <fast-menu-item>Menu item 2</fast-menu-item>
+        <fast-divider></fast-divider>
+        <fast-menu-item role="menuitemcheckbox">Checkbox 1</fast-menu-item>
+        <fast-menu-item role="menuitemcheckbox">Checkbox 2</fast-menu-item>
+        <fast-divider></fast-divider>
+        <fast-menu-item role="menuitemradio">Radio 1.1</fast-menu-item>
+        <fast-menu-item role="menuitemradio">Radio 1.2</fast-menu-item>
+        <fast-divider></fast-divider>
+        <fast-menu-item role="menuitemradio">Radio 2.1</fast-menu-item>
+        <fast-menu-item role="menuitemradio">Radio 2.2</fast-menu-item>
+    </fast-menu>
+</template>
+
 <template title="With icons">
     <fast-menu>
         <fast-menu-item>

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -910,6 +910,7 @@ export class MenuItem extends FASTElement {
     checked: boolean;
     disabled: boolean;
     expanded: boolean;
+    group: string;
     // @internal (undocumented)
     handleMenuItemClick: (e: MouseEvent) => void;
     // @internal (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -910,7 +910,6 @@ export class MenuItem extends FASTElement {
     checked: boolean;
     disabled: boolean;
     expanded: boolean;
-    group: string;
     // @internal (undocumented)
     handleMenuItemClick: (e: MouseEvent) => void;
     // @internal (undocumented)

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
@@ -120,6 +120,56 @@ describe("Menu item", () => {
         await disconnect();
     });
 
+    it("should toggle the aria-checked attribute of checkbox item when clicked", async () => {
+        const { element, connect, disconnect } = await setup();
+        element.role = MenuItemRole.menuitemcheckbox;
+
+        await connect();
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-checked")).to.equal(null);
+
+        element.click();
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-checked")).to.equal("true");
+
+        element.click();
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-checked")).to.equal("false");
+
+        await disconnect();
+    });
+
+    it("should aria-checked attribute of radio item to true when clicked", async () => {
+        const { element, connect, disconnect } = await setup();
+        element.role = MenuItemRole.menuitemradio;
+
+        await connect();
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-checked")).to.equal(null);
+
+        element.click();
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-checked")).to.equal("true");
+
+        element.click();
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-checked")).to.equal("true");
+
+        await disconnect();
+    });
+
     describe("events", () => {
         it("should fire an event on click", async () => {
             const { element, connect, disconnect } = await setup();

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -52,6 +52,11 @@ export class MenuItem extends FASTElement {
      */
     @attr
     public checked: boolean;
+    private checkedChanged(oldValue, newValue): void {
+        if (this.$fastController.isConnected) {
+            this.$emit("change");
+        }
+    }
 
     /**
      * @internal
@@ -89,9 +94,11 @@ export class MenuItem extends FASTElement {
                     this.checked = true;
                 }
                 break;
-        }
 
-        this.$emit("change");
+            case MenuItemRole.menuitem:
+                this.$emit("change");
+                break;
+        }
     };
 }
 

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -54,17 +54,6 @@ export class MenuItem extends FASTElement {
     public checked: boolean;
 
     /**
-     * The name of the radio group this item belongs to.
-     * Typically only relevant when the menu item's role is set to "menuitemradio"
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: group
-     */
-    @attr
-    public group: string;
-
-    /**
      * @internal
      */
     public handleMenuItemKeyDown = (e: KeyboardEvent): boolean => {

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -54,6 +54,17 @@ export class MenuItem extends FASTElement {
     public checked: boolean;
 
     /**
+     * The name of the radio group this item belongs to.
+     * Typically only relevant when the menu item's role is set to "menuitemradio"
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: group
+     */
+    @attr
+    public group: string;
+
+    /**
      * @internal
      */
     public handleMenuItemKeyDown = (e: KeyboardEvent): boolean => {
@@ -81,8 +92,13 @@ export class MenuItem extends FASTElement {
 
         switch (this.role) {
             case MenuItemRole.menuitemcheckbox:
-            case MenuItemRole.menuitemradio:
                 this.checked = !this.checked;
+                break;
+
+            case MenuItemRole.menuitemradio:
+                if (!this.checked) {
+                    this.checked = true;
+                }
                 break;
         }
 

--- a/packages/web-components/fast-foundation/src/menu/menu.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.spec.ts
@@ -3,6 +3,7 @@ import { Menu, MenuTemplate as template } from "./index";
 import { MenuItem, MenuItemTemplate as itemTemplate } from "../menu-item";
 import { fixture } from "../fixture";
 import { DOM, customElement, html } from "@microsoft/fast-element";
+import { KeyCodes } from "@microsoft/fast-web-utilities";
 
 @customElement({
     name: "fast-menu",
@@ -16,7 +17,18 @@ class FASTMenu extends Menu {}
 })
 class FASTMenuItem extends MenuItem {}
 
-// TODO: Add tests for keyboard handling
+const arrowUpEvent = new KeyboardEvent("keydown", {
+    key: "ArrowUp",
+    keyCode: KeyCodes.arrowUp,
+    bubbles: true,
+} as KeyboardEventInit);
+
+const arrowDownEvent = new KeyboardEvent("keydown", {
+    key: "ArrowDown",
+    keyCode: KeyCodes.arrowDown,
+    bubbles: true,
+} as KeyboardEventInit);
+
 describe("Menu", () => {
     it("should include a role of menu", async () => {
         const { element, connect, disconnect } = await fixture<Menu>("fast-menu");
@@ -112,6 +124,52 @@ describe("Menu", () => {
         expect(
             element.querySelector("[role='menuitemradio']")?.getAttribute("tabindex")
         ).to.equal("0");
+
+        await disconnect();
+    });
+
+    it("should navigate the menu on arrow up/down keys", async () => {
+        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
+            <fast-menu>
+                <fast-menu-item id="id1">Foo</fast-menu-item>
+                <fast-menu-item role="menuitem" id="id2">Bar</fast-menu-item>
+                <div>I put a div in my menu</div>
+                <fast-menu-item role="menuitemradio" id="id3">Baz</fast-menu-item>
+                <div>I put a div in my menu</div>
+                <fast-menu-item role="menuitemcheckbox" id="id4">Baz</fast-menu-item>
+            </fast-menu>
+        `);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        const item1 = element.querySelector('[id="id1"]');
+        (item1 as HTMLElement).focus();
+        expect(document.activeElement?.id).to.equal("id1");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id2");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id3");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id4");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id4");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
+        expect(document.activeElement?.id).to.equal("id3");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
+        expect(document.activeElement?.id).to.equal("id2");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
+        expect(document.activeElement?.id).to.equal("id1");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
+        expect(document.activeElement?.id).to.equal("id1");
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/menu/menu.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.spec.ts
@@ -131,12 +131,12 @@ describe("Menu", () => {
     it("should navigate the menu on arrow up/down keys", async () => {
         const { element, connect, disconnect } = await fixture(html<FASTMenu>`
             <fast-menu>
-                <fast-menu-item id="id1">Foo</fast-menu-item>
-                <fast-menu-item role="menuitem" id="id2">Bar</fast-menu-item>
+                <fast-menu-item id="id1">One</fast-menu-item>
+                <fast-menu-item role="menuitem" id="id2">Two</fast-menu-item>
                 <div>I put a div in my menu</div>
-                <fast-menu-item role="menuitemradio" id="id3">Baz</fast-menu-item>
+                <fast-menu-item role="menuitemradio" id="id3">Three</fast-menu-item>
                 <div>I put a div in my menu</div>
-                <fast-menu-item role="menuitemcheckbox" id="id4">Baz</fast-menu-item>
+                <fast-menu-item role="menuitemcheckbox" id="id4">Four</fast-menu-item>
             </fast-menu>
         `);
 
@@ -170,6 +170,142 @@ describe("Menu", () => {
 
         document.activeElement?.dispatchEvent(arrowUpEvent);
         expect(document.activeElement?.id).to.equal("id1");
+
+        await disconnect();
+    });
+
+    it("should treat all checkbox menu items as individually selectable items", async () => {
+        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
+            <fast-menu>
+                <fast-menu-item role="menuitemcheckbox" id="id1">One</fast-menu-item>
+                <fast-menu-item role="menuitemcheckbox" id="id2">Two</fast-menu-item>
+                <fast-menu-item role="menuitemcheckbox" id="id3">Three</fast-menu-item>
+            </fast-menu>
+        `);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        const item1 = element.querySelector('[id="id1"]');
+        const item2 = element.querySelector('[id="id2"]');
+        const item3 = element.querySelector('[id="id3"]');
+
+        expect(item1?.getAttribute("aria-checked")).to.equal(null);
+        expect(item2?.getAttribute("aria-checked")).to.equal(null);
+        expect(item3?.getAttribute("aria-checked")).to.equal(null);
+
+        (item1 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("true");
+        expect(item2?.getAttribute("aria-checked")).to.equal(null);
+        expect(item3?.getAttribute("aria-checked")).to.equal(null);
+
+        (item2 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("true");
+        expect(item2?.getAttribute("aria-checked")).to.equal("true");
+        expect(item3?.getAttribute("aria-checked")).to.equal(null);
+
+        (item3 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("true");
+        expect(item2?.getAttribute("aria-checked")).to.equal("true");
+        expect(item3?.getAttribute("aria-checked")).to.equal("true");
+
+        (item3 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("true");
+        expect(item2?.getAttribute("aria-checked")).to.equal("true");
+        expect(item3?.getAttribute("aria-checked")).to.equal("false");
+
+        await disconnect();
+    });
+
+    it("should treat all radio menu items as a 'radio group' and limit selection to one item within the group by default", async () => {
+        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
+            <fast-menu>
+                <fast-menu-item role="menuitemradio" id="id1">One</fast-menu-item>
+                <fast-menu-item role="menuitemradio" id="id2">Two</fast-menu-item>
+                <fast-menu-item role="menuitemradio" id="id3">Three</fast-menu-item>
+            </fast-menu>
+        `);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        const item1 = element.querySelector('[id="id1"]');
+        const item2 = element.querySelector('[id="id2"]');
+        const item3 = element.querySelector('[id="id3"]');
+
+        expect(item1?.getAttribute("aria-checked")).to.equal(null);
+        expect(item2?.getAttribute("aria-checked")).to.equal(null);
+        expect(item3?.getAttribute("aria-checked")).to.equal(null);
+
+        (item1 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("true");
+        expect(item2?.getAttribute("aria-checked")).to.equal("false");
+        expect(item3?.getAttribute("aria-checked")).to.equal("false");
+
+        (item2 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("false");
+        expect(item2?.getAttribute("aria-checked")).to.equal("true");
+        expect(item3?.getAttribute("aria-checked")).to.equal("false");
+
+        (item3 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("false");
+        expect(item2?.getAttribute("aria-checked")).to.equal("false");
+        expect(item3?.getAttribute("aria-checked")).to.equal("true");
+
+        await disconnect();
+    });
+
+    it("should use elements with role='separator' to divide radio menu items into different radio groups ", async () => {
+        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
+            <fast-menu>
+                <fast-menu-item role="menuitemradio" id="id1">One</fast-menu-item>
+                <fast-menu-item role="menuitemradio" id="id2">Two</fast-menu-item>
+                <div role="separator"></div>
+                <fast-menu-item role="menuitemradio" id="id3">Three</fast-menu-item>
+                <fast-menu-item role="menuitemradio" id="id4">Four</fast-menu-item>
+            </fast-menu>
+        `);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        const item1 = element.querySelector('[id="id1"]');
+        const item2 = element.querySelector('[id="id2"]');
+        const item3 = element.querySelector('[id="id3"]');
+        const item4 = element.querySelector('[id="id4"]');
+
+        expect(item1?.getAttribute("aria-checked")).to.equal(null);
+        expect(item2?.getAttribute("aria-checked")).to.equal(null);
+        expect(item3?.getAttribute("aria-checked")).to.equal(null);
+        expect(item4?.getAttribute("aria-checked")).to.equal(null);
+
+        (item1 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("true");
+        expect(item2?.getAttribute("aria-checked")).to.equal("false");
+        expect(item3?.getAttribute("aria-checked")).to.equal(null);
+        expect(item4?.getAttribute("aria-checked")).to.equal(null);
+
+        (item2 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("false");
+        expect(item2?.getAttribute("aria-checked")).to.equal("true");
+        expect(item3?.getAttribute("aria-checked")).to.equal(null);
+        expect(item4?.getAttribute("aria-checked")).to.equal(null);
+
+        (item3 as HTMLElement).click();
+        await DOM.nextUpdate();
+        expect(item1?.getAttribute("aria-checked")).to.equal("false");
+        expect(item2?.getAttribute("aria-checked")).to.equal("true");
+        expect(item3?.getAttribute("aria-checked")).to.equal("true");
+        expect(item4?.getAttribute("aria-checked")).to.equal("false");
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -9,7 +9,7 @@ import {
     keyCodeEnd,
     keyCodeHome,
 } from "@microsoft/fast-web-utilities";
-import { MenuItemRole } from "../menu-item/index";
+import { MenuItem, MenuItemRole } from "../menu-item/index";
 
 /**
  * A Menu Custom HTML Element.
@@ -49,6 +49,8 @@ export class Menu extends FASTElement {
     public connectedCallback(): void {
         super.connectedCallback();
         this.menuItems = this.domChildren();
+
+        this.addEventListener("change", this.changeHandler);
     }
 
     /**
@@ -57,6 +59,8 @@ export class Menu extends FASTElement {
     public disconnectedCallback(): void {
         super.disconnectedCallback();
         this.menuItems = [];
+
+        this.removeEventListener("change", this.changeHandler);
     }
 
     /**
@@ -143,6 +147,45 @@ export class Menu extends FASTElement {
     private resetItems = (oldValue: any): void => {
         for (let item: number = 0; item < oldValue.length; item++) {
             oldValue[item].removeEventListener("blur", this.handleMenuItemFocus);
+        }
+    };
+
+    /**
+     * handle change from child element
+     */
+    private changeHandler = (e: CustomEvent): void => {
+        const changedMenuItem: MenuItem = e.target as MenuItem;
+        const changeItemIndex: number = this.menuItems.indexOf(changedMenuItem);
+
+        if (changeItemIndex === -1) {
+            return;
+        }
+
+        if (
+            changedMenuItem.role === "menuitemradio" &&
+            changedMenuItem.checked === true
+        ) {
+            for (let i = changeItemIndex - 1; i >= 0; --i) {
+                const item: Element = this.menuItems[i];
+                const role: string | null = item.getAttribute("role");
+                if (role === MenuItemRole.menuitemradio) {
+                    (item as MenuItem).checked = false;
+                }
+                if (role === "separator") {
+                    break;
+                }
+            }
+            const maxIndex: number = this.menuItems.length - 1;
+            for (let i = changeItemIndex + 1; i <= maxIndex; ++i) {
+                const item: Element = this.menuItems[i];
+                const role: string | null = item.getAttribute("role");
+                if (role === MenuItemRole.menuitemradio) {
+                    (item as MenuItem).checked = false;
+                }
+                if (role === "separator") {
+                    break;
+                }
+            }
         }
     };
 


### PR DESCRIPTION
# Description
Menu items in the same menu with the role "menuitemradio" should behave as "radio groups" allowing only one item of the group to be selected at a time.  Elements with a role of "separator" placed between radio menu items serve to break up radio buttons into independent groups.

## Motivation & context
Menu items with role of "menuitemradio" must follow a group selection behavior as per https://www.w3.org/TR/wai-aria-1.2/#menuitemradio

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.