### PR TITLE
feat: create a utility that consolidates the changes made to the data structure to preserve as much of the data dictionary as possible

### DIFF
--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.spec.ts
@@ -1,5 +1,9 @@
+import { SchemaDictionary } from "../message-system";
 import { linkedDataSchema } from "../schemas";
-import { mapVSCodeParsedHTMLToDataDictionary } from "./mapping.vscode-html-languageservice";
+import {
+    mapVSCodeHTMLAndDataDictionaryToDataDictionary,
+    mapVSCodeParsedHTMLToDataDictionary,
+} from "./mapping.vscode-html-languageservice";
 import { DataType, ReservedElementMappingKeyword } from "./types";
 
 const textSchema = {
@@ -387,5 +391,802 @@ describe("mapVSCodeParsedHTMLToDataDictionary", () => {
                 },
             ],
         });
+    });
+});
+
+describe("mapVSCodeHTMLAndDataDictionaryToDataDictionary", () => {
+    test("should map a parsed HTML value to a data dictionary", () => {
+        expect(
+            mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+                "",
+                "text",
+                [
+                    {
+                        root: {
+                            schemaId: "div",
+                            data: {
+                                foo: "bar",
+                            },
+                        },
+                    },
+                    "root",
+                ],
+                {
+                    div: {
+                        mapsToTagName: "div",
+                    },
+                }
+            )
+        ).toEqual(null);
+    });
+    describe("should map an existing data dictionary item with values to a parsed HTML value", () => {
+        test("originating from the message system", () => {
+            expect(
+                mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+                    '<div id="baz"></div>',
+                    "text",
+                    [
+                        {
+                            root: {
+                                schemaId: "div",
+                                data: {
+                                    foo: "bar",
+                                },
+                            },
+                        },
+                        "root",
+                    ],
+                    {
+                        div: {
+                            mapsToTagName: "div",
+                        },
+                    }
+                )
+            ).toEqual([
+                {
+                    root: {
+                        schemaId: "div",
+                        data: {
+                            id: "baz",
+                        },
+                    },
+                },
+                "root",
+            ]);
+        });
+    });
+    test("should map an existing data dictionary with children to a parsed HTML value with children", () => {
+        expect(
+            mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+                '<div id="baz"><span></span></div>',
+                "text",
+                [
+                    {
+                        root: {
+                            schemaId: "div",
+                            data: {
+                                foo: "bar",
+                                Slot: [
+                                    {
+                                        id: "foo",
+                                    },
+                                ],
+                            },
+                        },
+                        foo: {
+                            schemaId: "span",
+                            parent: {
+                                dataLocation: "Slot",
+                                id: "root",
+                            },
+                            data: {},
+                        },
+                    },
+                    "root",
+                ],
+                {
+                    div: {
+                        mapsToTagName: "div",
+                        properties: {
+                            Slot: {
+                                mapsToSlot: "",
+                            },
+                        },
+                    },
+                    span: {
+                        mapsToTagName: "span",
+                        properties: {
+                            Slot: {
+                                mapsToSlot: "",
+                            },
+                        },
+                    },
+                }
+            )
+        ).toEqual([
+            {
+                root: {
+                    schemaId: "div",
+                    data: {
+                        id: "baz",
+                        Slot: [
+                            {
+                                id: "foo",
+                            },
+                        ],
+                    },
+                },
+                foo: {
+                    schemaId: "span",
+                    parent: {
+                        dataLocation: "Slot",
+                        id: "root",
+                    },
+                    data: {},
+                },
+            },
+            "root",
+        ]);
+    });
+    test("should map an existing data dictionary item with children to an existing parsed HTML value without children", () => {
+        expect(
+            mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+                '<div id="baz"></div>',
+                "text",
+                [
+                    {
+                        root: {
+                            schemaId: "div",
+                            data: {
+                                foo: "bar",
+                                Slot: [
+                                    {
+                                        id: "foo",
+                                    },
+                                ],
+                            },
+                        },
+                        foo: {
+                            schemaId: "span",
+                            parent: {
+                                dataLocation: "Slot",
+                                id: "root",
+                            },
+                            data: {},
+                        },
+                    },
+                    "root",
+                ],
+                {
+                    div: {
+                        mapsToTagName: "div",
+                        properties: {
+                            Slot: {
+                                mapsToSlot: "",
+                            },
+                        },
+                    },
+                }
+            )
+        ).toEqual([
+            {
+                root: {
+                    schemaId: "div",
+                    data: {
+                        id: "baz",
+                    },
+                },
+            },
+            "root",
+        ]);
+    });
+    test("should map an existing data dictionary item without children to an existing parsed HTML value with a child node", () => {
+        const mappedData = mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+            '<div id="baz"><span></span></div>',
+            "text",
+            [
+                {
+                    root: {
+                        schemaId: "div",
+                        data: {
+                            foo: "bar",
+                        },
+                    },
+                },
+                "root",
+            ],
+            {
+                div: {
+                    $id: "div",
+                    id: "div",
+                    mapsToTagName: "div",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+                span: {
+                    $id: "span",
+                    id: "span",
+                    mapsToTagName: "span",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+            }
+        );
+
+        const keys = Object.keys(mappedData[0]);
+
+        expect(keys).toHaveLength(2);
+        expect((mappedData[0][mappedData[1]].data as any).Slot).toEqual([
+            {
+                id: keys[1],
+            },
+        ]);
+        expect(mappedData[0][keys[1]]).toEqual({
+            schemaId: "span",
+            parent: {
+                dataLocation: "Slot",
+                id: "root",
+            },
+            data: {},
+        });
+    });
+    test("should map an existing data dictionary item without children to an existing parsed HTML value with multiple child nodes", () => {
+        const mappedData = mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+            '<div id="baz"><span></span><input /></div>',
+            "text",
+            [
+                {
+                    root: {
+                        schemaId: "div",
+                        data: {
+                            foo: "bar",
+                        },
+                    },
+                },
+                "root",
+            ],
+            {
+                div: {
+                    $id: "div",
+                    id: "div",
+                    mapsToTagName: "div",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+                span: {
+                    $id: "span",
+                    id: "span",
+                    mapsToTagName: "span",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+                input: {
+                    $id: "input",
+                    id: "input",
+                    mapsToTagName: "input",
+                    properties: {},
+                },
+            }
+        );
+
+        const keys = Object.keys(mappedData[0]);
+
+        expect(keys).toHaveLength(3);
+        expect((mappedData[0][keys[0]].data as any).Slot).toEqual([
+            {
+                id: keys[1],
+            },
+            {
+                id: keys[2],
+            },
+        ]);
+    });
+    test("should map an existing data dictionary item without children to an existing parsed HTML value with a text node", () => {
+        const mappedData = mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+            '<div id="baz">FooBar</div>',
+            "text",
+            [
+                {
+                    root: {
+                        schemaId: "div",
+                        data: {
+                            foo: "bar",
+                        },
+                    },
+                },
+                "root",
+            ],
+            {
+                div: {
+                    $id: "div",
+                    id: "div",
+                    mapsToTagName: "div",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+                text: {
+                    $id: "text",
+                    id: "text",
+                    type: "string",
+                },
+            }
+        );
+
+        const keys = Object.keys(mappedData[0]);
+
+        expect(keys).toHaveLength(2);
+        expect((mappedData[0][keys[0]].data as any).Slot).toEqual([
+            {
+                id: keys[1],
+            },
+        ]);
+        expect(mappedData[0][keys[1]]).toEqual({
+            schemaId: "text",
+            parent: {
+                id: "root",
+                dataLocation: "Slot",
+            },
+            data: "FooBar",
+        });
+    });
+    test("should map an existing data dictionary with multiple matching children to an existing parsed HTML value with multiple children", () => {
+        const schemaDictionary: SchemaDictionary = {
+            div: {
+                $id: "div",
+                id: "div",
+                mapsToTagName: "div",
+                properties: {
+                    Slot: {
+                        mapsToSlot: "",
+                    },
+                },
+            },
+            span: {
+                $id: "span",
+                id: "span",
+                mapsToTagName: "span",
+                properties: {
+                    Slot: {
+                        mapsToSlot: "",
+                    },
+                },
+            },
+            text: {
+                $id: "text",
+                id: "text",
+                type: "string",
+            },
+        };
+        const mappedData1 = mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+            '<div id="baz">FooBar<span></span></div>',
+            "text",
+            [
+                {
+                    root: {
+                        schemaId: "div",
+                        data: {
+                            foo: "bar",
+                            Slot: [
+                                {
+                                    id: "bar",
+                                },
+                                {
+                                    id: "foo",
+                                },
+                            ],
+                        },
+                    },
+                    foo: {
+                        schemaId: "span",
+                        parent: {
+                            id: "root",
+                            dataLocation: "Slot",
+                        },
+                        data: {},
+                    },
+                    bar: {
+                        schemaId: "text",
+                        parent: {
+                            id: "root",
+                            dataLocation: "Slot",
+                        },
+                        data: "FooBar",
+                    },
+                },
+                "root",
+            ],
+            schemaDictionary
+        );
+        const keys1 = Object.keys(mappedData1[0]);
+        const mappedData2 = mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+            '<div id="baz"><span></span>FooBar</div>',
+            "text",
+            [
+                {
+                    root: {
+                        schemaId: "div",
+                        data: {
+                            foo: "bar",
+                            Slot: [
+                                {
+                                    id: "foo",
+                                },
+                                {
+                                    id: "bar",
+                                },
+                            ],
+                        },
+                    },
+                    foo: {
+                        schemaId: "span",
+                        parent: {
+                            id: "root",
+                            dataLocation: "Slot",
+                        },
+                        data: {},
+                    },
+                    bar: {
+                        schemaId: "text",
+                        parent: {
+                            id: "root",
+                            dataLocation: "Slot",
+                        },
+                        data: "FooBar",
+                    },
+                },
+                "root",
+            ],
+            schemaDictionary
+        );
+        const keys2 = Object.keys(mappedData2[0]);
+
+        expect(keys1).toHaveLength(3);
+        expect(mappedData1).toEqual([
+            {
+                root: {
+                    schemaId: "div",
+                    data: {
+                        id: "baz",
+                        Slot: [
+                            {
+                                id: "bar",
+                            },
+                            {
+                                id: "foo",
+                            },
+                        ],
+                    },
+                },
+                foo: {
+                    schemaId: "span",
+                    parent: {
+                        id: "root",
+                        dataLocation: "Slot",
+                    },
+                    data: {},
+                },
+                bar: {
+                    schemaId: "text",
+                    parent: {
+                        id: "root",
+                        dataLocation: "Slot",
+                    },
+                    data: "FooBar",
+                },
+            },
+            "root",
+        ]);
+        expect(keys2).toHaveLength(3);
+        expect(mappedData2).toEqual([
+            {
+                root: {
+                    schemaId: "div",
+                    data: {
+                        id: "baz",
+                        Slot: [
+                            {
+                                id: "foo",
+                            },
+                            {
+                                id: "bar",
+                            },
+                        ],
+                    },
+                },
+                foo: {
+                    schemaId: "span",
+                    parent: {
+                        id: "root",
+                        dataLocation: "Slot",
+                    },
+                    data: {},
+                },
+                bar: {
+                    schemaId: "text",
+                    parent: {
+                        id: "root",
+                        dataLocation: "Slot",
+                    },
+                    data: "FooBar",
+                },
+            },
+            "root",
+        ]);
+    });
+    test("should map an existing data dictionary with multiple children to an existing parsed HTML value with multiple matching children and new children", () => {
+        const mappedData = mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+            '<div id="baz"><span></span>FooBar<div></div></div>',
+            "text",
+            [
+                {
+                    root: {
+                        schemaId: "div",
+                        data: {
+                            foo: "bar",
+                            Slot: [
+                                {
+                                    id: "foo",
+                                },
+                                {
+                                    id: "bar",
+                                },
+                            ],
+                        },
+                    },
+                    foo: {
+                        schemaId: "span",
+                        parent: {
+                            id: "root",
+                            dataLocation: "Slot",
+                        },
+                        data: {},
+                    },
+                    bar: {
+                        schemaId: "text",
+                        parent: {
+                            id: "root",
+                            dataLocation: "Slot",
+                        },
+                        data: "FooBar",
+                    },
+                },
+                "root",
+            ],
+            {
+                div: {
+                    $id: "div",
+                    id: "div",
+                    mapsToTagName: "div",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+                span: {
+                    $id: "span",
+                    id: "span",
+                    mapsToTagName: "span",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+                text: {
+                    $id: "text",
+                    id: "text",
+                    type: "string",
+                },
+            }
+        );
+
+        const keys = Object.keys(mappedData[0]);
+
+        expect(keys).toHaveLength(4);
+        expect((mappedData[0].root.data as any).Slot).toHaveLength(3);
+        expect((mappedData[0].root.data as any).Slot[2]).toEqual({
+            id: keys[3],
+        });
+        expect(mappedData[0][keys[3]]).toEqual({
+            schemaId: "div",
+            parent: {
+                id: "root",
+                dataLocation: "Slot",
+            },
+            data: {},
+        });
+    });
+    test("should map an existing data dictionary with multiple matching children to an existing parsed HTML value with multiple children and missing children", () => {
+        const mappedData = mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+            '<div id="baz"><span></span></div>',
+            "text",
+            [
+                {
+                    root: {
+                        schemaId: "div",
+                        data: {
+                            foo: "bar",
+                            Slot: [
+                                {
+                                    id: "foo",
+                                },
+                                {
+                                    id: "bar",
+                                },
+                            ],
+                        },
+                    },
+                    foo: {
+                        schemaId: "span",
+                        parent: {
+                            id: "root",
+                            dataLocation: "Slot",
+                        },
+                        data: {},
+                    },
+                    bar: {
+                        schemaId: "text",
+                        parent: {
+                            id: "root",
+                            dataLocation: "Slot",
+                        },
+                        data: "FooBar",
+                    },
+                },
+                "root",
+            ],
+            {
+                div: {
+                    $id: "div",
+                    id: "div",
+                    mapsToTagName: "div",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+                span: {
+                    $id: "span",
+                    id: "span",
+                    mapsToTagName: "span",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+                text: {
+                    $id: "text",
+                    id: "text",
+                    type: "string",
+                },
+            }
+        );
+
+        expect(mappedData).toEqual([
+            {
+                root: {
+                    schemaId: "div",
+                    data: {
+                        id: "baz",
+                        Slot: [
+                            {
+                                id: "foo",
+                            },
+                        ],
+                    },
+                },
+                foo: {
+                    schemaId: "span",
+                    parent: {
+                        id: "root",
+                        dataLocation: "Slot",
+                    },
+                    data: {},
+                },
+            },
+            "root",
+        ]);
+    });
+    test("should map an existing data dictionary with named slots to an existing parsed HTML value with named slots", () => {
+        const mappedData = mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+            '<div id="baz"><span slot="test"></span></div>',
+            "text",
+            [
+                {
+                    root: {
+                        schemaId: "div",
+                        data: {
+                            foo: "bar",
+                            SlotTest: [
+                                {
+                                    id: "foo",
+                                },
+                            ],
+                        },
+                    },
+                    foo: {
+                        schemaId: "span",
+                        parent: {
+                            id: "root",
+                            dataLocation: "SlotTest",
+                        },
+                        data: {
+                            slot: "test",
+                        },
+                    },
+                },
+                "root",
+            ],
+            {
+                div: {
+                    $id: "div",
+                    id: "div",
+                    mapsToTagName: "div",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                        SlotTest: {
+                            mapsToSlot: "test",
+                        },
+                    },
+                },
+                span: {
+                    $id: "span",
+                    id: "span",
+                    mapsToTagName: "span",
+                    properties: {
+                        Slot: {
+                            mapsToSlot: "",
+                        },
+                    },
+                },
+            }
+        );
+
+        expect(mappedData).toEqual([
+            {
+                root: {
+                    schemaId: "div",
+                    data: {
+                        id: "baz",
+                        SlotTest: [
+                            {
+                                id: "foo",
+                            },
+                        ],
+                    },
+                },
+                foo: {
+                    schemaId: "span",
+                    parent: {
+                        id: "root",
+                        dataLocation: "SlotTest",
+                    },
+                    data: {
+                        slot: "test",
+                    },
+                },
+            },
+            "root",
+        ]);
     });
 });

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.vscode-html-languageservice.ts
@@ -1,8 +1,15 @@
 import { Node, parse } from "vscode-html-languageservice/lib/esm/parser/htmlParser";
 import { uniqueId } from "lodash-es";
 import { pascalCase } from "@microsoft/fast-web-utilities";
