### PR TITLE
feat: add auto-update attribute for anchored region

### DIFF
--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
@@ -154,17 +154,8 @@ export const fastAnchoredRegionDefinition: WebComponentDefinition = {
                     description:
                         "Defines whether the component automatically updates its position",
                     type: DataType.string,
-                    values: [{ name: "none" }, { name: "auto" }, { name: "constant" }],
+                    values: [{ name: "anchor" }, { name: "auto" }],
                     default: "none",
-                    required: false,
-                },
-                {
-                    name: "auto-update-interval",
-                    title: "Auto update interval",
-                    description:
-                        "The time in ms between position checks when the component is auto updating.",
-                    type: DataType.number,
-                    default: undefined,
                     required: false,
                 },
             ],

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
@@ -154,7 +154,7 @@ export const fastAnchoredRegionDefinition: WebComponentDefinition = {
                     description:
                         "Defines whether the component automatically updates its position",
                     type: DataType.string,
-                    values: [{ name: "none" }, { name: "auto" }, { name: "constant" }],
+                    values: [{ name: "none" }, { name: "constant" }],
                     default: "none",
                     required: false,
                 },

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
@@ -154,7 +154,7 @@ export const fastAnchoredRegionDefinition: WebComponentDefinition = {
                     description:
                         "Defines whether the component automatically updates its position",
                     type: DataType.string,
-                    values: [{ name: "none" }, { name: "constant" }],
+                    values: [{ name: "none" }, { name: "auto" }, { name: "constant" }],
                     default: "none",
                     required: false,
                 },

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
@@ -89,7 +89,6 @@ export const fastAnchoredRegionDefinition: WebComponentDefinition = {
                     default: "content",
                     required: false,
                 },
-
                 {
                     name: "vertical-positioning-mode",
                     title: "Vertical positioning mode",
@@ -147,6 +146,25 @@ export const fastAnchoredRegionDefinition: WebComponentDefinition = {
                         "Fixed placement allows the region to break out of parent containers",
                     type: DataType.boolean,
                     default: false,
+                    required: false,
+                },
+                {
+                    name: "auto-update-mode",
+                    title: "Auto update mode",
+                    description:
+                        "Defines whether the component automatically updates its position",
+                    type: DataType.string,
+                    values: [{ name: "none" }, { name: "auto" }, { name: "constant" }],
+                    default: "none",
+                    required: false,
+                },
+                {
+                    name: "auto-update-interval",
+                    title: "Auto update interval",
+                    description:
+                        "The time in ms between position checks when the component is auto updating.",
+                    type: DataType.number,
+                    default: undefined,
                     required: false,
                 },
             ],

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
@@ -155,7 +155,7 @@ export const fastAnchoredRegionDefinition: WebComponentDefinition = {
                         "Defines whether the component automatically updates its position",
                     type: DataType.string,
                     values: [{ name: "anchor" }, { name: "auto" }],
-                    default: "none",
+                    default: "anchor",
                     required: false,
                 },
             ],

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
@@ -88,6 +88,16 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
                 scalingViewportPreviousXValue = target.scrollLeft;
                 scalingViewportPreviousYValue = target.scrollTop;
             });
+
+        const regionAutoUpdateAuto = document.getElementById(
+            "region-auto-update-auto"
+        ) as FASTAnchoredRegion;
+
+        const viewportAutoUpdateAuto = document.getElementById(
+            "viewport-auto-update-auto"
+        ) as HTMLElement;
+
+        viewportAutoUpdateAuto.onscroll = regionAutoUpdateAuto.update;
     }
 });
 

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
@@ -88,16 +88,6 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
                 scalingViewportPreviousXValue = target.scrollLeft;
                 scalingViewportPreviousYValue = target.scrollTop;
             });
-
-        const regionAutoUpdateAuto = document.getElementById(
-            "region-auto-update-auto"
-        ) as FASTAnchoredRegion;
-
-        const viewportAutoUpdateAuto = document.getElementById(
-            "viewport-auto-update-auto"
-        ) as HTMLElement;
-
-        viewportAutoUpdateAuto.onscroll = regionAutoUpdateAuto.update;
     }
 });
 

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -5,7 +5,6 @@
     vertical-inset="true"
     horizontal-positioning-mode="locktodefault"
     horizontal-default-position="right"
