### PR TITLE
DRAFT: Radio buttons auto populate empty aria-label

### DIFF
--- a/change/@microsoft-fast-components-c6f32a1d-4483-40e5-b738-fb6db238c071.json
+++ b/change/@microsoft-fast-components-c6f32a1d-4483-40e5-b738-fb6db238c071.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix aria labelling",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-484f5a4c-a1b2-4f52-a501-80d25d693300.json
+++ b/change/@microsoft-fast-foundation-484f5a4c-a1b2-4f52-a501-80d25d693300.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix aria labelling",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/checkbox/fixtures/base.html
+++ b/packages/web-components/fast-components/src/checkbox/fixtures/base.html
@@ -41,7 +41,21 @@
     <fast-checkbox checked>Oranges</fast-checkbox>
 </fieldset>
 
-<h2>Visual vs audio label</h2>
+<h2>Aria</h2>
 <fast-checkbox>
-    <span aria-label="Audio label">Visible label</span>
+    Labeled by content
 </fast-checkbox>
+
+<div style="display: flex; flex-direction: column; margin-top: 12px;">
+    <h3 id="externallabel">External label</h3>
+    <fast-checkbox aria-labeledby="externallabel">
+        Content not used as aria label
+    </fast-checkbox>
+</div>
+
+<div style="display: flex; flex-direction: column; margin-top: 12px;">
+    <h3 id="label1">Aria label attribute specified</h3>
+    <fast-checkbox aria-label="label specified by attribute">
+        Content not used as aria label
+    </fast-checkbox>
+</div>

--- a/packages/web-components/fast-components/src/radio/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio/fixtures/base.html
@@ -21,10 +21,19 @@
 
 <h2>Visual vs audio label</h2>
 <fast-radio>
-    <span aria-label="Audio label">Visible label</span>
+    Labeled by content
 </fast-radio>
 
 <div style="display: flex; flex-direction: column; margin-top: 12px;">
-    <label id="label1">Outside label</label>
-    <fast-radio aria-labelledby="label1"></fast-radio>
+    <label id="label1">External label</label>
+    <fast-radio aria-labeledby="external label">
+        Content not used as aria label
+    </fast-radio>
+</div>
+
+<div style="display: flex; flex-direction: column; margin-top: 12px;">
+    <label id="label1">Aria label attribute specified</label>
+    <fast-radio aria-label="label specified by attribute">
+        Content not used as aria label
+    </fast-radio>
 </div>

--- a/packages/web-components/fast-components/src/radio/fixtures/base.html
+++ b/packages/web-components/fast-components/src/radio/fixtures/base.html
@@ -19,20 +19,20 @@
 <fast-radio disabled>label</fast-radio>
 <fast-radio disabled checked id="anotherCheckedOne">checked</fast-radio>
 
-<h2>Visual vs audio label</h2>
+<h2>Aria</h2>
 <fast-radio>
     Labeled by content
 </fast-radio>
 
 <div style="display: flex; flex-direction: column; margin-top: 12px;">
-    <label id="label1">External label</label>
-    <fast-radio aria-labeledby="external label">
+    <h3 id="externallabel">External label</h3>
+    <fast-radio aria-labeledby="externallabel">
         Content not used as aria label
     </fast-radio>
 </div>
 
 <div style="display: flex; flex-direction: column; margin-top: 12px;">
-    <label id="label1">Aria label attribute specified</label>
+    <h3 id="label1">Aria label attribute specified</h3>
     <fast-radio aria-label="label specified by attribute">
         Content not used as aria label
     </fast-radio>

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1483,6 +1483,7 @@ export type ProxyElement = HTMLSelectElement | HTMLTextAreaElement | HTMLInputEl
 // @public
 export class Radio extends FormAssociatedRadio implements RadioControl {
     constructor();
+    ariaLabel: string;
     checked: boolean;
     checkedAttribute: boolean;
     // @internal (undocumented)

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
@@ -410,4 +410,33 @@ describe("Checkbox", () => {
             await disconnect();
         });
     });
