### PR TITLE
chore: use import types and add missing types and doc blocks in fast-components

### DIFF
--- a/change/@microsoft-fast-components-6a9143a6-a689-443c-80fe-ea13a69a4db6.json
+++ b/change/@microsoft-fast-components-6a9143a6-a689-443c-80fe-ea13a69a4db6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add types and docs to style exports",
+  "packageName": "@microsoft/fast-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -16,6 +16,7 @@ import { Button } from '@microsoft/fast-foundation';
 import { Checkbox } from '@microsoft/fast-foundation';
 import { ColorRGBA64 } from '@microsoft/fast-colors';
 import { Combobox } from '@microsoft/fast-foundation';
+import { CSSCustomPropertyBehavior } from '@microsoft/fast-foundation';
 import { DataGrid } from '@microsoft/fast-foundation';
 import { DataGridCell } from '@microsoft/fast-foundation';
 import { DataGridRow } from '@microsoft/fast-foundation';
@@ -24,6 +25,7 @@ import { Dialog } from '@microsoft/fast-foundation';
 import { Direction } from '@microsoft/fast-web-utilities';
 import { Disclosure } from '@microsoft/fast-foundation';
 import { Divider } from '@microsoft/fast-foundation';
+import { ElementStyles } from '@microsoft/fast-element';
 import { Flipper } from '@microsoft/fast-foundation';
 import { HorizontalScroll } from '@microsoft/fast-foundation';
 import { Listbox } from '@microsoft/fast-foundation';
@@ -61,10 +63,10 @@ export const accentFill: SwatchFamilyResolver<FillSwatchFamily>;
 export const accentFillActive: SwatchRecipe;
 
 // @public
-export const accentFillActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const accentFillFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentFillHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -72,7 +74,7 @@ export const accentFillFocusBehavior: import("@microsoft/fast-foundation").CSSCu
 export const accentFillHover: SwatchRecipe;
 
 // @public
-export const accentFillHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentFillLarge" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -85,10 +87,10 @@ export const accentFillLarge: SwatchFamilyResolver<FillSwatchFamily>;
 export const accentFillLargeActive: SwatchRecipe;
 
 // @public
-export const accentFillLargeActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillLargeActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const accentFillLargeFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillLargeFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentFillLargeHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -96,7 +98,7 @@ export const accentFillLargeFocusBehavior: import("@microsoft/fast-foundation").
 export const accentFillLargeHover: SwatchRecipe;
 
 // @public
-export const accentFillLargeHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillLargeHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentFillLargeRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -104,7 +106,7 @@ export const accentFillLargeHoverBehavior: import("@microsoft/fast-foundation").
 export const accentFillLargeRest: SwatchRecipe;
 
 // @public
-export const accentFillLargeRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillLargeRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentFillLargeSelected" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -112,7 +114,7 @@ export const accentFillLargeRestBehavior: import("@microsoft/fast-foundation").C
 export const accentFillLargeSelected: SwatchRecipe;
 
 // @public
