### PR TITLE
fix: ensure DesignToken works with falsey values

### DIFF
--- a/change/@microsoft-fast-foundation-bf618f1d-588a-4fef-8ee0-aadb2142c79b.json
+++ b/change/@microsoft-fast-foundation-bf618f1d-588a-4fef-8ee0-aadb2142c79b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ensure DesignToken works with falsey values",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2199,7 +2199,7 @@ export function whitespaceFilter(value: Node, index: number, array: Node[]): boo
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/design-token/design-token.d.ts:49:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
+// dist/dts/design-token/design-token.d.ts:50:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
 // dist/dts/di/di.d.ts:204:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -91,6 +91,21 @@ describe("A DesignToken", () => {
 
             expect(token.getValueFor(target)).to.equal(14);
         });
+
+        it("should support getting and setting falsey values", () => {
+            const target = addElement();
+            [false, null, 0, "", NaN].forEach(value => {
+                
+                const token = DesignToken.create<typeof value>("test");
+                token.setValueFor(target, value);
+
+                if (typeof value === "number" && isNaN(value)) {
+                    expect(isNaN(token.getValueFor(target) as number)).to.equal(true)
+                } else {
+                    expect(token.getValueFor(target)).to.equal(value);
+                }
+            })
+        })
     });
     describe("getting and setting derived values", () => {
         it("should get the return value of a derived value", () => {
@@ -187,6 +202,20 @@ describe("A DesignToken", () => {
             expect(tokenB.getValueFor(target)).to.equal(14);
             removeElement(ancestor);
         });
+        it("should support getting and setting falsey values", () => {
+            const target = addElement();
+            [false, null, 0, "", NaN].forEach(value => {
+                
+                const token = DesignToken.create<typeof value>("test");
+                token.setValueFor(target, () => value as any);
+
+                if (typeof value === "number" && isNaN(value)) {
+                    expect(isNaN(token.getValueFor(target) as number)).to.equal(true)
+                } else {
+                    expect(token.getValueFor(target)).to.equal(value);
+                }
+            })
+        })
     });
     describe("getting and setting a token value", () => {
         it("should retrieve the value of the token it was set to", () => {

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -230,7 +230,7 @@ class DesignTokenNode<T> {
         let current: DesignTokenNode<T> | undefined = node;
 
         while (current !== undefined) {
-            if (current.rawValue) {
+            if (current.rawValue !== undefined) {
                 const { rawValue } = current;
                 if (DesignTokenNode.isDerivedTokenValue(rawValue)) {
                     this.setupBindingObserver(rawValue);
@@ -406,6 +406,7 @@ class DesignTokenNode<T> {
 }
 
 function create<T extends Function>(name: string): never;
+function create<T extends undefined>(name: string): never;
 function create<T>(name: string): DesignToken<T>;
 function create<T>(name: string): any {
     return new DesignTokenImpl<T>(name);
@@ -418,3 +419,5 @@ function create<T>(name: string): any {
 export const DesignToken = Object.freeze({
     create,
 });
+
+const test = create<undefined>("foo");

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -406,7 +406,7 @@ class DesignTokenNode<T> {
 }
 
 function create<T extends Function>(name: string): never;
-function create<T extends undefined>(name: string): never;
+function create<T extends undefined | void>(name: string): never;
 function create<T>(name: string): DesignToken<T>;
 function create<T>(name: string): any {
     return new DesignTokenImpl<T>(name);
@@ -419,5 +419,3 @@ function create<T>(name: string): any {
 export const DesignToken = Object.freeze({
     create,
 });
-
-const test = create<undefined>("foo");


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
I noticed when doing some implementation tests that a `DesignToken` set to a *falsey* value would be un-resolvable for a node, throwing an exception. This changes resolution logic to correctly handle *falsey* values, so that values like `0`, `""`, `NaN`, and `null` are all valid values for a `DesignToken`.

This change also extends the type-guard to dis-allow `DesignToken<undefined>` and `DesignToken<void>`, because the `undefined` value is used to determine if a value should be resolved from a parent node.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->