### PR TITLE
chore: allow the monaco adapter to recieve information about the origin of change requests to the editors value

### DIFF
--- a/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service-action.ts
+++ b/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service-action.ts
@@ -10,7 +10,7 @@ export interface MonacoAdapterActionCallbackConfig {
     /**
      * Update the Monaco Model value
      */
-    updateMonacoModelValue: (value: string[]) => void;
+    updateMonacoModelValue: (value: string[], isExternal: boolean) => void;
 
     /**
      * The message system type to run on
@@ -26,7 +26,7 @@ export class MonacoAdapterAction extends MessageSystemServiceAction<
     MessageSystemType
 > {
     private getMonacoModelValue: () => string[];
-    private updateMonacoModelValue: (value: string[]) => void;
+    private updateMonacoModelValue: (value: string[], isExternal: boolean) => void;
     private messageSystemType: MessageSystemType;
 
     constructor(config) {

--- a/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.ts
+++ b/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.ts
@@ -184,7 +184,7 @@ export class MonacoAdapter extends MessageSystemService<
     /**
      * Update the Monaco Model value
      */
-    private updateMonacoModelValue = (value: string[]): void => {
+    private updateMonacoModelValue = (value: string[], isExternal: boolean): void => {
         /**
          * Normalize values by converting all new lines into an array
          * and remove the leading spaces
@@ -201,14 +201,17 @@ export class MonacoAdapter extends MessageSystemService<
         });
 
         this.updateDictionaryIdAndNavigationConfigIdFromDataDictionary(dataDictionary);
-        this.messageSystem.postMessage({
-            type: MessageSystemType.initialize,
-            dataDictionary,
-            schemaDictionary: this.schemaDictionary,
-            options: {
-                originatorId: monacoAdapterId,
-            },
-            dictionaryId: this.dictionaryId,
-        } as InitializeMessageIncoming);
+
+        if (!isExternal) {
+            this.messageSystem.postMessage({
+                type: MessageSystemType.initialize,
+                dataDictionary,
+                schemaDictionary: this.schemaDictionary,
+                options: {
+                    originatorId: monacoAdapterId,
+                },
+                dictionaryId: this.dictionaryId,
+            } as InitializeMessageIncoming);
+        }
     };
 }

--- a/sites/fast-component-explorer/app/explorer.tsx
+++ b/sites/fast-component-explorer/app/explorer.tsx
@@ -99,6 +99,7 @@ class Explorer extends Editor<ExplorerProps, ExplorerState> {
             activePivotTab: "code",
             mobileFormVisible: false,
             mobileNavigationVisible: false,
+            lastMappedDataDictionaryToMonacoEditorHTMLValue: "",
         };
     }
 

--- a/sites/fast-creator/app/creator.props.ts
+++ b/sites/fast-creator/app/creator.props.ts
@@ -83,6 +83,11 @@ export interface ProjectFile {
      * Preview background transparency
      */
     transparentBackground: boolean;
+
+    /**
+     * The last mapped data dictionary to monaco editor value
+     */
+    lastMappedDataDictionaryToMonacoEditorHTMLValue: string;
 }
 
 export type CreatorManagedClasses = ManagedClasses<{}>;

--- a/sites/fast-creator/app/creator.tsx
+++ b/sites/fast-creator/app/creator.tsx
@@ -141,6 +141,7 @@ class Creator extends Editor<{}, CreatorState> {
                 componentLinkedDataId,
             ],
             transparentBackground: false,
+            lastMappedDataDictionaryToMonacoEditorHTMLValue: "",
         };
     }
 

--- a/sites/site-utilities/src/components/editor/editor.props.ts
+++ b/sites/site-utilities/src/components/editor/editor.props.ts
@@ -17,7 +17,7 @@ export interface EditorState {
     /**
      * The last value that was changed from the data dictionary to
      * a value used by monaco editor.
-     * 
+     *
      * This can be used to determine where a change comes from since
      * any update to the monaco editors value is treated the same (making a change
      * from within the editor vs setting the value externally)

--- a/sites/site-utilities/src/components/editor/editor.props.ts
+++ b/sites/site-utilities/src/components/editor/editor.props.ts
@@ -13,4 +13,14 @@ export interface EditorState {
     direction: Direction;
     transparentBackground: boolean;
     previewReady: boolean;
+
+    /**
+     * The last value that was changed from the data dictionary to
+     * a value used by monaco editor.
+     * 
+     * This can be used to determine where a change comes from since
+     * any update to the monaco editors value is treated the same (making a change
+     * from within the editor vs setting the value externally)
+     */
+    lastMappedDataDictionaryToMonacoEditorHTMLValue: string;
 }

