### PR TITLE
Revert "feat: allow users to update display text for a data dictionary and navigation dictionary (#4371)"

### DIFF
--- a/packages/tooling/fast-tooling/src/message-system/data.props.ts
+++ b/packages/tooling/fast-tooling/src/message-system/data.props.ts
@@ -46,11 +46,6 @@ export interface Data<T> {
     schemaId: string;
 
     /**
-     * The display text
-     */
-    displayText?: string;
-
-    /**
      * The parent in the data dictionary
      */
     parent?: Parent;

--- a/packages/tooling/fast-tooling/src/message-system/data.spec.ts
+++ b/packages/tooling/fast-tooling/src/message-system/data.spec.ts
@@ -1,9 +1,4 @@
-import {
-    getLinkedData,
-    getLinkedDataDictionary,
-    getLinkedDataList,
-    updateDataDictionaryDisplayText,
-} from "./data";
+import { getLinkedData, getLinkedDataDictionary, getLinkedDataList } from "./data";
 import { LinkedDataDictionaryUpdate, LinkedDataPromise } from "./data.props";
 
 describe("getLinkedDataDictionary", () => {
@@ -460,61 +455,5 @@ describe("getLinkedDataList", () => {
                 "bar"
             )
         ).toEqual(["bat", "baz"]);
-    });
-});
-
-describe("updateDataDictionaryDisplayText", () => {
-    test("should add display text if no display text exists", () => {
-        expect(
-            updateDataDictionaryDisplayText(
-                [
-                    {
-                        root: {
-                            schemaId: "foo",
-                            data: {},
-                        },
-                    },
-                    "root",
-                ],
-                "root",
-                "bar"
-            )
-        ).toEqual([
-            {
-                root: {
-                    schemaId: "foo",
-                    displayText: "bar",
-                    data: {},
-                },
-            },
-            "root",
-        ]);
-    });
-    test("should update display text if display text exists", () => {
-        expect(
-            updateDataDictionaryDisplayText(
-                [
-                    {
-                        root: {
-                            schemaId: "foo",
-                            displayText: "foo",
-                            data: {},
-                        },
-                    },
-                    "root",
-                ],
-                "root",
-                "bar"
-            )
-        ).toEqual([
-            {
-                root: {
-                    schemaId: "foo",
-                    displayText: "bar",
-                    data: {},
-                },
-            },
-            "root",
-        ]);
     });
 });

--- a/packages/tooling/fast-tooling/src/message-system/data.ts
+++ b/packages/tooling/fast-tooling/src/message-system/data.ts
@@ -152,16 +152,3 @@ export function getLinkedDataList(
 
     return linkedDataIds;
 }
-
-/**
- * Updates display text within the data dictionary
- */
-export function updateDataDictionaryDisplayText(
-    dataDictionary: DataDictionary<unknown>,
-    dictionaryId: string,
-    displayText: string
-): DataDictionary<unknown> {
-    dataDictionary[0][dictionaryId].displayText = displayText;
-
-    return dataDictionary;
-}

