### PR TITLE
feat: add placeholder attribute to combobox component

### DIFF
--- a/packages/web-components/fast-components/src/combobox/combobox.definition.ts
+++ b/packages/web-components/fast-components/src/combobox/combobox.definition.ts
@@ -47,6 +47,15 @@ export const fastComboboxDefinition: WebComponentDefinition = {
                     values: Object.keys(SelectPosition).map(x => ({ name: x })),
                 },
                 {
+                    name: "placeholder",
+                    title: "Placeholder",
+                    description:
+                        "Sets the placeholder value of the combobox to provide a hint to the user",
+                    required: false,
+                    type: DataType.string,
+                    default: undefined,
+                },
+                {
                     name: "value",
                     title: "Value",
                     description: "The initial value of the combobox",

--- a/packages/web-components/fast-components/src/combobox/fixtures/base.html
+++ b/packages/web-components/fast-components/src/combobox/fixtures/base.html
@@ -169,6 +169,15 @@
     <fast-option disabled>Extra Large</fast-option>
 </fast-combobox>
 
+<h2>Combobox with placeholder</h2>
+<fast-combobox placeholder="Please select a size" id="combobox-with-placeholder">
+    <fast-option>Extra Small</fast-option>
+    <fast-option>Small</fast-option>
+    <fast-option>Medium</fast-option>
+    <fast-option>Large</fast-option>
+    <fast-option>Extra Large</fast-option>
+</fast-combobox>
+
 <h2>Combobox with no items</h2>
 <fast-combobox id="combobox-with-no-items"></fast-combobox>
 

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -312,6 +312,7 @@ export class Combobox extends FormAssociatedCombobox {
     protected openChanged(): void;
     get options(): ListboxOption[];
     set options(value: ListboxOption[]);
+    placeholder: string;
     position: SelectPosition;
     positionAttribute: SelectPosition;
     role: SelectRole;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -313,6 +313,8 @@ export class Combobox extends FormAssociatedCombobox {
     get options(): ListboxOption[];
     set options(value: ListboxOption[]);
     placeholder: string;
+    // @internal
+    protected placeholderChanged(): void;
     position: SelectPosition;
     positionAttribute: SelectPosition;
     role: SelectRole;

--- a/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
@@ -226,6 +226,20 @@ describe("Combobox", () => {
         });
     });
 
+    it("should set the `placeholder` attribute on the internal control equal to the value provided", async () => {
+        const { element, connect, disconnect } = await setup();
+        const placeholder = "placeholder";
+
+        element.placeholder = placeholder;
+
+        await connect();
+        expect(
+            element.shadowRoot?.querySelector(".selected-value")?.getAttribute("placeholder")
+        ).to.equal(placeholder);
+
+        await disconnect();
+    });
+
     describe("when the owning form's reset() function is invoked", () => {
         it("should reset the value property to its initial value", async () => {
             const { connect, disconnect, element, parent } = await setup();

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -23,6 +23,7 @@ export const ComboboxTemplate = html<Combobox>`
                 <input
                     class="selected-value"
                     part="selected-value"
+                    placeholder="${x => x.placeholder}"
                     role="${x => x.role}"
                     type="text"
                     aria-activedescendant="${x =>

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -142,6 +142,21 @@ export class Combobox extends FormAssociatedCombobox {
     }
 
     /**
+     * Sets the placeholder value of the element, generally used to provide a hint to the user.
+     * @public
+     * @remarks
+     * HTML Attribute: placeholder
+     * Using this attribute is not a valid substitute for a labeling element.
+     */
+    @attr
+    public placeholder: string;
+    protected placeholderChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.placeholder = this.placeholder;
+        }
+    }
+
+    /**
      * The placement for the listbox when the combobox is open.
      *
      * @public

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -150,6 +150,11 @@ export class Combobox extends FormAssociatedCombobox {
      */
     @attr
     public placeholder: string;
+
+    /**
+     * Updates the placeholder on the proxy element.
+     * @internal
+     */
     protected placeholderChanged(): void {
         if (this.proxy instanceof HTMLElement) {
             this.proxy.placeholder = this.placeholder;


### PR DESCRIPTION
# Description
Adds a `placeholder` attribute to `<fast-combobox>`.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [x] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->