### PR TITLE
feat(di): enable use of the inject decorator on properties

### DIFF
--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -726,7 +726,7 @@ export const DI: Readonly<{
     getDependencies(Type: Constructable | Injectable): Key[];
     defineProperty(target: {}, propertyName: string, key: Key, respectConnection?: boolean): void;
     createInterface<K extends Key>(nameConfigOrCallback?: string | InterfaceConfiguration | ((builder: ResolverBuilder<K>) => Resolver<K>) | undefined, configuror?: ((builder: ResolverBuilder<K>) => Resolver<K>) | undefined): InterfaceSymbol<K>;
-    inject(...dependencies: Key[]): (target: Injectable, key?: string | number | undefined, descriptor?: number | PropertyDescriptor | undefined) => void;
+    inject(...dependencies: Key[]): (target: any, key?: string | number | undefined, descriptor?: number | PropertyDescriptor | undefined) => void;
     transient<T extends Constructable<{}>>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T>;
     singleton<T_1 extends Constructable<{}>>(target: T_1 & Partial<RegisterSelf<T_1>>, options?: SingletonOptions): T_1 & RegisterSelf<T_1>;
 }>;
@@ -998,7 +998,7 @@ export type HorizontalPosition = "start" | "end" | "left" | "right" | "unset";
 export function ignore(target: Injectable, property?: string | number, descriptor?: PropertyDescriptor | number): void;
 
 // @alpha (undocumented)
-export const inject: (...dependencies: Key[]) => (target: Injectable, key?: string | number | undefined, descriptor?: number | PropertyDescriptor | undefined) => void;
+export const inject: (...dependencies: Key[]) => (target: any, key?: string | number | undefined, descriptor?: number | PropertyDescriptor | undefined) => void;
 
 // @alpha (undocumented)
 export type Injectable<T = {}> = Constructable<T> & {

--- a/packages/web-components/fast-foundation/src/di/di.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.spec.ts
@@ -194,31 +194,20 @@ describe(`The inject decorator`, function () {
         expect(DI.getDependencies(Foo)).deep.eq([Dep1, Dep2, Dep3]);
     });
 
-    // it(`can decorate properties explicitly`, function () {
-    //     // @ts-ignore
-    //     class Foo {
-    //         @inject(Dep1) public dep1;
-    //         @inject(Dep2) public dep2;
-    //         @inject(Dep3) public dep3;
-    //     }
+    it(`can decorate properties explicitly`, function () {
+        // @ts-ignore
+        class Foo {
+            @inject(Dep1) public dep1;
+            @inject(Dep2) public dep2;
+            @inject(Dep3) public dep3;
+        }
 
-    //     expect(DI.getDependencies(Foo)["dep1"]).eq(Dep1, `Foo['inject'].dep1`);
-    //     expect(DI.getDependencies(Foo)["dep2"]).eq(Dep2, `Foo['inject'].dep2`);
-    //     expect(DI.getDependencies(Foo)["dep3"]).eq(Dep3, `Foo['inject'].dep3`);
-    // });
+        const instance = new Foo();
 
-    // it(`cannot decorate properties implicitly`, function () {
-    //     // @ts-ignore
-    //     class Foo {
-    //         @inject() public dep1: Dep1;
-    //         @inject() public dep2: Dep2;
-    //         @inject() public dep3: Dep3;
-    //     }
-
-    //     expect(DI.getDependencies(Foo)["dep1"]).eq(undefined, `Foo['inject'].dep1`);
-    //     expect(DI.getDependencies(Foo)["dep2"]).eq(undefined, `Foo['inject'].dep2`);
-    //     expect(DI.getDependencies(Foo)["dep3"]).eq(undefined, `Foo['inject'].dep3`);
-    // });
+        expect(instance.dep1).instanceof(Dep1);
+        expect(instance.dep2).instanceof(Dep2);
+        expect(instance.dep3).instanceof(Dep3);
+    });
 });
 
 describe(`The transient decorator`, function () {

--- a/packages/web-components/fast-foundation/src/di/di.ts
+++ b/packages/web-components/fast-foundation/src/di/di.ts
@@ -525,12 +525,12 @@ export const DI = Object.freeze({
     inject(
         ...dependencies: Key[]
     ): (
-        target: Injectable,
+        target: any,
         key?: string | number,
         descriptor?: PropertyDescriptor | number
     ) => void {
         return function (
-            target: Injectable,
+            target: any,
             key?: string | number,
             descriptor?: PropertyDescriptor | number
         ): void {
@@ -542,14 +542,7 @@ export const DI = Object.freeze({
                     annotationParamtypes[descriptor] = dep;
                 }
             } else if (key) {
-                // It's a property decorator. Not supported by the container without plugins.
-                const annotationParamtypes = DI.getOrCreateAnnotationParamTypes(
-                    ((target as unknown) as { constructor: Injectable }).constructor
-                );
-                const dep = dependencies[0];
-                if (dep !== void 0) {
-                    annotationParamtypes[key as number] = dep;
-                }
+                DI.defineProperty(target, key as string, dependencies[0]);
             } else {
                 const annotationParamtypes = descriptor
                     ? DI.getOrCreateAnnotationParamTypes(descriptor.value)


### PR DESCRIPTION
# Description

This PR enables the use of the `@inject` decorator and the `DI.inject` imperative API on properties of web components. This enables injecting concrete types without a special DI key and also the use of special resolvers such as `@all`.

### Example

```ts
export class MyComponent extends FASTEement {
  @inject(SomeConcreteThing) thing: SomeConcreteThing;
  @all(AnotherThing) otherStuff: AnotherThing[];
}
```

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.