### PR TITLE
fix: declarations throw an error when using TypeScript ^4.0

### DIFF
--- a/packages/web-components/fast-foundation/src/combobox/combobox.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.form-associated.ts
@@ -2,15 +2,21 @@ import { Listbox } from "../listbox/listbox";
 import { FormAssociated } from "../form-associated/form-associated";
 
 /**
+ * Normally this would be passed as an anonymous class directly to the
+ * {@link (FormAssociated:function)} mixin function. TypeScript 4+ throws an
+ * error when base accessors are overridden in a subclass. Combobox overrides
+ * the `options` accessors in Listbox.
+ */
+class ComboboxListbox extends Listbox {
+    public proxy: HTMLInputElement = document.createElement("input");
+}
+
+/**
  * A form-associated base class for the {@link (Combobox:class)} component.
  *
  * @internal
  */
-export class FormAssociatedCombobox extends FormAssociated(
-    class extends Listbox {
-        public proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
+export class FormAssociatedCombobox extends FormAssociated(ComboboxListbox) {}
 
 /**
  * @internal


### PR DESCRIPTION
# Description
The emitted declarations throw an error when used in TypeScript ^4.0 (4.2.3 at the time of this PR). By moving the anonymous mixin class out of the function call, we can get the proper signature for `options`.

## Motivation & context
Related to at least these three issues:
* microsoft/typescript#37894
* microsoft/typescript#41347
* microsoft/typescript#41994

Our original ticket to track the issue: #4435 

Test method:
1. in `fast-foundation`, run `yarn link`
2. In a new workspace, add `fast-components` with `yarn add @microsoft/fast-components`
3. Create a new file `test.ts`:
    ```ts
    export * from "@microsoft/fast-components";
    ```
4. Build with tsc: `npx -p typescript@4.2.3 tsc --moduleResolution "Node" --noEmit --target "ESNext" test.ts`
    An error should occur: 
      ```
      node_modules/@microsoft/fast-foundation/dist/fast-foundation.d.ts:1294:9 - error TS2611: 'options' is defined as a property in class 'FormAssociatedCombobox', but is overridden here in 'Combobox' as an accessor.
      
      1294     get options(): ListboxOption[];
                   ~~~~~~~


      Found 1 error.
      ```
  
5. Switch to the previously linked version of `@microsoft/fast-foundation` with `yarn link "@microsoft/fast-foundation"`
6. Rerun the line from step 4. The build should complete without any issues.

This only affects the generated `dist/index.d.ts` in `fast-foundation`.

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.