### PR TITLE
fix:false positive test in breadcrumb.spec.js. The spec to not rende…

### DIFF
--- a/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.spec.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { Breadcrumb, BreadcrumbTemplate as template } from "./index";
 import { fixture } from "../fixture";
 import { customElement, html } from "@microsoft/fast-element";
+import { BreadcrumbItem } from "../breadcrumb-item";
 
 @customElement({
     name: "fast-breadcrumb",
@@ -51,9 +52,11 @@ describe("Breadcrumb", () => {
 
         await connect();
 
-        expect(
-            element.querySelectorAll("fast-breadcrumb-item")[2].getAttribute("separator")
-        ).to.equal(null);
+        let items: NodeListOf<BreadcrumbItem> = element.querySelectorAll("fast-breadcrumb-item");
+
+        let lastItem: BreadcrumbItem = items[items.length - 1];
+
+        expect(lastItem.separator).to.equal(false);
 
         await disconnect();
     });


### PR DESCRIPTION
Fix a false positive test in breadcrumb.spec.ts

# Description

There is passing test with a wrong expectation in breadcrumb.spec.ts. The assertion was checking against an attribute that doesn't exist in the component, **because it is a property.** Separator is not an attribute, it is a boolean property in BreadcrumbItem.ts

## Motivation & context

Breadcrumb.spec.ts line: 54
`expect(element.querySelectorAll("fast-breadcrumb-item")[2].getAttribute("separator")).to.equal(null);
`

 Instead of checking the attribute it should check the separator property. the expectation now looks like this
`expect(lastIem.separator).to.equal(false);`