### PR TITLE
feat: add auto position tracking to tooltip

### DIFF
--- a/change/@microsoft-fast-components-18104f7b-3775-42fb-bb97-2a2af5e65ece.json
+++ b/change/@microsoft-fast-components-18104f7b-3775-42fb-bb97-2a2af5e65ece.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add auto position tracking to tooltip",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-2f030e0c-1487-4a5b-ad03-a9b6e1cf80e2.json
+++ b/change/@microsoft-fast-foundation-2f030e0c-1487-4a5b-ad03-a9b6e1cf80e2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add auto position tracking to tooltip",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/tooltip/fixtures/base.html
+++ b/packages/web-components/fast-components/src/tooltip/fixtures/base.html
@@ -12,16 +12,40 @@
 
 <h2>Show/Hide</h2>
 <div style="height: 400px; width: 400px; background: lightgray;">
-    <fast-tooltip id="tooltip-show-1" anchor="anchor-show" visible position="top">
+    <fast-tooltip
+        id="tooltip-show-1"
+        anchor="anchor-show"
+        visible
+        position="top"
+        auto-update-mode="auto"
+    >
         Always visible
     </fast-tooltip>
-    <fast-tooltip id="tooltip-show-2" anchor="anchor-show" visible position="right">
+    <fast-tooltip
+        id="tooltip-show-2"
+        anchor="anchor-show"
+        visible
+        position="right"
+        auto-update-mode="auto"
+    >
         Always visible
     </fast-tooltip>
-    <fast-tooltip id="tooltip-show-3" anchor="anchor-show" visible position="bottom">
+    <fast-tooltip
+        id="tooltip-show-3"
+        anchor="anchor-show"
+        visible
+        position="bottom"
+        auto-update-mode="auto"
+    >
         Always visible
     </fast-tooltip>
