### PR TITLE
(horizontal-scroll) performance improvements

### DIFF
--- a/packages/web-components/fast-components/src/horizontal-scroll/fixtures/horizontal-scroll.html
+++ b/packages/web-components/fast-components/src/horizontal-scroll/fixtures/horizontal-scroll.html
@@ -22,11 +22,11 @@
     }
 
     .top-align {
-        --scroll-align: top;
+        --scroll-align: flex-start;
     }
 
     .bottom-align {
-        --scroll-align: bottom;
+        --scroll-align: flex-end;
     }
 
     .full-width,

--- a/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.styles.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.styles.ts
@@ -1,5 +1,5 @@
 import { css } from "@microsoft/fast-element";
-import { DirectionalStyleSheetBehavior } from "@microsoft/fast-foundation";
+import { DirectionalStyleSheetBehavior, display } from "@microsoft/fast-foundation";
 
 const ltrActionsStyles = css`
     .scroll-prev {
@@ -7,32 +7,34 @@ const ltrActionsStyles = css`
         left: 0;
     }
 
-    .scroll.scroll-next:before {
+    .scroll.scroll-next::before,
+    .scroll-next .scroll-action {
         left: auto;
         right: 0;
+    }
+
+    .scroll.scroll-next::before {
         background: linear-gradient(to right, transparent, var(--scroll-fade-next));
     }
 
     .scroll-next .scroll-action {
-        left: auto;
-        right: 0;
         transform: translate(50%, -50%);
     }
 `;
 
 const rtlActionsStyles = css`
-    div.scroll-next {
+    .scroll.scroll-next {
         right: auto;
         left: 0;
     }
 
-    .scroll.scroll-next:before {
+    .scroll.scroll-next::before {
+        background: linear-gradient(to right, var(--scroll-fade-next), transparent);
         left: auto;
         right: 0;
-        background: linear-gradient(to right, var(--scroll-fade-next), transparent);
     }
 
-    .scroll.scroll-prev:before {
+    .scroll.scroll-prev::before {
         background: linear-gradient(to right, transparent, var(--scroll-fade-previous));
     }
 
@@ -57,35 +59,38 @@ export const ActionsStyles = css`
     }
 
     .scroll {
-        width: 100px;
-        position: absolute;
-        top: 0;
         bottom: 0;
-        right: 0;
         pointer-events: none;
+        position: absolute;
+        right: 0;
+        top: 0;
+        user-select: none;
+        width: 100px;
     }
 
     .scroll.disabled {
         display: none;
     }
 
-    .scroll:before {
+    .scroll::before,
+    .scroll-action {
+        left: 0;
+        position: absolute;
+    }
+
+    .scroll::before {
+        background: linear-gradient(to right, var(--scroll-fade-previous), transparent);
         content: "";
         display: block;
-        width: 100%;
         height: 100%;
-        position: absolute;
-        left: 0;
-        background: linear-gradient(to right, var(--scroll-fade-previous), transparent);
+        width: 100%;
     }
 
     .scroll-action {
-        position: absolute;
-        top: 50%;
-        left: 0;
-        right: auto;
-        transform: translate(-50%, -50%);
         pointer-events: auto;
+        right: auto;
+        top: 50%;
+        transform: translate(-50%, -50%);
     }
 `.withBehaviors(new DirectionalStyleSheetBehavior(ltrActionsStyles, rtlActionsStyles));
 
@@ -94,9 +99,9 @@ export const ActionsStyles = css`
  * @public
  */
 export const HorizontalScrollStyles = css`
-    :host {
-        --scroll-align: middle;
-        display: block;
+    ${display("block")} :host {
+        --scroll-align: center;
+        contain: layout;
         position: relative;
     }
 
@@ -110,26 +115,9 @@ export const HorizontalScrollStyles = css`
     }
 
     .content-container {
-        white-space: nowrap;
+        align-items: var(--scroll-align);
+        display: inline-flex;
+        flex-wrap: nowrap;
         position: relative;
     }
-
-    .content-container ::slotted(*) {
-        display: inline-block;
-        white-space: normal;
-        vertical-align: var(--scroll-align);
-    }
-`.withBehaviors(
-    new DirectionalStyleSheetBehavior(
-        css`
-            .content-container {
-                float: left;
-            }
-        `,
-        css`
-            .content-container {
-                float: right;
-            }
-        `
-    )
-);
+`;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1102,6 +1102,7 @@ export class HorizontalScroll extends FASTElement {
     resized(): void;
     scrollContainer: HTMLDivElement;
     scrolled(): void;
+    scrollItems: HTMLElement[];
     scrollToNext(): void;
     scrollToPosition(newPosition: number, position?: number): void;
     scrollToPrevious(): void;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -56,9 +56,6 @@ export const AccordionItemTemplate: import("@microsoft/fast-element").ViewTempla
 // @public
 export const AccordionTemplate: import("@microsoft/fast-element").ViewTemplate<Accordion, any>;
 
-// @public (undocumented)
-export const ActionsTemplate: import("@microsoft/fast-element").ViewTemplate<HorizontalScroll, any>;
-
 // @alpha (undocumented)
 export const all: (key: any, searchAncestors?: boolean | undefined) => ReturnType<typeof DI.inject>;
 

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
@@ -1,22 +1,6 @@
-import { elements, html, ref, slotted } from "@microsoft/fast-element";
+import { elements, html, ref, slotted, when } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns";
 import { HorizontalScroll } from "./horizontal-scroll";
-
-/**
- * @public
- */
-export const ActionsTemplate = html<HorizontalScroll>`
-    <div ${ref("previousFlipper")} class="scroll scroll-prev">
-        <div @click="${x => x.scrollToPrevious()}" class="scroll-action">
-            <slot name="previous-flipper"></slot>
-        </div>
-    </div>
-    <div ${ref("nextFlipper")} class="scroll scroll-next">
-        <div @click="${x => x.scrollToNext()}" class="scroll-action">
-            <slot name="next-flipper"></slot>
-        </div>
-    </div>
-`;
 
 /**
  * @public
@@ -27,8 +11,8 @@ export const HorizontalScrollTemplate = html<HorizontalScroll>`
         <div class="scroll-area">
             <div
                 class="scroll-view"
-                ${ref("scrollContainer")}
                 @scroll="${x => x.scrolled()}"
+                ${ref("scrollContainer")}
             >
                 <div class="content-container">
                     <slot
@@ -39,7 +23,29 @@ export const HorizontalScrollTemplate = html<HorizontalScroll>`
                     ></slot>
                 </div>
             </div>
-            ${x => (x.view === "mobile" ? "" : ActionsTemplate)}
+            ${when(
+                x => x.view !== "mobile",
+                html<HorizontalScroll>`
+                    <div
+                        class="scroll scroll-prev"
+                        part="scroll-prev"
+                        ${ref("previousFlipper")}
+                    >
+                        <div class="scroll-action" @click="${x => x.scrollToPrevious()}">
+                            <slot name="previous-flipper"></slot>
+                        </div>
+                    </div>
+                    <div
+                        class="scroll scroll-next"
+                        part="scroll-next"
+                        ${ref("nextFlipper")}
+                    >
+                        <div class="scroll-action" @click="${x => x.scrollToNext()}">
+                            <slot name="next-flipper"></slot>
+                        </div>
+                    </div>
+                `
+            )}
         </div>
         ${endTemplate}
     </template>

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
@@ -1,4 +1,4 @@
-import { html, ref } from "@microsoft/fast-element";
+import { elements, html, ref, slotted } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns";
 import { HorizontalScroll } from "./horizontal-scroll";
 
@@ -31,7 +31,12 @@ export const HorizontalScrollTemplate = html<HorizontalScroll>`
                 @scroll="${x => x.scrolled()}"
             >
                 <div class="content-container">
-                    <slot></slot>
+                    <slot
+                        ${slotted({
+                            property: "scrollItems",
+                            filter: elements(),
+                        })}
+                    ></slot>
                 </div>
             </div>
             ${x => (x.view === "mobile" ? "" : ActionsTemplate)}

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -65,6 +65,20 @@ export class HorizontalScroll extends FASTElement {
     }
 
     /**
+     * The timeout identifier for the scroll event throttling.
+     *
+     * @internal
+     */
+    private resizeTimeout?: number | void;
+
+    /**
+     * The timeout identifier for the scroll event throttling.
+     *
+     * @internal
+     */
+    private scrollTimeout?: number | void;
+
+    /**
      * Speed of scroll in pixels per second
      * @public
      */
@@ -394,8 +408,14 @@ export class HorizontalScroll extends FASTElement {
      * @public
      */
     public resized(): void {
-        this.width = this.offsetWidth;
-        this.setFlippers();
+        if (this.resizeTimeout) {
+            this.resizeTimeout = clearTimeout(this.resizeTimeout);
+        }
+
+        this.resizeTimeout = setTimeout(() => {
+            this.width = this.offsetWidth;
+            this.setFlippers();
+        }, this.frameTime);
     }
 
     /**
@@ -403,7 +423,13 @@ export class HorizontalScroll extends FASTElement {
      * @public
      */
     public scrolled(): void {
-        this.setFlippers();
+        if (this.scrollTimeout) {
+            this.scrollTimeout = clearTimeout(this.scrollTimeout);
+        }
+
+        this.scrollTimeout = setTimeout(() => {
+            this.setFlippers();
+        }, this.frameTime);
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -56,6 +56,15 @@ export class HorizontalScroll extends FASTElement {
     private framesPerSecond: number = 120;
 
     /**
+     * The calculated duration for a frame.
+     *
+     * @internal
+     */
+    private get frameTime(): number {
+        return 1000 / this.framesPerSecond;
+    }
+
+    /**
      * Speed of scroll in pixels per second
      * @public
      */
@@ -347,7 +356,7 @@ export class HorizontalScroll extends FASTElement {
 
         steps.push(newPosition);
 
-        this.move(steps, 1000 / this.framesPerSecond);
+        this.move(steps, this.frameTime);
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -235,29 +235,10 @@ export class HorizontalScroll extends FASTElement {
     }
 
     /**
-     * The previously set scroll position.
-     * @internal
-     */
-    private cachedScrollPosition: number;
-
-    /**
-     * Flag to determine if the returned scroll position will be live or cached.
-     * @internal
-     */
-    private useCachedPosition: boolean = true;
-
-    /**
      * Returns the current scroll position of the scrollContainer
      * @internal
      */
     private getScrollPosition(): number {
-        if (this.useCachedPosition && this.cachedScrollPosition) {
-            this.useCachedPosition = false;
-            return this.cachedScrollPosition;
-        }
-
-        this.useCachedPosition = true;
-        this.cachedScrollPosition = this.scrollContainer.scrollLeft;
         return this.scrollContainer.scrollLeft;
     }
 

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -281,7 +281,7 @@ export class HorizontalScroll extends FASTElement {
         let nextIndex: number = this.scrollStops.findIndex(
             (stop: number): boolean => Math.abs(stop) + this.width > right
         );
-        if (nextIndex > current || !nextIndex) {
+        if (nextIndex > current || nextIndex === -1) {
             nextIndex = current > 0 ? current - 1 : 0;
         }
         this.scrollToPosition(this.scrollStops[nextIndex], scrollPosition);

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -338,8 +338,8 @@ export class HorizontalScroll extends FASTElement {
             return;
         }
 
-        for (let i = 0; i <= stepCount - 1; i++) {
-            const progress: number = i / stepCount;
+        for (let i = 0; i < stepCount; i++) {
+            const progress = i / stepCount;
             const easingFactor = this.getEasedFactor(this.easing, progress);
             const travel = scrollDistance * easingFactor * direction;
             steps.push(travel + position);


### PR DESCRIPTION
# Description

* Switches from `display: inline-block` to `display: inline-flex` for item container
* Replaces `setTimeout` loop with paced `requestAnimationFrame`
* Caches `getScrollPosition` to prevent layout thrashing

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.