-    horizontal-scaling="fit-content"
     style="z-index: 11;"
 >
     <div style="height: 100%; width: 100%; background: blue;">
@@ -494,6 +493,39 @@
                 horizontal-default-position="end"
             >
                 <div style="height: 100px; width: 100px; background: green;"></div>
+            </fast-anchored-region>
+        </div>
+    </div>
+
+    <h2>Auto update constant</h2>
+    <div
+        id="viewport-auto-update-constant"
+        style="
+            height: 400px;
+            width: 400px;
+            background: lightgray;
+            overflow: scroll;
+            position: relative;
+        "
+    >
+        <div style="height: 1000px; width: 1000px; overflow: hidden;">
+            <button
+                id="anchor-auto-update-constant"
+                style="margin-left: 500px; margin-top: 500px;"
+            >
+                anchor
+            </button>
+            <fast-anchored-region
+                auto-update-mode="constant"
+                id="region-auto-update-constant"
+                anchor="anchor-auto-update-constant"
+                viewport="viewport-auto-update-constant"
+                vertical-positioning-mode="dynamic"
+                vertical-scaling="fill"
+                horizontal-positioning-mode="dynamic"
+                horizontal-scaling="fill"
+            >
+                <div style="height: 100%; width: 100%; background: yellow;"></div>
             </fast-anchored-region>
         </div>
     </div>

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -529,6 +529,39 @@
             </fast-anchored-region>
         </div>
     </div>
+
+    <h2>Auto update auto</h2>
+    <div
+        id="viewport-auto-update-auto"
+        style="
+            height: 400px;
+            width: 400px;
+            background: lightgray;
+            overflow: scroll;
+            position: relative;
+        "
+    >
+        <div style="height: 1000px; width: 1000px; overflow: hidden;">
+            <button
+                id="anchor-auto-update-auto"
+                style="margin-left: 500px; margin-top: 500px;"
+            >
+                anchor
+            </button>
+            <fast-anchored-region
+                auto-update-mode="auto"
+                id="region-auto-update-auto"
+                anchor="anchor-auto-update-auto"
+                viewport="viewport-auto-update-auto"
+                vertical-positioning-mode="dynamic"
+                vertical-scaling="fill"
+                horizontal-positioning-mode="dynamic"
+                horizontal-scaling="fill"
+            >
+                <div style="height: 100%; width: 100%; background: yellow;"></div>
+            </fast-anchored-region>
+        </div>
+    </div>
 </div>
 <fast-anchored-region
     anchor="anchor-fixed"

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -529,39 +529,6 @@
             </fast-anchored-region>
         </div>
     </div>
-
-    <h2>Auto update auto</h2>
-    <div
-        id="viewport-auto-update-auto"
-        style="
-            height: 400px;
-            width: 400px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
-        "
-    >
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button
-                id="anchor-auto-update-auto"
-                style="margin-left: 500px; margin-top: 500px;"
-            >
-                anchor
-            </button>
-            <fast-anchored-region
-                auto-update-mode="auto"
-                id="region-auto-update-auto"
-                anchor="anchor-auto-update-auto"
-                viewport="viewport-auto-update-auto"
-                vertical-positioning-mode="dynamic"
-                vertical-scaling="fill"
-                horizontal-positioning-mode="dynamic"
-                horizontal-scaling="fill"
-            >
-                <div style="height: 100%; width: 100%; background: yellow;"></div>
-            </fast-anchored-region>
-        </div>
-    </div>
 </div>
 <fast-anchored-region
     anchor="anchor-fixed"

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -497,39 +497,6 @@
         </div>
     </div>
 
-    <h2>Auto update constant</h2>
-    <div
-        id="viewport-auto-update-constant"
-        style="
-            height: 400px;
-            width: 400px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
-        "
-    >
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button
-                id="anchor-auto-update-constant"
-                style="margin-left: 500px; margin-top: 500px;"
-            >
-                anchor
-            </button>
-            <fast-anchored-region
-                auto-update-mode="constant"
-                id="region-auto-update-constant"
-                anchor="anchor-auto-update-constant"
-                viewport="viewport-auto-update-constant"
-                vertical-positioning-mode="dynamic"
-                vertical-scaling="fill"
-                horizontal-positioning-mode="dynamic"
-                horizontal-scaling="fill"
-            >
-                <div style="height: 100%; width: 100%; background: yellow;"></div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
     <h2>Auto update auto</h2>
     <div
         id="viewport-auto-update-auto"

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -151,8 +151,8 @@ export class ARIAGlobalStatesAndProperties {
     ariaRoledescription: string;
 }
 
