### PR TITLE
fix: anchored region default positioning without "threshold" set can position incorrectly on initial layout

### DIFF
--- a/change/@microsoft-fast-components-3c8fe4fa-c966-40a0-8ac4-41e2aed261f2.json
+++ b/change/@microsoft-fast-components-3c8fe4fa-c966-40a0-8ac4-41e2aed261f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix anchored region positioning bugs",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-6a63ccca-5dd8-4d21-aa10-8b15d06966d8.json
+++ b/change/@microsoft-fast-foundation-6a63ccca-5dd8-4d21-aa10-8b15d06966d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix anchored region positioning bugs",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -1,13 +1,14 @@
 <fast-anchored-region
     anchor="anchor-fixed"
+    auto-update-mode="auto"
     vertical-positioning-mode="dynamic"
     vertical-scaling="anchor"
     vertical-inset="true"
-    horizontal-positioning-mode="locktodefault"
+    horizontal-positioning-mode="dynamic"
     horizontal-default-position="right"
     style="z-index: 11;"
 >
-    <div style="height: 100%; width: 100%; background: blue;">
+    <div style="height: 100%; width: 100%; background: purple;">
         outside
     </div>
 </fast-anchored-region>
@@ -353,6 +354,7 @@
                 vertical-positioning-mode="dynamic"
                 vertical-default-position="top"
                 horizontal-positioning-mode="dynamic"
+                horizontal-default-position="left"
             >
                 <div style="height: 100px; width: 100px; background: yellow;"></div>
             </fast-anchored-region>
@@ -537,6 +539,7 @@
     vertical-inset="true"
     horizontal-positioning-mode="locktodefault"
     horizontal-default-position="left"
+    auto-update-mode="auto"
     fixed-placement="true"
     style="z-index: 11;"
 >

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -36,6 +36,7 @@
         horizontal-positioning-mode="dynamic"
         horizontal-scaling="anchor"
         horizontal-inset="true"
+        auto-update-mode="auto"
     >
         <div style="height: 100%; width: 100%; background: yellow;">
             inside
@@ -207,6 +208,7 @@
                 vertical-inset="true"
                 horizontal-positioning-mode="dynamic"
                 horizontal-inset="true"
+                auto-update-mode="auto"
             >
                 <div
                     style="height: 100px; width: 100px; background: yellow; opacity: 0.5;"
@@ -235,10 +237,11 @@
                 viewport="viewport-thresholds"
                 vertical-positioning-mode="dynamic"
                 vertical-default-position="top"
-                vertical-threshold="0"
+                vertical-threshold="200"
                 horizontal-positioning-mode="dynamic"
                 horizontal-default-position="left"
                 horizontal-threshold="200"
+                auto-update-mode="auto"
             >
                 <div style="height: 100px; width: 100px; background: yellow;"></div>
             </fast-anchored-region>

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -1,17 +1,18 @@
 import { attr, DOM, FASTElement, observable } from "@microsoft/fast-element";
-import { Direction, eventScroll, eventResize } from "@microsoft/fast-web-utilities";
+import type {
+    ConstructibleResizeObserver,
+    ResizeObserverClassDefinition,
+} from "./resize-observer";
+import { Direction, eventResize, eventScroll } from "@microsoft/fast-web-utilities";
+
 import { getDirection } from "../utilities";
 import { IntersectionService } from "./intersection-service";
+import type { ResizeObserverEntry } from "./resize-observer-entry";
 
 // TODO: the Resize Observer related files are a temporary stopgap measure until
 // Resize Observer types are pulled into TypeScript, which seems imminent
 // At that point these files should be deleted.
 // https://github.com/microsoft/TypeScript/issues/37861
