### PR TITLE
fix: combobox escape and arrow keys prevent listbox navigation

### DIFF
--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -378,15 +378,19 @@ export class Combobox extends FormAssociatedCombobox {
             }
 
             case "Escape": {
+                if (!this.isAutocompleteInline) {
+                    this.selectedIndex = -1;
+                }
+
                 if (this.open) {
                     this.open = false;
-                    this.filter = this.control.value;
-                    this.filterOptions();
                     break;
                 }
 
                 this.value = "";
                 this.control.value = "";
+                this.filter = "";
+                this.filterOptions();
                 break;
             }
 
@@ -404,12 +408,12 @@ export class Combobox extends FormAssociatedCombobox {
 
             case "ArrowUp":
             case "ArrowDown": {
+                this.filterOptions();
+
                 if (!this.open) {
                     this.open = true;
-                    return true;
+                    break;
                 }
-
-                this.filterOptions();
 
                 if (this.filteredOptions.length > 0) {
                     super.keydownHandler(e);


### PR DESCRIPTION
# Description
Allows proper navigation for combobox elements with autocomplete after pressing `Escape` or using the `ArrowDown` and `ArrowUp` keys.

## Motivation & context

Fixes #4440.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