-// @public
-export type AutoUpdateMode = "none" | "constant" | "auto";
+// @public (undocumented)
+export type AutoUpdateMode = "none" | "constant";
 
 // @beta
 export type AxisPositioningMode = "uncontrolled" | "locktodefault" | "dynamic";

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -88,7 +88,7 @@ export class AnchoredRegion extends FASTElement {
     adoptedCallback(): void;
     anchor: string;
     anchorElement: HTMLElement | null;
-    // @public (undocumented)
+    // (undocumented)
     autoUpdateMode: AutoUpdateMode;
     // @internal (undocumented)
     connectedCallback(): void;
@@ -149,7 +149,7 @@ export class ARIAGlobalStatesAndProperties {
     ariaRoledescription: string;
 }
 
-// @public
+// @beta
 export type AutoUpdateMode = "anchor" | "auto";
 
 // @beta

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -88,6 +88,10 @@ export class AnchoredRegion extends FASTElement {
     adoptedCallback(): void;
     anchor: string;
     anchorElement: HTMLElement | null;
+    // @public
+    autoUpdateInterval: number;
+    // @public (undocumented)
+    autoUpdateMode: AutoUpdateMode;
     // @internal (undocumented)
     connectedCallback(): void;
     // @internal (undocumented)
@@ -146,6 +150,9 @@ export class ARIAGlobalStatesAndProperties {
     ariaRelevant: "additions" | "additions text" | "all" | "removals" | "text";
     ariaRoledescription: string;
 }
+
+// @public (undocumented)
+export type AutoUpdateMode = "none" | "constant";
 
 // @beta
 export type AxisPositioningMode = "uncontrolled" | "locktodefault" | "dynamic";

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -151,8 +151,8 @@ export class ARIAGlobalStatesAndProperties {
     ariaRoledescription: string;
 }
 
-// @public (undocumented)
-export type AutoUpdateMode = "none" | "constant";
+// @public
+export type AutoUpdateMode = "none" | "constant" | "auto";
 
 // @beta
 export type AxisPositioningMode = "uncontrolled" | "locktodefault" | "dynamic";

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -88,8 +88,6 @@ export class AnchoredRegion extends FASTElement {
     adoptedCallback(): void;
     anchor: string;
     anchorElement: HTMLElement | null;
-    // @public
-    autoUpdateInterval: number;
     // @public (undocumented)
     autoUpdateMode: AutoUpdateMode;
     // @internal (undocumented)
@@ -152,7 +150,7 @@ export class ARIAGlobalStatesAndProperties {
 }
 
 // @public
-export type AutoUpdateMode = "none" | "constant" | "auto";
+export type AutoUpdateMode = "anchor" | "auto";
 
 // @beta
 export type AxisPositioningMode = "uncontrolled" | "locktodefault" | "dynamic";

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -197,8 +197,7 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 - vertical-inset - Boolean that indicates whether the region should overlap the anchor on the vertical axis. Default is false which places the region adjacent to the anchor element.
 - vertical-threshold - Numeric value that defines how small the region must be to the edge of the viewport to switch to the opposite side of the anchor. The component favors the default position until this value is crossed.  When there is not enough space on either side or the value is unset the side with the most space is chosen.
 - vertical-scaling - Can be 'anchor', 'fill' or 'content'. Default is 'content' 
-- auto-update-mode - Can be 'none' or 'constant'. Default is 'none' 
-- auto-update-interval - The duration in ms between position checks when auto-updating. Default is 30. 
+- auto-update-mode - Can be 'anchor' or 'auto'. Default is 'anchor'. In 'anchor' mode only anchor resizes and attribute changes will provoke an update.  In 'auto' mode the component also updates because of - any scroll event on the document, window resizes and viewport resizes. Authors can always provoke an update via the 'update()' function.
 
 *Properties:*
 - anchorElement - Holds a reference to the HTMLElement currently being used as the anchor.  Can be set directly or be populated by setting the anchor attribute.

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -197,7 +197,7 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 - vertical-inset - Boolean that indicates whether the region should overlap the anchor on the vertical axis. Default is false which places the region adjacent to the anchor element.
 - vertical-threshold - Numeric value that defines how small the region must be to the edge of the viewport to switch to the opposite side of the anchor. The component favors the default position until this value is crossed.  When there is not enough space on either side or the value is unset the side with the most space is chosen.
 - vertical-scaling - Can be 'anchor', 'fill' or 'content'. Default is 'content' 
-- auto-update-mode - Can be 'none', 'auto' or 'constant'. Default is 'none' 
+- auto-update-mode - Can be 'none' or 'constant'. Default is 'none' 
 - auto-update-interval - The duration in ms between position checks when auto-updating. Default is 30. 
 
 *Properties:*

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -10,14 +10,21 @@ It is envisioned that this component would be used as a building block for other
 
 ### Features
 
-- **Relative positioning:** Users can use it to position an element relative to another another element, like enabling a menu to open above or below a trigger button. Additionally, the same anchored region can change which element it is anchored to dynamically, for example a single tooltip instance in a page could be positioned next to any other element on the page by switching the anchor property of the anchored region that contains it.
+- **Relative positioning:** 
+Authors can use it to position an element relative to another another element, like enabling a menu to open above or below a trigger button. Additionally, the same anchored region can change which element it is anchored to dynamically, for example a single tooltip instance in a page could be positioned next to any other element on the page by switching the anchor property of the anchored region that contains it.
 
-- **Responsive positioning:** Users can use it to position an element relative to another element based on available space, for example a menu could open upwards if the trigger button is near the bottom of the page, and downwards if it is nearer the top.  Authors can call the component's update() function to reevaluate positioning.
+- **Responsive positioning:** 
+Authors can use it to position an element relative to another element based on available space, for example a menu could open upwards if the trigger button is near the bottom of the page, and downwards if it is nearer the top.  Authors can call the component's update() function to reevaluate positioning.
 
-- **Responsive scaling:** Users can use it to create a layout region that dynamically sizes depending on space between the anchor and the viewport elements.
+- **Responsive scaling:** 
+Authors can use it to create a layout region that dynamically sizes depending on space between the anchor and the viewport elements.
 
+- **Auto updating**
+Authors can control when the component updates its position after the initial render.
 
 For a more in-depth understanding of how this component works under the covers please refer to the [intersection observer api](https://developer.mozilla.org/en-US/docs/Web/API/Intersection_Observer_API). 
+
+
 
 ### Risks and Challenges
 - must keep an eye on performance
@@ -190,6 +197,8 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 - vertical-inset - Boolean that indicates whether the region should overlap the anchor on the vertical axis. Default is false which places the region adjacent to the anchor element.
 - vertical-threshold - Numeric value that defines how small the region must be to the edge of the viewport to switch to the opposite side of the anchor. The component favors the default position until this value is crossed.  When there is not enough space on either side or the value is unset the side with the most space is chosen.
 - vertical-scaling - Can be 'anchor', 'fill' or 'content'. Default is 'content' 
+- auto-update-mode - Can be 'none', 'auto' or 'constant'. Default is 'none' 
+- auto-update-interval - The duration in ms between position checks when auto-updating. Default is 30. 
 
 *Properties:*
 - anchorElement - Holds a reference to the HTMLElement currently being used as the anchor.  Can be set directly or be populated by setting the anchor attribute.

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -1,5 +1,10 @@
 import { attr, DOM, FASTElement, observable } from "@microsoft/fast-element";
-import { Direction, eventVisibilityChange } from "@microsoft/fast-web-utilities";
+import {
+    Direction,
+    eventVisibilityChange,
+    eventScroll,
+    eventResize,
+} from "@microsoft/fast-web-utilities";
 import { getDirection } from "../utilities";
 import { IntersectionService } from "./intersection-service";
 
@@ -48,9 +53,13 @@ export type HorizontalPosition = "start" | "end" | "left" | "right" | "unset";
 export type VerticalPosition = "top" | "bottom" | "unset";
 
 /**
- *
+ * Defines if the component updates its position automatically
+ * none - no auto updating
+ * constant - the component checks its position on a timer based on the auto-update-interval value
+ * auto - The component enters constant mode for 1000 ms after the last "triggering event", otherwise no timer based checking.
+ *        "triggering events" are: component initial layout, window resize, bubbled scroll events, and any call to to update()
  */
-export type AutoUpdateMode = "none" | "constant";
+export type AutoUpdateMode = "none" | "constant" | "auto";
 
 /**
  * @internal
@@ -316,12 +325,23 @@ export class AnchoredRegion extends FASTElement {
      */
     @attr({ attribute: "auto-update-mode" })
     public autoUpdateMode: AutoUpdateMode = "none";
-    private autoUpdateModeChanged(): void {
+    private autoUpdateModeChanged(
+        prevMode: AutoUpdateMode,
+        newMode: AutoUpdateMode
+    ): void {
         if (
             (this as FASTElement).$fastController.isConnected &&
             this.initialLayoutComplete
         ) {
-            if (this.autoUpdateMode === "constant") {
+            if (prevMode === "auto") {
+                this.stopAutoUpdateEventListeners();
+            }
+
+            if (newMode === "auto") {
+                this.startAutoUpdateEventListeners();
+            }
+
+            if (this.autoUpdateMode !== null) {
                 this.startUpdateTimer();
             } else {
                 this.clearUpdateTimer();
@@ -432,11 +452,25 @@ export class AnchoredRegion extends FASTElement {
     private updateTimer: number | null = null;
 
     /**
+     * The time in MS that the component will actively check for updates after the last
+     * "triggering event" when auto-update-mode is set to "auto"
+     */
+    private autoUpdateActiveModeDuration: number = 200;
+
+    /**
+     * Records the time at which the last auto update trigger event happened
+     */
+    private lastAutoUpdateTriggerTimestamp: number;
+
+    /**
      * @internal
      */
     connectedCallback() {
         super.connectedCallback();
         document.addEventListener(eventVisibilityChange, this.handleVisibilityChange);
+        if (this.autoUpdateMode === "auto") {
+            this.startAutoUpdateEventListeners();
+        }
         this.initialize();
     }
 
@@ -445,6 +479,9 @@ export class AnchoredRegion extends FASTElement {
      */
     public disconnectedCallback(): void {
         super.disconnectedCallback();
+        if (this.autoUpdateMode === "auto") {
+            this.stopAutoUpdateEventListeners();
+        }
         document.removeEventListener(eventVisibilityChange, this.handleVisibilityChange);
         this.stopObservers();
         this.disconnectResizeDetector();
@@ -461,12 +498,11 @@ export class AnchoredRegion extends FASTElement {
      * update position
      */
     public update = (): void => {
-        if (this.viewportRect === null || this.regionDimension === null) {
-            this.requestLayoutUpdate();
+        if (this.autoUpdateMode === "none") {
+            this.doUpdate();
             return;
         }
-
-        this.requestPositionUpdates();
+        this.startUpdateTimer();
     };
 
     /**
@@ -519,7 +555,7 @@ export class AnchoredRegion extends FASTElement {
             (this as FASTElement).$fastController.isConnected &&
             this.initialLayoutComplete
         ) {
-            this.update();
+            this.doUpdate();
         }
     }
 
@@ -800,11 +836,8 @@ export class AnchoredRegion extends FASTElement {
         if (!this.initialLayoutComplete) {
             return;
         }
-        entries.forEach((entry: ResizeObserverEntry) => {
-            if (entry.target === this.anchorElement) {
-                this.update();
-            }
-        });
+
+        this.update();
     };
 
     /**
@@ -1278,12 +1311,15 @@ export class AnchoredRegion extends FASTElement {
      * starts the update timer if not currently running
      */
     private startUpdateTimer = (): void => {
-        this.clearUpdateTimer();
+        this.lastAutoUpdateTriggerTimestamp = Date.now();
+        if (this.updateTimer !== null) {
+            return;
+        }
         if (
             !document.hidden &&
             this.initialLayoutComplete &&
             this.autoUpdateInterval > 0 &&
-            this.autoUpdateMode === "constant"
+            this.autoUpdateMode !== "none"
         ) {
             this.updateTimer = window.setInterval((): void => {
                 this.updateTimerTick();
@@ -1292,15 +1328,33 @@ export class AnchoredRegion extends FASTElement {
     };
 
     /**
-     *
+     * Auto update interval has passed
      */
     private updateTimerTick = (): void => {
         if (this.initialLayoutComplete) {
-            this.update();
+            this.doUpdate();
         }
-        if (document.hidden || this.autoUpdateMode !== "constant") {
+        if (
+            document.hidden ||
+            this.autoUpdateMode === "none" ||
+            (this.autoUpdateMode === "auto" && this.autoUpdateTimeStampExpired())
+        ) {
             this.clearUpdateTimer();
         }
+    };
+
+    /**
+     * check to see if enough time has passed since an auto update trigger event
+     * to stop
+     */
+    private autoUpdateTimeStampExpired = (): boolean => {
+        if (
+            this.lastAutoUpdateTriggerTimestamp + this.autoUpdateActiveModeDuration >
+            Date.now()
+        ) {
+            return true;
+        }
+        return false;
     };
 
     /**
@@ -1317,8 +1371,42 @@ export class AnchoredRegion extends FASTElement {
      * Restarts autoupdating when a hidden document is shown
      */
     private handleVisibilityChange = (): void => {
-        if (!document.hidden && this.autoUpdateMode === "constant") {
+        if (!document.hidden && this.autoUpdateMode !== "none") {
             this.startUpdateTimer();
+        }
+    };
+
+    /**
+     * internal version of update that does not reset autoUpdating
+     */
+    private doUpdate = (): void => {
+        if (this.viewportRect === null || this.regionDimension === null) {
+            this.requestLayoutUpdate();
+            return;
+        }
+
+        this.requestPositionUpdates();
+    };
+
+    /**
+     * starts event listeners that can trigger auto updating
+     */
+    private startAutoUpdateEventListeners = (): void => {
+        window.addEventListener(eventResize, this.startUpdateTimer);
+        window.addEventListener(eventScroll, this.startUpdateTimer, true);
+        if (this.resizeDetector !== null && this.viewportElement !== null) {
+            this.resizeDetector.observe(this.viewportElement);
+        }
+    };
+
+    /**
+     * stops event listeners that can trigger auto updating
+     */
+    private stopAutoUpdateEventListeners = (): void => {
+        window.removeEventListener(eventResize, this.startUpdateTimer);
+        window.removeEventListener(eventScroll, this.startUpdateTimer);
+        if (this.resizeDetector !== null && this.viewportElement !== null) {
+            this.resizeDetector.unobserve(this.viewportElement);
         }
     };
 }

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -56,6 +56,8 @@ export type VerticalPosition = "top" | "bottom" | "unset";
  * - the window resizes
  * - the viewport resizes
  * - any scroll event in the document
+ *
+ * @beta
  */
 export type AutoUpdateMode = "anchor" | "auto";
 
@@ -297,7 +299,7 @@ export class AnchoredRegion extends FASTElement {
     /**
      *
      *
-     * @public
+     * @beta
      * @remarks
      * HTML Attribute: auto-update-mode
      */

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -337,11 +337,11 @@ export class AnchoredRegion extends FASTElement {
                 this.stopAutoUpdateEventListeners();
             }
 
-            if (this.autoUpdateMode === "auto") {
+            if (newMode === "auto") {
                 this.startAutoUpdateEventListeners();
             }
 
-            if (this.autoUpdateMode === "constant" || this.autoUpdateMode === "auto") {
+            if (this.autoUpdateMode !== null) {
                 this.startUpdateTimer();
             } else {
                 this.clearUpdateTimer();
@@ -1330,7 +1330,7 @@ export class AnchoredRegion extends FASTElement {
     };
 
     /**
-     *
+     * Auto update interval has passed
      */
     private updateTimerTick = (): void => {
         if (this.initialLayoutComplete) {
@@ -1346,7 +1346,8 @@ export class AnchoredRegion extends FASTElement {
     };
 
     /**
-     *
+     * check to see if enough time has passed since an auto update trigger event
+     * to stop
      */
     private autoUpdateTimeStampExpired = (): boolean => {
         if (
@@ -1390,7 +1391,7 @@ export class AnchoredRegion extends FASTElement {
     };
 
     /**
-     *
+     * starts event listeners that can trigger auto updating
      */
     private startAutoUpdateEventListeners = (): void => {
         window.addEventListener(eventResize, this.startUpdateTimer);
@@ -1399,7 +1400,7 @@ export class AnchoredRegion extends FASTElement {
     };
 
     /**
-     *
+     * stops event listeners that can trigger auto updating
      */
     private stopAutoUpdateEventListeners = (): void => {
         window.removeEventListener(eventResize, this.startUpdateTimer);

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -420,6 +420,10 @@ export class AnchoredRegion extends FASTElement {
     private pendingReset: boolean = false;
     private currentDirection: Direction = Direction.ltr;
 
+    // defines how big a difference in pixels there must be between states to
+    // justify a layout update that affects the dom (prevents repeated sub-pixel corrections)
+    private updateThreshold: number = 0.5;
+
     private static intersectionService: IntersectionService = new IntersectionService();
 
     /**
@@ -726,6 +730,7 @@ export class AnchoredRegion extends FASTElement {
             return false;
         }
 
+        // don't update the dom unless there is a significant difference in rect positions
         if (
             this.regionRect === null ||
             this.anchorRect === null ||
@@ -754,12 +759,11 @@ export class AnchoredRegion extends FASTElement {
         rectA: DOMRect | ClientRect,
         rectB: DOMRect | ClientRect
     ): boolean => {
-        const threshold: number = 0.5;
         if (
-            Math.abs(rectA.top - rectB.top) > threshold ||
-            Math.abs(rectA.right - rectB.right) > threshold ||
-            Math.abs(rectA.bottom - rectB.bottom) > threshold ||
-            Math.abs(rectA.left - rectB.left) > threshold
+            Math.abs(rectA.top - rectB.top) > this.updateThreshold ||
+            Math.abs(rectA.right - rectB.right) > this.updateThreshold ||
+            Math.abs(rectA.bottom - rectB.bottom) > this.updateThreshold ||
+            Math.abs(rectA.left - rectB.left) > this.updateThreshold
         ) {
             return true;
         }

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -452,7 +452,12 @@ export class AnchoredRegion extends FASTElement {
      * update position
      */
     public update = (): void => {
-        this.doUpdate();
+        if (this.viewportRect === null || this.regionDimension === null) {
+            this.requestLayoutUpdate();
+            return;
+        }
+
+        this.requestPositionUpdates();
     };
 
     /**
@@ -500,7 +505,7 @@ export class AnchoredRegion extends FASTElement {
             (this as FASTElement).$fastController.isConnected &&
             this.initialLayoutComplete
         ) {
-            this.doUpdate();
+            this.update();
         }
     }
 
@@ -1248,18 +1253,6 @@ export class AnchoredRegion extends FASTElement {
         }
 
         return newRegionDimension;
-    };
-
-    /**
-     * internal version of update that does not reset autoUpdating
-     */
-    private doUpdate = (): void => {
-        if (this.viewportRect === null || this.regionDimension === null) {
-            this.requestLayoutUpdate();
-            return;
-        }
-
-        this.requestPositionUpdates();
     };
 
     /**

--- a/sites/site-utilities/statics/assets/components/fast-anchored-region.schema.json
+++ b/sites/site-utilities/statics/assets/components/fast-anchored-region.schema.json
@@ -124,6 +124,17 @@
       "mapsToAttribute": "fixed-placement",
       "type": "boolean"
     },
+    "auto-update-mode": {
+      "enum": [
+        "anchor",
+        "auto"
+      ],
+      "default": "anchor",
+      "title": "Auto update mode",
+      "description": "Defines whether the component automatically updates its position",
+      "mapsToAttribute": "auto-update-mode",
+      "type": "string"
+    },
     "Slot": {
       "title": "Default slot",
       "description": "The content of the anchored region",


### PR DESCRIPTION
# Description

Normally anchored region will only recalculate placement based on either attribute/prop changes, a resize event on the anchor element, or a call to update().  With this change we add an "auto-update" attribute to anchored region that allows for an additional mode - 'auto', which  will prompt the anchored region to additionally check it's placement when the window resizes, the viewport resizes and on any scroll event on the page.

## Motivation & context
Needed to support document level scaling menus.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [c] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