--- a/sites/site-utilities/src/components/editor/index.tsx
+++ b/sites/site-utilities/src/components/editor/index.tsx
@@ -77,8 +77,9 @@ abstract class Editor<P, S extends EditorState> extends React.Component<P, S> {
                     action: (config: MonacoAdapterActionCallbackConfig): void => {
                         // trigger an update to the monaco value that
                         // also updates the DataDictionary which fires a
-                        // postMessage to the MessageSystem
-                        config.updateMonacoModelValue(this.monacoValue);
+                        // postMessage to the MessageSystem if the udpate
+                        // is coming from Monaco and not a data dictionary update
+                        config.updateMonacoModelValue(this.monacoValue, this.state.lastMappedDataDictionaryToMonacoEditorHTMLValue === this.monacoValue[0]);
                     },
                 }),
             ],
@@ -144,11 +145,17 @@ abstract class Editor<P, S extends EditorState> extends React.Component<P, S> {
 
     public updateEditorContent(dataDictionary: DataDictionary<unknown>): void {
         if (this.editor) {
-            this.editor.setValue(
-                html_beautify(
-                    mapDataDictionaryToMonacoEditorHTML(dataDictionary, schemaDictionary)
-                )
+            const lastMappedDataDictionaryToMonacoEditorHTMLValue = html_beautify(
+                mapDataDictionaryToMonacoEditorHTML(dataDictionary, schemaDictionary)
             );
+
+            this.setState({
+                lastMappedDataDictionaryToMonacoEditorHTMLValue,
+            }, () => {
+                this.editor.setValue(
+                    lastMappedDataDictionaryToMonacoEditorHTMLValue
+                );
+            });
         }
     }
 

--- a/sites/site-utilities/src/components/editor/index.tsx
+++ b/sites/site-utilities/src/components/editor/index.tsx
@@ -79,7 +79,11 @@ abstract class Editor<P, S extends EditorState> extends React.Component<P, S> {
                         // also updates the DataDictionary which fires a
                         // postMessage to the MessageSystem if the udpate
                         // is coming from Monaco and not a data dictionary update
-                        config.updateMonacoModelValue(this.monacoValue, this.state.lastMappedDataDictionaryToMonacoEditorHTMLValue === this.monacoValue[0]);
+                        config.updateMonacoModelValue(
+                            this.monacoValue,
+                            this.state.lastMappedDataDictionaryToMonacoEditorHTMLValue ===
+                                this.monacoValue[0]
+                        );
                     },
                 }),
             ],
@@ -149,13 +153,14 @@ abstract class Editor<P, S extends EditorState> extends React.Component<P, S> {
                 mapDataDictionaryToMonacoEditorHTML(dataDictionary, schemaDictionary)
             );
 
-            this.setState({
-                lastMappedDataDictionaryToMonacoEditorHTMLValue,
-            }, () => {
-                this.editor.setValue(
-                    lastMappedDataDictionaryToMonacoEditorHTMLValue
-                );
-            });
+            this.setState(
+                {
+                    lastMappedDataDictionaryToMonacoEditorHTMLValue,
+                },
+                () => {
+                    this.editor.setValue(lastMappedDataDictionaryToMonacoEditorHTMLValue);
+                }
+            );
         }
     }
 


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
The two data types, `DataDictionary` which the `fast-tooling` package uses, and a `string[]` value that the Monaco Editor uses, are currently kept in sync using the `onDidChangeContent` callback for Monaco Editor and `postMessage` to the `MessageSystem`.

This creates an issue where any setting of the value of the Monaco editor causes the `onDidChangeContent` to be called which we cannot control. To mitigate this issue, an additional check in the `MonacoAdapter` service uses the string value last set by the Monaco Editor, and if the change does not affect it this means that the update came from `fast-tooling` and that the Monaco editor need not fire a `postMessage` to update the `DataDictionary`.

This work is currently still being evaluated as the `MonacoAdapter` has still not been released publicly and is subject to change as the features mature.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [x] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->