### PR TITLE
fix: default selected option in listbox

### DIFF
--- a/packages/web-components/fast-components/src/listbox/fixtures/base.html
+++ b/packages/web-components/fast-components/src/listbox/fixtures/base.html
@@ -1,16 +1,83 @@
 <h1>Listbox</h1>
+
 <h2>Default</h2>
-<fast-listbox>
-    <fast-option>This option has no value</fast-option>
-    <fast-option disabled>This option is disabled</fast-option>
-    <fast-option value="hi">This option has a value</fast-option>
-    <fast-option selected>This option is selected by default</fast-option>
+<fast-listbox id="listbox">
+    <fast-option>William Hartnell</fast-option>
+    <fast-option>Patrick Troughton</fast-option>
+    <fast-option>Jon Pertwee</fast-option>
+    <fast-option>Tom Baker</fast-option>
+    <fast-option>Peter Davidson</fast-option>
+    <fast-option>Colin Baker</fast-option>
+    <fast-option>Sylvester McCoy</fast-option>
+    <fast-option>Paul McGann</fast-option>
+    <fast-option>Christopher Eccleston</fast-option>
+    <fast-option>David Tenant</fast-option>
+    <fast-option>Matt Smith</fast-option>
+    <fast-option>Peter Capaldi</fast-option>
+    <fast-option>Jodie Whittaker</fast-option>
 </fast-listbox>
 
-<h2>No Options</h2>
-<fast-listbox></fast-listbox>
+<h2>Listbox with a default selected item</h2>
+<fast-listbox id="listbox-with-default">
+    <fast-option>John</fast-option>
+    <fast-option>Paul</fast-option>
+    <fast-option selected>George</fast-option>
+    <fast-option>Ringo</fast-option>
+</fast-listbox>
 
-<h2>Long list</h2>
+<h2>Listbox with disabled items</h2>
+<fast-listbox id="listbox-with-every-other-disabled">
+    <fast-option>Extra Small</fast-option>
+    <fast-option disabled>Small</fast-option>
+    <fast-option>Medium</fast-option>
+    <fast-option disabled>Large</fast-option>
+    <fast-option>Extra Large</fast-option>
+</fast-listbox>
+
+<fast-listbox id="listbox-with-adjacent-disabled-start">
+    <fast-option disabled>Extra Small</fast-option>
+    <fast-option disabled>Small</fast-option>
+    <fast-option>Medium</fast-option>
+    <fast-option>Large</fast-option>
+    <fast-option>Extra Large</fast-option>
+</fast-listbox>
+
+<fast-listbox id="listbox-with-adjacent-disabled-middle">
+    <fast-option>Extra Small</fast-option>
+    <fast-option disabled>Small</fast-option>
+    <fast-option disabled>Medium</fast-option>
+    <fast-option>Large</fast-option>
+    <fast-option>Extra Large</fast-option>
+</fast-listbox>
+
+<fast-listbox id="listbox-with-adjacent-disabled-end">
+    <fast-option>Extra Small</fast-option>
+    <fast-option>Small</fast-option>
+    <fast-option>Medium</fast-option>
+    <fast-option disabled>Large</fast-option>
+    <fast-option disabled>Extra Large</fast-option>
+</fast-listbox>
+
+<fast-listbox id="listbox-with-all-but-one-disabled">
+    <fast-option disabled>Extra Small</fast-option>
+    <fast-option disabled>Small</fast-option>
+    <fast-option disabled>Medium</fast-option>
+    <fast-option disabled>Large</fast-option>
+    <fast-option>Extra Large</fast-option>
+</fast-listbox>
+
+<fast-listbox id="listbox-with-all-disabled">
+    <fast-option disabled>Extra Small</fast-option>
+    <fast-option disabled>Small</fast-option>
+    <fast-option disabled>Medium</fast-option>
+    <fast-option disabled>Large</fast-option>
+    <fast-option disabled>Extra Large</fast-option>
+</fast-listbox>
+
+<h2>Empty Listbox</h2>
+<fast-listbox id="listbox-empty"></fast-listbox>
+
+<h2>Listbox with long list</h2>
 <fast-listbox>
     <fast-option value="AL">Alabama</fast-option>
     <fast-option value="AK">Alaska</fast-option>

--- a/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
@@ -73,4 +73,34 @@ describe("Listbox", () => {
 
         await disconnect();
     });
+
+    it("should select the first option when no options have the `selected` attribute", async () => {
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
+
+        await connect();
+
+        expect(element.selectedIndex).to.equal(0);
+
+        expect(element.selectedOptions).to.contain(option1);
+        expect(element.selectedOptions).to.not.contain(option2);
+        expect(element.selectedOptions).to.not.contain(option3);
+
+        await disconnect();
+    });
+
+    it("should select the option with a `selected` attribute", async () => {
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
+
+        option2.setAttribute("selected", "");
+
+        await connect();
+
+        expect(element.selectedIndex).to.equal(1);
+
+        expect(element.selectedOptions).to.not.contain(option1);
+        expect(element.selectedOptions).to.contain(option2);
+        expect(element.selectedOptions).to.not.contain(option3);
+
+        await disconnect();
+    });
 });

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -144,8 +144,8 @@ export class Listbox extends FASTElement {
      */
     protected setDefaultSelectedOption() {
         if (this.options && this.$fastController.isConnected) {
-            const selectedIndex = this.options.findIndex(el =>
-                el.getAttribute("selected")
+            const selectedIndex = this.options.findIndex(
+                el => el.getAttribute("selected") !== null
             );
 
             if (selectedIndex !== -1) {

--- a/packages/web-components/fast-foundation/src/select/select.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.spec.ts
@@ -90,11 +90,33 @@ describe("Select", () => {
     });
 
     it("should set its value to the first enabled option", async () => {
-        const { element, connect, disconnect } = await setup();
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
 
         await connect();
 
         expect(element.value).to.equal("one");
+        expect(element.selectedIndex).to.equal(0);
+
+        expect(element.selectedOptions).to.contain(option1);
+        expect(element.selectedOptions).to.not.contain(option2);
+        expect(element.selectedOptions).to.not.contain(option3);
+
+        await disconnect();
+    });
+
+    it("should select the first option with a `selected` attribute", async () => {
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
+
+        option2.setAttribute("selected", "");
+
+        await connect();
+
+        expect(element.value).to.equal("two");
+        expect(element.selectedIndex).to.equal(1);
+
+        expect(element.selectedOptions).to.not.contain(option1);
+        expect(element.selectedOptions).to.contain(option2);
+        expect(element.selectedOptions).to.not.contain(option3);
 
         await disconnect();
     });


### PR DESCRIPTION
# Description

- Check for a non-null value when finding the default selected listbox option
- Update listbox fixture content to be more usable

## Motivation & context
Setting the `selected` attribute on a `<fast-option>` in a `<fast-listbox>` or `<fast-select>` wasn't being handled properly on page load.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.