### PR TITLE
docs(angular.md): add notes on ngDefaultControl

### DIFF
--- a/packages/web-components/fast-foundation/docs/integrations/angular.md
+++ b/packages/web-components/fast-foundation/docs/integrations/angular.md
@@ -129,13 +129,13 @@ fast-card > fast-button {
 }
 ```
 
-:::tip
+:::note
 
 Third party controls require a ControlValueAccessor for writing a value and listening to changes on input elements. Add ngDefaultControl attribute to your component to have two-way binding working with FormControlDirective, FormControlName or NgModel directives:
 
 :::
 
-```html 
+```html
 <fast-text-field placeholder="name" id="name" formControlName="name" ngDefaultControl></fast-text-field>
 ```
 

--- a/packages/web-components/fast-foundation/docs/integrations/angular.md
+++ b/packages/web-components/fast-foundation/docs/integrations/angular.md
@@ -129,7 +129,11 @@ fast-card > fast-button {
 }
 ```
 
+:::tip
+
 Third party controls require a ControlValueAccessor for writing a value and listening to changes on input elements. Add ngDefaultControl attribute to your component to have two-way binding working with FormControlDirective, FormControlName or NgModel directives:
+
+:::
 
 ```html 
 <fast-text-field placeholder="name" id="name" formControlName="name" ngDefaultControl></fast-text-field>

--- a/packages/web-components/fast-foundation/docs/integrations/angular.md
+++ b/packages/web-components/fast-foundation/docs/integrations/angular.md
@@ -129,4 +129,10 @@ fast-card > fast-button {
 }
 ```
 
+Third party controls require a ControlValueAccessor for writing a value and listening to changes on input elements. Add ngDefaultControl attribute to your component to have two-way binding working with FormControlDirective, FormControlName or NgModel directives:
+
+```html 
+<fast-text-field placeholder="name" id="name" formControlName="name" ngDefaultControl></fast-text-field>
+```
+
 Congratulations! You're now set up to use FAST and Angular!


### PR DESCRIPTION
tip to help with angular forms integration with input components

# Description

add default value accessor for input controls using ngDefaultControl