### PR TITLE
fix: anchored region pointer-events value should be controllable after initial layout

### DIFF
--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.styles.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.styles.ts
@@ -4,5 +4,11 @@ export const AnchoredRegionStyles = css`
     :host {
         contain: layout;
         display: block;
+        pointer-events: "none";
+    }
+
+    :host(.loading) {
+        pointer-events: "none";
+        opacity: 0;
     }
 `;

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.styles.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.styles.ts
@@ -4,11 +4,5 @@ export const AnchoredRegionStyles = css`
     :host {
         contain: layout;
         display: block;
-        pointer-events: "none";
-    }
-
-    :host(.loading) {
-        pointer-events: "none";
-        opacity: 0;
     }
 `;

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -901,10 +901,12 @@ export class AnchoredRegion extends FASTElement {
         this.classList.toggle("inset-left", this.horizontalPosition === "insetLeft");
         this.classList.toggle("inset-right", this.horizontalPosition === "insetRight");
 
+        // this.classList.toggle("loading", !this.initialLayoutComplete);
+
+        this.style.opacity = this.initialLayoutComplete ? "1" : "0";
+        this.style.pointerEvents = this.initialLayoutComplete ? "" : "none";
         this.style.position = this.fixedPlacement ? "fixed" : "absolute";
         this.style.transformOrigin = `${this.yTransformOrigin} ${this.xTransformOrigin}`;
-        this.style.opacity = this.initialLayoutComplete ? "1" : "0";
-        this.style.pointerEvents = this.initialLayoutComplete ? "unset" : "none";
 
         if (this.horizontalPositioningMode === "uncontrolled") {
             this.style.width = "unset";

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -901,10 +901,8 @@ export class AnchoredRegion extends FASTElement {
         this.classList.toggle("inset-left", this.horizontalPosition === "insetLeft");
         this.classList.toggle("inset-right", this.horizontalPosition === "insetRight");
 
-        // this.classList.toggle("loading", !this.initialLayoutComplete);
-
         this.style.opacity = this.initialLayoutComplete ? "1" : "0";
-        this.style.pointerEvents = this.initialLayoutComplete ? "" : "none";
+        this.style.pointerEvents = this.initialLayoutComplete ? "${void}" : "none";
         this.style.position = this.fixedPlacement ? "fixed" : "absolute";
         this.style.transformOrigin = `${this.yTransformOrigin} ${this.xTransformOrigin}`;
 


### PR DESCRIPTION
# Description
Setting the anchored region's pointer-events css value to "unset" prevented devs from ever overriding it.  Setting it to void after initial placement permits that.  

## Motivation & context
Trying to set pointer-events for an anchored region during development didn't work as expected.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