-import { DataDictionary, LinkedData, SchemaDictionary } from "../message-system";
+import {
+    Data,
+    DataDictionary,
+    LinkedData,
+    Parent,
+    SchemaDictionary,
+} from "../message-system";
 import { DataType } from "./types";
+import { XOR } from "./type.utilities";
 
 export interface MapNodeToDataDictionaryConfig {
     /**
@@ -295,4 +302,350 @@ export function mapVSCodeParsedHTMLToDataDictionary(
         textSchemaId,
         config.schemaDictionary
     )[0];
+}
+
+export interface Attribute {
+    name: string;
+    value: any;
+}
+
+export interface ParsedValue {
+    children: ParsedValue[];
+    tag: string;
+    attributes: { [key: string]: string };
+    start: number;
+    end: number;
+    startTagEnd: number;
+    endTagStart?: number;
+    content?: string;
+}
+
+function consolidateHTMLElementsWithTextNodes(
+    value: string,
+    parsedValue: ParsedValue
+): Node[] {
+    const consolidatedNodes = [];
+
+    if (!parsedValue.children) {
+        return consolidatedNodes;
+    }
+
+    const nodeChildrenLength = parsedValue.children.length;
+
+    // Check for text nodes when there are no HTML element children
+    if (
+        nodeChildrenLength === 0 &&
+        parsedValue.endTagStart &&
+        parsedValue.startTagEnd !== parsedValue.endTagStart
+    ) {
+        consolidatedNodes.push({
+            tag: null,
+            content: value.slice(parsedValue.startTagEnd, parsedValue.endTagStart),
+        });
+    } else if (nodeChildrenLength > 0) {
+        // Check for text nodes before children
+        if (parsedValue.children[0].start !== parsedValue.startTagEnd) {
+            consolidatedNodes.push({
+                tag: null,
+                content: value.slice(
+                    parsedValue.startTagEnd,
+                    parsedValue.children[0].start
+                ),
+            });
+        }
+
+        // Check for text nodes in the middle
+        for (let i = 0; i < nodeChildrenLength; i++) {
+            consolidatedNodes.push(parsedValue.children[i]);
+
+            if (
+                parsedValue.children[i + 1] &&
+                parsedValue.children[i].end !== parsedValue.children[i + 1].start
+            ) {
+                consolidatedNodes.push({
+                    tag: null,
+                    content: value.slice(
+                        parsedValue.children[i].end,
+                        parsedValue.children[i + 1].start
+                    ),
+                });
+            }
+        }
+
+        // Check for text nodes after children
+        if (
+            parsedValue.children[nodeChildrenLength - 1].end !== parsedValue.endTagStart
+        ) {
+            consolidatedNodes.push({
+                tag: null,
+                content: value.slice(
+                    parsedValue.children[nodeChildrenLength - 1].end,
+                    parsedValue.endTagStart
+                ),
+            });
+        }
+    }
+
+    return consolidatedNodes;
+}
+
+/**
+ * Takes the parsed value from the VSCode HTML language service
+ * and transforms it into an array with an array of elements as the first
+ * index and any
+ */
+function identifyElementsFromParsedValue(
+    value: string,
+    parsedValue: ParsedValue[]
+): Node[] {
+    return parsedValue.map(parsedValueItem => {
+        const children = consolidateHTMLElementsWithTextNodes(value, parsedValueItem);
+
+        return {
+            tag: parsedValueItem.tag,
+            attributes: parsedValueItem.attributes
+                ? Object.entries(parsedValueItem.attributes).map(
+                      ([name, value]: [string, string]) => {
+                          return {
+                              name,
+                              value: JSON.parse(value),
+                          };
+                      }
+                  )
+                : [],
+            children: identifyElementsFromParsedValue(value, children),
+            content: parsedValueItem.content,
+        };
+    });
+}
+
+function mapElementAttributes(element): { [key: string]: any } {
+    return element.attributes.reduce((prevValue, currentValue) => {
+        return {
+            ...prevValue,
+            [currentValue.name]: currentValue.value,
+        };
+    }, {});
+}
+
+function resolveDataDictionaryFromElement(
+    linkedDataId: string,
+    schemaId: string,
+    node: Node,
+    parent: Parent,
+    slotAttributes: { [key: string]: LinkedData[] },
+    schemaDictionary: SchemaDictionary
+): DataDictionary<unknown> {
+    return [
+        {
+            [linkedDataId]: {
+                schemaId,
+                parent,
+                data:
+                    typeof node.content === "string"
+                        ? node.content
+                        : mapAttributesAndSlotsToData(
+                              node,
+                              slotAttributes,
+                              schemaId,
+                              schemaDictionary
+                          ),
+            },
+        },
+        linkedDataId,
+    ];
+}
+
+function mapElementToDataDictionary(
+    node: Node,
+    textSchemaId: string,
+    schemaDictionary: SchemaDictionary,
+    parent: Parent
+): DataDictionary<unknown> {
+    const linkedDataId = uniqueId("fast");
+    const schemaId: string =
+        Object.keys(schemaDictionary).find((key: string) => {
+            if (
+                schemaDictionary[key] &&
+                node &&
+                schemaDictionary[key].mapsToTagName === node.tag
+            ) {
+                return schemaDictionary[key].$id;
+            }
+
+            return false;
+        }) || textSchemaId;
+
+    return resolveDataDictionaryFromElement(
+        linkedDataId,
+        schemaId,
+        node,
+        parent,
+        {},
+        schemaDictionary
+    );
+}
+
+function mapElementChildren(
+    element: Node,
+    textSchemaId: string,
+    schemaDictionary: SchemaDictionary,
+    currentDictionaryId: string,
+    dataDictionary: DataDictionary<unknown>
+): [{ [key: string]: LinkedData[] }, { [key: string]: Data<unknown> }] {
+    const elementChildren: { [key: string]: LinkedData[] } = {};
+    const dataDictionaryChildItems: { [key: string]: Data<unknown> } = {};
+
+    element.children.forEach(child => {
+        const slotAttribute: Attribute | undefined = child.attributes.find(
+            (attribute: Attribute) => {
+                return attribute.name === "slot";
+            }
+        );
+
+        const slotName = slotAttribute === undefined ? "" : slotAttribute.value;
+        const schemaSlotName = `Slot${pascalCase(slotName)}`;
+
+        // Find current dictionary item slots
+        if (Array.isArray(dataDictionary[0][currentDictionaryId].data[schemaSlotName])) {
+            const matchingChild: LinkedData = dataDictionary[0][currentDictionaryId].data[
+                schemaSlotName
+            ].find((item: LinkedData) => {
+                return (
+                    schemaDictionary[dataDictionary[0][item.id].schemaId]
+                        .mapsToTagName === child.tag ||
+                    (schemaDictionary[dataDictionary[0][item.id].schemaId].id ===
+                        textSchemaId &&
+                        typeof child.content === "string")
+                );
+            });
+
+            if (!Array.isArray(elementChildren[schemaSlotName])) {
+                elementChildren[schemaSlotName] = [];
+            }
+
+            if (matchingChild) {
+                elementChildren[schemaSlotName].push(matchingChild);
+
+                /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                const mappedDataDictionaryChildItem = mapUpdatesFromMonacoEditor(
+                    child,
+                    textSchemaId,
+                    matchingChild.id,
+                    dataDictionary,
+                    schemaDictionary
+                );
+
+                dataDictionaryChildItems[mappedDataDictionaryChildItem[1]] =
+                    mappedDataDictionaryChildItem[0][mappedDataDictionaryChildItem[1]];
+            } else {
+                // children are present but do not match
+                const newNode = mapElementToDataDictionary(
+                    child,
+                    textSchemaId,
+                    schemaDictionary,
+                    {
+                        id: currentDictionaryId,
+                        dataLocation: schemaSlotName,
+                    }
+                );
+
+                elementChildren[schemaSlotName].push({
+                    id: newNode[1],
+                });
+
+                dataDictionaryChildItems[newNode[1]] = newNode[0][newNode[1]];
+            }
+        } else {
+            const newNode = mapElementToDataDictionary(
+                child,
+                textSchemaId,
+                schemaDictionary,
+                {
+                    id: currentDictionaryId,
+                    dataLocation: schemaSlotName,
+                }
+            );
+
+            if (Array.isArray(elementChildren[schemaSlotName])) {
+                elementChildren[schemaSlotName].push({
+                    id: newNode[1],
+                });
+            } else {
+                elementChildren[schemaSlotName] = [
+                    {
+                        id: newNode[1],
+                    },
+                ];
+            }
+
+            dataDictionaryChildItems[newNode[1]] = newNode[0][newNode[1]];
+        }
+    });
+
+    return [elementChildren, dataDictionaryChildItems];
+}
+
+/**
+ * Map data updates coming from the monaco editor
+ * which will take precendence over data stored in the data dictionary
+ */
+function mapUpdatesFromMonacoEditor(
+    element: Node,
+    textSchemaId: string,
+    dataDictionaryId: string,
+    previousDataDictionary: DataDictionary<unknown>,
+    schemaDictionary: SchemaDictionary
+): XOR<DataDictionary<unknown>, null> {
+    const schema = schemaDictionary[previousDataDictionary[0][dataDictionaryId].schemaId];
+    const isTextNode = schema.id === textSchemaId;
+    const children = mapElementChildren(
+        element,
+        textSchemaId,
+        schemaDictionary,
+        dataDictionaryId,
+        previousDataDictionary
+    );
+
+    return [
+        {
+            [dataDictionaryId]: {
+                ...previousDataDictionary[0][dataDictionaryId],
+                data: isTextNode
+                    ? element.content
+                    : {
+                          ...mapElementAttributes(element),
+                          ...children[0],
+                      },
+            },
+            ...children[1],
+        },
+        dataDictionaryId,
+    ];
+}
+
+/**
+ * Map data updates coming from the monaco editor and consolidate
+ * them with the current data dictionary stored in the Message System
+ */
+export function mapVSCodeHTMLAndDataDictionaryToDataDictionary(
+    value: string,
+    textSchemaId: string,
+    previousDataDictionary: DataDictionary<unknown>,
+    schemaDictionary: SchemaDictionary
+): XOR<DataDictionary<unknown>, null> {
+    const parsedValue = parse(value);
+    const elements = identifyElementsFromParsedValue(value, parsedValue.roots);
+
+    if (parsedValue.roots && elements[0]) {
+        return mapUpdatesFromMonacoEditor(
+            elements[0],
+            textSchemaId,
+            previousDataDictionary[1],
+            previousDataDictionary,
+            schemaDictionary
+        );
+    }
+
+    return null;
 }


### PR DESCRIPTION
<!--- Provide a summary of your changes in the title field above. For guidance on formatting, see the comment at the bottom of this template. -->

# Description

<!--- Describe your changes. -->
In order to better preserve interactions between the `DataDictionary` from the `fast-tooling` `MessageSystem` and the Monaco Editors text value, a new utility has been created to consolidate these formats where possible. The utility `mapVSCodeHTMLAndDataDictionaryToDataDictionary` will parse the Monaco Editor text value using an existing `DataDictionary` to create an updated `DataDictionary`.

## Motivation & context

<!--- What problem does this change solve? -->
<!--- Provide a link if you are addressing an open issue. -->
This should help keep data structures and navigation more in sync while editing the `DataDictionary` from the Monaco Editor.

## Issue type checklist

<!--- What type of change are you submitting? Put an x in the box that applies: -->

- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

<!--- If yes, describe the impact. -->

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

<!--- Review the list and check the boxes that apply. -->

- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

<!---
Formatting guidelines:

Accepted peer review title format:
<type>: <description>

Example titles:
    chore: add unit tests for all components
    feat: add a border radius to button
    fix: update design system to use 3px border radius

    <type> is required to be one of the following:

        - chore: A change that does not impact distributed packages.
        - fix: A change which fixes an issue.
        - feat: A that adds functionality.

    <description> is required for the CHANGELOG and speaks to what the user gets from this PR:

        - Be concise.
        - Use all lowercase characters. 
        - Use imperative, present tense (e.g. `add` not `adds`.)
        - Do not end your description with a period.
        - Avoid redundant words.

For additional information regarding working on FAST, check out our documentation site:
https://www.fast.design/docs/community/contributor-guide
-->