### PR TITLE
fix: reduce surface area for form-associated component types

### DIFF
--- a/packages/web-components/fast-foundation/.eslintrc.js
+++ b/packages/web-components/fast-foundation/.eslintrc.js
@@ -12,5 +12,14 @@ module.exports = {
                 allowSingleExtends: true,
             },
         ],
+        "@typescript-eslint/class-name-casing": "off",
+        "@typescript-eslint/naming-convention": [
+            "error",
+            {
+                selector: "typeLike",
+                format: ["UPPER_CASE", "camelCase", "PascalCase"],
+                leadingUnderscore: "allow",
+            },
+        ],
     },
 };

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -367,7 +367,7 @@ export const ComponentPresentation: Readonly<{
 export function composedParent<T extends HTMLElement>(element: T): HTMLElement | null;
 
 // @alpha
-export type ConstructableFormAssociated = Constructable<FASTElement & HTMLElement & FormAssociatedProxy>;
+export type ConstructableFormAssociated = Constructable<HTMLElement & FASTElement>;
 
 // Warning: (ae-forgotten-export) The symbol "CustomPropertyManagerBase" needs to be exported by the entry point index.d.ts
 //
@@ -499,7 +499,7 @@ export interface CSSCustomPropertyDefinition {
 // @public
 export interface CSSCustomPropertyTarget {
     // (undocumented)
-    disconnectedCSSCustomPropertyRegistry: CSSCustomPropertyDefinition[] | void;
+    disconnectedCSSCustomPropertyRegistry?: CSSCustomPropertyDefinition[] | void;
     // (undocumented)
     registerCSSCustomProperty(behavior: CSSCustomPropertyDefinition): void;
     // (undocumented)
@@ -776,8 +776,8 @@ export class DesignSystemProvider extends FASTElement implements CSSCustomProper
     // (undocumented)
     disconnectedCallback(): void;
     // @deprecated
-    disconnectedCSSCustomPropertyRegistry: CSSCustomPropertyDefinition[];
-    disconnectedRegistry: Array<(provider: DesignSystemProvider) => void> | void;
+    disconnectedCSSCustomPropertyRegistry?: CSSCustomPropertyDefinition[];
+    disconnectedRegistry?: Array<(provider: DesignSystemProvider) => void> | void;
     evaluate(definition: CSSCustomPropertyDefinition): string;
     static findProvider(el: HTMLElement & Partial<DesignSystemConsumer>): DesignSystemProvider | null;
     static isDesignSystemProvider(el: HTMLElement | DesignSystemProvider): el is DesignSystemProvider;
@@ -1041,7 +1041,7 @@ export interface FormAssociatedProxy {
     // (undocumented)
     nameChanged?(previous: any, next: any): void;
     // (undocumented)
-    proxy: HTMLSelectElement | HTMLTextAreaElement | HTMLInputElement;
+    proxy: ProxyElement;
     // (undocumented)
     valueChanged?(previous: any, next: any): void;
 }
@@ -1445,10 +1445,14 @@ export class PropertyStyleSheetBehavior implements Behavior {
     unbind(source: typeof FASTElement & HTMLElement): void;
     }
 
+// @alpha
+export type ProxyElement = HTMLSelectElement | HTMLTextAreaElement | HTMLInputElement;
+
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedRadio" needs to be exported by the entry point index.d.ts
 //
 // @public
 export class Radio extends FormAssociatedRadio implements RadioControl {
+    constructor();
     checked: boolean;
     checkedAttribute: boolean;
     // @internal (undocumented)
@@ -1707,9 +1711,7 @@ export type SkeletonShape = "rect" | "circle";
 // @public
 export const SkeletonTemplate: ViewTemplate<Skeleton>;
 
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedSlider" needs to be exported by the entry point index.d.ts
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Slider" because one of its declarations is marked as @internal
 //
 // @public
 export class Slider extends FormAssociatedSlider implements SliderConfiguration {
@@ -1752,10 +1754,6 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     // @internal (undocumented)
     valueChanged(previous: any, next: any): void;
     valueTextFormatter: (value: string) => string | null;
-}
-
-// @internal (undocumented)
-export interface Slider extends FormAssociatedSlider {
 }
 
 // @public
@@ -1848,6 +1846,7 @@ export const supportsElementInternals: boolean;
 //
 // @public
 export class Switch extends FormAssociatedSwitch {
+    constructor();
     checked: boolean;
     checkedAttribute: boolean;
     // @internal (undocumented)

--- a/packages/web-components/fast-foundation/src/button/button.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/button/button.form-associated.ts
@@ -1,18 +1,14 @@
 import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 
+class _Button extends FASTElement {}
+interface _Button extends FormAssociated {}
+
 /**
- * A form-associated base class for the {@link (Button:class)} component.
+ * A form-associated base class for the {@link @microsoft/fast-foundation#(Button:class)} component.
  *
  * @internal
  */
-export class FormAssociatedButton extends FormAssociated(
-    class extends FASTElement {
-        public proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedButton extends FormAssociated {}
+export class FormAssociatedButton extends FormAssociated(_Button) {
+    proxy = document.createElement("input");
+}

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -40,7 +40,7 @@ export class Button extends FormAssociatedButton {
     @attr
     public formaction: string;
     private formactionChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.formAction = this.formaction;
         }
     }
@@ -55,7 +55,7 @@ export class Button extends FormAssociatedButton {
     @attr
     public formenctype: string;
     private formenctypeChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.formEnctype = this.formenctype;
         }
     }
@@ -70,7 +70,7 @@ export class Button extends FormAssociatedButton {
     @attr
     public formmethod: string;
     private formmethodChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.formMethod = this.formmethod;
         }
     }
@@ -85,7 +85,7 @@ export class Button extends FormAssociatedButton {
     @attr({ mode: "boolean" })
     public formnovalidate: boolean;
     private formnovalidateChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.formNoValidate = this.formnovalidate;
         }
     }
@@ -100,7 +100,7 @@ export class Button extends FormAssociatedButton {
     @attr
     public formtarget: "_self" | "_blank" | "_parent" | "_top";
     private formtargetChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.formTarget = this.formtarget;
         }
     }
@@ -118,7 +118,7 @@ export class Button extends FormAssociatedButton {
         previous: "submit" | "reset" | "button" | void,
         next: "submit" | "reset" | "button"
     ): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.type = this.type;
         }
 

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.form-associated.ts
@@ -1,18 +1,14 @@
 import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 
+class _Checkbox extends FASTElement {}
+interface _Checkbox extends FormAssociated {}
+
 /**
- * A form-associated base class for the {@link (Checkbox:class)} component.
+ * A form-associated base class for the {@link @microsoft/fast-foundation#(Checkbox:class)} component.
  *
  * @internal
  */
-export class FormAssociatedCheckbox extends FormAssociated(
-    class extends FASTElement {
-        public proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedCheckbox extends FormAssociated {}
+export class FormAssociatedCheckbox extends FormAssociated(_Checkbox) {
+    proxy = document.createElement("input");
+}

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -18,7 +18,7 @@ export class Checkbox extends FormAssociatedCheckbox {
     @attr({ attribute: "readonly", mode: "boolean" })
     public readOnly: boolean; // Map to proxy element
     private readOnlyChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.readOnly = this.readOnly;
         }
     }
@@ -58,7 +58,7 @@ export class Checkbox extends FormAssociatedCheckbox {
      * @public
      */
     @observable
-    public defaultChecked: boolean = !!this.checkedAttribute;
+    public defaultChecked: boolean;
     private defaultCheckedChanged(): void {
         if (!this.dirtyChecked) {
             // Setting this.checked will cause us to enter a dirty state,
@@ -75,7 +75,7 @@ export class Checkbox extends FormAssociatedCheckbox {
      * @public
      */
     @observable
-    public checked: boolean = this.defaultChecked;
+    public checked: boolean;
     private checkedChanged(): void {
         if (!this.dirtyChecked) {
             this.dirtyChecked = true;
@@ -83,7 +83,7 @@ export class Checkbox extends FormAssociatedCheckbox {
 
         this.updateForm();
 
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.checked = this.checked;
         }
 
@@ -114,6 +114,9 @@ export class Checkbox extends FormAssociatedCheckbox {
 
     constructor() {
         super();
+
+        this.defaultChecked = !!this.checkedAttribute;
+        this.checked = this.defaultChecked;
 
         this.constructed = true;
     }

--- a/packages/web-components/fast-foundation/src/combobox/combobox.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.form-associated.ts
@@ -1,24 +1,14 @@
-import { Listbox } from "../listbox/listbox";
 import { FormAssociated } from "../form-associated/form-associated";
+import { Listbox } from "../listbox/listbox";
 
-/**
- * Normally this would be passed as an anonymous class directly to the
- * {@link (FormAssociated:function)} mixin function. TypeScript 4+ throws an
- * error when base accessors are overridden in a subclass. Combobox overrides
- * the `options` accessors in Listbox.
- */
-class ComboboxListbox extends Listbox {
-    public proxy: HTMLInputElement = document.createElement("input");
-}
+class _Combobox extends Listbox {}
+interface _Combobox extends FormAssociated {}
 
 /**
  * A form-associated base class for the {@link (Combobox:class)} component.
  *
  * @internal
  */
-export class FormAssociatedCombobox extends FormAssociated(ComboboxListbox) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedCombobox extends FormAssociated {}
+export class FormAssociatedCombobox extends FormAssociated(_Combobox) {
+    proxy = document.createElement("input");
+}

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -151,7 +151,7 @@ export class Combobox extends FormAssociatedCombobox {
      * @internal
      */
     protected placeholderChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.placeholder = this.placeholder;
         }
     }

--- a/packages/web-components/fast-foundation/src/custom-properties/behavior.ts
+++ b/packages/web-components/fast-foundation/src/custom-properties/behavior.ts
@@ -23,7 +23,7 @@ export interface CSSCustomPropertyDefinition {
 export interface CSSCustomPropertyTarget {
     registerCSSCustomProperty(behavior: CSSCustomPropertyDefinition): void;
     unregisterCSSCustomProperty(behavior: CSSCustomPropertyDefinition): void;
-    disconnectedCSSCustomPropertyRegistry: CSSCustomPropertyDefinition[] | void;
+    disconnectedCSSCustomPropertyRegistry?: CSSCustomPropertyDefinition[] | void;
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
+++ b/packages/web-components/fast-foundation/src/design-system-provider/design-system-provider.ts
@@ -283,7 +283,7 @@ export class DesignSystemProvider extends FASTElement
      * @public
      * @deprecated - use disconnectedRegistry
      */
-    public disconnectedCSSCustomPropertyRegistry: CSSCustomPropertyDefinition[];
+    public disconnectedCSSCustomPropertyRegistry?: CSSCustomPropertyDefinition[];
 
     /**
      * Allows arbitrary registration to the provider before the constructor runs.
@@ -292,7 +292,7 @@ export class DesignSystemProvider extends FASTElement
      *
      * @public
      */
-    public disconnectedRegistry: Array<(provider: DesignSystemProvider) => void> | void;
+    public disconnectedRegistry?: Array<(provider: DesignSystemProvider) => void> | void;
 
     /**
      * Handle changes to design-system-provider IDL and content attributes

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -1,11 +1,5 @@
-import {
-    attr,
-    Constructable,
-    DOM,
-    emptyArray,
-    FASTElement,
-    observable,
-} from "@microsoft/fast-element";
+import { attr, DOM, emptyArray, observable } from "@microsoft/fast-element";
+import type { Constructable, FASTElement } from "@microsoft/fast-element";
 import { keyCodeEnter } from "@microsoft/fast-web-utilities";
 
 /**
@@ -129,13 +123,19 @@ export interface FormAssociated extends Omit<ElementInternals, "labels"> {
 }
 
 /**
+ * Avaiable types for the `proxy` property.
+ * @alpha
+ */
+export type ProxyElement = HTMLSelectElement | HTMLTextAreaElement | HTMLInputElement;
+
+/**
  * Identifies a class as having a proxy element and optional submethods related
  * to the proxy element.
  *
  * @alpha
  */
 export interface FormAssociatedProxy {
-    proxy: HTMLSelectElement | HTMLTextAreaElement | HTMLInputElement;
+    proxy: ProxyElement;
     disabledChanged?(previous: boolean, next: boolean): void;
     formDisabledCallback?(disabled: boolean): void;
     formResetCallback?(): void;
@@ -159,9 +159,7 @@ export type FormAssociatedElement = FormAssociated &
  *
  * @alpha
  */
-export type ConstructableFormAssociated = Constructable<
-    FASTElement & HTMLElement & FormAssociatedProxy
->;
+export type ConstructableFormAssociated = Constructable<HTMLElement & FASTElement>;
 
 /**
  * Base function for providing Custom Element Form Association.
@@ -176,7 +174,7 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
          *
          * @alpha
          */
-        public proxy: HTMLSelectElement | HTMLTextAreaElement | HTMLInputElement;
+        public proxy: ProxyElement;
 
         /**
          * Must evaluate to true to enable elementInternals.

--- a/packages/web-components/fast-foundation/src/number-field/number-field.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.form-associated.ts
@@ -1,18 +1,14 @@
 import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 
+class _NumberField extends FASTElement {}
+interface _NumberField extends FormAssociated {}
+
 /**
- * A form-associated base class for the {@link (NumberField:class)} component.
+ * A form-associated base class for the {@link @microsoft/fast-foundation#(NumberField:class)} component.
  *
  * @internal
  */
-export class FormAssociatedNumberField extends FormAssociated(
-    class extends FASTElement {
-        public proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedNumberField extends FormAssociated {}
+export class FormAssociatedNumberField extends FormAssociated(_NumberField) {
+    proxy = document.createElement("input");
+}

--- a/packages/web-components/fast-foundation/src/radio/radio.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.form-associated.ts
@@ -1,18 +1,14 @@
 import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 
+class _Radio extends FASTElement {}
+interface _Radio extends FormAssociated {}
+
 /**
- * A form-associated base class for the {@link (Radio:class)} component.
+ * A form-associated base class for the {@link @microsoft/fast-foundation#(Radio:class)} component.
  *
  * @internal
  */
-export class FormAssociatedRadio extends FormAssociated(
-    class extends FASTElement {
-        public proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedRadio extends FormAssociated {}
+export class FormAssociatedRadio extends FormAssociated(_Radio) {
+    proxy = document.createElement("input");
+}

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -27,7 +27,7 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     @attr({ attribute: "readonly", mode: "boolean" })
     public readOnly: boolean; // Map to proxy element
     private readOnlyChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.readOnly = this.readOnly;
         }
     }
@@ -92,7 +92,7 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
      * @public
      */
     @observable
-    public checked: boolean = this.defaultChecked ?? false;
+    public checked: boolean;
     private checkedChanged(): void {
         if (this.$fastController.isConnected) {
             // changing the value via code and from radio-group
@@ -102,7 +102,7 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
 
             this.updateForm();
 
-            if (this.proxy instanceof HTMLElement) {
+            if (this.proxy instanceof HTMLInputElement) {
                 this.proxy.checked = this.checked;
             }
 
@@ -150,6 +150,11 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
                 }
             }
         }
+    }
+
+    constructor() {
+        super();
+        this.checked = this.defaultChecked ?? false;
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/select/select.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/select/select.form-associated.ts
@@ -1,18 +1,14 @@
 import { Listbox } from "../listbox/listbox";
 import { FormAssociated } from "../form-associated/form-associated";
 
+class _Select extends Listbox {}
+interface _Select extends FormAssociated {}
+
 /**
- * A form-associated base class for the {@link (Select:class)} component.
+ * A form-associated base class for the {@link @microsoft/fast-foundation#(Select:class)} component.
  *
  * @internal
  */
-export class FormAssociatedSelect extends FormAssociated(
-    class extends Listbox {
-        public proxy: HTMLSelectElement = document.createElement("select");
-    }
-) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedSelect extends FormAssociated {}
+export class FormAssociatedSelect extends FormAssociated(_Select) {
+    proxy = document.createElement("select");
+}

--- a/packages/web-components/fast-foundation/src/slider/slider.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.form-associated.ts
@@ -1,18 +1,14 @@
 import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 
+class _Slider extends FASTElement {}
+interface _Slider extends FormAssociated {}
+
 /**
- * A form-associated base class for the {@link (Slider:class)} component.
+ * A form-associated base class for the {@link @microsoft/fast-foundation#(Slider:class)} component.
  *
  * @internal
  */
-export class FormAssociatedSlider extends FormAssociated(
-    class extends FASTElement {
-        public proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedSlider extends FormAssociated {}
+export class FormAssociatedSlider extends FormAssociated(_Slider) {
+    proxy = document.createElement("input");
+}

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -51,7 +51,7 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     @attr({ attribute: "readonly", mode: "boolean" })
     public readOnly: boolean; // Map to proxy element
     private readOnlyChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.readOnly = this.readOnly;
         }
     }
@@ -145,7 +145,7 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     @attr({ converter: nullableNumberConverter })
     public min: number = 0; // Map to proxy element.
     private minChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.min = `${this.min}`;
         }
 
@@ -163,7 +163,7 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     @attr({ converter: nullableNumberConverter })
     public max: number = 10; // Map to proxy element.
     private maxChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.max = `${this.max}`;
         }
         this.validate();
@@ -179,7 +179,7 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     @attr({ converter: nullableNumberConverter })
     public step: number = 1; // Map to proxy element.
     private stepChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.step = `${this.step}`;
         }
 
@@ -456,8 +456,3 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
         return constrainedValue + this.min;
     };
 }
-
-/**
- * @internal
- */
-export interface Slider extends FormAssociatedSlider {}

--- a/packages/web-components/fast-foundation/src/switch/switch.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.form-associated.ts
@@ -1,18 +1,14 @@
 import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 
+class _Switch extends FASTElement {}
+interface _Switch extends FormAssociated {}
+
 /**
- * A form-associated base class for the {@link (Switch:class)} component.
+ * A form-associated base class for the {@link @microsoft/fast-foundation#(Switch:class)} component.
  *
  * @internal
  */
-export class FormAssociatedSwitch extends FormAssociated(
-    class extends FASTElement {
-        public proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedSwitch extends FormAssociated {}
+export class FormAssociatedSwitch extends FormAssociated(_Switch) {
+    proxy = document.createElement("input");
+}

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -18,7 +18,7 @@ export class Switch extends FormAssociatedSwitch {
     @attr({ attribute: "readonly", mode: "boolean" })
     public readOnly: boolean; // Map to proxy element
     private readOnlyChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.readOnly = this.readOnly;
         }
 
@@ -60,7 +60,7 @@ export class Switch extends FormAssociatedSwitch {
      * @public
      */
     @observable
-    public defaultChecked: boolean = !!this.checkedAttribute;
+    public defaultChecked: boolean;
     private defaultCheckedChanged(): void {
         if (!this.dirtyChecked) {
             // Setting this.checked will cause us to enter a dirty state,
@@ -77,7 +77,7 @@ export class Switch extends FormAssociatedSwitch {
      * @public
      */
     @observable
-    public checked: boolean = this.defaultChecked;
+    public checked: boolean;
     private checkedChanged(): void {
         if (!this.dirtyChecked) {
             this.dirtyChecked = true;
@@ -85,7 +85,7 @@ export class Switch extends FormAssociatedSwitch {
 
         this.updateForm();
 
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.checked = this.checked;
         }
 
@@ -112,6 +112,13 @@ export class Switch extends FormAssociatedSwitch {
         this.proxy.setAttribute("type", "checkbox");
 
         this.updateForm();
+    }
+
+    public constructor() {
+        super();
+
+        this.defaultChecked = !!this.checkedAttribute;
+        this.checked = this.defaultChecked;
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/text-area/text-area.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.form-associated.ts
@@ -1,18 +1,14 @@
 import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 
+class _TextArea extends FASTElement {}
+interface _TextArea extends FormAssociated {}
+
 /**
- * A form-associated base class for the {@link (TextArea:class)} component.
+ * A form-associated base class for the {@link @microsoft/fast-foundation#(TextArea:class)} component.
  *
  * @internal
  */
-export class FormAssociatedTextArea extends FormAssociated(
-    class extends FASTElement {
-        public proxy: HTMLTextAreaElement = document.createElement("textarea");
-    }
-) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedTextArea extends FormAssociated {}
+export class FormAssociatedTextArea extends FormAssociated(_TextArea) {
+    proxy = document.createElement("textarea");
+}

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -22,7 +22,7 @@ export class TextArea extends FormAssociatedTextArea {
     @attr({ mode: "boolean" })
     public readOnly: boolean;
     private readOnlyChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLTextAreaElement) {
             this.proxy.readOnly = this.readOnly;
         }
     }
@@ -51,7 +51,7 @@ export class TextArea extends FormAssociatedTextArea {
     @attr({ mode: "boolean" })
     public autofocus: boolean;
     private autofocusChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLTextAreaElement) {
             this.proxy.autofocus = this.autofocus;
         }
     }
@@ -72,7 +72,7 @@ export class TextArea extends FormAssociatedTextArea {
     @attr
     public list: string;
     private listChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLTextAreaElement) {
             this.proxy.setAttribute("list", this.list);
         }
     }
@@ -86,7 +86,7 @@ export class TextArea extends FormAssociatedTextArea {
     @attr({ converter: nullableNumberConverter })
     public maxlength: number;
     private maxlengthChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLTextAreaElement) {
             this.proxy.maxLength = this.maxlength;
         }
     }
@@ -100,7 +100,7 @@ export class TextArea extends FormAssociatedTextArea {
     @attr({ converter: nullableNumberConverter })
     public minlength: number;
     private minlengthChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLTextAreaElement) {
             this.proxy.minLength = this.minlength;
         }
     }
@@ -154,7 +154,7 @@ export class TextArea extends FormAssociatedTextArea {
     @attr({ mode: "boolean" })
     public spellcheck: boolean;
     private spellcheckChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLTextAreaElement) {
             this.proxy.spellcheck = this.spellcheck;
         }
     }

--- a/packages/web-components/fast-foundation/src/text-field/text-field.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.form-associated.ts
@@ -1,18 +1,14 @@
 import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
 
+class _TextField extends FASTElement {}
+interface _TextField extends FormAssociated {}
+
 /**
- * A form-associated base class for the {@link (TextField:class)} component.
+ * A form-associated base class for the {@link @microsoft/fast-foundation#(TextField:class)} component.
  *
  * @internal
  */
-export class FormAssociatedTextField extends FormAssociated(
-    class extends FASTElement {
-        public proxy: HTMLInputElement = document.createElement("input");
-    }
-) {}
-
-/**
- * @internal
- */
-export interface FormAssociatedTextField extends FormAssociated {}
+export class FormAssociatedTextField extends FormAssociated(_TextField) {
+    proxy = document.createElement("input");
+}

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -22,7 +22,7 @@ export class TextField extends FormAssociatedTextField {
     @attr({ attribute: "readonly", mode: "boolean" })
     public readOnly: boolean;
     private readOnlyChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.readOnly = this.readOnly;
             this.validate();
         }
@@ -37,7 +37,7 @@ export class TextField extends FormAssociatedTextField {
     @attr({ mode: "boolean" })
     public autofocus: boolean;
     private autofocusChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.autofocus = this.autofocus;
             this.validate();
         }
@@ -53,7 +53,7 @@ export class TextField extends FormAssociatedTextField {
     @attr
     public placeholder: string;
     private placeholderChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.placeholder = this.placeholder;
         }
     }
@@ -67,7 +67,7 @@ export class TextField extends FormAssociatedTextField {
     @attr
     public type: TextFieldType = TextFieldType.text;
     private typeChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.type = this.type;
             this.validate();
         }
@@ -82,7 +82,7 @@ export class TextField extends FormAssociatedTextField {
     @attr
     public list: string;
     private listChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.setAttribute("list", this.list);
             this.validate();
         }
@@ -97,7 +97,7 @@ export class TextField extends FormAssociatedTextField {
     @attr({ converter: nullableNumberConverter })
     public maxlength: number;
     private maxlengthChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.maxLength = this.maxlength;
             this.validate();
         }
@@ -112,7 +112,7 @@ export class TextField extends FormAssociatedTextField {
     @attr({ converter: nullableNumberConverter })
     public minlength: number;
     private minlengthChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.minLength = this.minlength;
             this.validate();
         }
@@ -127,7 +127,7 @@ export class TextField extends FormAssociatedTextField {
     @attr
     public pattern: string;
     private patternChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.pattern = this.pattern;
             this.validate();
         }
@@ -142,7 +142,7 @@ export class TextField extends FormAssociatedTextField {
     @attr({ converter: nullableNumberConverter })
     public size: number;
     private sizeChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.size = this.size;
         }
     }
@@ -156,7 +156,7 @@ export class TextField extends FormAssociatedTextField {
     @attr({ mode: "boolean" })
     public spellcheck: boolean;
     private spellcheckChanged(): void {
-        if (this.proxy instanceof HTMLElement) {
+        if (this.proxy instanceof HTMLInputElement) {
             this.proxy.spellcheck = this.spellcheck;
         }
     }


### PR DESCRIPTION
# Description
This change updates all form-associated components to create a named local class before applying the `FormAssociated` mixin function.

## Motivation & context

It turns out this solves a lot of the `import()` problems that are preventing us from upgrading the API Extractor and TypeScript 4. It also reduces the opportunities for collisions as mitigated in #4475,

## Issue type checklist

- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

This change should only affect the generated `.d.ts` files.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist

- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
