### PR TITLE
fix: menu reset items attempts to remove event listener on wrong item

### DIFF
--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -192,27 +192,18 @@ export class Menu extends FASTElement {
             this.focusIndex = focusIndex;
         }
 
-        for (let item: number = 0; item < this.menuItems.length; item++) {
-            this.menuItems[item].setAttribute(
-                "tabindex",
-                item === focusIndex ? "0" : "-1"
-            );
-            this.menuItems[item].addEventListener(
-                "expanded-change",
-                this.handleExpandedChanged
-            );
-            this.menuItems[item].addEventListener("focus", this.handleItemFocus);
-        }
+        this.menuItems.forEach((item: HTMLElement, index: number) => {
+            item.setAttribute("tabindex", index === focusIndex ? "0" : "-1");
+            item.addEventListener("expanded-change", this.handleExpandedChanged);
+            item.addEventListener("focus", this.handleItemFocus);
+        });
     };
 
-    private resetItems = (oldValue: any): void => {
-        for (let item: number = 0; item < oldValue.length; item++) {
-            oldValue[item].removeEventListener(
-                "expanded-change",
-                this.handleExpandedChanged
-            );
-            this.menuItems[item].removeEventListener("focus", this.handleItemFocus);
-        }
+    private resetItems = (oldValue: HTMLElement[]): void => {
+        oldValue.forEach((item: HTMLElement) => {
+            item.removeEventListener("expanded-change", this.handleExpandedChanged);
+            item.removeEventListener("focus", this.handleItemFocus);
+        });
     };
 
     /**


### PR DESCRIPTION
# Description
Coding error referenced wrong array.  Corrected and changed to a foreach iterator which seemed more appropriate in this case.

## Motivation & context
Error could throw.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist*
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
