### PR TITLE
fix: data grid should not force fast header

### DIFF
--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -555,6 +555,8 @@ export class DataGrid extends FASTElement {
     handleRowFocus(e: Event): void;
     headerCellItemTemplate?: ViewTemplate;
     // @internal
+    prefix: string;
+    // @internal
     rowElements: HTMLElement[];
     rowItemTemplate: ViewTemplate;
     rowsData: object[];

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
@@ -18,7 +18,7 @@ function createHeaderCellItemTemplate(prefix: string): ViewTemplate {
         cell-type="columnheader"
         grid-column="${(x, c) => c.index + 1}"
         :columnDefinition="${x => x}"
-    ></${prefix}-data-grid-header-cell>
+    ></${prefix}-data-grid-cell>
 `;
 }
 

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
@@ -24,6 +24,7 @@ export function createDataGridTemplate(prefix: string): ViewTemplate {
         <template
             role="grid"
             tabindex="0"
+            :prefix=${prefix}
             :defaultRowItemTemplate="${rowItemTemplate}"
             ${children({
                 property: "rowElements",

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -256,6 +256,14 @@ export class DataGrid extends FASTElement {
     public defaultRowItemTemplate: ViewTemplate;
 
     /**
+     * Component prefix (ie. "fast" vs. "fluent" vs. "<mylib>").  Set by the component templates.
+     *
+     * @internal
+     */
+    @observable
+    public prefix: string;
+
+    /**
      * Children that are rows
      *
      * @internal
@@ -531,7 +539,7 @@ export class DataGrid extends FASTElement {
 
         if (this.generateHeader !== GenerateHeaderOptions.none) {
             const generatedHeaderElement: HTMLElement = document.createElement(
-                "fast-data-grid-row"
+                `${this.prefix}-data-grid-row`
             );
             this.generatedHeader = (generatedHeaderElement as unknown) as DataGridRow;
             this.generatedHeader.columnDefinitions = this.columnDefinitions;


### PR DESCRIPTION
# Description
Data grid was incorrectly forcing "fast-data-grid-row" headers and not applying provided prefix.

## Motivation & context
Data grid rows should create headers to match prefix.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