-import type {
-    ConstructibleResizeObserver,
-    ResizeObserverClassDefinition,
-} from "./resize-observer";
-import type { ResizeObserverEntry } from "./resize-observer-entry";
 
 declare global {
     interface WindowWithResizeObserver extends Window {
@@ -413,6 +414,7 @@ export class AnchoredRegion extends FASTElement {
     private pendingLayoutUpdate: boolean = false;
     private pendingReset: boolean = false;
     private currentDirection: Direction = Direction.ltr;
+    private regionVisible: boolean = false;
 
     // defines how big a difference in pixels there must be between states to
     // justify a layout update that affects the dom (prevents repeated sub-pixel corrections)
@@ -476,7 +478,7 @@ export class AnchoredRegion extends FASTElement {
         this.anchorTop = this.anchorTop + verticalOffsetDelta;
         this.anchorBottom = this.anchorBottom + verticalOffsetDelta;
 
-        this.requestLayoutUpdate();
+        this.updateLayout();
     };
 
     /**
@@ -528,7 +530,7 @@ export class AnchoredRegion extends FASTElement {
     private requestLayoutUpdate(): void {
         if (this.pendingLayoutUpdate === false && this.pendingReset === false) {
             this.pendingLayoutUpdate = true;
-            DOM.queueUpdate(this.updateLayout);
+            DOM.queueUpdate(() => this.updateLayout());
         }
     }
 
@@ -542,7 +544,7 @@ export class AnchoredRegion extends FASTElement {
         ) {
             this.pendingLayoutUpdate = false;
             this.setInitialState();
-            DOM.queueUpdate(this.reset);
+            DOM.queueUpdate(() => this.reset());
             this.pendingReset = true;
         }
     }
@@ -552,6 +554,7 @@ export class AnchoredRegion extends FASTElement {
      */
     private setInitialState(): void {
         this.initialLayoutComplete = false;
+        this.regionVisible = false;
         this.regionTop = "0";
         this.regionRight = "0";
         this.regionBottom = "0";
@@ -690,7 +693,7 @@ export class AnchoredRegion extends FASTElement {
         }
 
         this.updateRegionOffset(this.regionRect);
-        this.requestLayoutUpdate();
+        this.updateLayout();
     };
 
     /**
@@ -816,10 +819,6 @@ export class AnchoredRegion extends FASTElement {
      *  Recalculate layout related state values
      */
     private updateLayout = (): void => {
-        if (!this.pendingLayoutUpdate) {
-            return;
-        }
-
         this.pendingLayoutUpdate = false;
 
         let desiredVerticalPosition: AnchoredRegionVerticalPositionLabel = "undefined";
@@ -942,10 +941,16 @@ export class AnchoredRegion extends FASTElement {
 
         if (!this.initialLayoutComplete) {
             this.initialLayoutComplete = true;
+            this.requestPositionUpdates();
+            return;
+        }
+
+        if (!this.regionVisible) {
+            this.regionVisible = true;
             this.style.removeProperty("pointer-events");
             this.style.removeProperty("opacity");
             this.classList.toggle("loaded", true);
-            DOM.queueUpdate(() => this.$emit("loaded", this, { bubbles: false }));
+            this.$emit("loaded", this, { bubbles: false });
         }
 
         if (positionChanged) {
@@ -1168,7 +1173,6 @@ export class AnchoredRegion extends FASTElement {
         if (this.horizontalInset) {
             return ["insetLeft", "insetRight"];
         }
-
         return ["left", "right"];
     };
 
@@ -1179,7 +1183,6 @@ export class AnchoredRegion extends FASTElement {
         if (this.verticalInset) {
             return ["insetTop", "insetBottom"];
         }
-
         return ["top", "bottom"];
     };
 

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -954,6 +954,10 @@ export class AnchoredRegion extends FASTElement {
         }
 
         if (positionChanged) {
+            // do a position check to ensure we're in the right spot
+            // temporary until method for recalculating offsets on position changes improved
+            this.requestPositionUpdates();
+            // emit change event
             this.$emit("positionchange", this, { bubbles: false });
         }
     };


### PR DESCRIPTION
# Pull Request

Anchored region could use wrong contents dimensions on the initial layout pass when using region dimensions instead of fixed thresholds to determine dynamic placement with default position set.

## 📖 Description
- Needed to tweak anchored region initial layout timing so that default positioning was able to use the actual size of the anchored region's contents to determine placement.   The previous implementation was grabbing the dimensions of the region too early which could result in incorrect placement.

### 🎫 Issues
- found issue during implemention of component in another library.

## 👩‍💻 Reviewer Notes


## 📑 Test Plan
Currently working on adding a battery of anchored region tests now that we have a test env that works.  Hope to have a pr for that soon.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
Expand anchored region testing suite