### PR TITLE
fix: accordion arrow key press moves focus from content to accordion header

### DIFF
--- a/packages/web-components/fast-components/src/accordion/fixtures/base.html
+++ b/packages/web-components/fast-components/src/accordion/fixtures/base.html
@@ -66,7 +66,7 @@
             </svg>
             Panel one content
         </fast-accordion-item>
-        <fast-accordion-item>
+        <fast-accordion-item expanded>
             <span slot="heading">Panel two</span>
             <svg
                 slot="collapsed-icon"
@@ -113,7 +113,9 @@
                     stroke-linejoin="round"
                 />
             </svg>
-            Panel two content
+
+            <fast-button tabindex="0">Button</fast-button>
+            <fast-button tabindex="0">Button</fast-button>
         </fast-accordion-item>
         <fast-accordion-item expanded>
             <span slot="heading">Panel three</span>

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -127,25 +127,29 @@ export class Accordion extends FASTElement {
     }
 
     private handleItemKeyDown = (event: KeyboardEvent): void => {
-        const keyCode: number = event.keyCode;
-        this.accordionIds = this.getItemIds();
-        switch (keyCode) {
-            case keyCodeArrowUp:
-                event.preventDefault();
-                this.adjust(-1);
-                break;
-            case keyCodeArrowDown:
-                event.preventDefault();
-                this.adjust(1);
-                break;
-            case keyCodeHome:
-                this.activeItemIndex = 0;
-                this.focusItem();
-                break;
-            case keyCodeEnd:
-                this.activeItemIndex = this.accordionItems.length - 1;
-                this.focusItem();
-                break;
+        // only handle the keydown if the event target is the accordion item
+        // prevents arrow keys from moving focus to accordion headers when focus is on accordion item panel content
+        if (event.target === event.currentTarget) {
+            const keyCode: number = event.keyCode;
+            this.accordionIds = this.getItemIds();
+            switch (keyCode) {
+                case keyCodeArrowUp:
+                    event.preventDefault();
+                    this.adjust(-1);
+                    break;
+                case keyCodeArrowDown:
+                    event.preventDefault();
+                    this.adjust(1);
+                    break;
+                case keyCodeHome:
+                    this.activeItemIndex = 0;
+                    this.focusItem();
+                    break;
+                case keyCodeEnd:
+                    this.activeItemIndex = this.accordionItems.length - 1;
+                    this.focusItem();
+                    break;
+            }
         }
     };
 

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -129,27 +129,28 @@ export class Accordion extends FASTElement {
     private handleItemKeyDown = (event: KeyboardEvent): void => {
         // only handle the keydown if the event target is the accordion item
         // prevents arrow keys from moving focus to accordion headers when focus is on accordion item panel content
-        if (event.target === event.currentTarget) {
-            const keyCode: number = event.keyCode;
-            this.accordionIds = this.getItemIds();
-            switch (keyCode) {
-                case keyCodeArrowUp:
-                    event.preventDefault();
-                    this.adjust(-1);
-                    break;
-                case keyCodeArrowDown:
-                    event.preventDefault();
-                    this.adjust(1);
-                    break;
-                case keyCodeHome:
-                    this.activeItemIndex = 0;
-                    this.focusItem();
-                    break;
-                case keyCodeEnd:
-                    this.activeItemIndex = this.accordionItems.length - 1;
-                    this.focusItem();
-                    break;
-            }
+        if (event.target !== event.currentTarget) {
+            return;
+        }
+        const keyCode: number = event.keyCode;
+        this.accordionIds = this.getItemIds();
+        switch (keyCode) {
+            case keyCodeArrowUp:
+                event.preventDefault();
+                this.adjust(-1);
+                break;
+            case keyCodeArrowDown:
+                event.preventDefault();
+                this.adjust(1);
+                break;
+            case keyCodeHome:
+                this.activeItemIndex = 0;
+                this.focusItem();
+                break;
+            case keyCodeEnd:
+                this.activeItemIndex = this.accordionItems.length - 1;
+                this.focusItem();
+                break;
         }
     };
 


### PR DESCRIPTION
Added focusable content to default example
Added check for target to equal current target before handling accordion item key down event.

If the event.target and event.currentTarget are the same then the arrow key press happened on the accordion itself, which is the event we want to act on with arrow up/down keys.

Note: this _also_ makes focus _not_ move if it is on one of the start or end items in the accordion header. I believe this is the appropriate response, as that is focusable content so  the accordion item key down handler should not act on that. Only if the actual accordion item is focused do we want the arrow keys to move focus between accordion items.

<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description
 closes #4326 
<!--- Describe your changes. -->

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->