### PR TITLE
fix: Allow nonce usage in canUseFocusVisible

### DIFF
--- a/packages/utilities/fast-web-utilities/src/dom.spec.ts
+++ b/packages/utilities/fast-web-utilities/src/dom.spec.ts
@@ -5,6 +5,7 @@ import {
     getDisplayedNodes,
     getKeyCode,
     isHTMLElement,
+    resetDocumentCache,
 } from "./dom";
 import { KeyCodes } from "./key-codes";
 
@@ -196,6 +197,9 @@ describe("getKeyCode", () => {
 });
 
 describe("canUseFocusVisible", () => {
+    beforeEach(() => {
+        resetDocumentCache();
+    });
     test("should not throw", () => {
         expect(() => {
             canUseFocusVisible();
@@ -204,9 +208,29 @@ describe("canUseFocusVisible", () => {
     test("should return true if the environment supports focus-visible selectors", () => {
         expect(canUseFocusVisible()).toBe(true);
     });
+    test("should use a nonce if once is present on the page", () => {
+        const nonce: string = "foo-nonce";
+        const metaEl: HTMLMetaElement = document.createElement("meta");
+        metaEl.setAttribute("property", "csp-nonce");
+        metaEl.setAttribute("content", nonce);
+        document.head.appendChild(metaEl);
+
+        // Run the function and intercept its appendChild call
+        const realAppendChild = document.head.appendChild;
+        const mockAppendChild = jest.fn(realAppendChild);
+        Object.defineProperty(document.head, "appendChild", { value: mockAppendChild });
+        canUseFocusVisible();
+
+        expect(mockAppendChild).toBeCalledTimes(1);
+        const createdStyleElement = mockAppendChild.mock.calls[0][0] as HTMLStyleElement;
+        expect(createdStyleElement.nonce).toEqual(nonce);
+    });
 });
 
 describe("canUseCssGrid", () => {
+    beforeEach(() => {
+        resetDocumentCache();
+    });
     test("should not throw", () => {
         expect(() => {
             canUseCssGrid();

--- a/packages/utilities/fast-web-utilities/src/dom.spec.ts
+++ b/packages/utilities/fast-web-utilities/src/dom.spec.ts
@@ -218,12 +218,38 @@ describe("canUseFocusVisible", () => {
         // Run the function and intercept its appendChild call
         const realAppendChild = document.head.appendChild;
         const mockAppendChild = jest.fn(realAppendChild);
-        Object.defineProperty(document.head, "appendChild", { value: mockAppendChild });
+        Object.defineProperty(document.head, "appendChild", {
+            value: mockAppendChild,
+            configurable: true,
+        });
         canUseFocusVisible();
 
         expect(mockAppendChild).toBeCalledTimes(1);
         const createdStyleElement = mockAppendChild.mock.calls[0][0] as HTMLStyleElement;
         expect(createdStyleElement.nonce).toEqual(nonce);
+        Object.defineProperty(document.head, "appendChild", {
+            value: realAppendChild,
+            configurable: true,
+        });
+    });
+    test("should cache the result for subsequent calls", () => {
+        const realAppendChild = document.head.appendChild;
+        const mockAppendChild = jest.fn(realAppendChild);
+        Object.defineProperty(document.head, "appendChild", {
+            value: mockAppendChild,
+            configurable: true,
+        });
+        canUseFocusVisible();
+
+        expect(mockAppendChild).toBeCalledTimes(1);
+        mockAppendChild.mockClear();
+
+        canUseFocusVisible();
+        expect(mockAppendChild).toBeCalledTimes(0);
+        Object.defineProperty(document.head, "appendChild", {
+            value: realAppendChild,
+            configurable: true,
+        });
     });
 });
 

--- a/packages/utilities/fast-web-utilities/src/dom.ts
+++ b/packages/utilities/fast-web-utilities/src/dom.ts
@@ -35,6 +35,20 @@ export function getKeyCode(event: KeyboardEvent): number {
 }
 
 /**
+ * Returns the nonce used in the page, if any.
+ *
+ * Based on https://github.com/cssinjs/jss/blob/master/packages/jss/src/DomRenderer.js
+ */
+function getNonce(): string | null {
+    const node = document.querySelector('meta[property="csp-nonce"]');
+    if (node) {
+        return node.getAttribute("content");
+    } else {
+        return null;
+    }
+}
+
+/**
  * Test if the document supports :focus-visible
  */
 let _canUseFocusVisible: boolean;
@@ -51,6 +65,13 @@ export function canUseFocusVisible(): boolean {
 
     // Check to see if the document supports the focus-visible element
     const styleElement: HTMLStyleElement = document.createElement("style");
+
+    // If nonces are present on the page, use it when creating the style element
+    // to test focus-visible support.
+    const styleNonce = getNonce();
+    if (styleNonce !== null) {
+        styleElement.setAttribute("nonce", styleNonce);
+    }
     document.head.appendChild(styleElement);
 
     try {
@@ -86,6 +107,11 @@ export function canUseForcedColors(): boolean {
         (window.matchMedia("(forced-colors: none)").matches ||
             window.matchMedia("(forced-colors: active)").matches)
     );
+}
+
+export function resetDocumentCache(): void {
+    _canUseCssGrid = undefined;
+    _canUseFocusVisible = undefined;
 }
 
 /**


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
Detects and uses a nonce when testing `canUseFocusVisible`
<!--- Describe your changes. -->

## Motivation & context
Some pages set a CSP nonce for security. This would block the temp stylesheet created by canUseFocusVisible. Instead, use the same approach as JSS and detect/use a page's nonce if found.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