+
+    it("should set aria-label to match content when not aria-label is not set", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        element.appendChild(new Text("test"));
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-label")).to.equal("test");
+
+        await disconnect();
+    });
+
+    it("should not set aria to match content when not aria-label is set", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        element.setAttribute("aria-label", "author set");
+        element.appendChild(new Text("test"));
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-label")).to.equal("author set");
+
+        await disconnect();
+    });
 });

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -50,6 +50,11 @@ export class Checkbox extends FormAssociatedCheckbox {
      */
     @observable
     public defaultSlottedNodes: Node[];
+    private defaultSlottedNodesChanged(): void {
+        if (this.$fastController.isConnected) {
+            this.updateAriaLabelForNodeChange();
+        }
+    }
 
     /**
      * Initialized to the value of the checked attribute. Can be changed independently of the "checked" attribute,
@@ -112,6 +117,12 @@ export class Checkbox extends FormAssociatedCheckbox {
      */
     private constructed: boolean = false;
 
+    /**
+     * Tracks whether the "aria-label" property is being defined by
+     * the component's contents or has been set externally
+     */
+    private labelDerivedFromContent: boolean = false;
+
     constructor() {
         super();
 
@@ -130,6 +141,8 @@ export class Checkbox extends FormAssociatedCheckbox {
         this.proxy.setAttribute("type", "checkbox");
 
         this.updateForm();
+
+        this.updateAriaLabelForNodeChange();
     }
 
     /**
@@ -164,4 +177,16 @@ export class Checkbox extends FormAssociatedCheckbox {
             this.checked = !this.checked;
         }
     };
+
+    private updateAriaLabelForNodeChange(): void {
+        if (
+            (this.getAttribute("aria-label") === null || this.labelDerivedFromContent) &&
+            this.defaultSlottedNodes.length > 0 &&
+            this.defaultSlottedNodes[0].nodeType === Node.TEXT_NODE &&
+            this.defaultSlottedNodes[0].nodeValue !== null
+        ) {
+            this.setAttribute("aria-label", this.defaultSlottedNodes[0].nodeValue);
+            this.labelDerivedFromContent = true;
+        }
+    }
 }

--- a/packages/web-components/fast-foundation/src/radio/radio.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.spec.ts
@@ -409,4 +409,34 @@ describe("Radio", () => {
             await disconnect();
         });
     });
+
+    
+    it("should set aria-label to match content when not aria-label is not set", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        element.appendChild(new Text("test"));
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-label")).to.equal("test");
+
+        await disconnect();
+    });
+
+    it("should not set aria to match content when not aria-label is set", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        element.setAttribute("aria-label", "author set");
+        element.appendChild(new Text("test"));
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-label")).to.equal("author set");
+
+        await disconnect();
+    });
 });

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -61,10 +61,34 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     }
 
     /**
+     * Maps to aria-label attribute
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: aria-label
+     */
+    @attr({ attribute: "aria-label" })
+    public ariaLabel: string;
+    private ariaLabelChanged(): void {
+        this.labelDerivedFromContent = false;
+    }
+
+    /**
      * @internal
      */
     @observable
     public defaultSlottedNodes: Node[];
+    private defaultSlottedNodesChanged(): void {
+        if (
+            (this.getAttribute("aria-label") === null || this.labelDerivedFromContent) &&
+            this.defaultSlottedNodes.length > 0 &&
+            this.defaultSlottedNodes[0].nodeType === Node.TEXT_NODE &&
+            this.defaultSlottedNodes[0].nodeValue !== null
+        ) {
+            this.setAttribute("aria-label", this.defaultSlottedNodes[0].nodeValue);
+            this.labelDerivedFromContent = true;
+        }
+    }
 
     /**
      * Initialized to the value of the checked attribute. Can be changed independently of the "checked" attribute,
@@ -118,6 +142,12 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
      * normal input radios
      */
     private dirtyChecked: boolean = false;
+
+    /**
+     * Tracks whether the "aria-label" property is being defined by
+     * the component's contents or has been set externally
+     */
+    private labelDerivedFromContent: boolean = false;
 
     /**
      * @internal

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -79,14 +79,8 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     @observable
     public defaultSlottedNodes: Node[];
     private defaultSlottedNodesChanged(): void {
-        if (
-            (this.getAttribute("aria-label") === null || this.labelDerivedFromContent) &&
-            this.defaultSlottedNodes.length > 0 &&
-            this.defaultSlottedNodes[0].nodeType === Node.TEXT_NODE &&
-            this.defaultSlottedNodes[0].nodeValue !== null
-        ) {
-            this.setAttribute("aria-label", this.defaultSlottedNodes[0].nodeValue);
-            this.labelDerivedFromContent = true;
+        if (this.$fastController.isConnected) {
+            this.updateAriaLabelForNodeChange();
         }
     }
 
@@ -180,6 +174,8 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
                 }
             }
         }
+
+        this.updateAriaLabelForNodeChange();
     }
 
     constructor() {
@@ -205,6 +201,18 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     private updateForm(): void {
         const value = this.checked ? this.value : null;
         this.setFormValue(value, value);
+    }
+
+    private updateAriaLabelForNodeChange(): void {
+        if (
+            (this.getAttribute("aria-label") === null || this.labelDerivedFromContent) &&
+            this.defaultSlottedNodes.length > 0 &&
+            this.defaultSlottedNodes[0].nodeType === Node.TEXT_NODE &&
+            this.defaultSlottedNodes[0].nodeValue !== null
+        ) {
+            this.setAttribute("aria-label", this.defaultSlottedNodes[0].nodeValue);
+            this.labelDerivedFromContent = true;
+        }
     }
 
     /**


### PR DESCRIPTION
## 📖 Description
I think it would be good if basic radio buttons with simple text labels automatically did the right thing as far as Aria attributes is concerned.  This change adds a mechanism that uses the text content of a radio button as the aria-label attribute if the author does not set it themselves.  It just makes accessibility more automatic.

### 🎫 Issues
Thinking of ways to make accessibility easier.

## 👩‍💻 Reviewer Notes


## 📑 Test Plan


## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
