### PR TITLE
fix: reduce text clipping when changing design-unit on listbox option

### DIFF
--- a/packages/web-components/fast-components/src/listbox-option/fixtures/base.html
+++ b/packages/web-components/fast-components/src/listbox-option/fixtures/base.html
@@ -32,3 +32,10 @@
     </svg>
     This option has an icon in its start and end slots.
 </fast-option>
+
+<h2>Styled Option</h2>
+<fast-option style="--design-unit: 2;">Should be shorter than normal</fast-option>
+<fast-option selected style="--design-unit: 2;">
+    Should be shorter than normal
+</fast-option>
+<fast-option style="--body-font: Comic Sans MS;">Should be Comic Sans</fast-option>

--- a/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
+++ b/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
@@ -25,6 +25,7 @@ import { heightNumber } from "../styles/size";
 
 export const OptionStyles = css`
     ${display("inline-flex")} :host {
+        align-items: center;
         font-family: var(--body-font);
         border-radius: calc(var(--corner-radius) * 1px);
         border: calc(var(--focus-outline-width) * 1px) solid transparent;
@@ -38,7 +39,7 @@ export const OptionStyles = css`
         margin: 0 calc(var(--design-unit) * 1px);
         outline: none;
         overflow: hidden;
-        padding: calc(var(--design-unit) * 2.25px);
+        padding: 0 calc(var(--design-unit) * 2.25px);
         user-select: none;
         white-space: nowrap;
     }

--- a/packages/web-components/fast-components/src/select/fixtures/base.html
+++ b/packages/web-components/fast-components/src/select/fixtures/base.html
@@ -116,3 +116,10 @@
     <fast-option>Position forced below</fast-option>
     <fast-option>Option Two</fast-option>
 </fast-select>
+
+<h2>Custom Styles</h2>
+<fast-select id="select-with-short-options" style="--design-unit: 2;">
+    <fast-option>This option is short</fast-option>
+    <fast-option>In a visual height sense</fast-option>
+    <fast-option>Not character count</fast-option>
+</fast-select>

--- a/packages/web-components/fast-components/src/select/select.styles.ts
+++ b/packages/web-components/fast-components/src/select/select.styles.ts
@@ -144,6 +144,9 @@ export const SelectStyles = css`
         flex: 1 1 auto;
         font-family: inherit;
         text-align: start;
+        white-space: nowrap;
+        text-overflow: ellipsis;
+        overflow: hidden;
     }
 
     .indicator {


### PR DESCRIPTION
# Description

* Ensure that changing the `--design-unit` on a `fast-option` doesn't cause the text to get clipped
* Force ellipsis on control value when a `fast-select` has an explicit `width` or `max-width`

## Motivation & context

### Ensure `--design-unit` doesn't cause text clipping for `fast-option`

Example snippet:
```html
<fast-select style="--design-unit: 2;">
    <fast-option>This option is short</fast-option>
    <fast-option>In a visual height sense</fast-option>
    <fast-option>Not character count</fast-option>
</fast-select>
```

Before:
![image](https://user-images.githubusercontent.com/863023/110867362-71fe1f80-827b-11eb-9f3b-ab539ab2634d.png)


After:
![image](https://user-images.githubusercontent.com/863023/110867187-38c5af80-827b-11eb-8f29-736f284354b3.png)

### Force ellipsis on control value for `fast-select`

Example snippet:
```html
<fast-select style="width: 100px; min-width: 0">
    <fast-option>This option is short</fast-option>
    <fast-option>In a visual height sense</fast-option>
    <fast-option>Not character count</fast-option>
</fast-select>
```

Before:
![image](https://user-images.githubusercontent.com/863023/110867663-f94b9300-827b-11eb-8313-a5bc1150ca94.png)

After:
![image](https://user-images.githubusercontent.com/863023/110867791-3ca60180-827c-11eb-995f-96da8483fa82.png)



## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->