-    <fast-tooltip id="tooltip-show-4" anchor="anchor-show" visible position="left">
+    <fast-tooltip
+        id="tooltip-show-4"
+        anchor="anchor-show"
+        visible
+        position="left"
+        auto-update-mode="auto"
+    >
         Always visible
     </fast-tooltip>
     <fast-button id="anchor-show" style="margin: 200px;">

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2043,6 +2043,8 @@ export const toolbarTemplate: (context: ElementDefinitionContext, definition: Fo
 export class Tooltip extends FoundationElement {
     anchor: string;
     anchorElement: HTMLElement | null;
+    // Warning: (ae-incompatible-release-tags) The symbol "autoUpdateMode" is marked as @public, but its signature references "AutoUpdateMode" which is marked as @beta
+    autoUpdateMode: AutoUpdateMode;
     // (undocumented)
     connectedCallback(): void;
     // @internal

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.md
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.md
@@ -35,13 +35,15 @@ _Attributes:_
 -   `anchor` - The html id of the HTMLElement which the tooltip is attached to.
 -   `delay` - time in milliseconds to wait before showing and hiding the tooltip. Defaults to 300.
 -   `visible` - boolean value to toggle the visibility of the tooltip (defaults to undefined).
--   `position` - enum; where the tooltip should appear relative to its target. 'start' and 'end' are like 'left' and 'right' but are inverted when the direction is 'rtl' When the position is undefined the tooltip is placed above or below the anchor based on available space.
+-   `position` - where the tooltip should appear relative to its target. 'start' and 'end' are like 'left' and 'right' but are inverted when the direction is 'rtl' When the position is undefined the tooltip is placed above or below the anchor based on available space.
     -   top
     -   bottom
     -   left
     -   right
     -   start
     -   end
+
+- auto-update-mode - Corresponds to anchored region's auto update mode and governs when the tooltip checks its position.  Default is "auto".
 
 _Properties:_
 

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
@@ -90,6 +90,17 @@ describe("Tooltip", () => {
         await disconnect();
     });
 
+    it("should set update mode to 'auto' by default", async () => {
+        const { element, connect, disconnect } = await setup();
+        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+
+        await connect();
+
+        expect(tooltip.autoUpdateMode).to.equal("auto");
+
+        await disconnect();
+    });
+
     it("should not set a default position by default", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
@@ -90,13 +90,13 @@ describe("Tooltip", () => {
         await disconnect();
     });
 
-    it("should set update mode to 'auto' by default", async () => {
+    it("should set update mode to 'anchor' by default", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         await connect();
 
-        expect(tooltip.autoUpdateMode).to.equal("auto");
+        expect(tooltip.autoUpdateMode).to.equal("anchor");
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
@@ -22,6 +22,7 @@ export const tooltipTemplate: (
             html<Tooltip>`
             <${context.tagFor(AnchoredRegion)}
                 fixed-placement="true"
+                auto-update-mode="${x => x.autoUpdateMode}"
                 vertical-positioning-mode="${x => x.verticalPositioningMode}"
                 vertical-default-position="${x => x.verticalDefaultPosition}"
                 vertical-inset="${x => x.verticalInset}"

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -79,14 +79,15 @@ export class Tooltip extends FoundationElement {
     }
 
     /**
-     * Controls when the tooltip updates its position, default is auto.
+     * Controls when the tooltip updates its position, default is 'anchor' which only updates when
+     * the anchor is resized.  'auto' will update on scroll/resize events.
      * Corresponds to anchored-region auto-update-mode.
      * @public
      * @remarks
      * HTML Attribute: auto-update-mode
      */
     @attr({ attribute: "auto-update-mode" })
-    public autoUpdateMode: AutoUpdateMode = "auto";
+    public autoUpdateMode: AutoUpdateMode = "anchor";
 
     /**
      * the html element currently being used as anchor.

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -2,6 +2,7 @@ import { attr, DOM, FASTElement, observable } from "@microsoft/fast-element";
 import { Direction, keyCodeEscape } from "@microsoft/fast-web-utilities";
 import type {
     AnchoredRegion,
+    AutoUpdateMode,
     AxisPositioningMode,
     AxisScalingMode,
 } from "../anchored-region";
@@ -76,6 +77,16 @@ export class Tooltip extends FoundationElement {
             this.updateLayout();
         }
     }
+
+    /**
+     * Controls when the tooltip updates its position, default is auto.
+     * Corresponds to anchored-region auto-update-mode.
+     * @public
+     * @remarks
+     * HTML Attribute: auto-update-mode
+     */
+    @attr({ attribute: "auto-update-mode" })
+    public autoUpdateMode: AutoUpdateMode = "auto";
 
     /**
      * the html element currently being used as anchor.

--- a/sites/site-utilities/statics/assets/components/fast-tooltip.schema.json
+++ b/sites/site-utilities/statics/assets/components/fast-tooltip.schema.json
@@ -41,6 +41,17 @@
       "mapsToAttribute": "position",
       "type": "string"
     },
+    "auto-update-mode": {
+      "enum": [
+        "anchor",
+        "auto"
+      ],
+      "default": "auto",
+      "title": "Auto update mode",
+      "description": "Defines whether the component automatically updates its position",
+      "mapsToAttribute": "auto-update-mode",
+      "type": "string"
+    },
     "Slot": {
       "title": "Default slot",
       "description": "The tooltip content",

--- a/sites/site-utilities/statics/assets/components/fast-tooltip.schema.json
+++ b/sites/site-utilities/statics/assets/components/fast-tooltip.schema.json
@@ -41,17 +41,6 @@
       "mapsToAttribute": "position",
       "type": "string"
     },
-    "auto-update-mode": {
-      "enum": [
-        "anchor",
-        "auto"
-      ],
-      "default": "auto",
-      "title": "Auto update mode",
-      "description": "Defines whether the component automatically updates its position",
-      "mapsToAttribute": "auto-update-mode",
-      "type": "string"
-    },
     "Slot": {
       "title": "Default slot",
       "description": "The tooltip content",


### PR DESCRIPTION
# Description
This change applies anchored region's new auto-update feature to tooltip.  Tooltips will now track their anchors when things scroll or the page resizes.  Authors can retain the current behavior by specifying auto-update-mode="anchor"

## Motivation & context
Tooltips should track the item they are anchored to as much as possible.

## Issue type checklist
- [ ] **Chore**: A change that does not impact distributed packages.
- [ ] **Bug fix**: A change that fixes an issue, link to the issue above.
- [x] **New feature**: A change that adds functionality.

**Is this a breaking change?**
- [ ] This change causes current functionality to break.

**Adding or modifying component(s) in `@microsoft/fast-components` checklist**
- [ ] I have added a new component
- [x] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## Process & policy checklist
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
