### PR TITLE
fix: added new grid for horizontal tabs with start and end elements

### DIFF
--- a/packages/web-components/fast-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tabs.styles.ts
@@ -40,14 +40,6 @@ export const TabsStyles = css`
         align-self: center;
     }
 
-    :host([orientation="horizontal"]) .start {
-        grid-column: 1;
-    }
-
-    :host([orientation="horizontal"]) .end {
-        grid-column: 3;
-    }
-
     .activeIndicator {
         grid-row: 2;
         grid-column: 1;

--- a/packages/web-components/fast-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tabs.styles.ts
@@ -29,9 +29,23 @@ export const TabsStyles = css`
         box-sizing: border-box;
     }
 
+    .tablist-container {
+        display: grid;
+        grid-template-columns: auto auto auto;
+        grid-template-rows: auto;
+    }
+
     .start,
     .end {
         align-self: center;
+    }
+
+    :host([orientation="horizontal"]) .start {
+        grid-column: 1;
+    }
+
+    :host([orientation="horizontal"]) .end {
+        grid-column: 3;
     }
 
     .activeIndicator {

--- a/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
@@ -8,22 +8,24 @@ import { Tabs } from "./tabs";
  */
 export const TabsTemplate = html<Tabs>`
     <template class="${x => x.orientation}">
-        ${startTemplate}
-        <div class="tablist" part="tablist" role="tablist">
-            <slot class="tab" name="tab" part="tab" ${slotted("tabs")}></slot>
+        <div class="tablist-container">
+            ${startTemplate}
+            <div class="tablist" part="tablist" role="tablist">
+                <slot class="tab" name="tab" part="tab" ${slotted("tabs")}></slot>
+                ${when(
+                    x => x.showActiveIndicator,
+                    html<Tabs>`
+                        <div
+                            ${ref("activeIndicatorRef")}
+                            class="activeIndicator"
+                            part="activeIndicator"
+                        ></div>
+                    `
+                )}
 
-            ${when(
-                x => x.showActiveIndicator,
-                html<Tabs>`
-                    <div
-                        ${ref("activeIndicatorRef")}
-                        class="activeIndicator"
-                        part="activeIndicator"
-                    ></div>
-                `
-            )}
+            </div>
+            ${endTemplate}
         </div>
-        ${endTemplate}
         <div class="tabpanel">
             <slot name="tabpanel" part="tabpanel" ${slotted("tabpanels")}></slot>
         </div>

--- a/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
@@ -22,7 +22,6 @@ export const TabsTemplate = html<Tabs>`
                         ></div>
                     `
                 )}
-
             </div>
             ${endTemplate}
         </div>


### PR DESCRIPTION
When utilizing the start and end slots in the tabs control, I expect that they will line up on either side of the tabs and not have the end pushed out to the width of the tabs control.

# Description

Adding another grid to encompass the horizontal tabs and a start and end slot if utilized. The start and end slot columns are auto sized so if they are not used, that space will be filled with the tabs only. This change requires no logic change in the tabs class and does not affect tabs without start/end slots.

![Screen Shot 2021-01-06 at 3 31 14 PM](https://user-images.githubusercontent.com/25805778/103832875-4a4cca00-5034-11eb-8500-5c25a2d5bc25.png)


situation before change:
![Screen Shot 2021-01-06 at 3 29 05 PM](https://user-images.githubusercontent.com/25805778/103832763-fa6e0300-5033-11eb-9de6-cb9af66425b7.png)


## Motivation & context

The motivation came through needing to use the end slot for a button that should be just on the other side of the last tab.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.