### PR TITLE
fix: add display:grid to flipper slots to prevent container from changing glyph position

### DIFF
--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -50,7 +50,7 @@ export const FlipperStyles = css`
 
     .next,
     .previous {
-        position: absolute;
+        position: relative;
         ${
             /* Glyph size and display: grid are temporary - 
             replace when adaptive typography is figured out */ ""

--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -50,13 +50,13 @@ export const FlipperStyles = css`
 
     .next,
     .previous {
-        position: relative;
+        position: absolute;
         ${
-            /* Glyph size and font-size is temporary - 
+            /* Glyph size and display: grid are temporary - 
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;
-        font-size: 0;
+        display: grid;
     }
 
     :host([disabled]) {

--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -52,10 +52,11 @@ export const FlipperStyles = css`
     .previous {
         position: relative;
         ${
-            /* Glyph size and margin-left is temporary - 
+            /* Glyph size and font-size is temporary - 
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;
+        font-size: 0;
     }
 
     :host([disabled]) {


### PR DESCRIPTION
# Description
Set `font-size:0` in flipper.styles.ts for the `.next` and `.previous` slot classes so the glyphs will render in their proper positions regardless of container's inheritable font-size

## Motivation & context
Fixes #4497 

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [x] **Bug fix**: A change that fixes an issue, link to the issue above.
- [ ] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**

<!-- Do your changes add or modify components in the @microsoft/fast-components package? Put an x in the box that applies: -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

