### PR TITLE
fix: update the event listener to be passed to a config to the message system

### DIFF
--- a/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.ts
+++ b/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.ts
@@ -90,7 +90,8 @@ export function findUpdatedDictionaryId(
 }
 
 export class MonacoAdapter extends MessageSystemService<
-    MonacoAdapterActionCallbackConfig
+    MonacoAdapterActionCallbackConfig,
+    {}
 > {
     private monacoModelValue: string[];
     private schemaDictionary: SchemaDictionary;

--- a/packages/tooling/fast-tooling/src/message-system-service/shortcuts.service.spec.md
+++ b/packages/tooling/fast-tooling/src/message-system-service/shortcuts.service.spec.md
@@ -84,68 +84,25 @@ The `ShortcutsAction` class should also contain a `matches` method that takes a 
 
 ## Attaching the event listener
 
-A keypress event listener will be created and passed through the `MessageSystem` so that a user can choose where to attach them.
+A keypress event listener will be created and passed as part of the Shortcuts service config through the `MessageSystem` so that a user can retrieve it.
 
-An example of the custom event that might be sent:
+An example of retrieving the Shortcuts service config:
 
 ```typescript
-{
-    type: MessageSystemType.custom,
-    id: "shortcuts",
-    action: "initialize",
-    eventListener: listener,
-    eventListenerType: "keypress",
-    shortcuts: [
-        {
-            name: "Random action",
-            keys: [
-                {
-                    altKey: true,
-                },
-                {
-                    value: "Tab"
-                }
-            ],
-            // executing this passed function should
-            // perform the same action
-            action: func
-        },
-        {
-            name: "Duplicate",
-            keys: [
-                {
-                    ctrlKey: true,
-                },
-                {
-                    value: "d"
-                }
-            ],
-            action: func
-        }
-    ]
-}
+messageSystem.getConfigById(shortcutsId).eventListener;
 ```
 
-An example of a React component using the custom event to allow all shortcuts to be performed on an anchor:
+An example of using the custom event to allow all shortcuts to be performed on an anchor:
 
-```tsx
-class Example extends React.Component<{}, {}> {
-    public render(): React.ReactNode {
-        return <a ref={this.anchorRef}>MyAnchor</a>;
-    }
+```html
+<a id="foo">MyAnchor</a>
+```
 
-    private handleMessageSystem = (e: MessageEvent): void => {
-        if (
-            e.type === MessageSystemType.custom
-            && e.id === "shortcuts"
-        ) {
-            this.anchorRef.current.addEventListener(
-                e.eventListenerType,
-                eventListener
-            );
-        }
-    }
-}
+```ts
+const myAnchor = document.getElementById("foo");
+const config = messageSystem.getConfigById(shortcutsId);
+
+myAnchor.addEventListener(config.eventListenerType, config.eventListener);
 ```
 
 ## Additional notes

--- a/packages/tooling/fast-tooling/src/message-system-service/shortcuts.service.spec.ts
+++ b/packages/tooling/fast-tooling/src/message-system-service/shortcuts.service.spec.ts
@@ -1,5 +1,5 @@
 import { MessageSystem, MessageSystemType, Register } from "../message-system";
-import { Shortcuts } from "./shortcuts.service";
+import { Shortcuts, ShortcutsConfig, shortcutsId } from "./shortcuts.service";
 import { ShortcutsAction } from "./shortcuts.service-action";
 
 describe("Shortcuts", () => {
@@ -161,15 +161,8 @@ describe("Shortcuts", () => {
         expect(postMessageCallback.mock.calls[0][0].type).toEqual(
             MessageSystemType.custom
         );
-        expect(postMessageCallback.mock.calls[0][0].id).toEqual("shortcuts");
+        expect(postMessageCallback.mock.calls[0][0].id).toEqual(shortcutsId);
         expect(postMessageCallback.mock.calls[0][0].action).toEqual("initialize");
-        expect(postMessageCallback.mock.calls[0][0].eventListenerType).toEqual(
-            "keypress"
-        );
-        expect(typeof postMessageCallback.mock.calls[0][0].eventListener).toEqual(
-            "function"
-        );
-        expect(postMessageCallback.mock.calls[0][0].shortcuts.length).toEqual(1);
     });
     test("should pass meta key if meta key is used", () => {
         const postMessageCallback: any = jest.fn();
@@ -203,7 +196,7 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        postMessageCallback.mock.calls[0][0].eventListener({ metaKey: true });
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ metaKey: true } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should pass alt key if alt key is used", () => {
@@ -238,7 +231,7 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        postMessageCallback.mock.calls[0][0].eventListener({ altKey: true });
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ altKey: true } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should pass ctrl key if ctrl key is used", () => {
@@ -273,7 +266,7 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        postMessageCallback.mock.calls[0][0].eventListener({ ctrlKey: true });
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ ctrlKey: true } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should pass shift key if shift key is used", () => {
@@ -308,7 +301,7 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        postMessageCallback.mock.calls[0][0].eventListener({ shiftKey: true });
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ shiftKey: true } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should pass a specific key if a specific key is used", () => {
@@ -343,7 +336,7 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        postMessageCallback.mock.calls[0][0].eventListener({ key: "d" });
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ key: "d" } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should not invoke an action if the keys do not match", () => {
@@ -378,7 +371,7 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        postMessageCallback.mock.calls[0][0].eventListener({ key: "d" });
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ key: "d" } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(0);
     });
     test("should run an action if the id matches", () => {

--- a/packages/tooling/fast-tooling/src/message-system-service/shortcuts.service.spec.ts
+++ b/packages/tooling/fast-tooling/src/message-system-service/shortcuts.service.spec.ts
@@ -196,7 +196,9 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ metaKey: true } as any);
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({
+            metaKey: true,
+        } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should pass alt key if alt key is used", () => {
@@ -231,7 +233,9 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ altKey: true } as any);
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({
+            altKey: true,
+        } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should pass ctrl key if ctrl key is used", () => {
@@ -266,7 +270,9 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ ctrlKey: true } as any);
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({
+            ctrlKey: true,
+        } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should pass shift key if shift key is used", () => {
@@ -301,7 +307,9 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ shiftKey: true } as any);
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({
+            shiftKey: true,
+        } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should pass a specific key if a specific key is used", () => {
@@ -336,7 +344,9 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ key: "d" } as any);
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({
+            key: "d",
+        } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(1);
     });
     test("should not invoke an action if the keys do not match", () => {
@@ -371,7 +381,9 @@ describe("Shortcuts", () => {
                 },
             } as any);
         });
-        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({ key: "d" } as any);
+        (messageSystem.getConfigById(shortcutsId) as ShortcutsConfig).eventListener({
+            key: "d",
+        } as any);
         expect(shortcutAction).toHaveBeenCalledTimes(0);
     });
     test("should run an action if the id matches", () => {


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

This change fixes the issue where the event listener was passed through postMessage which should only accent JSON data but was passing tests as the test environment did not throw an error. It will now be passed to the message system which can be retrieved by other services after initialization.

Reliant on the completion of #4355

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->