--- a/packages/tooling/fast-tooling/src/message-system/message-system.utilities.props.ts
+++ b/packages/tooling/fast-tooling/src/message-system/message-system.utilities.props.ts
@@ -19,7 +19,6 @@ export enum MessageSystemDataTypeAction {
     removeLinkedData = "remove-linked-data",
     addLinkedData = "add-linked-data",
     reorderLinkedData = "reorder-linked-data",
-    updateDisplayText = "update-display-text",
 }
 
 export enum MessageSystemNavigationDictionaryTypeAction {
@@ -114,28 +113,6 @@ export interface GetDataDictionaryMessageOutgoing<TConfig = {}>
     action: MessageSystemDataDictionaryTypeAction.get;
     dataDictionary: DataDictionary<unknown>;
     activeDictionaryId: string;
-}
-
-/**
- * The message to update display text in the data dictionary
- */
-export interface UpdateDisplayTextDataMessageIncoming<TConfig = {}>
-    extends ArbitraryMessageIncoming<TConfig> {
-    type: MessageSystemType.data;
-    action: MessageSystemDataTypeAction.updateDisplayText;
-    dictionaryId: string;
-    displayText: string;
-}
-
-/**
- * The message that display text in the data dictionary and navigation has been updated
- */
-export interface UpdateDisplayTextDataMessageOutgoing<TConfig = {}>
-    extends ArbitraryMessageOutgoing<TConfig> {
-    type: MessageSystemType.data;
-    action: MessageSystemDataTypeAction.updateDisplayText;
-    navigationDictionary: NavigationConfigDictionary;
-    dataDictionary: DataDictionary<unknown>;
 }
 
 /**
@@ -449,8 +426,7 @@ export type DataMessageIncoming =
     | AddDataMessageIncoming
     | AddLinkedDataDataMessageIncoming
     | RemoveLinkedDataDataMessageIncoming
-    | ReorderLinkedDataDataMessageIncoming
-    | UpdateDisplayTextDataMessageIncoming;
+    | ReorderLinkedDataDataMessageIncoming;
 
 /**
  * Outgoing data messages to the message system
@@ -462,8 +438,7 @@ export type DataMessageOutgoing =
     | UpdateDataMessageOutgoing
     | AddLinkedDataDataMessageOutgoing
     | RemoveLinkedDataDataMessageOutgoing
-    | ReorderLinkedDataDataMessageOutgoing
-    | UpdateDisplayTextDataMessageOutgoing;
+    | ReorderLinkedDataDataMessageOutgoing;
 
 /**
  * The message to update navigation

--- a/packages/tooling/fast-tooling/src/message-system/message-system.utilities.spec.ts
+++ b/packages/tooling/fast-tooling/src/message-system/message-system.utilities.spec.ts
@@ -25,7 +25,6 @@ import {
     UpdateActiveIdNavigationDictionaryMessageIncoming,
     UpdateActiveIdNavigationDictionaryMessageOutgoing,
     UpdateDataMessageOutgoing,
-    UpdateDisplayTextDataMessageOutgoing,
     ValidationMessageIncoming,
 } from "./message-system.utilities.props";
 import { MessageSystemType } from "./types";
@@ -939,59 +938,6 @@ describe("getMessage", () => {
             expect((message.data as any).linkedData.length).toEqual(2);
             expect((message.data as any).linkedData[0].id).toEqual("bar");
             expect((message.data as any).linkedData[1].id).toEqual("foo");
-        });
-        test("should return a data dictionary with updated display text", () => {
-            getMessage({
-                type: MessageSystemType.initialize,
-                data: [
-                    {
-                        data: {
-                            schemaId: "foo",
-                            data: {
-                                linkedData: [
-                                    {
-                                        id: "foo",
-                                    },
-                                    {
-                                        id: "bar",
-                                    },
-                                ],
-                            },
-                        },
-                        foo: {
-                            schemaId: "foo",
-                            data: {
-                                test: "hello world",
-                            },
-                        },
-                        bar: {
-                            schemaId: "foo",
-                            data: {
-                                test: "hello world",
-                            },
-                        },
-                    },
-                    "data",
-                ],
-                schemaDictionary: {
-                    foo: { id: "foo" },
-                },
-            });
-            const message: UpdateDisplayTextDataMessageOutgoing = getMessage({
-                type: MessageSystemType.data,
-                action: MessageSystemDataTypeAction.updateDisplayText,
-                displayText: "foobarbat",
-                dictionaryId: "data",
-            }) as UpdateDisplayTextDataMessageOutgoing;
-
-            expect((message as any).dataDictionary[0].data.displayText).toEqual(
-                "foobarbat"
-            );
-            expect(
-                (message as any).navigationDictionary[0].data[0][
-                    (message as any).navigationDictionary[0].data[1]
-                ].text
-            ).toEqual("foobarbat");
         });
     });
     describe("navigation", () => {

--- a/packages/tooling/fast-tooling/src/message-system/message-system.utilities.ts
+++ b/packages/tooling/fast-tooling/src/message-system/message-system.utilities.ts
@@ -4,11 +4,7 @@ import {
     getDataUpdatedWithoutSourceData,
     getDataUpdatedWithSourceData,
 } from "../data-utilities/relocate";
-import {
-    getLinkedDataDictionary,
-    getLinkedDataList,
-    updateDataDictionaryDisplayText,
-} from "./data";
+import { getLinkedDataDictionary, getLinkedDataList } from "./data";
 import { MessageSystemType } from "./types";
 import {
     DataDictionaryMessageIncoming,
@@ -411,23 +407,6 @@ function getDataMessage(data: DataMessageIncoming): DataMessageOutgoing {
                 navigation: navigationDictionary[0][activeDictionaryId],
                 navigationDictionary,
                 options: data.options,
-            };
-        case MessageSystemDataTypeAction.updateDisplayText:
-            dataDictionary = updateDataDictionaryDisplayText(
-                dataDictionary,
-                data.dictionaryId,
-                data.displayText
-            );
-            navigationDictionary = getNavigationDictionary(
-                schemaDictionary,
-                dataDictionary
-            );
-
-            return {
-                type: MessageSystemType.data,
-                action: MessageSystemDataTypeAction.updateDisplayText,
-                navigationDictionary,
-                dataDictionary,
             };
     }
 }

--- a/packages/tooling/fast-tooling/src/message-system/navigation.ts
+++ b/packages/tooling/fast-tooling/src/message-system/navigation.ts
@@ -18,7 +18,6 @@ function getNavigationRecursive(
     disabled: boolean,
     data?: any,
     dictionaryParent?: Parent,
-    displayText?: string,
     dataLocation: string = "",
     schemaLocation: string = "",
     parent: string | null = null,
@@ -32,8 +31,7 @@ function getNavigationRecursive(
         data,
         dataLocation,
         schemaLocation,
-        self,
-        displayText
+        self
     );
 
     return [
@@ -53,7 +51,7 @@ function getNavigationRecursive(
                 schema,
                 disabled,
                 data,
-                text: displayText && parent === null ? displayText : schema.title,
+                text: schema.title,
                 type: schema.type || DataType.unknown,
                 items: items.map((item: NavigationConfig) => {
                     return item[1];
@@ -73,10 +71,9 @@ function getNavigationRecursive(
 export function getNavigation(
     schema: any,
     data?: any,
-    parent?: Parent,
-    displayText?: string
+    parent?: Parent
 ): NavigationConfig {
-    return getNavigationRecursive(schema, !!schema.disabled, data, parent, displayText);
+    return getNavigationRecursive(schema, !!schema.disabled, data, parent);
 }
 
 export function getNavigationDictionary(
@@ -91,8 +88,7 @@ export function getNavigationDictionary(
                 [dataKey]: getNavigation(
                     schemaDictionary[data[0][dataKey].schemaId],
                     data[0][dataKey].data,
-                    data[0][dataKey].parent,
-                    data[0][dataKey].displayText
+                    data[0][dataKey].parent
                 ),
             },
             dataKey,
@@ -121,8 +117,7 @@ function getNavigationItems(
     data: any,
     dataLocation: string,
     schemaLocation: string,
-    parent: string,
-    displayText: string
+    parent: string
 ): NavigationConfig[] {
     const combiningKeyword: CombiningKeyword | void = schema[CombiningKeyword.oneOf]
         ? CombiningKeyword.oneOf
@@ -145,7 +140,6 @@ function getNavigationItems(
                 disabled || !!subSchema.disabled,
                 data,
                 undefined,
-                displayText,
                 dataLocation,
                 currentSchemaLocation,
                 parent,
@@ -163,7 +157,6 @@ function getNavigationItems(
                         disabled || !!schema.properties[propertyKey].disabled,
                         get(data, propertyKey) ? data[propertyKey] : void 0,
                         undefined,
-                        displayText,
                         dataLocation ? `${dataLocation}.${propertyKey}` : propertyKey,
                         schemaLocation
                             ? `${schemaLocation}.${PropertyKeyword.properties}.${propertyKey}`
@@ -180,7 +173,6 @@ function getNavigationItems(
                         disabled || !!schema.items.disabled,
                         data[index],
                         undefined,
-                        displayText,
                         `${dataLocation}[${index}]`,
                         schemaLocation
                             ? `${schemaLocation}.${itemsKeyword}`


### PR DESCRIPTION
This reverts commit d30fd5bd246a30b3dd1541b35c358eb7d7bf761a.

<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
An issue was found with integration in the Monaco Editor service where the data in Monaco must reflect values stored in the DataDictionary, the display text is outside these bounds and therefore this solution does not work.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->