### PR TITLE
feat: open up getter and setter functions of a DesignToken to HTMLElement types

### DIFF
--- a/change/@microsoft-fast-foundation-c67228bc-274a-4837-a69d-21e8dc259e5f.json
+++ b/change/@microsoft-fast-foundation-c67228bc-274a-4837-a69d-21e8dc259e5f.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "open up getter and setter functions to HTMLElement",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -743,7 +743,7 @@ export interface DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {
 }
 
 // @alpha
-export type DerivedDesignTokenValue<T> = T extends Function ? never : (target: DesignTokenTarget) => T;
+export type DerivedDesignTokenValue<T> = T extends Function ? never : (target: HTMLElement) => T;
 
 // @alpha (undocumented)
 export class DesignSystem {
@@ -820,24 +820,21 @@ export const DesignSystemRegistrationContext: InterfaceSymbol<DesignSystemRegist
 
 // @alpha
 export interface DesignToken<T> extends CSSDirective {
-    addCustomPropertyFor(element: DesignTokenTarget): this;
+    addCustomPropertyFor(element: HTMLElement & FASTElement): this;
     readonly cssCustomProperty: string;
-    deleteValueFor(element: DesignTokenTarget): this;
-    getValueFor(element: DesignTokenTarget): StaticDesignTokenValue<T>;
+    deleteValueFor(element: HTMLElement): this;
+    getValueFor(element: HTMLElement): StaticDesignTokenValue<T>;
     // (undocumented)
     readonly name: string;
     // (undocumented)
-    removeCustomPropertyFor(element: DesignTokenTarget): this;
-    setValueFor(element: DesignTokenTarget, value: DesignTokenValue<T> | DesignToken<T>): void;
+    removeCustomPropertyFor(element: HTMLElement & FASTElement): this;
+    setValueFor(element: HTMLElement, value: DesignTokenValue<T> | DesignToken<T>): void;
 }
 
 // @alpha
 export const DesignToken: Readonly<{
     create: typeof create;
 }>;
-
-// @alpha
-export type DesignTokenTarget = (HTMLElement & FASTElement) | HTMLBodyElement;
 
 // @alpha
 export type DesignTokenValue<T> = StaticDesignTokenValue<T> | DerivedDesignTokenValue<T>;

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -13,7 +13,6 @@ import { DI, InterfaceSymbol, Registration } from "../di/di";
 import { CustomPropertyManager } from "./custom-property-manager";
 import type {
     DerivedDesignTokenValue,
-    DesignTokenTarget,
     DesignTokenValue,
     StaticDesignTokenValue,
 } from "./interfaces";
@@ -35,36 +34,33 @@ export interface DesignToken<T> extends CSSDirective {
      * Adds the token as a CSS Custom Property to an element
      * @param element - The element to add the CSS Custom Property to
      */
-    addCustomPropertyFor(element: DesignTokenTarget): this;
+    addCustomPropertyFor(element: HTMLElement & FASTElement): this;
 
     /**
      *
      * @param element - The element to remove the CSS Custom Property from
      */
-    removeCustomPropertyFor(element: DesignTokenTarget): this;
+    removeCustomPropertyFor(element: HTMLElement & FASTElement): this;
 
     /**
      * Get the token value for an element.
      * @param element - The element to get the value for
      * @returns - The value set for the element, or the value set for the nearest element ancestor.
      */
-    getValueFor(element: DesignTokenTarget): StaticDesignTokenValue<T>;
+    getValueFor(element: HTMLElement): StaticDesignTokenValue<T>;
 
     /**
      * Sets the token to a value for an element.
      * @param element - The element to set the value for.
      * @param value - The value.
      */
-    setValueFor(
-        element: DesignTokenTarget,
-        value: DesignTokenValue<T> | DesignToken<T>
-    ): void;
+    setValueFor(element: HTMLElement, value: DesignTokenValue<T> | DesignToken<T>): void;
 
     /**
      * Removes a value set for an element.
      * @param element - The element to remove the value from
      */
-    deleteValueFor(element: DesignTokenTarget): this;
+    deleteValueFor(element: HTMLElement): this;
 }
 
 interface Disposable {
@@ -77,7 +73,7 @@ interface Disposable {
 class DesignTokenImpl<T> extends CSSDirective implements DesignToken<T> {
     private cssVar: string;
     private customPropertyChangeHandlers: WeakMap<
-        DesignTokenTarget,
+        HTMLElement & FASTElement,
         Subscriber & Disposable
     > = new Map();
 
@@ -94,19 +90,19 @@ class DesignTokenImpl<T> extends CSSDirective implements DesignToken<T> {
 
     public readonly cssCustomProperty: string;
 
-    public getValueFor(element: DesignTokenTarget): StaticDesignTokenValue<T> {
+    public getValueFor(element: HTMLElement): StaticDesignTokenValue<T> {
         const node = DesignTokenNode.for(this, element);
         Observable.track(node, "value");
         return DesignTokenNode.for(this, element).value;
     }
 
     public setValueFor(
-        element: DesignTokenTarget,
+        element: HTMLElement,
         value: DesignTokenValue<T> | DesignToken<T>
     ): this {
         if (value instanceof DesignTokenImpl) {
             const _value = value;
-            value = ((_element: DesignTokenTarget) =>
+            value = ((_element: HTMLElement) =>
                 DesignTokenNode.for<T>(_value, _element)
                     .value) as DerivedDesignTokenValue<T>;
         }
@@ -114,12 +110,12 @@ class DesignTokenImpl<T> extends CSSDirective implements DesignToken<T> {
         return this;
     }
 
-    public deleteValueFor(element: DesignTokenTarget): this {
+    public deleteValueFor(element: HTMLElement): this {
         DesignTokenNode.for(this, element).delete();
         return this;
     }
 
-    public addCustomPropertyFor(element: DesignTokenTarget): this {
+    public addCustomPropertyFor(element: HTMLElement & FASTElement): this {
         if (!this.customPropertyChangeHandlers.has(element)) {
             const node = DesignTokenNode.for(this, element);
             let value = node.value;
@@ -149,7 +145,7 @@ class DesignTokenImpl<T> extends CSSDirective implements DesignToken<T> {
         return this;
     }
 
-    public removeCustomPropertyFor(element: DesignTokenTarget): this {
+    public removeCustomPropertyFor(element: HTMLElement & FASTElement): this {
         if (this.customPropertyChangeHandlers.has(element)) {
             this.customPropertyChangeHandlers.get(element)!.dispose();
         }
@@ -168,10 +164,10 @@ class DesignTokenImpl<T> extends CSSDirective implements DesignToken<T> {
 class DesignTokenBehavior<T> implements Behavior {
     constructor(public token: DesignToken<T>) {}
 
-    bind(target: DesignTokenTarget) {
+    bind(target: HTMLElement & FASTElement) {
         this.token.addCustomPropertyFor(target);
     }
-    unbind(target: DesignTokenTarget) {
+    unbind(target: HTMLElement & FASTElement) {
         this.token.removeCustomPropertyFor(target);
     }
 }
@@ -202,7 +198,7 @@ class DesignTokenNode<T> {
 
     constructor(
         public readonly token: DesignToken<T>,
-        public readonly target: DesignTokenTarget
+        public readonly target: HTMLElement | (HTMLElement & FASTElement)
     ) {
         if (nodeCache.has(target) && nodeCache.get(target)!.has(token)) {
             throw new Error(
@@ -297,7 +293,7 @@ class DesignTokenNode<T> {
         }
     }
 
-    public static for<T>(token: DesignToken<T>, target: DesignTokenTarget) {
+    public static for<T>(token: DesignToken<T>, target: HTMLElement) {
         const targetCache = nodeCache.has(target)
             ? nodeCache.get(target)!
             : nodeCache.set(target, new Map()) && nodeCache.get(target)!;

--- a/packages/web-components/fast-foundation/src/design-token/interfaces.ts
+++ b/packages/web-components/fast-foundation/src/design-token/interfaces.ts
@@ -1,11 +1,3 @@
-import type { FASTElement } from "@microsoft/fast-element";
-
-/**
- * The type of element that a {@link (DesignToken:interface)} can be set for.
- * @alpha
- */
-export type DesignTokenTarget = (HTMLElement & FASTElement) | HTMLBodyElement;
-
 /**
  * A {@link (DesignToken:interface)} value that is derived. These values can depend on other {@link (DesignToken:interface)}s
  * or arbitrary observable properties.
@@ -13,7 +5,7 @@ export type DesignTokenTarget = (HTMLElement & FASTElement) | HTMLBodyElement;
  */
 export type DerivedDesignTokenValue<T> = T extends Function
     ? never
-    : (target: DesignTokenTarget) => T;
+    : (target: HTMLElement) => T;
 
 /**
  * A design token value with no observable dependencies

--- a/packages/web-components/fast-foundation/src/index.ts
+++ b/packages/web-components/fast-foundation/src/index.ts
@@ -18,7 +18,6 @@ export {
     StaticDesignTokenValue,
     DerivedDesignTokenValue,
     DesignTokenValue,
-    DesignTokenTarget,
 } from "./design-token/interfaces";
 export * from "./di/index";
 export * from "./dialog/index";


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This PR opens up the types of elements that a `DesignToken` can be get, set, and deleted for to any HTMLElement. This has always worked, but was originally restricted to elements that have an observable connection state. We actually don't need connection observation for getting/setting though, only *using* values (emitting to CSS custom properties).

The `addCustomPropertyFor` and `removeCustomPropertyFor` API's are still locked down to `FASTEelement` elements because for those elements we need to observe connection state, re-evaluating the value when connection state changes.


### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->