### PR TITLE
fix: adjust automapping of native html element definitions

### DIFF
--- a/sites/site-utilities/src/definitions/native/common.definition.ts
+++ b/sites/site-utilities/src/definitions/native/common.definition.ts
@@ -5,6 +5,7 @@ export const commonHTMLAttributes: WebComponentAttribute[] = [
     {
         name: "style",
         type: DataType.string,
+        title: "CSS",
         description: "The inline CSS style",
         default: "",
         required: false,

--- a/sites/site-utilities/src/definitions/native/html-native.definition.ts
+++ b/sites/site-utilities/src/definitions/native/html-native.definition.ts
@@ -25,6 +25,7 @@ const valueSets: VSCodeNativeHTMLValueSet[] = vscodeHTMLData.valueSets;
 const defaultSlotValue: WebComponentSlot[] = [
     {
         name: "",
+        title: "Default slot",
         description: "The default slot",
     },
 ];
@@ -67,6 +68,7 @@ function convertAttributeData(tag: VSCodeNativeHTMLTag): WebComponentAttribute[]
     return tag.attributes?.map((attribute: VSCodeNativeHTMLAttribute) => {
         return {
             name: attribute.name,
+            title: attribute.name,
             description: attribute.name,
             type: getDataTypeForAttribute(attribute),
             default: "",
@@ -80,6 +82,7 @@ const convertedTags: WebComponentDefinitionTag[] = (vscodeHTMLData as VSCodeNati
     (tag: VSCodeNativeHTMLTag): WebComponentDefinitionTag => {
         const newWebComponentDefinitionTag: WebComponentDefinitionTag = {
             name: tag.name,
+            title: tag.name,
             description:
                 typeof tag.description === "string"
                     ? tag.description

--- a/sites/site-utilities/src/definitions/native/html-native.definition.ts
+++ b/sites/site-utilities/src/definitions/native/html-native.definition.ts
@@ -69,7 +69,6 @@ function convertAttributeData(tag: VSCodeNativeHTMLTag): WebComponentAttribute[]
         return {
             name: attribute.name,
             title: attribute.name,
-            description: attribute.name,
             type: getDataTypeForAttribute(attribute),
             default: "",
             required: false,


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
This maps the native HTML definitions to JSON schema using the new structure.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
Incorrect titles in the native HTML element definitions were being mapped.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->