### PR TITLE
fix: address broken high contrast colors on listbox and select components

### DIFF
--- a/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
+++ b/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
@@ -120,6 +120,8 @@ export const OptionStyles = css`
             :host {
                 border-color: transparent;
                 forced-color-adjust: none;
+                color: ${SystemColors.ButtonText};
+                fill: currentcolor;
             }
 
             :host(:not([aria-selected="true"]):hover),

--- a/packages/web-components/fast-components/src/listbox/listbox.styles.ts
+++ b/packages/web-components/fast-components/src/listbox/listbox.styles.ts
@@ -44,14 +44,6 @@ export const ListboxStyles = css`
                 color: ${SystemColors.HighlightText};
                 fill: currentcolor;
             }
-
-            ::slotted([role="option"]:not([aria-selected="true"]):not([disabled]):hover) {
-                forced-color-adjust: none;
-                color: ${SystemColors.ButtonText};
-                background: ${SystemColors.ButtonFace};
-                border-color: ${SystemColors.Highlight};
-                box-shadow: none;
-            }
         `
     ),
     neutralLayerFloatingBehavior,

--- a/packages/web-components/fast-components/src/select/select.styles.ts
+++ b/packages/web-components/fast-components/src/select/select.styles.ts
@@ -191,10 +191,28 @@ export const SelectStyles = css`
     accentForegroundFocusBehavior,
     forcedColorsStylesheetBehavior(
         css`
+            :host(:not([disabled]):hover),
+            :host(:not([disabled]):active) {
+                border-color: ${SystemColors.Highlight};
+            }
+
+            :host(:not([disabled]):${focusVisible}) {
+                background-color: ${SystemColors.ButtonFace};
+                box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) ${SystemColors.Highlight};
+                color: ${SystemColors.ButtonText};
+                fill: currentcolor;
+                forced-color-adjust: none;
+            }
+
+            :host(:not([disabled]):${focusVisible}) .listbox {
+                background: ${SystemColors.ButtonFace};
+            }
+
             :host([disabled]) {
                 border-color: ${SystemColors.GrayText};
                 background-color: ${SystemColors.ButtonFace};
                 color: ${SystemColors.GrayText};
+                fill: currentcolor;
                 opacity: 1;
                 forced-color-adjust: none;
             }
@@ -208,8 +226,13 @@ export const SelectStyles = css`
                 border-color: ${SystemColors.GrayText};
             }
 
+            :host([disabled]) .control .select-indicator {
+                fill: ${SystemColors.GrayText};
+            }
+
             :host(:${focusVisible}) ::slotted([aria-selected="true"][role="option"]),
-            :host(:${focusVisible}) ::slotted(option[aria-selected="true"]) {
+            :host(:${focusVisible}) ::slotted(option[aria-selected="true"]),
+            :host(:${focusVisible}) ::slotted([aria-selected="true"][role="option"]:not([disabled])) {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.ButtonText};
                 box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${SystemColors.HighlightText};
@@ -217,12 +240,13 @@ export const SelectStyles = css`
                 fill: currentcolor;
             }
 
-            ::slotted([role="option"]:not([aria-selected="true"]):not([disabled]):hover) {
-                forced-color-adjust: none;
+            .start,
+            .end,
+            .indicator,
+            .select-indicator,
+            ::slotted(svg) {
                 color: ${SystemColors.ButtonText};
-                background: ${SystemColors.ButtonFace};
-                border-color: ${SystemColors.Highlight};
-                box-shadow: none;
+                fill: currentcolor;
             }
         `
     ),


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

Set color on option component to fix high contrast white.
Removed the hover selector in listbox so the background on the item changes color and not just the border.
Fixed broken hover on select and focus on its listbox. Also fix the color of the indicator.


before
![image](https://user-images.githubusercontent.com/37851220/104062218-e8fd3600-51ae-11eb-8f9d-6ccd7fa6ac07.png)

after
![image](https://user-images.githubusercontent.com/37851220/104062230-ef8bad80-51ae-11eb-89fc-44d355232d68.png)


## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->