### PR TITLE
fix: tabs should respect activeid when child ids are generated

### DIFF
--- a/change/@microsoft-fast-components-ccda43b4-a353-4317-ba4b-f505c50ca44b.json
+++ b/change/@microsoft-fast-components-ccda43b4-a353-4317-ba4b-f505c50ca44b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix active id with generated ids",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-e4d94666-296c-4a6a-971b-effebf290618.json
+++ b/change/@microsoft-fast-foundation-e4d94666-296c-4a6a-971b-effebf290618.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix activeid with generated ids",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/tabs/fixtures/base.html
+++ b/packages/web-components/fast-components/src/tabs/fixtures/base.html
@@ -39,6 +39,23 @@
     <div>Testing</div>
 </fast-tabs>
 
+<h2>No specified id's</h2>
+<fast-tabs activeId="tab-2">
+    <fast-tab>Tab one</fast-tab>
+    <fast-tab>Tab two</fast-tab>
+    <fast-tab>Tab three</fast-tab>
+    <fast-tab-panel>
+        Tab one content. This is for testing.
+    </fast-tab-panel>
+    <fast-tab-panel>
+        Tab two content. This is for testing.
+    </fast-tab-panel>
+    <fast-tab-panel>
+        Tab three content. This is for testing.
+    </fast-tab-panel>
+    <div>Testing</div>
+</fast-tabs>
+
 <h2>Vertical</h2>
 <fast-tabs orientation="vertical">
     <fast-tab id="TabOne">Tab one</fast-tab>

--- a/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
@@ -246,6 +246,33 @@ describe("Tabs", () => {
             await disconnect();
         });
 
+        it("should set an `aria-selected` attribute on the active tab when `activeId` is provided and no id's are set", async () => {
+            const { element, connect, disconnect } = await fixture<FASTTabs>(html<
+                FASTTabs
+            >`
+                <fast-tabs activeid="tab-2">
+                    <fast-tab>Tab one</fast-tab>
+                    <fast-tab>Tab two</fast-tab>
+                    <fast-tab>Tab three</fast-tab>
+                    <fast-tab-panel>
+                        Tab one content. This is for testing.
+                    </fast-tab-panel>
+                    <fast-tab-panel>
+                        Tab two content. This is for testing.
+                    </fast-tab-panel>
+                    <fast-tab-panel>
+                        Tab three content. This is for testing.
+                    </fast-tab-panel>
+                </fast-tabs>
+            `);
+
+            await connect();
+
+            expect(element.querySelector("[id='tab-2']")?.getAttribute("aria-selected")).to.equal("true");
+
+            await disconnect();
+        });
+
         it("should default the first tab as the active index if `activeId` is NOT provided", async () => {
             const { connect, disconnect, tab1 } = await setup();
 

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -1,4 +1,4 @@
-import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, DOM, FASTElement, observable } from "@microsoft/fast-element";
 import {
     keyCodeArrowDown,
     keyCodeArrowLeft,
@@ -53,9 +53,7 @@ export class Tabs extends FASTElement {
             this.$fastController.isConnected &&
             this.tabs.length <= this.tabpanels.length
         ) {
-            this.setTabs();
-            this.setTabPanels();
-            this.handleActiveIndicatorPosition();
+            this.updateTabs();
         }
     }
 
@@ -72,9 +70,7 @@ export class Tabs extends FASTElement {
             this.$fastController.isConnected &&
             this.tabs.length <= this.tabpanels.length
         ) {
-            this.setTabs();
-            this.setTabPanels();
-            this.handleActiveIndicatorPosition();
+            this.updateTabs();
         }
     }
 
@@ -91,9 +87,7 @@ export class Tabs extends FASTElement {
             this.$fastController.isConnected &&
             this.tabpanels.length <= this.tabs.length
         ) {
-            this.setTabs();
-            this.setTabPanels();
-            this.handleActiveIndicatorPosition();
+            this.updateTabs();
         }
     }
 
@@ -228,9 +222,7 @@ export class Tabs extends FASTElement {
         if (this.activeTabIndex !== this.prevActiveTabIndex) {
             this.activeid = this.tabIds[this.activeTabIndex] as string;
             this.change();
-            this.setTabs();
-            this.handleActiveIndicatorPosition();
-            this.setTabPanels();
+            this.updateTabs();
             this.focusTab();
             this.change();
         }
@@ -395,15 +387,21 @@ export class Tabs extends FASTElement {
         this.tabs[this.activeTabIndex].focus();
     }
 
+    private updateTabs(): void {
+        this.setTabs();
+        this.setTabPanels();
+        this.handleActiveIndicatorPosition();
+    }
+
     /**
      * @internal
      */
     public connectedCallback(): void {
         super.connectedCallback();
 
-        this.tabIds = this.getTabIds();
-        this.tabpanelIds = this.getTabPanelIds();
-        this.activeTabIndex = this.getActiveIndex();
+        DOM.queueUpdate(() => {
+            this.updateTabs();
+        });
     }
 }
 


### PR DESCRIPTION
## 📖 Description
Tabs was not initially showing the tab specified by the activeid attribute when the id's of child tabs were auto generated.  This change fixes that.

### 🎫 Issues

## 👩‍💻 Reviewer Notes


## 📑 Test Plan
Added a test

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