-export const accentFillLargeSelectedBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillLargeSelectedBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentFillRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -120,7 +122,7 @@ export const accentFillLargeSelectedBehavior: import("@microsoft/fast-foundation
 export const accentFillRest: SwatchRecipe;
 
 // @public
-export const accentFillRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentFillSelected" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -128,7 +130,7 @@ export const accentFillRestBehavior: import("@microsoft/fast-foundation").CSSCus
 export const accentFillSelected: SwatchRecipe;
 
 // @public
-export const accentFillSelectedBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentFillSelectedBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentForeground" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -141,7 +143,7 @@ export const accentForeground: SwatchFamilyResolver;
 export const accentForegroundActive: SwatchRecipe;
 
 // @public
-export const accentForegroundActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentForegroundActiveBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentForegroundCut" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -154,10 +156,10 @@ export const accentForegroundCut: SwatchRecipe;
 export const accentForegroundCutLarge: SwatchRecipe;
 
 // @public
-export const accentForegroundCutRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentForegroundCutRestBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const accentForegroundFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentForegroundFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentForegroundHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -165,7 +167,7 @@ export const accentForegroundFocusBehavior: import("@microsoft/fast-foundation")
 export const accentForegroundHover: SwatchRecipe;
 
 // @public
-export const accentForegroundHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentForegroundHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentForegroundLarge" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -178,10 +180,10 @@ export const accentForegroundLarge: SwatchFamilyResolver;
 export const accentForegroundLargeActive: SwatchRecipe;
 
 // @public
-export const accentForegroundLargeActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentForegroundLargeActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const accentForegroundLargeFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentForegroundLargeFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentForegroundLargeHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -189,7 +191,7 @@ export const accentForegroundLargeFocusBehavior: import("@microsoft/fast-foundat
 export const accentForegroundLargeHover: SwatchRecipe;
 
 // @public
-export const accentForegroundLargeHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentForegroundLargeHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentForegroundLargeRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -197,7 +199,7 @@ export const accentForegroundLargeHoverBehavior: import("@microsoft/fast-foundat
 export const accentForegroundLargeRest: SwatchRecipe;
 
 // @public
-export const accentForegroundLargeRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentForegroundLargeRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "accentForegroundRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -205,64 +207,73 @@ export const accentForegroundLargeRestBehavior: import("@microsoft/fast-foundati
 export const accentForegroundRest: SwatchRecipe;
 
 // @public
-export const accentForegroundRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const accentForegroundRestBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const AccordionItemStyles: import("@microsoft/fast-element").ElementStyles;
+export const AccordionItemStyles: ElementStyles;
 
 // @public
-export const AccordionStyles: import("@microsoft/fast-element").ElementStyles;
+export const AccordionStyles: ElementStyles;
+
+// @public
+export const ActionsStyles: ElementStyles;
 
 // @public
 export type AnchorAppearance = ButtonAppearance | "hypertext";
 
 // @public
-export const AnchoredRegionStyles: import("@microsoft/fast-element").ElementStyles;
+export const AnchoredRegionStyles: ElementStyles;
 
 // @public
-export const AnchorStyles: import("@microsoft/fast-element").ElementStyles;
+export const AnchorStyles: ElementStyles;
 
 // @public
-export const BadgeStyles: import("@microsoft/fast-element").ElementStyles;
+export const BadgeStyles: ElementStyles;
+
+// @public
+export const BreadcrumbItemStyles: ElementStyles;
+
+// @public
+export const BreadcrumbStyles: ElementStyles;
 
 // @public
 export type ButtonAppearance = "accent" | "lightweight" | "neutral" | "outline" | "stealth";
 
 // @public
-export const ButtonStyles: import("@microsoft/fast-element").ElementStyles;
+export const ButtonStyles: ElementStyles;
 
 // @public
-export const CardStyles: import("@microsoft/fast-element").ElementStyles;
+export const CardStyles: ElementStyles;
 
 // @public
-export const CheckboxStyles: import("@microsoft/fast-element").ElementStyles;
+export const CheckboxStyles: ElementStyles;
 
 // @public
-export const ComboboxStyles: import("@microsoft/fast-element").ElementStyles;
+export const ComboboxStyles: ElementStyles;
 
 // @public
 export function createColorPalette(baseColor: any): string[];
 
 // @public
-export const DataGridCellStyles: import("@microsoft/fast-element").ElementStyles;
+export const DataGridCellStyles: ElementStyles;
 
 // @public
-export const DataGridRowStyles: import("@microsoft/fast-element").ElementStyles;
+export const DataGridRowStyles: ElementStyles;
 
 // @public
-export const DataGridStyles: import("@microsoft/fast-element").ElementStyles;
+export const DataGridStyles: ElementStyles;
 
 // @public
-export const DialogStyles: import("@microsoft/fast-element").ElementStyles;
+export const DialogStyles: ElementStyles;
 
 // @public
 export type DisclosureAppearance = "accent" | "lightweight";
 
 // @public
-export const DisclosureStyles: import("@microsoft/fast-element").ElementStyles;
+export const DisclosureStyles: ElementStyles;
 
 // @public
-export const DividerStyles: import("@microsoft/fast-element").ElementStyles;
+export const DividerStyles: ElementStyles;
 
 // @public
 export class FASTAccordion extends Accordion {
@@ -675,25 +686,31 @@ export class FASTTreeView extends TreeView {
 }
 
 // @public
-export const FlipperStyles: import("@microsoft/fast-element").ElementStyles;
+export const FlipperStyles: ElementStyles;
 
 // @public
-export const inlineEndBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const HorizontalScrollStyles: ElementStyles;
 
 // @public
-export const inlineStartBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const horizontalSliderStyles: ElementStyles;
+
+// @public
+export const inlineEndBehavior: CSSCustomPropertyBehavior;
+
+// @public
+export const inlineStartBehavior: CSSCustomPropertyBehavior;
 
 // @public
 export function isDarkMode(designSystem: FASTDesignSystem): boolean;
 
 // @public
-export const ListboxStyles: import("@microsoft/fast-element").ElementStyles;
+export const ListboxStyles: ElementStyles;
 
 // @public
-export const MenuItemStyles: import("@microsoft/fast-element").ElementStyles;
+export const MenuItemStyles: ElementStyles;
 
 // @public
-export const MenuStyles: import("@microsoft/fast-element").ElementStyles;
+export const MenuStyles: ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralContrastFill" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -706,10 +723,10 @@ export const neutralContrastFill: SwatchFamilyResolver;
 export const neutralContrastFillActive: SwatchRecipe;
 
 // @public
-export const neutralContrastFillActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralContrastFillActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const neutralContrastFillFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralContrastFillFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralContrastFillHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -717,7 +734,7 @@ export const neutralContrastFillFocusBehavior: import("@microsoft/fast-foundatio
 export const neutralContrastFillHover: SwatchRecipe;
 
 // @public
-export const neutralContrastFillHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralContrastFillHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralContrastFillRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -725,10 +742,10 @@ export const neutralContrastFillHoverBehavior: import("@microsoft/fast-foundatio
 export const neutralContrastFillRest: SwatchRecipe;
 
 // @public
-export const neutralContrastFillRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralContrastFillRestBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const neutralContrastForegroundRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralContrastForegroundRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralDividerRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -736,7 +753,7 @@ export const neutralContrastForegroundRestBehavior: import("@microsoft/fast-foun
 export const neutralDividerRest: SwatchRecipe;
 
 // @public
-export const neutralDividerRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralDividerRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-forgotten-export) The symbol "ColorRecipe" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "neutralFill" should be prefixed with an underscore because the declaration is marked as @internal
@@ -750,7 +767,7 @@ export const neutralFill: ColorRecipe<FillSwatchFamily>;
 export const neutralFillActive: SwatchRecipe;
 
 // @public
-export const neutralFillActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillActiveBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-forgotten-export) The symbol "Swatch" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "neutralFillCard" should be prefixed with an underscore because the declaration is marked as @internal
@@ -764,10 +781,10 @@ export function neutralFillCard(designSystem: FASTDesignSystem): Swatch;
 export function neutralFillCard(backgroundResolver: SwatchResolver): SwatchResolver;
 
 // @public
-export const neutralFillCardRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillCardRestBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const neutralFillFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -775,7 +792,7 @@ export const neutralFillFocusBehavior: import("@microsoft/fast-foundation").CSSC
 export const neutralFillHover: SwatchRecipe;
 
 // @public
-export const neutralFillHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInput" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -788,10 +805,10 @@ export const neutralFillInput: ColorRecipe<FillSwatchFamily>;
 export const neutralFillInputActive: ColorRecipe<string>;
 
 // @public
-export const neutralFillInputActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillInputActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const neutralFillInputFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillInputFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -799,7 +816,7 @@ export const neutralFillInputFocusBehavior: import("@microsoft/fast-foundation")
 export const neutralFillInputHover: ColorRecipe<string>;
 
 // @public
-export const neutralFillInputHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillInputHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -807,7 +824,7 @@ export const neutralFillInputHoverBehavior: import("@microsoft/fast-foundation")
 export const neutralFillInputRest: ColorRecipe<string>;
 
 // @public
-export const neutralFillInputRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillInputRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillInputSelected" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -815,7 +832,7 @@ export const neutralFillInputRestBehavior: import("@microsoft/fast-foundation").
 export const neutralFillInputSelected: ColorRecipe<string>;
 
 // @public
-export const neutralFillInputSelectedBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillInputSelectedBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -823,7 +840,7 @@ export const neutralFillInputSelectedBehavior: import("@microsoft/fast-foundatio
 export const neutralFillRest: SwatchRecipe;
 
 // @public
-export const neutralFillRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillSelected" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -831,7 +848,7 @@ export const neutralFillRestBehavior: import("@microsoft/fast-foundation").CSSCu
 export const neutralFillSelected: SwatchRecipe;
 
 // @public
-export const neutralFillSelectedBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillSelectedBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillStealth" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -844,10 +861,10 @@ export const neutralFillStealth: ColorRecipe<FillSwatchFamily>;
 export const neutralFillStealthActive: ColorRecipe<Swatch>;
 
 // @public
-export const neutralFillStealthActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillStealthActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const neutralFillStealthFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillStealthFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillStealthHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -855,7 +872,7 @@ export const neutralFillStealthFocusBehavior: import("@microsoft/fast-foundation
 export const neutralFillStealthHover: ColorRecipe<Swatch>;
 
 // @public
-export const neutralFillStealthHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillStealthHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillStealthRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -863,7 +880,7 @@ export const neutralFillStealthHoverBehavior: import("@microsoft/fast-foundation
 export const neutralFillStealthRest: ColorRecipe<Swatch>;
 
 // @public
-export const neutralFillStealthRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillStealthRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillStealthSelected" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -871,7 +888,7 @@ export const neutralFillStealthRestBehavior: import("@microsoft/fast-foundation"
 export const neutralFillStealthSelected: ColorRecipe<Swatch>;
 
 // @public
-export const neutralFillStealthSelectedBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillStealthSelectedBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillToggle" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -884,10 +901,10 @@ export const neutralFillToggle: SwatchFamilyResolver;
 export const neutralFillToggleActive: SwatchRecipe;
 
 // @public
-export const neutralFillToggleActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillToggleActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const neutralFillToggleFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillToggleFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillToggleHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -895,7 +912,7 @@ export const neutralFillToggleFocusBehavior: import("@microsoft/fast-foundation"
 export const neutralFillToggleHover: SwatchRecipe;
 
 // @public
-export const neutralFillToggleHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillToggleHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFillToggleRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -903,7 +920,7 @@ export const neutralFillToggleHoverBehavior: import("@microsoft/fast-foundation"
 export const neutralFillToggleRest: SwatchRecipe;
 
 // @public
-export const neutralFillToggleRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFillToggleRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralFocus" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -911,7 +928,7 @@ export const neutralFillToggleRestBehavior: import("@microsoft/fast-foundation")
 export const neutralFocus: ColorRecipe<Swatch>;
 
 // @public
-export const neutralFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-forgotten-export) The symbol "DesignSystemResolver" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "neutralFocusInnerAccent" should be prefixed with an underscore because the declaration is marked as @internal
@@ -920,7 +937,7 @@ export const neutralFocusBehavior: import("@microsoft/fast-foundation").CSSCusto
 export function neutralFocusInnerAccent(accentFillColor: DesignSystemResolver<string>): DesignSystemResolver<string>;
 
 // @public
-export const neutralFocusInnerAccentBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralFocusInnerAccentBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralForeground" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -933,10 +950,10 @@ export const neutralForeground: SwatchFamilyResolver;
 export const neutralForegroundActive: SwatchRecipe;
 
 // @public
-export const neutralForegroundActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralForegroundActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const neutralForegroundFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralForegroundFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralForegroundHint" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -944,7 +961,7 @@ export const neutralForegroundFocusBehavior: import("@microsoft/fast-foundation"
 export const neutralForegroundHint: SwatchRecipe;
 
 // @public
-export const neutralForegroundHintBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralForegroundHintBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralForegroundHintLarge" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -952,7 +969,7 @@ export const neutralForegroundHintBehavior: import("@microsoft/fast-foundation")
 export const neutralForegroundHintLarge: SwatchRecipe;
 
 // @public
-export const neutralForegroundHintLargeBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralForegroundHintLargeBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralForegroundHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -960,7 +977,7 @@ export const neutralForegroundHintLargeBehavior: import("@microsoft/fast-foundat
 export const neutralForegroundHover: SwatchRecipe;
 
 // @public
-export const neutralForegroundHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralForegroundHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralForegroundRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -968,7 +985,7 @@ export const neutralForegroundHoverBehavior: import("@microsoft/fast-foundation"
 export const neutralForegroundRest: SwatchRecipe;
 
 // @public
-export const neutralForegroundRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralForegroundRestBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralForegroundToggle" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -976,7 +993,7 @@ export const neutralForegroundRestBehavior: import("@microsoft/fast-foundation")
 export const neutralForegroundToggle: SwatchRecipe;
 
 // @public
-export const neutralForegroundToggleBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralForegroundToggleBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralForegroundToggleLarge" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -984,7 +1001,7 @@ export const neutralForegroundToggleBehavior: import("@microsoft/fast-foundation
 export const neutralForegroundToggleLarge: SwatchRecipe;
 
 // @public
-export const neutralForegroundToggleLargeBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralForegroundToggleLargeBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralLayerCard" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -992,7 +1009,7 @@ export const neutralForegroundToggleLargeBehavior: import("@microsoft/fast-found
 export const neutralLayerCard: ColorRecipe<Swatch>;
 
 // @public
-export const neutralLayerCardBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralLayerCardBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralLayerCardContainer" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1000,7 +1017,7 @@ export const neutralLayerCardBehavior: import("@microsoft/fast-foundation").CSSC
 export const neutralLayerCardContainer: ColorRecipe<Swatch>;
 
 // @public
-export const neutralLayerCardContainerBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralLayerCardContainerBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralLayerFloating" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1008,7 +1025,7 @@ export const neutralLayerCardContainerBehavior: import("@microsoft/fast-foundati
 export const neutralLayerFloating: ColorRecipe<Swatch>;
 
 // @public
-export const neutralLayerFloatingBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralLayerFloatingBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralLayerL1" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1021,10 +1038,10 @@ export const neutralLayerL1: ColorRecipe<Swatch>;
 export const neutralLayerL1Alt: ColorRecipe<Swatch>;
 
 // @public
-export const neutralLayerL1AltBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralLayerL1AltBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const neutralLayerL1Behavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralLayerL1Behavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralLayerL2" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1032,7 +1049,7 @@ export const neutralLayerL1Behavior: import("@microsoft/fast-foundation").CSSCus
 export const neutralLayerL2: ColorRecipe<Swatch>;
 
 // @public
-export const neutralLayerL2Behavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralLayerL2Behavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralLayerL3" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1040,7 +1057,7 @@ export const neutralLayerL2Behavior: import("@microsoft/fast-foundation").CSSCus
 export const neutralLayerL3: ColorRecipe<Swatch>;
 
 // @public
-export const neutralLayerL3Behavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralLayerL3Behavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralLayerL4" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1048,7 +1065,7 @@ export const neutralLayerL3Behavior: import("@microsoft/fast-foundation").CSSCus
 export const neutralLayerL4: ColorRecipe<Swatch>;
 
 // @public
-export const neutralLayerL4Behavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralLayerL4Behavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-forgotten-export) The symbol "SwatchFamily" needs to be exported by the entry point index.d.ts
 // Warning: (ae-internal-missing-underscore) The name "neutralOutline" should be prefixed with an underscore because the declaration is marked as @internal
@@ -1062,10 +1079,10 @@ export const neutralOutline: ColorRecipe<SwatchFamily>;
 export const neutralOutlineActive: SwatchRecipe;
 
 // @public
-export const neutralOutlineActiveBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralOutlineActiveBehavior: CSSCustomPropertyBehavior;
 
 // @public
-export const neutralOutlineFocusBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralOutlineFocusBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralOutlineHover" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1073,7 +1090,7 @@ export const neutralOutlineFocusBehavior: import("@microsoft/fast-foundation").C
 export const neutralOutlineHover: SwatchRecipe;
 
 // @public
-export const neutralOutlineHoverBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralOutlineHoverBehavior: CSSCustomPropertyBehavior;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralOutlineRest" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1081,16 +1098,16 @@ export const neutralOutlineHoverBehavior: import("@microsoft/fast-foundation").C
 export const neutralOutlineRest: SwatchRecipe;
 
 // @public
-export const neutralOutlineRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
+export const neutralOutlineRestBehavior: CSSCustomPropertyBehavior;
 
 // @public
 export type NumberFieldAppearance = "filled" | "outline";
 
 // @public
-export const NumberFieldStyles: import("@microsoft/fast-element").ElementStyles;
+export const NumberFieldStyles: ElementStyles;
 
 // @public
-export const OptionStyles: import("@microsoft/fast-element").ElementStyles;
+export const OptionStyles: ElementStyles;
 
 // @public
 export type Palette = Swatch[];
@@ -1112,28 +1129,28 @@ export enum PaletteType {
 export const parseColorString: (color: string) => ColorRGBA64;
 
 // @public
-export const ProgressRingStyles: import("@microsoft/fast-element").ElementStyles;
+export const ProgressRingStyles: ElementStyles;
 
 // @public
-export const ProgressStyles: import("@microsoft/fast-element").ElementStyles;
+export const ProgressStyles: ElementStyles;
 
 // @public
-export const RadioGroupStyles: import("@microsoft/fast-element").ElementStyles;
+export const RadioGroupStyles: ElementStyles;
 
 // @public
-export const RadioStyles: import("@microsoft/fast-element").ElementStyles;
+export const RadioStyles: ElementStyles;
 
 // @public
-export const SelectStyles: import("@microsoft/fast-element").ElementStyles;
+export const SelectStyles: ElementStyles;
 
 // @public
-export const SkeletonStyles: import("@microsoft/fast-element").ElementStyles;
+export const SkeletonStyles: ElementStyles;
 
 // @public
-export const SliderLabelStyles: import("@microsoft/fast-element").ElementStyles;
+export const SliderLabelStyles: ElementStyles;
 
 // @public
-export const SliderStyles: import("@microsoft/fast-element").ElementStyles;
+export const SliderStyles: ElementStyles;
 
 // @public
 export enum StandardLuminance {
@@ -1144,34 +1161,40 @@ export enum StandardLuminance {
 }
 
 // @public
-export const SwitchStyles: import("@microsoft/fast-element").ElementStyles;
+export const SwitchStyles: ElementStyles;
 
 // @public
-export const TabPanelStyles: import("@microsoft/fast-element").ElementStyles;
+export const TabPanelStyles: ElementStyles;
 
 // @public
-export const TabsStyles: import("@microsoft/fast-element").ElementStyles;
+export const TabsStyles: ElementStyles;
 
 // @public
-export const TabStyles: import("@microsoft/fast-element").ElementStyles;
+export const TabStyles: ElementStyles;
 
 // @public
 export type TextAreaAppearance = "filled" | "outline";
 
 // @public
-export const TextAreaStyles: import("@microsoft/fast-element").ElementStyles;
+export const TextAreaStyles: ElementStyles;
 
 // @public
 export type TextFieldAppearance = "filled" | "outline";
 
 // @public
-export const TextFieldStyles: import("@microsoft/fast-element").ElementStyles;
+export const TextFieldStyles: ElementStyles;
 
 // @public
-export const TreeItemStyles: import("@microsoft/fast-element").ElementStyles;
+export const TooltipStyles: ElementStyles;
 
 // @public
-export const TreeViewStyles: import("@microsoft/fast-element").ElementStyles;
+export const TreeItemStyles: ElementStyles;
+
+// @public
+export const TreeViewStyles: ElementStyles;
+
+// @public
+export const verticalSliderStyles: ElementStyles;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     display,
     focusVisible,
@@ -16,7 +17,12 @@ import {
 } from "../styles/recipes";
 import { heightNumber } from "../styles/size";
 
-export const AccordionItemStyles = css`
+/**
+ * Styles for the {@link FASTAccordionItem|FASTAccordionItem component}.
+ *
+ * @public
+ */
+export const AccordionItemStyles: ElementStyles = css`
     ${display("flex")} :host {
         box-sizing: border-box;
         font-family: var(--body-font);
@@ -25,7 +31,7 @@ export const AccordionItemStyles = css`
         line-height: var(--type-ramp-minus-1-line-height);
         border-bottom: calc(var(--outline-width) * 1px) solid var(--neutral-divider-rest);
     }
-    
+
     .region {
         display: none;
         padding: calc((6 + (var(--design-unit) * 2 * var(--density))) * 1px);
@@ -108,7 +114,7 @@ export const AccordionItemStyles = css`
     slot[name="expanded-icon"] {
         display: none;
     }
-    
+
     :host([expanded]) slot[name="expanded-icon"] {
         display: flex;
     }

--- a/packages/web-components/fast-components/src/accordion-item/index.ts
+++ b/packages/web-components/fast-components/src/accordion-item/index.ts
@@ -12,7 +12,7 @@ import { AccordionItemStyles as styles } from "./accordion-item.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-accordion-item\>
+ * HTML Element: `<fast-accordion-item>`
  */
 @customElement({
     name: "fast-accordion-item",
@@ -21,8 +21,4 @@ import { AccordionItemStyles as styles } from "./accordion-item.styles";
 })
 export class FASTAccordionItem extends AccordionItem {}
 
-/**
- * Styles for AccordionItem
- * @public
- */
-export const AccordionItemStyles = styles;
+export { AccordionItemStyles } from "./accordion-item.styles";

--- a/packages/web-components/fast-components/src/accordion/accordion.styles.ts
+++ b/packages/web-components/fast-components/src/accordion/accordion.styles.ts
@@ -1,11 +1,17 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 import {
     neutralDividerRestBehavior,
     neutralForegroundRestBehavior,
 } from "../styles/recipes";
 
-export const AccordionStyles = css`
+/**
+ * Styles for the {@link FASTAccordion|FASTAccordion component}.
+ *
+ * @public
+ */
+export const AccordionStyles: ElementStyles = css`
     ${display("flex")} :host {
         box-sizing: border-box;
         flex-direction: column;

--- a/packages/web-components/fast-components/src/accordion/index.ts
+++ b/packages/web-components/fast-components/src/accordion/index.ts
@@ -2,8 +2,6 @@ import { customElement } from "@microsoft/fast-element";
 import { Accordion, AccordionTemplate as template } from "@microsoft/fast-foundation";
 import { AccordionStyles as styles } from "./accordion.styles";
 
-export * from "../accordion-item/index";
-
 /**
  * The FAST Accordion Element. Implements {@link @microsoft/fast-foundation#Accordion},
  * {@link @microsoft/fast-foundation#AccordionTemplate}
@@ -11,7 +9,7 @@ export * from "../accordion-item/index";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-accordion\>
+ * HTML Element: `<fast-accordion>`
  */
 @customElement({
     name: "fast-accordion",
@@ -20,8 +18,5 @@ export * from "../accordion-item/index";
 })
 export class FASTAccordion extends Accordion {}
 
-/**
- * Styles for Accordion
- * @public
- */
-export const AccordionStyles = styles;
+export * from "../accordion-item";
+export { AccordionStyles } from "./accordion.styles";

--- a/packages/web-components/fast-components/src/anchor/anchor.styles.ts
+++ b/packages/web-components/fast-components/src/anchor/anchor.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     AccentButtonStyles,
     BaseButtonStyles,
@@ -6,10 +7,15 @@ import {
     LightweightButtonStyles,
     OutlineButtonStyles,
     StealthButtonStyles,
-} from "../styles/index";
+} from "../styles/patterns/button";
 import { appearanceBehavior } from "../utilities/behaviors";
 
-export const AnchorStyles = css`
+/**
+ * Styles for the {@link FASTAnchor|FASTAnchor component}.
+ *
+ * @public
+ */
+export const AnchorStyles: ElementStyles = css`
     ${BaseButtonStyles}
 `.withBehaviors(
     appearanceBehavior("accent", AccentButtonStyles),

--- a/packages/web-components/fast-components/src/anchor/index.ts
+++ b/packages/web-components/fast-components/src/anchor/index.ts
@@ -1,6 +1,6 @@
 import { attr, customElement } from "@microsoft/fast-element";
 import { Anchor, AnchorTemplate as template } from "@microsoft/fast-foundation";
-import { ButtonAppearance } from "../button";
+import type { ButtonAppearance } from "../button";
 import { AnchorStyles as styles } from "./anchor.styles";
 
 /**
@@ -16,7 +16,7 @@ export type AnchorAppearance = ButtonAppearance | "hypertext";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-anchor\>
+ * HTML Element: `<fast-anchor>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */
@@ -74,8 +74,4 @@ export class FASTAnchor extends Anchor {
     }
 }
 
-/**
- * Styles for Anchor
- * @public
- */
-export const AnchorStyles = styles;
+export { AnchorStyles } from "./anchor.styles";

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.definition.ts
@@ -1,11 +1,5 @@
 import type { WebComponentDefinition } from "@microsoft/fast-tooling/dist/esm/data-utilities/web-component";
 import { DataType } from "@microsoft/fast-tooling";
-import {
-    AxisPositioningMode,
-    AxisScalingMode,
-    HorizontalPosition,
-    VerticalPosition,
-} from "@microsoft/fast-foundation";
 
 export const fastAnchoredRegionDefinition: WebComponentDefinition = {
     version: 1,

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.styles.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.styles.ts
@@ -1,6 +1,12 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 
-export const AnchoredRegionStyles = css`
+/**
+ * Styles for the {@link FASTAnchoredRegion|FASTAnchoredRegion component}.
+ *
+ * @public
+ */
+export const AnchoredRegionStyles: ElementStyles = css`
     :host {
         contain: layout;
         display: block;

--- a/packages/web-components/fast-components/src/anchored-region/index.ts
+++ b/packages/web-components/fast-components/src/anchored-region/index.ts
@@ -12,7 +12,7 @@ import { AnchoredRegionStyles as styles } from "./anchored-region.styles";
  *
  * @beta
  * @remarks
- * HTML Element: \<fast-anchored-region\>
+ * HTML Element: `<fast-anchored-region>`
  */
 @customElement({
     name: "fast-anchored-region",
@@ -21,8 +21,4 @@ import { AnchoredRegionStyles as styles } from "./anchored-region.styles";
 })
 export class FASTAnchoredRegion extends AnchoredRegion {}
 
-/**
- * Styles for AnchoredRegion
- * @public
- */
-export const AnchoredRegionStyles = styles;
+export { AnchoredRegionStyles } from "./anchored-region.styles";

--- a/packages/web-components/fast-components/src/badge/badge.styles.ts
+++ b/packages/web-components/fast-components/src/badge/badge.styles.ts
@@ -1,8 +1,15 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
-import { accentForegroundRestBehavior, heightNumber } from "../styles/index";
+import { accentForegroundRestBehavior } from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const BadgeStyles = css`
+/**
+ * Styles for the {@link FASTBadge|FASTBadge component}.
+ *
+ * @public
+ */
+export const BadgeStyles: ElementStyles = css`
     ${display("inline-block")} :host {
         box-sizing: border-box;
         font-family: var(--body-font);

--- a/packages/web-components/fast-components/src/badge/index.ts
+++ b/packages/web-components/fast-components/src/badge/index.ts
@@ -9,7 +9,7 @@ import { BadgeStyles as styles } from "./badge.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-badge\>
+ * HTML Element: `<fast-badge>`
  */
 @customElement({
     name: "fast-badge",
@@ -17,9 +17,4 @@ import { BadgeStyles as styles } from "./badge.styles";
     styles,
 })
 export class FASTBadge extends Badge {}
-
-/**
- * Styles for Badge
- * @public
- */
-export const BadgeStyles = styles;
+export { BadgeStyles } from "./badge.styles";

--- a/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.styles.ts
@@ -1,19 +1,25 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     display,
     focusVisible,
     forcedColorsStylesheetBehavior,
 } from "@microsoft/fast-foundation";
+import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
     accentForegroundActiveBehavior,
     accentForegroundHoverBehavior,
     accentForegroundRestBehavior,
     neutralForegroundRestBehavior,
-    heightNumber,
-} from "../styles/index";
-import { SystemColors } from "@microsoft/fast-web-utilities";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const BreadcrumbItemStyles = css`
+/**
+ * Styles for the {@link FASTBreadcrumbItem|FASTBreadcrumbItem component}.
+ *
+ * @public
+ */
+export const BreadcrumbItemStyles: ElementStyles = css`
     ${display("inline-flex")} :host {
         background: transparent;
         box-sizing: border-box;
@@ -98,7 +104,7 @@ export const BreadcrumbItemStyles = css`
 
     ::slotted(svg) {
         ${
-            /* Glyph size and margin-left is temporary - 
+            /* Glyph size and margin-left is temporary -
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;

--- a/packages/web-components/fast-components/src/breadcrumb-item/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/index.ts
@@ -12,7 +12,7 @@ import { BreadcrumbItemStyles as styles } from "./breadcrumb-item.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-breadcrumb-item\>
+ * HTML Element: `<fast-breadcrumb-item>`
  */
 @customElement({
     name: "fast-breadcrumb-item",
@@ -23,3 +23,5 @@ import { BreadcrumbItemStyles as styles } from "./breadcrumb-item.styles";
     },
 })
 export class FASTBreadcrumbItem extends BreadcrumbItem {}
+
+export { BreadcrumbItemStyles } from "./breadcrumb-item.styles";

--- a/packages/web-components/fast-components/src/breadcrumb/breadcrumb.definition.ts
+++ b/packages/web-components/fast-components/src/breadcrumb/breadcrumb.definition.ts
@@ -1,5 +1,4 @@
 import type { WebComponentDefinition } from "@microsoft/fast-tooling/dist/esm/data-utilities/web-component";
-import { DataType } from "@microsoft/fast-tooling";
 
 export const fastBreadcrumbDefinition: WebComponentDefinition = {
     version: 1,

--- a/packages/web-components/fast-components/src/breadcrumb/breadcrumb.styles.ts
+++ b/packages/web-components/fast-components/src/breadcrumb/breadcrumb.styles.ts
@@ -1,7 +1,13 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 
-export const BreadcrumbStyles = css`
+/**
+ * Styles for the {@link FASTBreadcrumb|FASTBreadcrumb component}.
+ *
+ * @public
+ */
+export const BreadcrumbStyles: ElementStyles = css`
     ${display("inline-block")} :host {
         box-sizing: border-box;
         font-family: var(--body-font);

--- a/packages/web-components/fast-components/src/breadcrumb/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb/index.ts
@@ -9,7 +9,7 @@ import { BreadcrumbStyles as styles } from "./breadcrumb.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-breadcrumb\>
+ * HTML Element: `<fast-breadcrumb>`
  */
 @customElement({
     name: "fast-breadcrumb",
@@ -17,3 +17,5 @@ import { BreadcrumbStyles as styles } from "./breadcrumb.styles";
     styles,
 })
 export class FASTBreadcrumb extends Breadcrumb {}
+
+export { BreadcrumbStyles } from "./breadcrumb.styles";

--- a/packages/web-components/fast-components/src/button/button.styles.ts
+++ b/packages/web-components/fast-components/src/button/button.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     AccentButtonStyles,
     BaseButtonStyles,
@@ -8,7 +9,12 @@ import {
 } from "../styles/index";
 import { appearanceBehavior } from "../utilities/behaviors";
 
-export const ButtonStyles = css`
+/**
+ * Styles for the {@link FASTButton|FASTButton component}.
+ *
+ * @public
+ */
+export const ButtonStyles: ElementStyles = css`
     ${BaseButtonStyles}
 `.withBehaviors(
     appearanceBehavior("accent", AccentButtonStyles),

--- a/packages/web-components/fast-components/src/button/index.ts
+++ b/packages/web-components/fast-components/src/button/index.ts
@@ -20,7 +20,7 @@ export type ButtonAppearance =
  *
  * @public
  * @remarks
- * HTML Element: \<fast-button\>
+ * HTML Element: `<fast-button>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */
@@ -68,8 +68,4 @@ export class FASTButton extends Button {
     }
 }
 
-/**
- * Styles for Button
- * @public
- */
-export const ButtonStyles = styles;
+export { ButtonStyles } from "./button.styles";

--- a/packages/web-components/fast-components/src/card/card.styles.ts
+++ b/packages/web-components/fast-components/src/card/card.styles.ts
@@ -1,9 +1,15 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import { elevation } from "../styles/index";
 
-export const CardStyles = css`
+/**
+ * Styles for the {@link FASTCard|FASTCard component}.
+ *
+ * @public
+ */
+export const CardStyles: ElementStyles = css`
     ${display("block")} :host {
         --elevation: 4;
         display: block;

--- a/packages/web-components/fast-components/src/card/index.ts
+++ b/packages/web-components/fast-components/src/card/index.ts
@@ -5,7 +5,7 @@ import {
     DesignSystemProvider,
     CardTemplate as template,
 } from "@microsoft/fast-foundation";
-import { FASTDesignSystem } from "../fast-design-system";
+import type { FASTDesignSystem } from "../fast-design-system";
 import { createColorPalette, neutralFillCard } from "../color";
 import { CardStyles as styles } from "./card.styles";
 
@@ -18,7 +18,7 @@ const paletteCache = new Map();
  *
  * @public
  * @remarks
- * HTML Element: \<fast-card\>
+ * HTML Element: `<fast-card>`
  */
 @customElement({
     name: "fast-card",
@@ -105,8 +105,4 @@ export class FASTCard extends DesignSystemProvider
     }
 }
 
-/**
- * Styles for Card
- * @public
- */
-export const CardStyles = styles;
+export { CardStyles } from "./card.styles";

--- a/packages/web-components/fast-components/src/checkbox/checkbox.stories.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.stories.ts
@@ -2,7 +2,7 @@ import addons from "@storybook/addons";
 import { STORY_RENDERED } from "@storybook/core-events";
 import Examples from "./fixtures/base.html";
 import "./index";
-import { FASTCheckbox } from "./index";
+import type { FASTCheckbox } from "./index";
 
 addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
     if (name.toLowerCase().startsWith("checkbox")) {

--- a/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -23,7 +24,12 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const CheckboxStyles = css`
+/**
+ * Styles for the {@link FASTCheckbox|FASTCheckbox component}.
+ *
+ * @public
+ */
+export const CheckboxStyles: ElementStyles = css`
     ${display("inline-flex")} :host {
         align-items: center;
         outline: none;

--- a/packages/web-components/fast-components/src/checkbox/index.ts
+++ b/packages/web-components/fast-components/src/checkbox/index.ts
@@ -9,7 +9,7 @@ import { CheckboxStyles as styles } from "./checkbox.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-checkbox\>
+ * HTML Element: `<fast-checkbox>`
  */
 @customElement({
     name: "fast-checkbox",
@@ -18,8 +18,4 @@ import { CheckboxStyles as styles } from "./checkbox.styles";
 })
 export class FASTCheckbox extends Checkbox {}
 
-/**
- * Styles for Checkbox
- * @public
- */
-export const CheckboxStyles = styles;
+export { CheckboxStyles } from "./checkbox.styles";

--- a/packages/web-components/fast-components/src/color/accent-foreground-cut.spec.ts
+++ b/packages/web-components/fast-components/src/color/accent-foreground-cut.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { FASTDesignSystem, fastDesignSystemDefaults } from "../fast-design-system";
 import { accentForegroundCut, accentForegroundCutLarge } from "./accent-foreground-cut";
-import { Swatch } from "./common";
+import type { Swatch } from "./common";
 
 describe("Cut text", (): void => {
     it("should return white by by default", (): void => {

--- a/packages/web-components/fast-components/src/color/accent-foreground-cut.ts
+++ b/packages/web-components/fast-components/src/color/accent-foreground-cut.ts
@@ -1,5 +1,4 @@
-import { FASTDesignSystem } from "../fast-design-system";
-import { accentBaseColor } from "../fast-design-system";
+import { accentBaseColor, FASTDesignSystem } from "../fast-design-system";
 import { black, white } from "./color-constants";
 import { contrast, Swatch, SwatchRecipe, SwatchResolver } from "./common";
 

--- a/packages/web-components/fast-components/src/color/accent-foreground.spec.ts
+++ b/packages/web-components/fast-components/src/color/accent-foreground.spec.ts
@@ -1,9 +1,10 @@
 import { parseColorHexRGB } from "@microsoft/fast-colors";
 import { expect } from "chai";
-import { FASTDesignSystem, fastDesignSystemDefaults } from "../fast-design-system";
 import {
     accentPalette as getAccentPalette,
-    neutralPalette as getNeutralPalette,
+    FASTDesignSystem,
+    fastDesignSystemDefaults,
+    neutralPalette as getNeutralPalette
 } from "../fast-design-system";
 import {
     accentForegroundActive,
@@ -11,10 +12,10 @@ import {
     accentForegroundLargeActive,
     accentForegroundLargeHover,
     accentForegroundLargeRest,
-    accentForegroundRest,
+    accentForegroundRest
 } from "./accent-foreground";
-import { Palette } from "./palette";
 import { contrast, Swatch } from "./common";
+import type { Palette } from "./palette";
 
 describe("accentForeground", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);

--- a/packages/web-components/fast-components/src/color/accent-foreground.ts
+++ b/packages/web-components/fast-components/src/color/accent-foreground.ts
@@ -1,4 +1,3 @@
-import { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
 import {
     accentBaseColor,
     accentForegroundActiveDelta,
@@ -7,15 +6,9 @@ import {
     accentForegroundRestDelta,
     accentPalette,
     backgroundColor,
+    DesignSystemResolver,
+    FASTDesignSystem,
 } from "../fast-design-system";
-import {
-    findClosestSwatchIndex,
-    findSwatchIndex,
-    getSwatch,
-    isDarkMode,
-    Palette,
-    swatchByContrast,
-} from "./palette";
 import {
     colorRecipeFactory,
     Swatch,
@@ -25,6 +18,14 @@ import {
     SwatchFamilyType,
     SwatchRecipe,
 } from "./common";
+import {
+    findClosestSwatchIndex,
+    findSwatchIndex,
+    getSwatch,
+    isDarkMode,
+    Palette,
+    swatchByContrast,
+} from "./palette";
 
 function accentForegroundAlgorithm(
     contrastTarget: number

--- a/packages/web-components/fast-components/src/color/accessible-recipe.ts
+++ b/packages/web-components/fast-components/src/color/accessible-recipe.ts
@@ -1,7 +1,10 @@
-import { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
-import { evaluateDesignSystemResolver } from "../fast-design-system";
-import { backgroundColor } from "../fast-design-system";
-import { Swatch, SwatchFamily } from "./common";
+import {
+    backgroundColor,
+    DesignSystemResolver,
+    evaluateDesignSystemResolver,
+    FASTDesignSystem,
+} from "../fast-design-system";
+import type { Swatch, SwatchFamily } from "./common";
 import {
     findSwatchIndex,
     getSwatch,

--- a/packages/web-components/fast-components/src/color/common.ts
+++ b/packages/web-components/fast-components/src/color/common.ts
@@ -8,7 +8,7 @@ import {
     rgbToRelativeLuminance,
 } from "@microsoft/fast-colors";
 import { memoize } from "lodash-es";
-import { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
+import type { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
 
 /**
  * Describes the format of a single color in a palette

--- a/packages/web-components/fast-components/src/color/neutral-divider.ts
+++ b/packages/web-components/fast-components/src/color/neutral-divider.ts
@@ -1,7 +1,7 @@
-import { FASTDesignSystem } from "../fast-design-system";
 import { neutralDividerRestDelta, neutralPalette } from "../fast-design-system";
-import { findClosestBackgroundIndex, getSwatch, isDarkMode, Palette } from "./palette";
+import type { FASTDesignSystem } from "../fast-design-system";
 import { colorRecipeFactory, Swatch, SwatchRecipe, SwatchResolver } from "./common";
+import { findClosestBackgroundIndex, getSwatch, isDarkMode, Palette } from "./palette";
 
 const neutralDividerAlgorithm: SwatchResolver = (
     designSystem: FASTDesignSystem

--- a/packages/web-components/fast-components/src/color/neutral-fill-card.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill-card.ts
@@ -1,10 +1,10 @@
-import { FASTDesignSystem } from "../fast-design-system";
 import {
     backgroundColor,
+    FASTDesignSystem,
     neutralFillCardDelta,
     neutralPalette,
 } from "../fast-design-system";
-import { Swatch, SwatchResolver } from "./common";
+import type { Swatch, SwatchResolver } from "./common";
 import { findClosestSwatchIndex, getSwatch } from "./palette";
 
 const neutralCardFillAlgorithm: SwatchResolver = (

--- a/packages/web-components/fast-components/src/color/neutral-fill-input.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill-input.ts
@@ -1,5 +1,6 @@
-import { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
 import {
+    DesignSystemResolver,
+    FASTDesignSystem,
     neutralFillInputActiveDelta,
     neutralFillInputFocusDelta,
     neutralFillInputHoverDelta,
@@ -7,8 +8,8 @@ import {
     neutralFillInputSelectedDelta,
     neutralPalette,
 } from "../fast-design-system";
-import { findClosestBackgroundIndex, getSwatch, isDarkMode } from "./palette";
 import { ColorRecipe, colorRecipeFactory, FillSwatchFamily, Swatch } from "./common";
+import { findClosestBackgroundIndex, getSwatch, isDarkMode } from "./palette";
 
 /**
  * Algorithm for determining neutral backplate colors

--- a/packages/web-components/fast-components/src/color/neutral-fill-stealth.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill-stealth.spec.ts
@@ -12,8 +12,8 @@ import {
     neutralFillStealthRest,
     neutralFillStealthSelected,
 } from "./neutral-fill-stealth";
-import { Palette } from "./palette";
-import { FillSwatchFamily, Swatch } from "./common";
+import type { Palette } from "./palette";
+import type { FillSwatchFamily, Swatch } from "./common";
 
 describe("neutralFillStealth", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);

--- a/packages/web-components/fast-components/src/color/neutral-fill-stealth.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill-stealth.ts
@@ -1,4 +1,3 @@
-import { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
 import {
     neutralFillActiveDelta,
     neutralFillFocusDelta,
@@ -11,6 +10,7 @@ import {
     neutralFillStealthSelectedDelta,
     neutralPalette,
 } from "../fast-design-system";
+import type { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
 import {
     ColorRecipe,
     colorRecipeFactory,

--- a/packages/web-components/fast-components/src/color/neutral-fill.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill.spec.ts
@@ -12,8 +12,8 @@ import {
     neutralFillRest,
     neutralFillSelected,
 } from "./neutral-fill";
-import { Palette } from "./palette";
-import { FillSwatchFamily, Swatch } from "./common";
+import type { Palette } from "./palette";
+import type { FillSwatchFamily, Swatch } from "./common";
 
 describe("neutralFill", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);

--- a/packages/web-components/fast-components/src/color/neutral-fill.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill.ts
@@ -1,5 +1,6 @@
-import { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
 import {
+    DesignSystemResolver,
+    FASTDesignSystem,
     neutralFillActiveDelta,
     neutralFillFocusDelta,
     neutralFillHoverDelta,

--- a/packages/web-components/fast-components/src/color/neutral-focus.ts
+++ b/packages/web-components/fast-components/src/color/neutral-focus.ts
@@ -1,7 +1,12 @@
-import { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
-import { accentPalette, backgroundColor, neutralPalette } from "../fast-design-system";
-import { findClosestSwatchIndex, isDarkMode, Palette, swatchByContrast } from "./palette";
+import {
+    accentPalette,
+    backgroundColor,
+    DesignSystemResolver,
+    FASTDesignSystem,
+    neutralPalette,
+} from "../fast-design-system";
 import { ColorRecipe, colorRecipeFactory, Swatch, SwatchResolver } from "./common";
+import { findClosestSwatchIndex, isDarkMode, Palette, swatchByContrast } from "./palette";
 
 const targetRatio: number = 3.5;
 

--- a/packages/web-components/fast-components/src/color/neutral-foreground-hint.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-foreground-hint.spec.ts
@@ -8,7 +8,7 @@ import {
     neutralForegroundHint,
     neutralForegroundHintLarge,
 } from "./neutral-foreground-hint";
-import { Palette } from "./palette";
+import type { Palette } from "./palette";
 import { contrast, Swatch, SwatchRecipe } from "./common";
 
 describe("neutralForegroundHint", (): void => {

--- a/packages/web-components/fast-components/src/color/neutral-foreground-hint.ts
+++ b/packages/web-components/fast-components/src/color/neutral-foreground-hint.ts
@@ -1,4 +1,4 @@
-import { DesignSystemResolver } from "../fast-design-system";
+import type { DesignSystemResolver } from "../fast-design-system";
 import { neutralPalette } from "../fast-design-system";
 import {
     colorRecipeFactory,

--- a/packages/web-components/fast-components/src/color/neutral-foreground-toggle.ts
+++ b/packages/web-components/fast-components/src/color/neutral-foreground-toggle.ts
@@ -1,4 +1,4 @@
-import { FASTDesignSystem } from "../fast-design-system";
+import type { FASTDesignSystem } from "../fast-design-system";
 import { black, white } from "./color-constants";
 import { contrast, Swatch, SwatchRecipe, SwatchResolver } from "./common";
 import { neutralFillToggleRest } from "./neutral-fill-toggle";

--- a/packages/web-components/fast-components/src/color/neutral-layer.ts
+++ b/packages/web-components/fast-components/src/color/neutral-layer.ts
@@ -1,5 +1,4 @@
 import { clamp, ColorRGBA64 } from "@microsoft/fast-colors";
-import { add, multiply, subtract } from "../utilities/math";
 import {
     baseLayerLuminance,
     neutralFillActiveDelta,
@@ -8,14 +7,15 @@ import {
     neutralFillRestDelta,
     neutralPalette,
 } from "../fast-design-system";
-import { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
-import { findClosestSwatchIndex, getSwatch, swatchByMode } from "./palette";
+import type { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
+import { add, multiply, subtract } from "../utilities/math";
 import {
     ColorRecipe,
     colorRecipeFactory,
     designSystemResolverMax,
     Swatch,
 } from "./common";
+import { findClosestSwatchIndex, getSwatch, swatchByMode } from "./palette";
 
 /**
  * Recommended values for light and dark mode for {@link @microsoft/fast-components#FASTDesignSystem.baseLayerLuminance}.

--- a/packages/web-components/fast-components/src/color/neutral-outline.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-outline.spec.ts
@@ -12,8 +12,8 @@ import {
     neutralOutlineHover,
     neutralOutlineRest,
 } from "./neutral-outline";
-import { Palette } from "./palette";
-import { Swatch, SwatchFamily } from "./common";
+import type { Palette } from "./palette";
+import type { Swatch, SwatchFamily } from "./common";
 
 describe("neutralOutline", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);

--- a/packages/web-components/fast-components/src/color/neutral-outline.ts
+++ b/packages/web-components/fast-components/src/color/neutral-outline.ts
@@ -1,12 +1,11 @@
-import { FASTDesignSystem } from "../fast-design-system";
 import {
+    FASTDesignSystem,
     neutralOutlineActiveDelta,
     neutralOutlineFocusDelta,
     neutralOutlineHoverDelta,
     neutralOutlineRestDelta,
     neutralPalette,
 } from "../fast-design-system";
-import { findClosestBackgroundIndex, getSwatch, isDarkMode } from "./palette";
 import {
     ColorRecipe,
     colorRecipeFactory,
@@ -16,6 +15,7 @@ import {
     SwatchFamilyType,
     SwatchRecipe,
 } from "./common";
+import { findClosestBackgroundIndex, getSwatch, isDarkMode } from "./palette";
 
 const neutralOutlineAlgorithm: SwatchFamilyResolver = (
     designSystem: FASTDesignSystem

--- a/packages/web-components/fast-components/src/color/palette.spec.ts
+++ b/packages/web-components/fast-components/src/color/palette.spec.ts
@@ -13,7 +13,7 @@ import {
     swatchByContrast,
     swatchByMode,
 } from "./palette";
-import { Swatch } from "./common";
+import type { Swatch } from "./common";
 
 chai.use(spies);
 

--- a/packages/web-components/fast-components/src/color/palette.ts
+++ b/packages/web-components/fast-components/src/color/palette.ts
@@ -1,4 +1,4 @@
-import { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
+import type { DesignSystemResolver, FASTDesignSystem } from "../fast-design-system";
 import {
     accentPalette,
     backgroundColor,

--- a/packages/web-components/fast-components/src/combobox/combobox.styles.ts
+++ b/packages/web-components/fast-components/src/combobox/combobox.styles.ts
@@ -1,8 +1,14 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { disabledCursor, focusVisible } from "@microsoft/fast-foundation";
 import { SelectStyles } from "../select/select.styles";
 
-export const ComboboxStyles = css`
+/**
+ * Styles for the {@link FASTCombobox|FASTCombobox component}.
+ *
+ * @public
+ */
+export const ComboboxStyles: ElementStyles = css`
     ${SelectStyles}
 
     :host(:empty) .listbox {

--- a/packages/web-components/fast-components/src/combobox/index.ts
+++ b/packages/web-components/fast-components/src/combobox/index.ts
@@ -8,7 +8,7 @@ import { ComboboxStyles as styles } from "./combobox.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-combobox\>
+ * HTML Element: `<fast-combobox>`
  *
  */
 @customElement({
@@ -18,8 +18,4 @@ import { ComboboxStyles as styles } from "./combobox.styles";
 })
 export class FASTCombobox extends Combobox {}
 
-/**
- * Styles for combobox
- * @public
- */
-export const ComboboxStyles = styles;
+export { ComboboxStyles } from "./combobox.styles";

--- a/packages/web-components/fast-components/src/data-grid/data-grid-cell.styles.ts
+++ b/packages/web-components/fast-components/src/data-grid/data-grid-cell.styles.ts
@@ -1,13 +1,19 @@
 import { css } from "@microsoft/fast-element";
-import { SystemColors } from "@microsoft/fast-web-utilities";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { focusVisible, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
+import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
     neutralFocusBehavior,
     neutralForegroundActiveBehavior,
     neutralForegroundRestBehavior,
 } from "../styles/recipes";
 
-export const DataGridCellStyles = css`
+/**
+ * Styles for the {@link FASTDataGridCell|FASTDataGridCell component}.
+ *
+ * @public
+ */
+export const DataGridCellStyles: ElementStyles = css`
     :host {
         padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 3px);
         color: ${neutralForegroundRestBehavior.var};

--- a/packages/web-components/fast-components/src/data-grid/data-grid-row.styles.ts
+++ b/packages/web-components/fast-components/src/data-grid/data-grid-row.styles.ts
@@ -1,8 +1,14 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { neutralDividerRestBehavior, neutralFillRestBehavior } from "../styles/recipes";
 
-export const DataGridRowStyles = css`
+/**
+ * Styles for the {@link FASTDataGridRow|FASTDataGridRow component}.
+ *
+ * @public
+ */
+export const DataGridRowStyles: ElementStyles = css`
     :host {
         display: grid;
         padding: 1px 0;

--- a/packages/web-components/fast-components/src/data-grid/data-grid.styles.ts
+++ b/packages/web-components/fast-components/src/data-grid/data-grid.styles.ts
@@ -1,6 +1,12 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 
-export const DataGridStyles = css`
+/**
+ * Styles for the {@link FASTDataGrid|FASTDataGrid component}.
+ *
+ * @public
+ */
+export const DataGridStyles: ElementStyles = css`
     :host {
         display: flex;
         position: relative;

--- a/packages/web-components/fast-components/src/data-grid/index.ts
+++ b/packages/web-components/fast-components/src/data-grid/index.ts
@@ -1,15 +1,15 @@
 import { customElement, ViewTemplate } from "@microsoft/fast-element";
 import {
-    DataGrid,
-    createDataGridTemplate,
-    DataGridRow,
-    createDataGridRowTemplate,
-    DataGridCell,
     createDataGridCellTemplate,
+    createDataGridRowTemplate,
+    createDataGridTemplate,
+    DataGrid,
+    DataGridCell,
+    DataGridRow,
 } from "@microsoft/fast-foundation";
-import { DataGridStyles as gridStyles } from "./data-grid.styles";
-import { DataGridRowStyles as rowStyles } from "./data-grid-row.styles";
 import { DataGridCellStyles as cellStyles } from "./data-grid-cell.styles";
+import { DataGridRowStyles as rowStyles } from "./data-grid-row.styles";
+import { DataGridStyles as gridStyles } from "./data-grid.styles";
 
 const gridTemplate: ViewTemplate = createDataGridTemplate("fast");
 const rowTemplate: ViewTemplate = createDataGridRowTemplate("fast");
@@ -20,7 +20,7 @@ const cellTemplate: ViewTemplate = createDataGridCellTemplate("fast");
  *
  * @public
  * @remarks
- * HTML Element: \<fast-data-grid\>
+ * HTML Element: `<fast-data-grid>`
  */
 @customElement({
     name: "fast-data-grid",
@@ -30,17 +30,11 @@ const cellTemplate: ViewTemplate = createDataGridCellTemplate("fast");
 export class FASTDataGrid extends DataGrid {}
 
 /**
- * Styles for DataGrid
- * @public
- */
-export const DataGridStyles = gridStyles;
-
-/**
  * The FAST Data Grid Row Element.
  *
  * @public
  * @remarks
- * HTML Element: \<fast-data-grid-row\>
+ * HTML Element: `<fast-data-grid-row>`
  */
 @customElement({
     name: "fast-data-grid-row",
@@ -50,17 +44,11 @@ export const DataGridStyles = gridStyles;
 export class FASTDataGridRow extends DataGridRow {}
 
 /**
- * Styles for DataGrid row
- * @public
- */
-export const DataGridRowStyles = rowStyles;
-
-/**
  * The FAST Data Grid Cell Element.
  *
  * @public
  * @remarks
- * HTML Element: \<fast-data-grid-cell\>
+ * HTML Element: `<fast-data-grid-cell>`
  */
 @customElement({
     name: "fast-data-grid-cell",
@@ -69,8 +57,6 @@ export const DataGridRowStyles = rowStyles;
 })
 export class FASTDataGridCell extends DataGridCell {}
 
-/**
- * Styles for DataGrid cell
- * @public
- */
-export const DataGridCellStyles = cellStyles;
+export { DataGridCellStyles } from "./data-grid-cell.styles";
+export { DataGridRowStyles } from "./data-grid-row.styles";
+export { DataGridStyles } from "./data-grid.styles";

--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -43,7 +43,7 @@ const backgroundStyles = css`
  *
  * @public
  * @remarks
- * HTML Element: \<fast-design-system-provider\>
+ * HTML Element: `<fast-design-system-provider>`
  */
 @designSystemProvider({
     name: "fast-design-system-provider",

--- a/packages/web-components/fast-components/src/dialog/dialog.styles.ts
+++ b/packages/web-components/fast-components/src/dialog/dialog.styles.ts
@@ -1,7 +1,13 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { elevation } from "../styles/elevation";
 
-export const DialogStyles = css`
+/**
+ * Styles for the {@link FASTDialog|FASTDialog component}.
+ *
+ * @public
+ */
+export const DialogStyles: ElementStyles = css`
     :host([hidden]) {
         display: none;
     }

--- a/packages/web-components/fast-components/src/dialog/index.ts
+++ b/packages/web-components/fast-components/src/dialog/index.ts
@@ -9,7 +9,7 @@ import { DialogStyles as styles } from "./dialog.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-dialog\>
+ * HTML Element: `<fast-dialog>`
  */
 @customElement({
     name: "fast-dialog",
@@ -18,8 +18,4 @@ import { DialogStyles as styles } from "./dialog.styles";
 })
 export class FASTDialog extends Dialog {}
 
-/**
- * Styles for Dialog
- * @public
- */
-export const DialogStyles = styles;
+export { DialogStyles } from "./dialog.styles";

--- a/packages/web-components/fast-components/src/disclosure/disclosure.styles.ts
+++ b/packages/web-components/fast-components/src/disclosure/disclosure.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
@@ -9,7 +10,12 @@ import {
     accentForegroundRestBehavior,
 } from "../styles/recipes";
 
-export const DisclosureStyles = css`
+/**
+ * Styles for the {@link FASTDisclosure|FASTDisclosure component}.
+ *
+ * @public
+ */
+export const DisclosureStyles: ElementStyles = css`
     .disclosure {
         transition: height 0.35s;
     }

--- a/packages/web-components/fast-components/src/disclosure/index.ts
+++ b/packages/web-components/fast-components/src/disclosure/index.ts
@@ -14,7 +14,7 @@ export type DisclosureAppearance = "accent" | "lightweight";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-Disclosure\>
+ * HTML Element: `<fast-disclosure>`
  *
  */
 @customElement({
@@ -86,8 +86,4 @@ export class FASTDisclosure extends Disclosure {
     }
 }
 
-/**
- * Styles for Disclosure
- * @public
- */
-export const DisclosureStyles = styles;
+export { DisclosureStyles } from "./disclosure.styles";

--- a/packages/web-components/fast-components/src/divider/divider.styles.ts
+++ b/packages/web-components/fast-components/src/divider/divider.styles.ts
@@ -1,8 +1,14 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 import { neutralDividerRestBehavior } from "../styles/index";
 
-export const DividerStyles = css`
+/**
+ * Styles for the {@link FASTDivider|FASTDivider component}.
+ *
+ * @public
+ */
+export const DividerStyles: ElementStyles = css`
     ${display("block")} :host {
         box-sizing: content-box;
         height: 0;

--- a/packages/web-components/fast-components/src/divider/index.ts
+++ b/packages/web-components/fast-components/src/divider/index.ts
@@ -9,7 +9,7 @@ import { DividerStyles as styles } from "./divider.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-divider\>
+ * HTML Element: `<fast-divider>`
  */
 @customElement({
     name: "fast-divider",
@@ -18,8 +18,4 @@ import { DividerStyles as styles } from "./divider.styles";
 })
 export class FASTDivider extends Divider {}
 
-/**
- * Styles for Divider
- * @public
- */
-export const DividerStyles = styles;
+export { DividerStyles } from "./divider.styles";

--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -11,15 +12,20 @@ import {
     accentFillHoverBehavior,
     accentFillRestBehavior,
     accentForegroundCutRestBehavior,
-    heightNumber,
     neutralFillStealthRestBehavior,
     neutralFocusBehavior,
     neutralFocusInnerAccentBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineRestBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const FlipperStyles = css`
+/**
+ * Styles for the {@link FASTFlipper|FASTFlipper component}.
+ *
+ * @public
+ */
+export const FlipperStyles: ElementStyles = css`
     ${display("inline-flex")} :host {
         width: calc(${heightNumber} * 1px);
         height: calc(${heightNumber} * 1px);
@@ -52,7 +58,7 @@ export const FlipperStyles = css`
     .previous {
         position: relative;
         ${
-            /* Glyph size and display: grid are temporary - 
+            /* Glyph size and display: grid are temporary -
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;

--- a/packages/web-components/fast-components/src/flipper/index.ts
+++ b/packages/web-components/fast-components/src/flipper/index.ts
@@ -9,7 +9,7 @@ import { FlipperStyles as styles } from "./flipper.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-flipper\>
+ * HTML Element: `<fast-flipper>`
  */
 @customElement({
     name: "fast-flipper",
@@ -18,8 +18,4 @@ import { FlipperStyles as styles } from "./flipper.styles";
 })
 export class FASTFlipper extends Flipper {}
 
-/**
- * Styles for Flipper
- * @public
- */
-export const FlipperStyles = styles;
+export { FlipperStyles } from "./flipper.styles";

--- a/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.definition.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.definition.ts
@@ -1,4 +1,4 @@
-import { WebComponentDefinition } from "@microsoft/fast-tooling/dist/esm/data-utilities/web-component";
+import type { WebComponentDefinition } from "@microsoft/fast-tooling/dist/esm/data-utilities/web-component";
 import { DataType } from "@microsoft/fast-tooling";
 
 export const fastHorizontalScrollDefinition: WebComponentDefinition = {

--- a/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.styles.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { DirectionalStyleSheetBehavior, display } from "@microsoft/fast-foundation";
 
 const ltrActionsStyles = css`
@@ -46,10 +47,11 @@ const rtlActionsStyles = css`
 `;
 
 /**
- * Styles used for the flipper container and gradient fade
+ * Styles used for the flipper container and gradient fade in the {@link FASTHorizontalScroll|FASTHorizontalScroll component}.
+ *
  * @public
  */
-export const ActionsStyles = css`
+export const ActionsStyles: ElementStyles = css`
     .scroll-area {
         position: relative;
     }
@@ -95,10 +97,11 @@ export const ActionsStyles = css`
 `.withBehaviors(new DirectionalStyleSheetBehavior(ltrActionsStyles, rtlActionsStyles));
 
 /**
- * Styles handling the scroll container and content
+ * Styles for the scroll container and content in the {@link FASTHorizontalScroll|FASTHorizontalScroll component}.
+ *
  * @public
  */
-export const HorizontalScrollStyles = css`
+export const HorizontalScrollStyles: ElementStyles = css`
     ${display("block")} :host {
         --scroll-align: center;
         --scroll-item-spacing: 5px;

--- a/packages/web-components/fast-components/src/horizontal-scroll/index.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/index.ts
@@ -15,7 +15,7 @@ import {
  *
  * @public
  * @remarks
- * HTML Element: \<fast-horizontal-scroll\>
+ * HTML Element: `<fast-horizontal-scroll>`
  */
 @customElement({
     name: "fast-horizontal-scroll",
@@ -34,3 +34,5 @@ export class FASTHorizontalScroll extends HorizontalScroll {
         }
     }
 }
+
+export { ActionsStyles, HorizontalScrollStyles } from "./horizontal-scroll.styles";

--- a/packages/web-components/fast-components/src/listbox-option/index.ts
+++ b/packages/web-components/fast-components/src/listbox-option/index.ts
@@ -12,7 +12,7 @@ import { OptionStyles as styles } from "./listbox-option.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-option\>
+ * HTML Element: `<fast-option>`
  *
  */
 @customElement({
@@ -22,8 +22,4 @@ import { OptionStyles as styles } from "./listbox-option.styles";
 })
 export class FASTOption extends ListboxOption {}
 
-/**
- * Styles for Option
- * @public
- */
-export const OptionStyles = styles;
+export { OptionStyles } from "./listbox-option.styles";

--- a/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
+++ b/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -23,7 +24,12 @@ import {
 } from "../styles/recipes";
 import { heightNumber } from "../styles/size";
 
-export const OptionStyles = css`
+/**
+ * Styles for the {@link FASTOption|FASTOption component}.
+ *
+ * @public
+ */
+export const OptionStyles: ElementStyles = css`
     ${display("inline-flex")} :host {
         align-items: center;
         font-family: var(--body-font);

--- a/packages/web-components/fast-components/src/listbox/index.ts
+++ b/packages/web-components/fast-components/src/listbox/index.ts
@@ -9,7 +9,7 @@ import { ListboxStyles as styles } from "./listbox.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-listbox\>
+ * HTML Element: `<fast-listbox>`
  *
  */
 @customElement({
@@ -19,8 +19,4 @@ import { ListboxStyles as styles } from "./listbox.styles";
 })
 export class FASTListbox extends Listbox {}
 
-/**
- * Styles for Listbox
- * @public
- */
-export const ListboxStyles = styles;
+export { ListboxStyles } from "./listbox.styles";

--- a/packages/web-components/fast-components/src/listbox/listbox.styles.ts
+++ b/packages/web-components/fast-components/src/listbox/listbox.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     display,
     focusVisible,
@@ -12,7 +13,12 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
 
-export const ListboxStyles = css`
+/**
+ * Styles for the {@link FASTListbox|FASTListbox component}.
+ *
+ * @public
+ */
+export const ListboxStyles: ElementStyles = css`
     ${display("inline-flex")} :host {
         background: ${neutralLayerFloatingBehavior.var};
         border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};

--- a/packages/web-components/fast-components/src/menu-item/index.ts
+++ b/packages/web-components/fast-components/src/menu-item/index.ts
@@ -1,5 +1,5 @@
 import { customElement } from "@microsoft/fast-element";
-import { MenuItem, createMenuItemTemplate } from "@microsoft/fast-foundation";
+import { createMenuItemTemplate, MenuItem } from "@microsoft/fast-foundation";
 import { MenuItemStyles as styles } from "./menu-item.styles";
 
 const template = createMenuItemTemplate("fast");
@@ -11,7 +11,7 @@ const template = createMenuItemTemplate("fast");
  *
  * @public
  * @remarks
- * HTML Element: \<fast-menu-item\>
+ * HTML Element: `<fast-menu-item>`
  */
 @customElement({
     name: "fast-menu-item",
@@ -20,8 +20,4 @@ const template = createMenuItemTemplate("fast");
 })
 export class FASTMenuItem extends MenuItem {}
 
-/**
- * Styles for MenuItem
- * @public
- */
-export const MenuItemStyles = styles;
+export { MenuItemStyles } from "./menu-item.styles";

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     DirectionalStyleSheetBehavior,
     disabledCursor,
@@ -9,16 +10,21 @@ import {
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
     accentFillRestBehavior,
-    heightNumber,
     neutralFillStealthRestBehavior,
     neutralFocusBehavior,
     neutralForegroundHoverBehavior,
     neutralForegroundRestBehavior,
     neutralLayerL2Behavior,
     neutralLayerL3Behavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const MenuItemStyles = css`
+/**
+ * Styles for the {@link FASTMenuItem|FASTMenuItem component}.
+ *
+ * @public
+ */
+export const MenuItemStyles: ElementStyles = css`
     ${display("grid")} :host {
         contain: layout;
         overflow: visible;
@@ -79,7 +85,7 @@ export const MenuItemStyles = css`
 
     .expand-collapse-glyph {
         ${
-            /* Glyph size is temporary - 
+            /* Glyph size is temporary -
             replace when glyph-size var is added */ ""
         } width: 16px;
         height: 16px;
@@ -99,10 +105,10 @@ export const MenuItemStyles = css`
         display: flex;
         justify-content: center;
     }
-    
+
     ::slotted(svg) {
         ${
-            /* Glyph size and margin-left is temporary - 
+            /* Glyph size and margin-left is temporary -
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;

--- a/packages/web-components/fast-components/src/menu/index.ts
+++ b/packages/web-components/fast-components/src/menu/index.ts
@@ -9,7 +9,7 @@ import { MenuStyles as styles } from "./menu.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-menu\>
+ * HTML Element: `<fast-menu>`
  */
 @customElement({
     name: "fast-menu",
@@ -18,8 +18,4 @@ import { MenuStyles as styles } from "./menu.styles";
 })
 export class FASTMenu extends Menu {}
 
-/**
- * Styles for Menu
- * @public
- */
-export const MenuStyles = styles;
+export { MenuStyles } from "./menu.styles";

--- a/packages/web-components/fast-components/src/menu/menu.styles.ts
+++ b/packages/web-components/fast-components/src/menu/menu.styles.ts
@@ -1,13 +1,19 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
-    elevation,
     neutralDividerRestBehavior,
     neutralLayerFloatingBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { elevation } from "../styles/elevation";
 
-export const MenuStyles = css`
+/**
+ * Styles for the {@link FASTMenu|FASTMenu component}.
+ *
+ * @public
+ */
+export const MenuStyles: ElementStyles = css`
     ${display("block")} :host {
         --elevation: 11;
         background: ${neutralLayerFloatingBehavior.var};

--- a/packages/web-components/fast-components/src/number-field/index.ts
+++ b/packages/web-components/fast-components/src/number-field/index.ts
@@ -15,7 +15,7 @@ export type NumberFieldAppearance = "filled" | "outline";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-number-field\>
+ * HTML Element: `<fast-number-field>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */
@@ -50,8 +50,4 @@ export class FASTNumberField extends NumberField {
     }
 }
 
-/**
- * Styles for NumberField
- * @public
- */
-export const NumberFieldStyles = styles;
+export { NumberFieldStyles } from "./number-field.styles";

--- a/packages/web-components/fast-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/fast-components/src/number-field/number-field.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -10,7 +11,6 @@ import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
-    heightNumber,
     neutralFillHoverBehavior,
     neutralFillInputHoverBehavior,
     neutralFillInputRestBehavior,
@@ -18,9 +18,15 @@ import {
     neutralFocusBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineRestBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const NumberFieldStyles = css`
+/**
+ * Styles for the {@link FASTNumberField|FASTNumberField component}.
+ *
+ * @public
+ */
+export const NumberFieldStyles: ElementStyles = css`
     ${display("inline-block")} :host {
         font-family: var(--body-font);
         outline: none;
@@ -109,7 +115,7 @@ export const NumberFieldStyles = css`
 
     ::slotted(svg) {
         ${
-            /* Glyph size and margin-left is temporary - 
+            /* Glyph size and margin-left is temporary -
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;

--- a/packages/web-components/fast-components/src/progress-ring/index.ts
+++ b/packages/web-components/fast-components/src/progress-ring/index.ts
@@ -12,7 +12,7 @@ import { ProgressRingStyles as styles } from "./progress-ring.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-progress-ring\>
+ * HTML Element: `<fast-progress-ring>`
  */
 @customElement({
     name: "fast-progress-ring",
@@ -21,8 +21,4 @@ import { ProgressRingStyles as styles } from "./progress-ring.styles";
 })
 export class FASTProgressRing extends BaseProgress {}
 
-/**
- * Styles for ProgressRing
- * @public
- */
-export const ProgressRingStyles = styles;
+export { ProgressRingStyles } from "./progress-ring.styles";

--- a/packages/web-components/fast-components/src/progress-ring/progress-ring.styles.ts
+++ b/packages/web-components/fast-components/src/progress-ring/progress-ring.styles.ts
@@ -1,14 +1,20 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
     accentForegroundRestBehavior,
-    heightNumber,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
-} from "../styles";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const ProgressRingStyles = css`
+/**
+ * Styles for the {@link FASTProgressRing|FASTProgressRing component}.
+ *
+ * @public
+ */
+export const ProgressRingStyles: ElementStyles = css`
     ${display("flex")} :host {
         align-items: center;
         outline: none;

--- a/packages/web-components/fast-components/src/progress/index.ts
+++ b/packages/web-components/fast-components/src/progress/index.ts
@@ -9,7 +9,7 @@ import { ProgressStyles as styles } from "./progress.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-progress\>
+ * HTML Element: `<fast-progress>`
  */
 @customElement({
     name: "fast-progress",
@@ -18,8 +18,4 @@ import { ProgressStyles as styles } from "./progress.styles";
 })
 export class FASTProgress extends BaseProgress {}
 
-/**
- * Styles for Progress
- * @public
- */
-export const ProgressStyles = styles;
+export { ProgressStyles } from "./progress.styles";

--- a/packages/web-components/fast-components/src/progress/progress.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress.styles.ts
@@ -1,13 +1,19 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
     accentForegroundRestBehavior,
     neutralFillRestBehavior,
     neutralForegroundHintBehavior,
-} from "../styles";
+} from "../styles/recipes";
 
-export const ProgressStyles = css`
+/**
+ * Styles for the {@link FASTProgress|FASTProgress component}.
+ *
+ * @public
+ */
+export const ProgressStyles: ElementStyles = css`
     ${display("flex")} :host {
         align-items: center;
         outline: none;

--- a/packages/web-components/fast-components/src/radio-group/index.ts
+++ b/packages/web-components/fast-components/src/radio-group/index.ts
@@ -9,7 +9,7 @@ import { RadioGroupStyles as styles } from "./radio-group.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-radio-group\>
+ * HTML Element: `<fast-radio-group>`
  */
 @customElement({
     name: "fast-radio-group",
@@ -18,8 +18,4 @@ import { RadioGroupStyles as styles } from "./radio-group.styles";
 })
 export class FASTRadioGroup extends RadioGroup {}
 
-/**
- * Styles for RadioGroup
- * @public
- */
-export const RadioGroupStyles = styles;
+export { RadioGroupStyles } from "./radio-group.styles";

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -1,7 +1,13 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 
-export const RadioGroupStyles = css`
+/**
+ * Styles for the {@link FASTRadioGroup|FASTRadioGroup component}.
+ *
+ * @public
+ */
+export const RadioGroupStyles: ElementStyles = css`
     ${display("flex")} :host {
         align-items: flex-start;
         margin: calc(var(--design-unit) * 1px) 0;

--- a/packages/web-components/fast-components/src/radio/index.ts
+++ b/packages/web-components/fast-components/src/radio/index.ts
@@ -9,7 +9,7 @@ import { RadioStyles as styles } from "./radio.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-radio\>
+ * HTML Element: `<fast-radio>`
  */
 @customElement({
     name: "fast-radio",
@@ -18,8 +18,4 @@ import { RadioStyles as styles } from "./radio.styles";
 })
 export class FASTRadio extends Radio {}
 
-/**
- * Styles for Radio
- * @public
- */
-export const RadioStyles = styles;
+export { RadioStyles } from "./radio.styles";

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -11,7 +12,6 @@ import {
     accentFillHoverBehavior,
     accentFillRestBehavior,
     accentForegroundCutRestBehavior,
-    heightNumber,
     neutralFillInputActiveBehavior,
     neutralFillInputHoverBehavior,
     neutralFillInputRestBehavior,
@@ -20,9 +20,15 @@ import {
     neutralOutlineActiveBehavior,
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const RadioStyles = css`
+/**
+ * Styles for the {@link FASTRadio|FASTRadio component}.
+ *
+ * @public
+ */
+export const RadioStyles: ElementStyles = css`
     ${display("inline-flex")} :host {
         --input-size: calc((${heightNumber} / 2) + var(--design-unit));
         align-items: center;

--- a/packages/web-components/fast-components/src/select/index.ts
+++ b/packages/web-components/fast-components/src/select/index.ts
@@ -9,7 +9,7 @@ import { SelectStyles as styles } from "./select.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-select\>
+ * HTML Element: `<fast-select>`
  *
  */
 @customElement({
@@ -19,8 +19,4 @@ import { SelectStyles as styles } from "./select.styles";
 })
 export class FASTSelect extends Select {}
 
-/**
- * Styles for Select
- * @public
- */
-export const SelectStyles = styles;
+export { SelectStyles } from "./select.styles";

--- a/packages/web-components/fast-components/src/select/select.styles.ts
+++ b/packages/web-components/fast-components/src/select/select.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -25,7 +26,12 @@ import {
 } from "../styles/recipes";
 import { heightNumber } from "../styles/size";
 
-export const SelectStyles = css`
+/**
+ * Styles for the {@link FASTSelect|FASTSelect component}.
+ *
+ * @public
+ */
+export const SelectStyles: ElementStyles = css`
     ${display("inline-flex")} :host {
         --elevation: 14;
         background: ${neutralFillInputRestBehavior.var};

--- a/packages/web-components/fast-components/src/skeleton/index.ts
+++ b/packages/web-components/fast-components/src/skeleton/index.ts
@@ -9,7 +9,7 @@ import { SkeletonStyles as styles } from "./skeleton.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-skeleton\>
+ * HTML Element: `<fast-skeleton>`
  */
 @customElement({
     name: "fast-skeleton",
@@ -18,8 +18,4 @@ import { SkeletonStyles as styles } from "./skeleton.styles";
 })
 export class FASTSkeleton extends Skeleton {}
 
-/**
- * Styles for Skeleton
- * @public
- */
-export const SkeletonStyles = styles;
+export { SkeletonStyles } from "./skeleton.styles";

--- a/packages/web-components/fast-components/src/skeleton/skeleton.styles.ts
+++ b/packages/web-components/fast-components/src/skeleton/skeleton.styles.ts
@@ -1,10 +1,15 @@
 import { css } from "@microsoft/fast-element";
-import { forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
+import type { ElementStyles } from "@microsoft/fast-element";
+import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
-import { display } from "@microsoft/fast-foundation";
-import { neutralFillRestBehavior } from "../styles";
+import { neutralFillRestBehavior } from "../styles/recipes";
 
-export const SkeletonStyles = css`
+/**
+ * Styles for the {@link FASTSkeleton|FASTSkeleton component}.
+ *
+ * @public
+ */
+export const SkeletonStyles: ElementStyles = css`
     ${display("block")} :host {
         --skeleton-fill-default: #e1dfdd;
         overflow: hidden;

--- a/packages/web-components/fast-components/src/slider-label/index.ts
+++ b/packages/web-components/fast-components/src/slider-label/index.ts
@@ -14,7 +14,7 @@ import {
  *
  * @public
  * @remarks
- * HTML Element: \<fast-slider-label\>
+ * HTML Element: `<fast-slider-label>`
  */
 @customElement({
     name: "fast-slider-label",
@@ -33,8 +33,8 @@ export class FASTSliderLabel extends SliderLabel {
     }
 }
 
-/**
- * Styles for SliderLabel
- * @public
- */
-export const SliderLabelStyles = styles;
+export {
+    horizontalSliderStyles,
+    SliderLabelStyles,
+    verticalSliderStyles,
+} from "./slider-label.styles";

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -1,13 +1,19 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
-    heightNumber,
     neutralForegroundRestBehavior,
     neutralOutlineRestBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const horizontalSliderStyles = css`
+/**
+ * Styles for the {@link FASTSliderLabel|FASTSliderLabel component} with a horizontal orientation.
+ *
+ * @public
+ */
+export const horizontalSliderStyles: ElementStyles = css`
     :host {
         align-self: start;
         grid-row: 2;
@@ -24,7 +30,12 @@ export const horizontalSliderStyles = css`
     }
 `;
 
-export const verticalSliderStyles = css`
+/**
+ * Styles for the {@link FASTSliderLabel|FASTSliderLabel component} with a vertical orientation.
+ *
+ * @public
+ */
+export const verticalSliderStyles: ElementStyles = css`
     :host {
         justify-self: start;
         grid-column: 2;
@@ -48,7 +59,12 @@ export const verticalSliderStyles = css`
     }
 `;
 
-export const SliderLabelStyles = css`
+/**
+ * Base styles for the {@link FASTSliderLabel|FASTSliderLabel component}.
+ *
+ * @public
+ */
+export const SliderLabelStyles: ElementStyles = css`
     ${display("block")} :host {
         font-family: var(--body-font);
         color: ${neutralForegroundRestBehavior.var};

--- a/packages/web-components/fast-components/src/slider/index.ts
+++ b/packages/web-components/fast-components/src/slider/index.ts
@@ -9,7 +9,7 @@ import { SliderStyles as styles } from "./slider.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-slider\>
+ * HTML Element: `<fast-slider>`
  */
 @customElement({
     name: "fast-slider",
@@ -18,8 +18,4 @@ import { SliderStyles as styles } from "./slider.styles";
 })
 export class FASTSlider extends Slider {}
 
-/**
- * Styles for Slider
- * @public
- */
-export const SliderStyles = styles;
+export { SliderStyles } from "./slider.styles";

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -7,16 +8,21 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
-    heightNumber,
     neutralFocusBehavior,
     neutralForegroundActiveBehavior,
     neutralForegroundHoverBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const SliderStyles = css`
+/**
+ * Styles for the {@link FASTSlider|FASTSlider component}.
+ *
+ * @public
+ */
+export const SliderStyles: ElementStyles = css`
     :host([hidden]) {
         display: none;
     }
@@ -53,7 +59,7 @@ export const SliderStyles = css`
     :host(:${focusVisible}) .thumb-cursor {
         box-shadow: 0 0 0 2px var(--background-color), 0 0 0 4px var(--neutral-focus);
     }
-    
+
     .thumb-container {
         position: absolute;
         height: calc(var(--thumb-size) * 1px);
@@ -152,7 +158,7 @@ export const SliderStyles = css`
             :host(:${focusVisible}) .thumb-cursor {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.Highlight};
-                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};    
+                box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
         `
     )

--- a/packages/web-components/fast-components/src/styles/direction.ts
+++ b/packages/web-components/fast-components/src/styles/direction.ts
@@ -1,7 +1,10 @@
-import { cssCustomPropertyBehaviorFactory } from "@microsoft/fast-foundation";
+import {
+    CSSCustomPropertyBehavior,
+    cssCustomPropertyBehaviorFactory,
+} from "@microsoft/fast-foundation";
 import { Direction } from "@microsoft/fast-web-utilities";
-import { direction, FASTDesignSystem } from "../fast-design-system";
 import { FASTDesignSystemProvider } from "../design-system-provider";
+import { direction, FASTDesignSystem } from "../fast-design-system";
 /**
  * Behavior to resolve and make available the inline-start CSS custom property.
  *
@@ -22,7 +25,7 @@ import { FASTDesignSystemProvider } from "../design-system-provider";
  * `.withBehaviors(inlineStartBehavior)
  * ```
  */
-export const inlineStartBehavior = cssCustomPropertyBehaviorFactory(
+export const inlineStartBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "inline-start",
     (designSystem: FASTDesignSystem) =>
         direction(designSystem) === Direction.ltr ? "left" : "right",
@@ -49,7 +52,7 @@ export const inlineStartBehavior = cssCustomPropertyBehaviorFactory(
  * `.withBehaviors(inlineEndBehavior)
  * ```
  */
-export const inlineEndBehavior = cssCustomPropertyBehaviorFactory(
+export const inlineEndBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "inline-end",
     (designSystem: FASTDesignSystem) =>
         direction(designSystem) === Direction.ltr ? "right" : "left",

--- a/packages/web-components/fast-components/src/styles/recipes.ts
+++ b/packages/web-components/fast-components/src/styles/recipes.ts
@@ -1,12 +1,16 @@
-import { cssCustomPropertyBehaviorFactory } from "@microsoft/fast-foundation";
+import {
+    CSSCustomPropertyBehavior,
+    cssCustomPropertyBehaviorFactory,
+} from "@microsoft/fast-foundation";
 import {
     accentFill,
     accentFillLarge,
     accentForeground,
     accentForegroundCut,
     accentForegroundLarge,
-    neutralDividerRest,
     neutralContrastFill,
+    neutralContrastFillRest,
+    neutralDividerRest,
     neutralFill,
     neutralFillCard,
     neutralFillInput,
@@ -17,6 +21,7 @@ import {
     neutralForeground,
     neutralForegroundHint,
     neutralForegroundHintLarge,
+    neutralForegroundRest,
     neutralForegroundToggle,
     neutralForegroundToggleLarge,
     neutralLayerCard,
@@ -28,17 +33,15 @@ import {
     neutralLayerL3,
     neutralLayerL4,
     neutralOutline,
-    neutralForegroundRest,
-    neutralContrastFillRest,
 } from "../color/index";
-import { accentBaseColor } from "../fast-design-system";
 import { FASTDesignSystemProvider } from "../design-system-provider/index";
+import { accentBaseColor } from "../fast-design-system";
 
 /**
  * Behavior to resolve and make available the neutral-foreground-rest CSS custom property.
  * @public
  */
-export const neutralForegroundRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralForegroundRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-foreground-rest",
     x => neutralForeground(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -47,7 +50,7 @@ export const neutralForegroundRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-foreground-hover CSS custom property.
  * @public
  */
-export const neutralForegroundHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralForegroundHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-foreground-hover",
     x => neutralForeground(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -56,7 +59,7 @@ export const neutralForegroundHoverBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-foreground-active CSS custom property.
  * @public
  */
-export const neutralForegroundActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralForegroundActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-foreground-active",
     x => neutralForeground(x).active,
     FASTDesignSystemProvider.findProvider
@@ -65,7 +68,7 @@ export const neutralForegroundActiveBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-foreground-focus CSS custom property.
  * @public
  */
-export const neutralForegroundFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralForegroundFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-foreground-focus",
     x => neutralForeground(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -74,7 +77,7 @@ export const neutralForegroundFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-foreground-toggle CSS custom property.
  * @public
  */
-export const neutralForegroundToggleBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralForegroundToggleBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-foreground-toggle",
     neutralForegroundToggle,
     FASTDesignSystemProvider.findProvider
@@ -83,7 +86,7 @@ export const neutralForegroundToggleBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-foreground-toggle-large CSS custom property.
  * @public
  */
-export const neutralForegroundToggleLargeBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralForegroundToggleLargeBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-foreground-toggle-large",
     neutralForegroundToggleLarge,
     FASTDesignSystemProvider.findProvider
@@ -92,7 +95,7 @@ export const neutralForegroundToggleLargeBehavior = cssCustomPropertyBehaviorFac
  * Behavior to resolve and make available the neutral-foreground-hint CSS custom property.
  * @public
  */
-export const neutralForegroundHintBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralForegroundHintBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-foreground-hint",
     neutralForegroundHint,
     FASTDesignSystemProvider.findProvider
@@ -101,7 +104,7 @@ export const neutralForegroundHintBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-foreground-hint-large CSS custom property.
  * @public
  */
-export const neutralForegroundHintLargeBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralForegroundHintLargeBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-foreground-hint-large",
     neutralForegroundHintLarge,
     FASTDesignSystemProvider.findProvider
@@ -110,7 +113,7 @@ export const neutralForegroundHintLargeBehavior = cssCustomPropertyBehaviorFacto
  * Behavior to resolve and make available the accent-foreground-rest CSS custom property.
  * @public
  */
-export const accentForegroundRestBehavior = cssCustomPropertyBehaviorFactory(
+export const accentForegroundRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-foreground-rest",
     x => accentForeground(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -119,7 +122,7 @@ export const accentForegroundRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-foreground-hover CSS custom property.
  * @public
  */
-export const accentForegroundHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const accentForegroundHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-foreground-hover",
     x => accentForeground(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -128,7 +131,7 @@ export const accentForegroundHoverBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-foreground-active CSS custom property.
  * @public
  */
-export const accentForegroundActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const accentForegroundActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-foreground-active",
     x => accentForeground(x).active,
     FASTDesignSystemProvider.findProvider
@@ -137,7 +140,7 @@ export const accentForegroundActiveBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-foreground-focus CSS custom property.
  * @public
  */
-export const accentForegroundFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const accentForegroundFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-foreground-focus",
     x => accentForeground(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -146,7 +149,7 @@ export const accentForegroundFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-foreground-cut-rest CSS custom property.
  * @public
  */
-export const accentForegroundCutRestBehavior = cssCustomPropertyBehaviorFactory(
+export const accentForegroundCutRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-foreground-cut-rest",
     x => accentForegroundCut(x),
     FASTDesignSystemProvider.findProvider
@@ -155,7 +158,7 @@ export const accentForegroundCutRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-foreground-large-rest CSS custom property.
  * @public
  */
-export const accentForegroundLargeRestBehavior = cssCustomPropertyBehaviorFactory(
+export const accentForegroundLargeRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-foreground-large-rest",
     x => accentForegroundLarge(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -164,7 +167,7 @@ export const accentForegroundLargeRestBehavior = cssCustomPropertyBehaviorFactor
  * Behavior to resolve and make available the accent-foreground-large-hover CSS custom property.
  * @public
  */
-export const accentForegroundLargeHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const accentForegroundLargeHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-foreground-large-hover",
     x => accentForegroundLarge(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -173,7 +176,7 @@ export const accentForegroundLargeHoverBehavior = cssCustomPropertyBehaviorFacto
  * Behavior to resolve and make available the accent-foreground-large-active CSS custom property.
  * @public
  */
-export const accentForegroundLargeActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const accentForegroundLargeActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-foreground-large-active",
     x => accentForegroundLarge(x).active,
     FASTDesignSystemProvider.findProvider
@@ -182,7 +185,7 @@ export const accentForegroundLargeActiveBehavior = cssCustomPropertyBehaviorFact
  * Behavior to resolve and make available the accent-foreground-large-focus CSS custom property.
  * @public
  */
-export const accentForegroundLargeFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const accentForegroundLargeFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-foreground-large-focus",
     x => accentForegroundLarge(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -191,7 +194,7 @@ export const accentForegroundLargeFocusBehavior = cssCustomPropertyBehaviorFacto
  * Behavior to resolve and make available the neutral-fill-rest CSS custom property.
  * @public
  */
-export const neutralFillRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-rest",
     x => neutralFill(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -200,7 +203,7 @@ export const neutralFillRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-hover CSS custom property.
  * @public
  */
-export const neutralFillHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-hover",
     x => neutralFill(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -209,7 +212,7 @@ export const neutralFillHoverBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-active CSS custom property.
  * @public
  */
-export const neutralFillActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-active",
     x => neutralFill(x).active,
     FASTDesignSystemProvider.findProvider
@@ -218,7 +221,7 @@ export const neutralFillActiveBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-focus CSS custom property.
  * @public
  */
-export const neutralFillFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-focus",
     x => neutralFill(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -227,7 +230,7 @@ export const neutralFillFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-selected CSS custom property.
  * @public
  */
-export const neutralFillSelectedBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillSelectedBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-selected",
     x => neutralFill(x).selected,
     FASTDesignSystemProvider.findProvider
@@ -236,7 +239,7 @@ export const neutralFillSelectedBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-stealth-rest CSS custom property.
  * @public
  */
-export const neutralFillStealthRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillStealthRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-stealth-rest",
     x => neutralFillStealth(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -246,7 +249,7 @@ export const neutralFillStealthRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-stealth-hover CSS custom property.
  * @public
  */
-export const neutralFillStealthHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillStealthHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-stealth-hover",
     x => neutralFillStealth(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -256,7 +259,7 @@ export const neutralFillStealthHoverBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-stealth-active CSS custom property.
  * @public
  */
-export const neutralFillStealthActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillStealthActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-stealth-active",
     x => neutralFillStealth(x).active,
     FASTDesignSystemProvider.findProvider
@@ -265,7 +268,7 @@ export const neutralFillStealthActiveBehavior = cssCustomPropertyBehaviorFactory
  * Behavior to resolve and make available the neutral-fill-stealth-focus CSS custom property.
  * @public
  */
-export const neutralFillStealthFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillStealthFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-stealth-focus",
     x => neutralFillStealth(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -274,7 +277,7 @@ export const neutralFillStealthFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-stealth-selected CSS custom property.
  * @public
  */
-export const neutralFillStealthSelectedBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillStealthSelectedBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-stealth-selected",
     x => neutralFillStealth(x).selected,
     FASTDesignSystemProvider.findProvider
@@ -283,7 +286,7 @@ export const neutralFillStealthSelectedBehavior = cssCustomPropertyBehaviorFacto
  * Behavior to resolve and make available the neutral-fill-toggle-rest CSS custom property.
  * @public
  */
-export const neutralFillToggleRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillToggleRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-toggle-rest",
     x => neutralFillToggle(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -292,7 +295,7 @@ export const neutralFillToggleRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-toggle-hover CSS custom property.
  * @public
  */
-export const neutralFillToggleHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillToggleHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-toggle-hover",
     x => neutralFillToggle(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -301,7 +304,7 @@ export const neutralFillToggleHoverBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-toggle-active CSS custom property.
  * @public
  */
-export const neutralFillToggleActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillToggleActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-toggle-active",
     x => neutralFillToggle(x).active,
     FASTDesignSystemProvider.findProvider
@@ -310,7 +313,7 @@ export const neutralFillToggleActiveBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-toggle-focus CSS custom property.
  * @public
  */
-export const neutralFillToggleFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillToggleFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-toggle-focus",
     x => neutralFillToggle(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -319,7 +322,7 @@ export const neutralFillToggleFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-input-rest CSS custom property.
  * @public
  */
-export const neutralFillInputRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillInputRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-input-rest",
     x => neutralFillInput(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -328,7 +331,7 @@ export const neutralFillInputRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-input-hover CSS custom property.
  * @public
  */
-export const neutralFillInputHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillInputHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-input-hover",
     x => neutralFillInput(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -338,7 +341,7 @@ export const neutralFillInputHoverBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-input-active CSS custom property.
  * @public
  */
-export const neutralFillInputActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillInputActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-input-active",
     x => neutralFillInput(x).active,
     FASTDesignSystemProvider.findProvider
@@ -347,7 +350,7 @@ export const neutralFillInputActiveBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-input-selected CSS custom property.
  * @public
  */
-export const neutralFillInputSelectedBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillInputSelectedBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-input-selected",
     x => neutralFillInput(x).selected,
     FASTDesignSystemProvider.findProvider
@@ -356,7 +359,7 @@ export const neutralFillInputSelectedBehavior = cssCustomPropertyBehaviorFactory
  * Behavior to resolve and make available the neutral-fill-input-focus CSS custom property.
  * @public
  */
-export const neutralFillInputFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillInputFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-input-focus",
     x => neutralFillInput(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -365,7 +368,7 @@ export const neutralFillInputFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-rest CSS custom property.
  * @public
  */
-export const accentFillRestBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-rest",
     x => accentFill(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -374,7 +377,7 @@ export const accentFillRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-hover CSS custom property.
  * @public
  */
-export const accentFillHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-hover",
     x => accentFill(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -383,7 +386,7 @@ export const accentFillHoverBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-active CSS custom property.
  * @public
  */
-export const accentFillActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-active",
     x => accentFill(x).active,
     FASTDesignSystemProvider.findProvider
@@ -392,7 +395,7 @@ export const accentFillActiveBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-focus CSS custom property.
  * @public
  */
-export const accentFillFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-focus",
     x => accentFill(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -401,7 +404,7 @@ export const accentFillFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-selected CSS custom property.
  * @public
  */
-export const accentFillSelectedBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillSelectedBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-selected",
     x => accentFill(x).selected,
     FASTDesignSystemProvider.findProvider
@@ -410,7 +413,7 @@ export const accentFillSelectedBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-large-rest CSS custom property.
  * @public
  */
-export const accentFillLargeRestBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillLargeRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-large-rest",
     x => accentFillLarge(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -419,7 +422,7 @@ export const accentFillLargeRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-large-hover CSS custom property.
  * @public
  */
-export const accentFillLargeHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillLargeHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-large-hover",
     x => accentFillLarge(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -428,7 +431,7 @@ export const accentFillLargeHoverBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-large-active CSS custom property.
  * @public
  */
-export const accentFillLargeActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillLargeActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-large-active",
     x => accentFillLarge(x).active,
     FASTDesignSystemProvider.findProvider
@@ -437,7 +440,7 @@ export const accentFillLargeActiveBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-large-focus CSS custom property.
  * @public
  */
-export const accentFillLargeFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillLargeFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-large-focus",
     x => accentFillLarge(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -446,7 +449,7 @@ export const accentFillLargeFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the accent-fill-large-selected CSS custom property.
  * @public
  */
-export const accentFillLargeSelectedBehavior = cssCustomPropertyBehaviorFactory(
+export const accentFillLargeSelectedBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "accent-fill-large-selected",
     x => accentFillLarge(x).selected,
     FASTDesignSystemProvider.findProvider
@@ -455,7 +458,7 @@ export const accentFillLargeSelectedBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-fill-card-rest CSS custom property.
  * @public
  */
-export const neutralFillCardRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFillCardRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-fill-card-rest",
     x => neutralFillCard(x),
     FASTDesignSystemProvider.findProvider
@@ -464,7 +467,7 @@ export const neutralFillCardRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-outline-rest CSS custom property.
  * @public
  */
-export const neutralOutlineRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralOutlineRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-outline-rest",
     x => neutralOutline(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -473,7 +476,7 @@ export const neutralOutlineRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-outline-hover CSS custom property.
  * @public
  */
-export const neutralOutlineHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralOutlineHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-outline-hover",
     x => neutralOutline(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -482,7 +485,7 @@ export const neutralOutlineHoverBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-outline-active CSS custom property.
  * @public
  */
-export const neutralOutlineActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralOutlineActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-outline-active",
     x => neutralOutline(x).active,
     FASTDesignSystemProvider.findProvider
@@ -491,7 +494,7 @@ export const neutralOutlineActiveBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-outline-focus CSS custom property.
  * @public
  */
-export const neutralOutlineFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralOutlineFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-outline-focus",
     x => neutralOutline(x).focus,
     FASTDesignSystemProvider.findProvider
@@ -500,7 +503,7 @@ export const neutralOutlineFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-divider-rest CSS custom property.
  * @public
  */
-export const neutralDividerRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralDividerRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-divider-rest",
     neutralDividerRest,
     FASTDesignSystemProvider.findProvider
@@ -509,7 +512,7 @@ export const neutralDividerRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-layer-floating CSS custom property.
  * @public
  */
-export const neutralLayerFloatingBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralLayerFloatingBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-layer-floating",
     neutralLayerFloating,
     FASTDesignSystemProvider.findProvider
@@ -518,7 +521,7 @@ export const neutralLayerFloatingBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-layer-card CSS custom property.
  * @public
  */
-export const neutralLayerCardBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralLayerCardBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-layer-card",
     neutralLayerCard,
     FASTDesignSystemProvider.findProvider
@@ -527,7 +530,7 @@ export const neutralLayerCardBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-layer-card-container CSS custom property.
  * @public
  */
-export const neutralLayerCardContainerBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralLayerCardContainerBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-layer-card-container",
     neutralLayerCardContainer,
     FASTDesignSystemProvider.findProvider
@@ -536,7 +539,7 @@ export const neutralLayerCardContainerBehavior = cssCustomPropertyBehaviorFactor
  * Behavior to resolve and make available the neutral-layer-l1 CSS custom property.
  * @public
  */
-export const neutralLayerL1Behavior = cssCustomPropertyBehaviorFactory(
+export const neutralLayerL1Behavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-layer-l1",
     neutralLayerL1,
     FASTDesignSystemProvider.findProvider
@@ -545,7 +548,7 @@ export const neutralLayerL1Behavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-layer-l1-alt CSS custom property.
  * @public
  */
-export const neutralLayerL1AltBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralLayerL1AltBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-layer-l1-alt",
     neutralLayerL1Alt,
     FASTDesignSystemProvider.findProvider
@@ -554,7 +557,7 @@ export const neutralLayerL1AltBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-layer-l2 CSS custom property.
  * @public
  */
-export const neutralLayerL2Behavior = cssCustomPropertyBehaviorFactory(
+export const neutralLayerL2Behavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-layer-l2",
     neutralLayerL2,
     FASTDesignSystemProvider.findProvider
@@ -563,7 +566,7 @@ export const neutralLayerL2Behavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-layer-l3 CSS custom property.
  * @public
  */
-export const neutralLayerL3Behavior = cssCustomPropertyBehaviorFactory(
+export const neutralLayerL3Behavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-layer-l3",
     neutralLayerL3,
     FASTDesignSystemProvider.findProvider
@@ -572,7 +575,7 @@ export const neutralLayerL3Behavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-layer-l4 CSS custom property.
  * @public
  */
-export const neutralLayerL4Behavior = cssCustomPropertyBehaviorFactory(
+export const neutralLayerL4Behavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-layer-l4",
     neutralLayerL4,
     FASTDesignSystemProvider.findProvider
@@ -581,7 +584,7 @@ export const neutralLayerL4Behavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-focus CSS custom property.
  * @public
  */
-export const neutralFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-focus",
     neutralFocus,
     FASTDesignSystemProvider.findProvider
@@ -590,7 +593,7 @@ export const neutralFocusBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-focus-inner-accent CSS custom property.
  * @public
  */
-export const neutralFocusInnerAccentBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralFocusInnerAccentBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-focus-inner-accent",
     neutralFocusInnerAccent(accentBaseColor),
     FASTDesignSystemProvider.findProvider
@@ -599,7 +602,7 @@ export const neutralFocusInnerAccentBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-contrast-foreground-rest CSS custom property.
  * @public
  */
-export const neutralContrastForegroundRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralContrastForegroundRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-contrast-foreground-rest",
     x => neutralForegroundRest(neutralContrastFillRest)(x),
     FASTDesignSystemProvider.findProvider
@@ -608,7 +611,7 @@ export const neutralContrastForegroundRestBehavior = cssCustomPropertyBehaviorFa
  * Behavior to resolve and make available the neutral-contrast-fill-rest CSS custom property.
  * @public
  */
-export const neutralContrastFillRestBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralContrastFillRestBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-contrast-fill-rest",
     x => neutralContrastFill(x).rest,
     FASTDesignSystemProvider.findProvider
@@ -617,7 +620,7 @@ export const neutralContrastFillRestBehavior = cssCustomPropertyBehaviorFactory(
  * Behavior to resolve and make available the neutral-contrast-fill-hover CSS custom property.
  * @public
  */
-export const neutralContrastFillHoverBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralContrastFillHoverBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-contrast-fill-hover",
     x => neutralContrastFill(x).hover,
     FASTDesignSystemProvider.findProvider
@@ -626,7 +629,7 @@ export const neutralContrastFillHoverBehavior = cssCustomPropertyBehaviorFactory
  * Behavior to resolve and make available the neutral-contrast-fill-active CSS custom property.
  * @public
  */
-export const neutralContrastFillActiveBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralContrastFillActiveBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-contrast-fill-active",
     x => neutralContrastFill(x).active,
     FASTDesignSystemProvider.findProvider
@@ -635,7 +638,7 @@ export const neutralContrastFillActiveBehavior = cssCustomPropertyBehaviorFactor
  * Behavior to resolve and make available the neutral-contrast-fill-focus CSS custom property.
  * @public
  */
-export const neutralContrastFillFocusBehavior = cssCustomPropertyBehaviorFactory(
+export const neutralContrastFillFocusBehavior: CSSCustomPropertyBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-contrast-fill-focus",
     x => neutralContrastFill(x).focus,
     FASTDesignSystemProvider.findProvider

--- a/packages/web-components/fast-components/src/switch/index.ts
+++ b/packages/web-components/fast-components/src/switch/index.ts
@@ -9,7 +9,7 @@ import { SwitchStyles as styles } from "./switch.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-switch\>
+ * HTML Element: `<fast-switch>`
  */
 @customElement({
     name: "fast-switch",
@@ -18,8 +18,4 @@ import { SwitchStyles as styles } from "./switch.styles";
 })
 export class FASTSwitch extends Switch {}
 
-/**
- * Styles for Switch
- * @public
- */
-export const SwitchStyles = styles;
+export { SwitchStyles } from "./switch.styles";

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     DirectionalStyleSheetBehavior,
     disabledCursor,
@@ -12,7 +13,6 @@ import {
     accentFillHoverBehavior,
     accentFillRestBehavior,
     accentForegroundCutRestBehavior,
-    heightNumber,
     neutralFillInputActiveBehavior,
     neutralFillInputHoverBehavior,
     neutralFillInputRestBehavior,
@@ -21,9 +21,15 @@ import {
     neutralOutlineActiveBehavior,
     neutralOutlineHoverBehavior,
     neutralOutlineRestBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const SwitchStyles = css`
+/**
+ * Styles for the {@link FASTSwitch|FASTSwitch component}.
+ *
+ * @public
+ */
+export const SwitchStyles: ElementStyles = css`
     :host([hidden]) {
         display: none;
     }

--- a/packages/web-components/fast-components/src/tab-panel/index.ts
+++ b/packages/web-components/fast-components/src/tab-panel/index.ts
@@ -9,7 +9,7 @@ import { TabPanelStyles as styles } from "./tab-panel.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tab-panel\>
+ * HTML Element: `<fast-tab-panel>`
  */
 @customElement({
     name: "fast-tab-panel",
@@ -18,8 +18,4 @@ import { TabPanelStyles as styles } from "./tab-panel.styles";
 })
 export class FASTTabPanel extends TabPanel {}
 
-/**
- * Styles for TabPanel
- * @public
- */
-export const TabPanelStyles = styles;
+export { TabPanelStyles } from "./tab-panel.styles";

--- a/packages/web-components/fast-components/src/tab-panel/tab-panel.styles.ts
+++ b/packages/web-components/fast-components/src/tab-panel/tab-panel.styles.ts
@@ -1,7 +1,13 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 
-export const TabPanelStyles = css`
+/**
+ * Styles for the {@link FASTTabPanel|FASTTabPanel component}.
+ *
+ * @public
+ */
+export const TabPanelStyles: ElementStyles = css`
     ${display("flex")} :host {
         box-sizing: border-box;
         font-size: var(--type-ramp-base-font-size);

--- a/packages/web-components/fast-components/src/tab/index.ts
+++ b/packages/web-components/fast-components/src/tab/index.ts
@@ -9,7 +9,7 @@ import { TabStyles as styles } from "./tab.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tab\>
+ * HTML Element: `<fast-tab>`
  */
 @customElement({
     name: "fast-tab",
@@ -18,8 +18,4 @@ import { TabStyles as styles } from "./tab.styles";
 })
 export class FASTTab extends Tab {}
 
-/**
- * Styles for Tab
- * @public
- */
-export const TabStyles = styles;
+export { TabStyles } from "./tab.styles";

--- a/packages/web-components/fast-components/src/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tab/tab.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -13,7 +14,6 @@ import {
     accentForegroundActiveBehavior,
     accentForegroundHoverBehavior,
     accentForegroundRestBehavior,
-    heightNumber,
     neutralFillActiveBehavior,
     neutralFillHoverBehavior,
     neutralFillRestBehavior,
@@ -23,9 +23,15 @@ import {
     neutralForegroundHintBehavior,
     neutralForegroundHoverBehavior,
     neutralForegroundRestBehavior,
-} from "../styles";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const TabStyles = css`
+/**
+ * Styles for the {@link FASTTab|FASTTab component}.
+ *
+ * @public
+ */
+export const TabStyles: ElementStyles = css`
     ${display("inline-flex")} :host {
         box-sizing: border-box;
         font-family: var(--body-font);

--- a/packages/web-components/fast-components/src/tabs/index.ts
+++ b/packages/web-components/fast-components/src/tabs/index.ts
@@ -9,7 +9,7 @@ import { TabsStyles as styles } from "./tabs.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tabs\>
+ * HTML Element: `<fast-tabs>`
  */
 @customElement({
     name: "fast-tabs",
@@ -17,10 +17,7 @@ import { TabsStyles as styles } from "./tabs.styles";
     styles,
 })
 export class FASTTabs extends Tabs {}
+
 export * from "../tab";
 export * from "../tab-panel";
-/**
- * Styles for Tabs
- * @public
- */
-export const TabsStyles = styles;
+export { TabsStyles } from "./tabs.styles";

--- a/packages/web-components/fast-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tabs.styles.ts
@@ -1,13 +1,16 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
-import {
-    accentFillRestBehavior,
-    heightNumber,
-    neutralForegroundRestBehavior,
-} from "../styles/index";
+import { accentFillRestBehavior, neutralForegroundRestBehavior } from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const TabsStyles = css`
+/**
+ * Styles for the {@link FASTTabs|FASTTabs component}.
+ *
+ * @public
+ */
+export const TabsStyles: ElementStyles = css`
     ${display("grid")} :host {
         box-sizing: border-box;
         font-family: var(--body-font);

--- a/packages/web-components/fast-components/src/text-area/index.ts
+++ b/packages/web-components/fast-components/src/text-area/index.ts
@@ -15,7 +15,7 @@ export type TextAreaAppearance = "filled" | "outline";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-text-area\>
+ * HTML Element: `<fast-text-area>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */
@@ -50,8 +50,4 @@ export class FASTTextArea extends TextArea {
     }
 }
 
-/**
- * Styles for TextArea
- * @public
- */
-export const TextAreaStyles = styles;
+export { TextAreaStyles } from "./text-area.styles";

--- a/packages/web-components/fast-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/fast-components/src/text-area/text-area.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -9,7 +10,6 @@ import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
-    heightNumber,
     neutralFillHoverBehavior,
     neutralFillInputActiveBehavior,
     neutralFillInputHoverBehavior,
@@ -18,9 +18,15 @@ import {
     neutralFocusBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineRestBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const TextAreaStyles = css`
+/**
+ * Styles for the {@link FASTTextArea|FASTTextArea component}.
+ *
+ * @public
+ */
+export const TextAreaStyles: ElementStyles = css`
     ${display("inline-block")} :host {
         font-family: var(--body-font);
         outline: none;

--- a/packages/web-components/fast-components/src/text-field/index.ts
+++ b/packages/web-components/fast-components/src/text-field/index.ts
@@ -15,7 +15,7 @@ export type TextFieldAppearance = "filled" | "outline";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-text-field\>
+ * HTML Element: `<fast-text-field>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */
@@ -50,8 +50,4 @@ export class FASTTextField extends TextField {
     }
 }
 
-/**
- * Styles for TextField
- * @public
- */
-export const TextFieldStyles = styles;
+export { TextFieldStyles } from "./text-field.styles";

--- a/packages/web-components/fast-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
@@ -10,7 +11,6 @@ import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
-    heightNumber,
     neutralFillHoverBehavior,
     neutralFillInputHoverBehavior,
     neutralFillInputRestBehavior,
@@ -18,9 +18,15 @@ import {
     neutralFocusBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineRestBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
-export const TextFieldStyles = css`
+/**
+ * Styles for the {@link FASTTextField|FASTTextField component}.
+ *
+ * @public
+ */
+export const TextFieldStyles: ElementStyles = css`
     ${display("inline-block")} :host {
         font-family: var(--body-font);
         outline: none;
@@ -84,7 +90,7 @@ export const TextFieldStyles = css`
 
     ::slotted(svg) {
         ${
-            /* Glyph size and margin-left is temporary - 
+            /* Glyph size and margin-left is temporary -
             replace when adaptive typography is figured out */ ""
         } width: 16px;
         height: 16px;

--- a/packages/web-components/fast-components/src/tooltip/index.ts
+++ b/packages/web-components/fast-components/src/tooltip/index.ts
@@ -1,10 +1,6 @@
 import { customElement } from "@microsoft/fast-element";
 import { createTooltipTemplate, Tooltip } from "@microsoft/fast-foundation";
 import { TooltipStyles as styles } from "./tooltip.styles";
-import { FASTAnchoredRegion } from "../anchored-region";
-
-// prevent tree shaking
-FASTAnchoredRegion;
 
 /**
  * The FAST Tooltip Custom Element. Implements {@link @microsoft/fast-foundation#Tooltip},
@@ -13,7 +9,7 @@ FASTAnchoredRegion;
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tooltip\>
+ * HTML Element: `<fast-tooltip>`
  */
 @customElement({
     name: "fast-tooltip",
@@ -21,3 +17,6 @@ FASTAnchoredRegion;
     styles,
 })
 export class FASTTooltip extends Tooltip {}
+
+export * from "../anchored-region";
+export { TooltipStyles } from "./tooltip.styles";

--- a/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import {
     accentFillActiveBehavior,
@@ -12,9 +13,14 @@ import {
     neutralFocusBehavior,
     neutralForegroundRestBehavior,
     neutralOutlineRestBehavior,
-} from "../styles/index";
+} from "../styles/recipes";
 
-export const TooltipStyles = css`
+/**
+ * Styles for the {@link FASTTooltip|FASTTooltip component}.
+ *
+ * @public
+ */
+export const TooltipStyles: ElementStyles = css`
     :host {
         contain: layout;
         overflow: visible;

--- a/packages/web-components/fast-components/src/tree-item/index.ts
+++ b/packages/web-components/fast-components/src/tree-item/index.ts
@@ -9,7 +9,7 @@ import { TreeItemStyles as styles } from "./tree-item.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tree-item\>
+ * HTML Element: `<fast-tree-item>`
  *
  */
 @customElement({
@@ -19,8 +19,4 @@ import { TreeItemStyles as styles } from "./tree-item.styles";
 })
 export class FASTTreeItem extends TreeItem {}
 
-/**
- * Styles for TreeItem
- * @public
- */
-export const TreeItemStyles = styles;
+export { TreeItemStyles } from "./tree-item.styles";

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -1,4 +1,4 @@
-import { css } from "@microsoft/fast-element";
+import { css, ElementStyles } from "@microsoft/fast-element";
 import {
     cssCustomPropertyBehaviorFactory,
     DirectionalStyleSheetBehavior,
@@ -8,9 +8,10 @@ import {
     forcedColorsStylesheetBehavior,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import { neutralFillStealthHover, neutralFillStealthSelected } from "../color/index";
+import { FASTDesignSystemProvider } from "../design-system-provider/index";
 import {
     accentForegroundRestBehavior,
-    heightNumber,
     neutralFillStealthActiveBehavior,
     neutralFillStealthHoverBehavior,
     neutralFillStealthRestBehavior,
@@ -19,9 +20,8 @@ import {
     neutralFocusInnerAccentBehavior,
     neutralForegroundActiveBehavior,
     neutralForegroundRestBehavior,
-} from "../styles/index";
-import { neutralFillStealthHover, neutralFillStealthSelected } from "../color/index";
-import { FASTDesignSystemProvider } from "../design-system-provider/index";
+} from "../styles/recipes";
+import { heightNumber } from "../styles/size";
 
 const ltr = css`
     .expand-collapse-glyph {
@@ -53,6 +53,11 @@ const rtl = css`
     }
 `;
 
+/**
+ * CSS Formula for the tree item's expand/collapse button size.
+ *
+ * @internal
+ */
 export const expandCollapseButtonSize =
     "((var(--base-height-multiplier) / 2) * var(--design-unit)) + ((var(--design-unit) * var(--density)) / 2)";
 
@@ -68,7 +73,12 @@ const selectedExpandCollapseHoverBehavior = cssCustomPropertyBehaviorFactory(
     FASTDesignSystemProvider.findProvider
 );
 
-export const TreeItemStyles = css`
+/**
+ * Styles for the {@link FASTTreeItem|FASTTreeItem component}.
+ *
+ * @public
+ */
+export const TreeItemStyles: ElementStyles = css`
     ${display("block")} :host {
         contain: content;
         position: relative;
@@ -133,7 +143,7 @@ export const TreeItemStyles = css`
     .items {
         display: none;
         ${
-            /* Font size should be based off calc(1em + (design-unit + glyph-size-number) * 1px) - 
+            /* Font size should be based off calc(1em + (design-unit + glyph-size-number) * 1px) -
             update when density story is figured out */ ""
         } font-size: calc(1em + (var(--design-unit) + 16) * 1px);
     }
@@ -143,7 +153,7 @@ export const TreeItemStyles = css`
         border: none;
         outline: none;
         ${
-            /* Width and Height should be based off calc(glyph-size-number + (design-unit * 4) * 1px) - 
+            /* Width and Height should be based off calc(glyph-size-number + (design-unit * 4) * 1px) -
             update when density story is figured out */ ""
         } width: calc((${expandCollapseButtonSize} + (var(--design-unit) * 2)) * 1px);
         height: calc((${expandCollapseButtonSize} + (var(--design-unit) * 2)) * 1px);
@@ -158,7 +168,7 @@ export const TreeItemStyles = css`
 
     .expand-collapse-glyph {
         ${
-            /* Glyph size is temporary - 
+            /* Glyph size is temporary -
             replace when glyph-size var is added */ ""
         } width: 16px;
         height: 16px;
@@ -176,7 +186,7 @@ export const TreeItemStyles = css`
 
      ::slotted(svg) {
         ${
-            /* Glyph size is temporary - 
+            /* Glyph size is temporary -
             replace when glyph-size var is added */ ""
         } width: 16px;
         height: 16px;
@@ -215,7 +225,7 @@ export const TreeItemStyles = css`
     :host(.nested) .expand-collapse-button:hover {
         background: ${expandCollapseHoverBehavior.var};
     }
-    
+
     :host([selected]) .positioning-region {
         background: ${neutralFillStealthSelectedBehavior.var};
     }

--- a/packages/web-components/fast-components/src/tree-view/index.ts
+++ b/packages/web-components/fast-components/src/tree-view/index.ts
@@ -9,7 +9,7 @@ import { TreeViewStyles as styles } from "./tree-view.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tree-view\>
+ * HTML Element: `<fast-tree-view>`
  *
  */
 @customElement({
@@ -19,8 +19,4 @@ import { TreeViewStyles as styles } from "./tree-view.styles";
 })
 export class FASTTreeView extends TreeView {}
 
-/**
- * Styles for TreeView
- * @public
- */
-export const TreeViewStyles = styles;
+export { TreeViewStyles } from "./tree-view.styles";

--- a/packages/web-components/fast-components/src/tree-view/tree-view.styles.ts
+++ b/packages/web-components/fast-components/src/tree-view/tree-view.styles.ts
@@ -1,7 +1,13 @@
 import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 
-export const TreeViewStyles = css`
+/**
+ * Styles for the {@link FASTTreeView|FASTTreeView component}.
+ *
+ * @public
+ */
+export const TreeViewStyles: ElementStyles = css`
     :host([hidden]) {
         display: none;
     }

--- a/packages/web-components/fast-components/src/utilities/behaviors.ts
+++ b/packages/web-components/fast-components/src/utilities/behaviors.ts
@@ -1,4 +1,4 @@
-import { ElementStyles } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import { PropertyStyleSheetBehavior } from "@microsoft/fast-foundation";
 
 /**

--- a/packages/web-components/fast-components/tsconfig.json
+++ b/packages/web-components/fast-components/tsconfig.json
@@ -4,6 +4,7 @@
         "declarationDir": "dist/dts",
         "outDir": "dist/esm",
         "strictNullChecks": true,
+        "importsNotUsedAsValues": "error",
         "experimentalDecorators": true,
         "target": "es2015",
         "module": "ESNext",


### PR DESCRIPTION
# Pull Request

## 📖 Description

- add explicit types to style exports
- add `importsNotUsedAsValues` to the `tsconfig.json` in `fast-components`
- Fix formatting in component docs by wrapping tag names in backticks
- Fix eslint errors

### 🎫 Issues

Related to PRs #4421, #4422

## 👩‍💻 Reviewer Notes

This is part of a series of PRs needed to allow us to upgrade the API Extractor (and by extension Typescript). The API Extractor can't handle the `import()` statements auto-generated by TS for implicit typing, so adding explicit types resolves the blocker preventing us from upgrading.

## 📑 Test Plan

This is a large PR with a lot of repetitive changes across most modules in `fast-components`. The changes should only fall into these categories:

* Adding doc blocks to exported component style blocks
* Typing exported style blocks as `ElementStyles`
* Sorting and normalizing imports
* Removing trailing blank spaces

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
