### PR TITLE
fix: remove redundant slot from DataDictionary when mapping an HTML string

### DIFF
--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.spec.ts
@@ -41,6 +41,10 @@ const inputSchema = {
         name: {
             type: DataType.string,
         },
+        SlotBar: {
+            [ReservedElementMappingKeyword.mapsToSlot]: "bar",
+            ...linkedDataSchema,
+        },
     },
 };
 
@@ -118,6 +122,19 @@ describe("mapVSCodeParsedHTMLToDataDictionary", () => {
             data: {
                 id: "bar",
             },
+        });
+    });
+    test("should return a DataDictionary containing an HTML element without a slot attribute as part of the data if an HTML element with a slot attribute has been passed", () => {
+        const value = mapVSCodeParsedHTMLToDataDictionary({
+            value: ['<input slot="bar" />'],
+            schemaDictionary: {
+                [inputSchema.id]: inputSchema,
+            },
+        });
+        const root: string = value[1];
+        expect(value[0][root]).toEqual({
+            schemaId: inputSchema.id,
+            data: {},
         });
     });
     test("should return a DataDictionary containing an HTML element with a number attribute if an HTML element with a number attribute has been passed", () => {

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.ts
@@ -49,19 +49,25 @@ function mapAttributesAndSlotsToData(
                 }
             }
 
-            try {
-                const parsedValue = JSON.parse(attributeValue);
+            if (attributeKey !== "slot") {
+                try {
+                    const parsedValue = JSON.parse(attributeValue);
 
-                return [attributeKey, parsedValue === null ? true : parsedValue];
-            } catch (e) {
-                return [attributeKey, ""];
+                    return [attributeKey, parsedValue === null ? true : parsedValue];
+                } catch (e) {
+                    return [attributeKey, ""];
+                }
             }
         })
         .reduce((previousValue, currentValue) => {
-            return {
-                ...previousValue,
-                [currentValue[0]]: currentValue[1],
-            };
+            if (currentValue) {
+                return {
+                    ...previousValue,
+                    [currentValue[0]]: currentValue[1],
+                };
+            }
+
+            return previousValue;
         }, slotAttributes);
 }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

This fixes an issue where the `slot` HTML attribute was added to the data, however this is already taken care of in the mapped `DataDictionary` structure and thus can result in duplicates.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->