### PR TITLE
fix: conditionally render input container for menuitemcheckbox and menuitemradio

### DIFF
--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -18,39 +18,46 @@ export const MenuItemTemplate = html<MenuItem>`
         @mouseover="${(x, c) => x.handleMouseOver(c.event as MouseEvent)}"
         @mouseout="${(x, c) => x.handleMouseOut(c.event as MouseEvent)}"
         class="${x => (x.disabled ? "disabled" : "")} ${x =>
-            x.expanded ? "expanded" : ""}"
+    x.expanded ? "expanded" : ""}"
     >
-        <div part="input-container" class="input-container">
+        
             ${when(
                 x => x.role === MenuItemRole.menuitemcheckbox,
                 html<MenuItem>`
-                    <span part="checkbox" class="checkbox">
-                        <slot name="checkbox-indicator">
-                            <svg
-                                aria-hidden="true"
-                                part="checkbox-indicator"
-                                class="checkbox-indicator"
-                                viewBox="0 0 20 20"
-                                xmlns="http://www.w3.org/2000/svg"
-                            >
-                                <path
-                                    fill-rule="evenodd"
-                                    clip-rule="evenodd"
-                                    d="M8.143 12.6697L15.235 4.5L16.8 5.90363L8.23812 15.7667L3.80005 11.2556L5.27591 9.7555L8.143 12.6697Z"
-                                />
-                            </svg>
-                        </slot>
-                    </span>
+                    <div part="input-container" class="input-container">
+                        <span part="checkbox" class="checkbox">
+                            <slot name="checkbox-indicator">
+                                <svg
+                                    aria-hidden="true"
+                                    part="checkbox-indicator"
+                                    class="checkbox-indicator"
+                                    viewBox="0 0 20 20"
+                                    xmlns="http://www.w3.org/2000/svg"
+                                >
+                                    <path
+                                        fill-rule="evenodd"
+                                        clip-rule="evenodd"
+                                        d="M8.143 12.6697L15.235 4.5L16.8 5.90363L8.23812 15.7667L3.80005 11.2556L5.27591 9.7555L8.143 12.6697Z"
+                                    />
+                                </svg>
+                            </slot>
+                        </span>
+                    </div>
                 `
             )}
             ${when(
                 x => x.role === MenuItemRole.menuitemradio,
                 html<MenuItem>`
-                    <span part="radio" class="radio">
-                        <slot name="radio-indicator">
-                            <span part="radio-indicator" class="radio-indicator"></span>
-                        </slot>
-                    </span>
+                    <div part="input-container" class="input-container">
+                        <span part="radio" class="radio">
+                            <slot name="radio-indicator">
+                                <span
+                                    part="radio-indicator"
+                                    class="radio-indicator"
+                                ></span>
+                            </slot>
+                        </span>
+                    </div>
                 `
             )}
         </div>


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

## Motivation & context
A breaking change was unintentionally introduced to menu items with the addition of menuitemcheckbox and menuitemradio styles. The internal template structure was changed which can create breaking changes for others in fast foundation. This PR updates the template to conditionally render the `input-container` only when a control which requires an input is included.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->