### PR TITLE
DRAFT feat: anchored region uses transforms for positioning

### DIFF
--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
@@ -42,68 +42,75 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
             }
         });
 
-        // toggle flyout
-        // document.querySelectorAll("[id^=toggle-flyout-anchor").forEach(anchor => {
-        //     anchor.addEventListener("click", (e: MouseEvent) => {
-        //         document
-        //             .getElementById("toggle-anchor-region")!
-        //             .setAttribute("anchor", (e.target as HTMLElement).id);
-        //     });
-        // });
+        const regionScalingUpdate = document.getElementById(
+            "region-upd1"
+        ) as FASTAnchoredRegion;
+        document
+            .getElementById("viewport-upd1")!
+            .addEventListener("scroll", () => regionScalingUpdate.update());
+
+        const togglesRegion = document.getElementById("toggles-region");
 
         // toggle anchor example
-        // document.querySelectorAll("[id^=toggle-anchor-anchor").forEach(anchor => {
-        //     anchor.addEventListener("click", (e: MouseEvent) => {
-        //         document
-        //             .getElementById("toggle-anchor-region")!
-        //             .setAttribute("anchor", (e.target as HTMLElement).id);
-        //     });
+        document.querySelectorAll("[id^=toggles1-anchor").forEach(anchor => {
+            anchor.addEventListener("click", (e: MouseEvent) => {
+                togglesRegion!.setAttribute("anchor", (e.target as HTMLElement).id);
+            });
+        });
+
+        document
+            .getElementById("toggle-positions-horizontal")!
+            .addEventListener("click", (e: MouseEvent) => {
+                if (
+                    togglesRegion?.getAttribute("horizontal-default-position") === "right"
+                ) {
+                    togglesRegion!.setAttribute("horizontal-default-position", "left");
+                } else {
+                    togglesRegion!.setAttribute("horizontal-default-position", "right");
+                }
+            });
+
+        document
+            .getElementById("toggle-positions-vertical")!
+            .addEventListener("click", (e: MouseEvent) => {
+                if (togglesRegion?.getAttribute("vertical-default-position") === "top") {
+                    togglesRegion!.setAttribute("vertical-default-position", "bottom");
+                } else {
+                    togglesRegion!.setAttribute("vertical-default-position", "top");
+                }
+            });
+
+        document
+            .querySelectorAll("[id^=anchor-menu-many]")
+            .forEach((el: HTMLButtonElement) => {
+                el.addEventListener("click", (e: MouseEvent) => {
+                    const menuNum = el.id.substr(16, el.id.length - 16);
+                    const menu: FASTAnchoredRegion = document.getElementById(
+                        `menu-many${menuNum}`
+                    ) as FASTAnchoredRegion;
+                    if (menu.style.display === "none") {
+                        menu.style.display = "";
+                    } else {
+                        menu.style.display = "none";
+                    }
+                });
+            });
+
+        // document.getElementById("toggle-inset-vertical")!.addEventListener("click", (e: MouseEvent) => {
+        //     if ((togglesRegion as FASTAnchoredRegion)!.verticalInset === true){
+        //         (togglesRegion as FASTAnchoredRegion)!.verticalInset = false;
+        //     } else {
+        //         (togglesRegion as FASTAnchoredRegion)!.verticalInset = true;
+        //     }
         // });
 
-        // const positionsRegion = document.getElementById("toggle-positions-region")!;
-        // document
-        //     .querySelectorAll("#toggle-positions-horizontal, #toggle-positions-vertical")
-        //     .forEach((el: HTMLElement) => {
-        //         el.addEventListener("click", (e: MouseEvent) => {
-        //             const isHorizontal = (e.target as HTMLElement).id.includes(
-        //                 "horizontal"
-        //             );
-        //             const direction = isHorizontal ? "horizontal" : "vertical";
-        //             const attr = `${direction}-default-position`;
-
-        //             const currentPosition = positionsRegion.getAttribute(attr);
-
-        //             positionsRegion.setAttribute(
-        //                 attr,
-        //                 isHorizontal
-        //                     ? currentPosition === "left"
-        //                         ? "right"
-        //                         : "left"
-        //                     : currentPosition === "top"
-        //                     ? "bottom"
-        //                     : "top"
-        //             );
-        //         });
-        //     });
-
-        // const smallContent = document.getElementById("toggle-positions-small")!;
-        // const largeContent = document.getElementById("toggle-positions-large")!;
-        // document
-        //     .querySelectorAll("[id^=btn-toggle-positions]")
-        //     .forEach((el: HTMLElement) => {
-        //         el.addEventListener("click", (e: MouseEvent) => {
-        //             const isSmall = (e.target as HTMLElement).id.includes("small");
-        //             smallContent.hidden = !isSmall;
-        //             largeContent.hidden = isSmall;
-        //         });
-        //     });
-
-        // const regionScalingUpdate = document.getElementById(
-        //     "region-scaling-update"
-        // ) as FASTAnchoredRegion;
-        // document
-        //     .getElementById("viewport-scaling-update")!
-        //     .addEventListener("scroll", () => regionScalingUpdate.update());
+        // document.getElementById("toggle-inset-horizontal")!.addEventListener("click", (e: MouseEvent) => {
+        //     if ((togglesRegion as FASTAnchoredRegion)!.horizontalInset === true){
+        //         (togglesRegion as FASTAnchoredRegion)!.horizontalInset = false;
+        //     } else {
+        //         (togglesRegion as FASTAnchoredRegion)!.horizontalInset = true;
+        //     }
+        // });
     }
 });
 

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
@@ -71,23 +71,6 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
         document
             .getElementById("viewport-scaling-update")!
             .addEventListener("scroll", () => regionScalingUpdate.update());
-
-        const regionScalingOffset = document.getElementById(
-            "region-scaling-offset"
-        ) as FASTAnchoredRegion;
-        document
-            .getElementById("viewport-scaling-offset")
-            ?.addEventListener("scroll", (e: MouseEvent) => {
-                const target = e.target as HTMLElement;
-
-                regionScalingOffset.updateAnchorOffset(
-                    scalingViewportPreviousXValue - target.scrollLeft,
-                    scalingViewportPreviousYValue - target.scrollTop
-                );
-
-                scalingViewportPreviousXValue = target.scrollLeft;
-                scalingViewportPreviousYValue = target.scrollTop;
-            });
     }
 });
 

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
@@ -5,11 +5,9 @@ import AnchoredRegionTemplate from "./fixtures/base.html";
 import type { FASTAnchoredRegion } from "./index";
 import "./index";
 
-let scalingViewportPreviousXValue: number = 250;
-let scalingViewportPreviousYValue: number = 250;
-
 addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
     if (name.toLowerCase().startsWith("anchored-region")) {
+        //scroll stuff into view
         document.querySelectorAll("div[id^=viewport]").forEach((el: HTMLElement) => {
             el.scrollTop = 280;
             RtlScrollConverter.setScrollLeft(
@@ -19,58 +17,93 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
             );
         });
 
-        document.querySelectorAll("[id^=toggle-anchor-anchor").forEach(anchor => {
-            anchor.addEventListener("click", (e: MouseEvent) => {
-                document
-                    .getElementById("toggle-anchor-region")!
-                    .setAttribute("anchor", (e.target as HTMLElement).id);
-            });
+        // header region
+        const headerFixedButton = document.getElementById("anchor-header-menu-fixed");
+        headerFixedButton?.addEventListener("click", (e: MouseEvent) => {
+            const menu: FASTAnchoredRegion = document.getElementById(
+                "header-menu-fixed"
+            ) as FASTAnchoredRegion;
+            if (menu.style.display === "none") {
+                menu.style.display = "";
+            } else {
+                menu.style.display = "none";
+            }
         });
 
-        const positionsRegion = document.getElementById("toggle-positions-region")!;
-        document
-            .querySelectorAll("#toggle-positions-horizontal, #toggle-positions-vertical")
-            .forEach((el: HTMLElement) => {
-                el.addEventListener("click", (e: MouseEvent) => {
-                    const isHorizontal = (e.target as HTMLElement).id.includes(
-                        "horizontal"
-                    );
-                    const direction = isHorizontal ? "horizontal" : "vertical";
-                    const attr = `${direction}-default-position`;
+        const headerScalingButton = document.getElementById("anchor-header-menu-scaling");
+        headerScalingButton?.addEventListener("click", (e: MouseEvent) => {
+            const menu: FASTAnchoredRegion = document.getElementById(
+                "header-menu-scaling"
+            ) as FASTAnchoredRegion;
+            if (menu.style.display === "none") {
+                menu.style.display = "";
+            } else {
+                menu.style.display = "none";
+            }
+        });
 
-                    const currentPosition = positionsRegion.getAttribute(attr);
+        // toggle flyout
+        // document.querySelectorAll("[id^=toggle-flyout-anchor").forEach(anchor => {
+        //     anchor.addEventListener("click", (e: MouseEvent) => {
+        //         document
+        //             .getElementById("toggle-anchor-region")!
+        //             .setAttribute("anchor", (e.target as HTMLElement).id);
+        //     });
+        // });
 
-                    positionsRegion.setAttribute(
-                        attr,
-                        isHorizontal
-                            ? currentPosition === "left"
-                                ? "right"
-                                : "left"
-                            : currentPosition === "top"
-                            ? "bottom"
-                            : "top"
-                    );
-                });
-            });
+        // toggle anchor example
+        // document.querySelectorAll("[id^=toggle-anchor-anchor").forEach(anchor => {
+        //     anchor.addEventListener("click", (e: MouseEvent) => {
+        //         document
+        //             .getElementById("toggle-anchor-region")!
+        //             .setAttribute("anchor", (e.target as HTMLElement).id);
+        //     });
+        // });
 
-        const smallContent = document.getElementById("toggle-positions-small")!;
-        const largeContent = document.getElementById("toggle-positions-large")!;
-        document
-            .querySelectorAll("[id^=btn-toggle-positions]")
-            .forEach((el: HTMLElement) => {
-                el.addEventListener("click", (e: MouseEvent) => {
-                    const isSmall = (e.target as HTMLElement).id.includes("small");
-                    smallContent.hidden = !isSmall;
-                    largeContent.hidden = isSmall;
-                });
-            });
+        // const positionsRegion = document.getElementById("toggle-positions-region")!;
+        // document
+        //     .querySelectorAll("#toggle-positions-horizontal, #toggle-positions-vertical")
+        //     .forEach((el: HTMLElement) => {
+        //         el.addEventListener("click", (e: MouseEvent) => {
+        //             const isHorizontal = (e.target as HTMLElement).id.includes(
+        //                 "horizontal"
+        //             );
+        //             const direction = isHorizontal ? "horizontal" : "vertical";
+        //             const attr = `${direction}-default-position`;
 
-        const regionScalingUpdate = document.getElementById(
-            "region-scaling-update"
-        ) as FASTAnchoredRegion;
-        document
-            .getElementById("viewport-scaling-update")!
-            .addEventListener("scroll", () => regionScalingUpdate.update());
+        //             const currentPosition = positionsRegion.getAttribute(attr);
+
+        //             positionsRegion.setAttribute(
+        //                 attr,
+        //                 isHorizontal
+        //                     ? currentPosition === "left"
+        //                         ? "right"
+        //                         : "left"
+        //                     : currentPosition === "top"
+        //                     ? "bottom"
+        //                     : "top"
+        //             );
+        //         });
+        //     });
+
+        // const smallContent = document.getElementById("toggle-positions-small")!;
+        // const largeContent = document.getElementById("toggle-positions-large")!;
+        // document
+        //     .querySelectorAll("[id^=btn-toggle-positions]")
+        //     .forEach((el: HTMLElement) => {
+        //         el.addEventListener("click", (e: MouseEvent) => {
+        //             const isSmall = (e.target as HTMLElement).id.includes("small");
+        //             smallContent.hidden = !isSmall;
+        //             largeContent.hidden = isSmall;
+        //         });
+        //     });
+
+        // const regionScalingUpdate = document.getElementById(
+        //     "region-scaling-update"
+        // ) as FASTAnchoredRegion;
+        // document
+        //     .getElementById("viewport-scaling-update")!
+        //     .addEventListener("scroll", () => regionScalingUpdate.update());
     }
 });
 

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -120,6 +120,9 @@
             An anchored-region is primarily intended to be used as the positioning element
             within other components like tooltips or flyout menus.
         </p>
+        Note that this page contains way more instances of anchored-region than is
+        expected in a normal scenario. Authors should consider performance impacts of many
+        instances.
     </span>
 
     <h2>
@@ -129,7 +132,8 @@
         This header element of this page has position:fixed and overflow: hidden. The
         flyout menus contained within it are wrapped in anchored regions with
         "fixed-placement" set to "true" which allows the menus render outside the bounds
-        of the parent header when it would otherwise be clipped.
+        of the parent header when it would otherwise be clipped. Click the buttons to open
+        the menus, resize the browser to see repositioning/resizing.
     </span>
 
     <h2>
@@ -167,8 +171,8 @@
     <div
         id="anchor-pos1"
         style="
-            height: 160px;
-            width: 160px;
+            height: 120px;
+            width: 120px;
             background: grey;
             margin: 200px;
             padding: 12px;
@@ -443,243 +447,1096 @@
                     Dynamic horizontal axis
                 </div>
             </fast-anchored-region>
+        </div>
+    </div>
 
-            <!-- <fast-anchored-region anchor="anchor-dyn1" viewport="viewport-dyn1" vertical-positioning-mode="dynamic"
-            horizontal-positioning-mode="dynamic" horizontal-inset="true" vertical-inset="true">
-            <div style="height: 100px; width: 100px; background: darkblue; padding: 12px;border: 2px solid white;">
-                inset top/<br>inset right
+    <h3>Thresholds</h3>
+    <span>
+        Dynamically place regions can favor one side over the other by setting a default
+        position. Authors can set horizontal and vertical threshold values that will keep
+        the region on the default side until the space available there is less than the
+        threshold value (ie. "display below the button as long as there is at least 200px
+        there."). If no threshold is specified the dimensions of the region are used
+        (except scaling is set to "fill" in which case a value is required).
+    </span>
+
+    <div
+        id="viewport-dyn2"
+        style="
+            height: 400px;
+            width: 80%;
+            margin-top: 20px;
+            background: lightgray;
+            overflow: scroll;
+            position: relative;
+        "
+    >
+        <div style="height: 1000px; width: 1000px; overflow: hidden;">
+            <div
+                id="anchor-dyn2"
+                style="
+                    margin-top: 450px;
+                    margin-left: 450px;
+                    height: 100px;
+                    width: 100px;
+                    background: grey;
+                    padding: 12px;
+                "
+            >
+                anchor
             </div>
-        </fast-anchored-region> -->
-        </div>
-
-        <!-- 
-    <h2>Manual scaling via update</h2>
-    <div id="viewport-scaling-update" style="
-            height: 400px;
-            width: 80%;
-            margin-left: 100px; background: lightgray;
-            overflow: scroll;
-            position: relative;
-        ">
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button id="anchor-scaling-update" style="margin-left: 500px; margin-top: 500px;">
-                anchor
-            </button>
-            <fast-anchored-region id="region-scaling-update" anchor="anchor-scaling-update"
-                viewport="viewport-scaling-update" vertical-positioning-mode="dynamic" vertical-scaling="fill"
-                horizontal-positioning-mode="dynamic" horizontal-scaling="fill">
-                <div style="height: 100%; width: 100%; background: yellow;"></div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h2>Inset</h2>
-    <div id="viewport-inset" style="
-            position: relative;
-            height: 400px;
-            width: 80%;
-            margin-left: 100px; background: lightgray;
-            overflow: scroll;
-        ">
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button id="anchor-inset" style="margin-left: 500px; margin-top: 500px;">
-                anchor
-            </button>
-            <fast-anchored-region anchor="anchor-inset" viewport="viewport-inset" vertical-positioning-mode="dynamic"
-                vertical-inset="true" horizontal-positioning-mode="dynamic" horizontal-inset="true"
-                auto-update-mode="auto">
-                <div style="height: 100px; width: 100px; background: yellow; opacity: 0.5;"></div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h2>Thresholds</h2>
-    <div id="viewport-thresholds" style="
-            position: relative;
-            height: 400px;
-            width: 80%;
-            margin-left: 100px; background: lightgray;
-            overflow: scroll;
-        ">
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button id="anchor-thresholds" style="margin-left: 500px; margin-top: 500px;">
-                anchor
-            </button>
-            <fast-anchored-region anchor="anchor-thresholds" viewport="viewport-thresholds"
-                vertical-positioning-mode="dynamic" vertical-default-position="top" vertical-threshold="200"
-                horizontal-positioning-mode="dynamic" horizontal-default-position="left" horizontal-threshold="200"
-                auto-update-mode="auto">
-                <div style="height: 100px; width: 100px; background: yellow;"></div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h2>Toggle anchor</h2>
-    <div id="viewport-toggle-anchor" style="
-            position: relative;
-            height: 400px;
-            width: 80%;
-            margin-left: 100px; background: lightgray;
-            overflow: scroll;
-        ">
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button id="toggle-anchor-anchor1" style="margin-left: 400px; margin-top: 500px;">
-                Set anchor 1
-            </button>
-            <button id="toggle-anchor-anchor2">
-                Set anchor 2
-            </button>
-            <fast-anchored-region id="toggle-anchor-region" anchor="toggle-anchor-anchor1"
-                viewport="viewport-toggle-anchor" vertical-positioning-mode="dynamic"
-                horizontal-positioning-mode="dynamic">
-                <div style="height: 100px; width: 100px; background: yellow;"></div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h2>Toggle positions and size</h2>
-    <div id="viewport-toggle-positions" style="
-            position: relative;
-            height: 400px;
-            width: 80%;
-            margin-left: 100px; background: lightgray;
-            overflow: scroll;
-        ">
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button id="anchor-toggle-positions" style="margin-left: 400px; margin-top: 500px;">
-                anchor
-            </button>
-            <fast-anchored-region id="toggle-positions-region" anchor="anchor-toggle-positions"
-                viewport="viewport-toggle-positions" vertical-positioning-mode="locktodefault"
-                vertical-default-position="bottom" horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="right">
-                <div id="toggle-positions-small" style="height: 50px; width: 50px; background: yellow;" hidden="true">
+            <fast-anchored-region
+                anchor="anchor-dyn2"
+                viewport="viewport-dyn2"
+                vertical-positioning-mode="dynamic"
+                vertical-default-position="bottom"
+                vertical-threshold="110"
+                horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="left"
+                horizontal-inset="true"
+                auto-update-mode="auto"
+            >
+                <div
+                    style="
+                        height: 100px;
+                        width: 100px;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    "
+                >
+                    Defaults to bottom
                 </div>
-                <div id="toggle-positions-large" style="height: 100px; width: 100px; background: yellow;"></div>
             </fast-anchored-region>
-            <div style="margin-top: 20px; display: flex; flex-direction: row;">
-                <button id="toggle-positions-horizontal" style="margin-left: 250px; margin-top: 120px;">
-                    toggle horizontal
-                </button>
-                <button id="toggle-positions-vertical" style="margin-top: 120px;">
-                    toggle vertical
-                </button>
-                <button id="btn-toggle-positions-small" style="margin-top: 120px;">
-                    small
-                </button>
-                <button id="btn-toggle-positions-large" style="margin-top: 120px;">
-                    large
-                </button>
+            <fast-anchored-region
+                anchor="anchor-dyn2"
+                viewport="viewport-dyn2"
+                horizontal-positioning-mode="dynamic"
+                horizontal-default-position="right"
+                horizontal-threshold="110"
+                vertical-positioning-mode="locktodefault"
+                vertical-default-position="top"
+                vertical-inset="true"
+                auto-update-mode="auto"
+            >
+                <div
+                    style="
+                        height: 100px;
+                        width: 100px;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    "
+                >
+                    defaults to right
+                </div>
+            </fast-anchored-region>
+        </div>
+    </div>
+
+    <h2>Region sizing</h2>
+    <span>
+        The region's size can be determined on each axis by the size of its
+        content(default), the size of the anchor, or the available space between the
+        anchor and the edge of the viewport.
+    </span>
+
+    <div
+        id="viewport-sz1"
+        style="
+            height: 400px;
+            width: 80%;
+            margin-top: 20px;
+            background: lightgray;
+            overflow: scroll;
+            position: relative;
+        "
+    >
+        <div style="height: 1000px; width: 1000px; overflow: hidden;">
+            <div
+                id="anchor-sz1"
+                style="
+                    margin-top: 450px;
+                    margin-left: 450px;
+                    height: 100px;
+                    width: 100px;
+                    background: grey;
+                    padding: 12px;
+                "
+            >
+                anchor
             </div>
+            <fast-anchored-region
+                anchor="anchor-sz1"
+                viewport="viewport-sz1"
+                vertical-positioning-mode="locktodefault"
+                vertical-default-position="top"
+                horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="left"
+            >
+                <div
+                    style="
+                        height: 60px;
+                        width: 120px;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    "
+                >
+                    Size to content
+                </div>
+            </fast-anchored-region>
+            <fast-anchored-region
+                anchor="anchor-sz1"
+                viewport="viewport-sz1"
+                vertical-scaling="anchor"
+                vertical-positioning-mode="locktodefault"
+                vertical-default-position="top"
+                horizontal-scaling="anchor"
+                horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="right"
+            >
+                <div
+                    style="
+                        box-sizing: border-box;
+                        height: 100%;
+                        width: 100%;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    "
+                >
+                    Size to anchor
+                </div>
+            </fast-anchored-region>
+            <fast-anchored-region
+                anchor="anchor-sz1"
+                viewport="viewport-sz1"
+                vertical-scaling="fill"
+                vertical-positioning-mode="locktodefault"
+                vertical-default-position="bottom"
+                horizontal-scaling="fill"
+                horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="right"
+                auto-update-mode="auto"
+            >
+                <div
+                    style="
+                        box-sizing: border-box;
+                        height: 100%;
+                        width: 100%;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    "
+                >
+                    Fill
+                </div>
+            </fast-anchored-region>
         </div>
     </div>
 
-    <h2>RTL-dynamic</h2>
-    <div id="viewport-rtl-dynamic" style="
-            position: relative;
+    <h2>Nesting</h2>
+    <span>
+        Anchored regions can be nested, as is the case with nested menus.
+    </span>
+
+    <fast-menu style="margin: 40px 0 80px 0;">
+        <fast-menu-item>
+            Menu item 1
+            <fast-menu slot="submenu">
+                <fast-menu-item>
+                    Nested Menu item 1.1
+                    <fast-menu>
+                        <fast-menu-item>Nested Menu item 1.1.1</fast-menu-item>
+                        <fast-menu-item>Nested Menu item 1.1.2</fast-menu-item>
+                        <fast-menu-item>Nested Menu item 1.1.3</fast-menu-item>
+                    </fast-menu>
+                </fast-menu-item>
+                <fast-menu-item>
+                    Nested Menu item 1.2
+                    <fast-menu slot="submenu">
+                        <fast-menu-item>Nested Menu item 1.2.1</fast-menu-item>
+                        <fast-menu-item>Nested Menu item 1.2.2</fast-menu-item>
+                        <fast-menu-item>Nested Menu item 1.2.3</fast-menu-item>
+                    </fast-menu>
+                </fast-menu-item>
+            </fast-menu>
+        </fast-menu-item>
+    </fast-menu>
+
+    <h2>Manual updating</h2>
+    <span>
+        Authors can force position updates by calling the component's update() function.
+    </span>
+
+    <div
+        id="viewport-upd1"
+        style="
             height: 400px;
             width: 80%;
-            margin-left: 100px; background: lightgray;
+            margin-top: 20px;
+            background: lightgray;
             overflow: scroll;
-        " dir="rtl">
-        <div style="height: 1000px; width: 1000px;">
-            <fast-anchored-region anchor="anchor-rtl-dynamic" viewport="viewport-rtl-dynamic"
-                vertical-positioning-mode="dynamic" vertical-default-position="top"
-                horizontal-positioning-mode="dynamic" horizontal-default-position="left">
-                <div style="height: 100px; width: 100px; background: yellow;"></div>
-            </fast-anchored-region>
-            <button id="anchor-rtl-dynamic" style="margin-right: 500px; margin-top: 500px;">
+            position: relative;
+        "
+    >
+        <div style="height: 1000px; width: 1000px; overflow: hidden;">
+            <div
+                id="anchor-upd1"
+                style="
+                    margin-top: 450px;
+                    margin-left: 450px;
+                    height: 100px;
+                    width: 100px;
+                    background: grey;
+                    padding: 12px;
+                "
+            >
                 anchor
-            </button>
+            </div>
+            <fast-anchored-region
+                id="region-upd1"
+                anchor="anchor-upd1"
+                viewport="viewport-upd1"
+                vertical-positioning-mode="dynamic"
+                vertical-scaling="fill"
+                horizontal-positioning-mode="dynamic"
+                horizontal-scaling="fill"
+            >
+                <div
+                    style="
+                        box-sizing: border-box;
+                        height: 100%;
+                        width: 100%;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    "
+                >
+                    Rescaling on update()
+                </div>
+            </fast-anchored-region>
         </div>
     </div>
 
-    <h2>Size to anchor</h2>
-    <div id="viewport-anchor-sized" style="
+    <h2>RTL - start and end position</h2>
+    <span>
+        Authors can use start/end instead of left/right to automatically change default
+        based on direction.
+    </span>
+
+    <div
+        id="anchor-rtl1"
+        style="
+            margin-top: 200px;
+            margin-left: 200px;
+            height: 100px;
+            width: 100px;
+            background: grey;
+            padding: 12px;
+        "
+    >
+        anchor
+    </div>
+    <fast-anchored-region
+        anchor="anchor-rtl1"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="start"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            top/start
+        </div>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        anchor="anchor-rtl1"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="end"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            top/end
+        </div>
+    </fast-anchored-region>
+    <fast-anchored-region
+        anchor="anchor-rtl1"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="start"
+        dir="rtl"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            bottom/start/rtl
+        </div>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        anchor="anchor-rtl1"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="end"
+        dir="rtl"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            bottom/end/rtl
+        </div>
+    </fast-anchored-region>
+
+    <h2 style="margin-top: 200px;">Toggling attributes</h2>
+    <span>
+        Test changing attributes on the fly
+    </span>
+
+    <div
+        id="viewport-toggles1"
+        style="
             position: relative;
             height: 400px;
+            margin-top: 20px;
             width: 80%;
-            margin-left: 100px; background: lightgray;
+            background: lightgray;
             overflow: scroll;
-        ">
-        <div style="height: 1000px; width: 1000px;">
-            <fast-anchored-region anchor="anchor-anchor-sized" viewport="viewport-anchor-sized"
-                vertical-positioning-mode="dynamic" vertical-scaling="anchor" horizontal-positioning-mode="dynamic"
-                horizontal-scaling="anchor" horizontal-inset="true">
-                <div style="height: 100%; width: 100%; background: yellow;"></div>
-            </fast-anchored-region>
-            <button id="anchor-anchor-sized" style="margin-left: 500px; margin-top: 500px;">
-                anchor
-            </button>
-        </div>
-    </div>
-
-    <h2>RTL-fill</h2>
-    <div id="viewport-rtl-fill" dir="rtl" style="
-            position: relative;
-            height: 400px;
-            width: 80%;
-            margin-left: 100px; background: lightgray;
-            overflow: scroll;
-        ">
-        <div style="height: 1000px; width: 1000px;">
-            <button id="anchor-rtl-fill" style="margin-right: 500px; margin-top: 500px;">
-                anchor
-            </button>
-            <fast-anchored-region anchor="anchor-rtl-fill" viewport="viewport-rtl-fill"
-                vertical-positioning-mode="dynamic" vertical-scaling="fill" horizontal-positioning-mode="dynamic"
-                horizontal-scaling="fill">
-                <div style="height: 100%; width: 100%; background: yellow;"></div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h2>Start & End</h2>
-    <div id="viewport-se" style="
-            position: relative;
-            height: 400px;
-            width: 80%;
-            margin-left: 100px; background: lightgray;
-            overflow: scroll;
-        ">
-        <div style="height: 1000px; width: 1000px;">
-            <button id="anchor-se" style="margin-left: 500px; margin-top: 500px;">
-                anchor
-            </button>
-            <fast-anchored-region anchor="anchor-se" viewport="viewport-se" horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="start">
-                <div style="height: 100px; width: 100px; background: yellow;"></div>
-            </fast-anchored-region>
-
-            <fast-anchored-region anchor="anchor-se" viewport="viewport-se" horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="end">
-                <div style="height: 100px; width: 100px; background: green;"></div>
+        "
+    >
+        <div style="height: 1000px; width: 1000px; overflow: hidden;">
+            <div
+                style="
+                    display: grid;
+                    grid-template-columns: 1fr auto 150px auto 1fr;
+                    grid-template-rows: 1fr auto 1fr;
+                    height: 100%;
+                    width: 100%;
+                "
+            >
+                <fast-button id="toggles1-anchor1" style="grid-column: 2; grid-row: 2;">
+                    Set as anchor
+                </fast-button>
+                <fast-button id="toggles1-anchor2" style="grid-column: 4; grid-row: 2;">
+                    Set as anchor
+                </fast-button>
+            </div>
+            <fast-anchored-region
+                id="toggles-region"
+                anchor="toggles1-anchor1"
+                viewport="viewport-toggles1"
+                vertical-positioning-mode="locktodefault"
+                horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="left"
+                vertical-default-position="top"
+            >
+                <div
+                    style="
+                        height: 100px;
+                        width: 100px;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                        box-sizing: border-box;
+                    "
+                ></div>
             </fast-anchored-region>
         </div>
     </div>
-
-    <h2>RTL-Start & End</h2>
-    <div id="viewport-rtl-se" dir="rtl" style="
-            position: relative;
-            height: 400px;
-            width: 80%;
-            margin-left: 100px; background: lightgray;
-            overflow: scroll;
-        ">
-        <div style="height: 1000px; width: 1000px;">
-            <button id="anchor-rtl-se" style="margin-right: 500px; margin-top: 500px;">
-                anchor
-            </button>
-            <fast-anchored-region anchor="anchor-rtl-se" viewport="viewport-rtl-se"
-                horizontal-positioning-mode="locktodefault" horizontal-default-position="start">
-                <div style="height: 100px; width: 100px; background: yellow;"></div>
-            </fast-anchored-region>
-
-            <fast-anchored-region anchor="anchor-rtl-se" viewport="viewport-rtl-se"
-                horizontal-positioning-mode="locktodefault" horizontal-default-position="end">
-                <div style="height: 100px; width: 100px; background: green;"></div>
-            </fast-anchored-region>
-        </div>
-    </div> -->
+    <div style="margin-top: 10px; display: flex; flex-direction: row;">
+        <fast-button id="toggle-positions-horizontal" style="margin: 20px;">
+            toggle horizontal position
+        </fast-button>
+        <fast-button id="toggle-positions-vertical" style="margin: 20px;">
+            toggle vertical position
+        </fast-button>
+        <!-- <fast-button id="toggle-inset-vertical" style="margin: 20px;">
+        toggle vertical inset
+    </fast-button>
+    <fast-button id="toggle-inset-horizontal" style="margin: 20px;">
+        toggle horizontal inset
+    </fast-button> -->
     </div>
+
+    <h2 style="margin-top: 20px;">Many...</h2>
+    <span>
+        Try out multiple open menus and resize/scroll the window.
+        <p>
+            These menus alternate between fixed and absolute positioning. While the fixed
+            menus more easily break out of parent containers to render in the foreground
+            they are also more prone to "jiggling" during resizing (in this case because
+            the text wrapping above resizing the scrolling container as it wraps for
+            different widths).
+        </p>
+    </span>
+
+    <div style="display: flex; flex-wrap: wrap;">
+        <fast-button
+            id="anchor-menu-many1"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many2"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many3"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many4"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many5"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many6"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many7"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many8"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many9"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many10"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many11"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many12"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many13"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many14"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many15"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many16"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many17"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many18"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many19"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many20"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many21"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many22"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many23"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Absolute position menu
+        </fast-button>
+
+        <fast-button
+            id="anchor-menu-many24"
+            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+        >
+            Fixed position menu
+        </fast-button>
+    </div>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many1"
+        anchor="anchor-menu-many1"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many2"
+        anchor="anchor-menu-many2"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many3"
+        anchor="anchor-menu-many3"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many4"
+        anchor="anchor-menu-many4"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many5"
+        anchor="anchor-menu-many5"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many6"
+        anchor="anchor-menu-many6"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many7"
+        anchor="anchor-menu-many7"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many8"
+        anchor="anchor-menu-many8"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many9"
+        anchor="anchor-menu-many9"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many10"
+        anchor="anchor-menu-many10"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many11"
+        anchor="anchor-menu-many11"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many12"
+        anchor="anchor-menu-many12"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many13"
+        anchor="anchor-menu-many13"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many14"
+        anchor="anchor-menu-many14"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many15"
+        anchor="anchor-menu-many15"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many16"
+        anchor="anchor-menu-many16"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many17"
+        anchor="anchor-menu-many17"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many18"
+        anchor="anchor-menu-many18"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many19"
+        anchor="anchor-menu-many19"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many20"
+        anchor="anchor-menu-many20"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many21"
+        anchor="anchor-menu-many21"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many22"
+        anchor="anchor-menu-many22"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many23"
+        anchor="anchor-menu-many23"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none;"
+        id="menu-many24"
+        anchor="anchor-menu-many24"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
 </div>

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -331,6 +331,61 @@
         </div>
     </div>
 
+    <h2>Viewport lock</h2>
+    <span>
+        When 'viewport lock' is enabled on a particular axis the region will not follow it's anchor 
+        out of the viewport.  To keep a tooltip in view, for example.
+    </span>
+
+    <div id="viewport-vloc1" style="
+            height: 400px;
+            width: 80%;
+            margin-top: 20px;
+            background: lightgray;
+            overflow: scroll;
+            position: relative;
+        ">
+        <div style="height: 2000px; width: 2000px; overflow: hidden;">
+            <div id="anchor-vloc1" style="
+                    margin-top: 650px;
+                    margin-left: 650px;
+                    height: 100px;
+                    width: 100px;
+                    background: grey;
+                    padding: 12px;
+                ">
+                anchor
+            </div>
+            <fast-anchored-region anchor="anchor-vloc1" viewport="viewport-vloc1" vertical-positioning-mode="dynamic"
+                horizontal-positioning-mode="dynamic" horizontal-inset="true"
+                auto-update-mode="auto" vertical-viewport-lock="true" horizontal-viewport-lock="true">
+                <div style="
+                        height: 100px;
+                        width: 100px;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    ">
+                    Horizontal inset
+                </div>
+            </fast-anchored-region>
+            <fast-anchored-region anchor="anchor-vloc1" viewport="viewport-vloc1" horizontal-positioning-mode="dynamic"
+                vertical-positioning-mode="dynamic" vertical-inset="true"
+                auto-update-mode="auto" vertical-viewport-lock="true" horizontal-viewport-lock="true">
+                <div style="
+                        height: 100px;
+                        width: 100px;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    ">
+                     Vertical inset
+                </div>
+            </fast-anchored-region>
+        </div>
+    </div>
+
+
     <h3>Thresholds</h3>
     <span>
         Dynamically place regions can favor one side over the other by setting a default

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -186,6 +186,7 @@
         vertical-default-position="top"
         horizontal-positioning-mode="locktodefault"
         horizontal-default-position="left"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -206,6 +207,7 @@
         vertical-default-position="top"
         horizontal-positioning-mode="locktodefault"
         horizontal-default-position="right"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -225,6 +227,7 @@
         vertical-default-position="bottom"
         horizontal-positioning-mode="locktodefault"
         horizontal-default-position="left"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -245,6 +248,7 @@
         vertical-default-position="bottom"
         horizontal-positioning-mode="locktodefault"
         horizontal-default-position="right"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -287,6 +291,7 @@
         horizontal-default-position="left"
         horizontal-inset="true"
         vertical-inset="true"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -311,6 +316,7 @@
         horizontal-default-position="right"
         horizontal-inset="true"
         vertical-inset="true"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -334,6 +340,7 @@
         horizontal-default-position="left"
         horizontal-inset="true"
         vertical-inset="true"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -358,6 +365,7 @@
         horizontal-default-position="right"
         horizontal-inset="true"
         vertical-inset="true"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -745,6 +753,7 @@
         vertical-default-position="top"
         horizontal-positioning-mode="locktodefault"
         horizontal-default-position="start"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -765,6 +774,7 @@
         vertical-default-position="top"
         horizontal-positioning-mode="locktodefault"
         horizontal-default-position="end"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -785,6 +795,7 @@
         horizontal-positioning-mode="locktodefault"
         horizontal-default-position="start"
         dir="rtl"
+        auto-update-mode="auto"
     >
         <div
             style="
@@ -806,6 +817,7 @@
         horizontal-positioning-mode="locktodefault"
         horizontal-default-position="end"
         dir="rtl"
+        auto-update-mode="auto"
     >
         <div
             style="

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -154,38 +154,6 @@
         </div>
     </div>
 
-    <h2>Scaling via offset</h2>
-    <div
-        id="viewport-scaling-offset"
-        style="
-            height: 400px;
-            width: 400px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
-        "
-    >
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button
-                id="anchor-scaling-offset"
-                style="margin-left: 500px; margin-top: 500px;"
-            >
-                anchor
-            </button>
-            <fast-anchored-region
-                id="region-scaling-offset"
-                anchor="anchor-scaling-offset"
-                viewport="viewport-scaling-offset"
-                vertical-positioning-mode="dynamic"
-                vertical-scaling="fill"
-                horizontal-positioning-mode="dynamic"
-                horizontal-scaling="fill"
-            >
-                <div style="height: 100%; width: 100%; background: yellow;"></div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
     <h2>Inset</h2>
     <div
         id="viewport-inset"

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -1,296 +1,564 @@
-<fast-anchored-region
-    anchor="anchor-fixed"
-    auto-update-mode="auto"
-    vertical-positioning-mode="dynamic"
-    vertical-scaling="anchor"
-    vertical-inset="true"
-    horizontal-positioning-mode="dynamic"
-    horizontal-default-position="right"
-    style="z-index: 11;"
->
-    <div style="height: 100%; width: 100%; background: purple;">
-        outside
-    </div>
-</fast-anchored-region>
-
 <div
     style="
+        margin: 20px;
         position: fixed;
-        height: 80px;
-        width: 100%;
-        background: darkgray;
+        height: 100px;
+        width: calc(100% - 60px);
+        box-sizing: border-box;
+        background: black;
+        border-color: white;
+        border: 2px solid;
         overflow: hidden;
-        display: flex;
+        display: grid;
+        grid-template-rows: 1fr;
+        grid-template-columns: 1fr auto auto;
         z-index: 10;
     "
     id="fixed-header"
 >
-    <h1>Anchored region</h1>
-    <button id="anchor-fixed" style="margin-left: 200px; margin-top: 20px; height: 20px;">
-        anchor in fixed container
-    </button>
+    <div
+        style="
+            grid-column: 1 / 3;
+            line-height: 60%;
+            height: 50px;
+            padding: 0 8px;
+            white-space: nowrap;
+        "
+    >
+        <h1>
+            Anchored region
+        </h1>
+    </div>
+    <fast-button
+        id="anchor-header-menu-fixed"
+        style="grid-row: 2; margin: 8px 10px; height: 30px; width: 200px; grid-column: 2;"
+    >
+        Fixed size menu
+    </fast-button>
+    <fast-tooltip position="top" anchor="anchor-header-menu-fixed" style="z-index: 1000;">
+        This menu is of fixed height and avoids the performance cost of resizing itself.
+    </fast-tooltip>
+    <fast-button
+        id="anchor-header-menu-scaling"
+        style="grid-row: 2; margin: 8px 10px; height: 30px; width: 200px; grid-column: 3;"
+    >
+        Scaling menu
+    </fast-button>
+    <fast-tooltip
+        position="top"
+        anchor="anchor-header-menu-scaling"
+        style="z-index: 1000;"
+    >
+        <span style="max-width: 200px;">
+            This menu scales with the parent document and gains scrollbars when it needs
+            to.
+        </span>
+    </fast-tooltip>
     <fast-anchored-region
-        anchor="anchor-fixed"
-        vertical-positioning-mode="dynamic"
-        vertical-scaling="anchor"
-        horizontal-positioning-mode="dynamic"
+        style="display: none;"
+        id="header-menu-fixed"
+        anchor="anchor-header-menu-fixed"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
         horizontal-scaling="anchor"
         horizontal-inset="true"
         auto-update-mode="auto"
     >
-        <div style="height: 100%; width: 100%; background: yellow;">
-            inside
-        </div>
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        style="display: none; overflow-y: auto;"
+        id="header-menu-scaling"
+        anchor="anchor-header-menu-scaling"
+        fixed-placement="true"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        vertical-scaling="fill"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-scaling="anchor"
+        horizontal-inset="true"
+        auto-update-mode="auto"
+    >
+        <fast-listbox style="width: 100%;">
+            <fast-option>William Hartnell</fast-option>
+            <fast-option>Patrick Troughton</fast-option>
+            <fast-option>Jon Pertwee</fast-option>
+            <fast-option>Tom Baker</fast-option>
+            <fast-option>Peter Davidson</fast-option>
+            <fast-option>Colin Baker</fast-option>
+            <fast-option>Sylvester McCoy</fast-option>
+            <fast-option>Paul McGann</fast-option>
+            <fast-option>Christopher Eccleston</fast-option>
+            <fast-option>David Tenant</fast-option>
+            <fast-option>Matt Smith</fast-option>
+            <fast-option>Peter Capaldi</fast-option>
+            <fast-option>Jodie Whittaker</fast-option>
+        </fast-listbox>
     </fast-anchored-region>
 </div>
 
-<div style="margin-top: 80px; overflow: auto; height: 100%;">
-    <h2>Dynamic - default</h2>
+<div style="overflow: auto; height: 100%; padding: 140px 20px; position: relative;">
+    <h2>
+        About
+    </h2>
+    <span>
+        The "anchored-region" component is a container that can position itself relative
+        to another html element in the same document referred to as the "anchor".
+        Additionally, the component can choose its position based on the available space
+        between the anchor element and the a "viewport" element (the document is used as
+        viewport if not otherwise specified).
+        <p>
+            An anchored-region is primarily intended to be used as the positioning element
+            within other components like tooltips or flyout menus.
+        </p>
+    </span>
+
+    <h2>
+        Header samples
+    </h2>
+    <span>
+        This header element of this page has position:fixed and overflow: hidden. The
+        flyout menus contained within it are wrapped in anchored regions with
+        "fixed-placement" set to "true" which allows the menus render outside the bounds
+        of the parent header when it would otherwise be clipped.
+    </span>
+
+    <h2>
+        Position updates
+    </h2>
+    <span>
+        The component always calculates its position on screen when it is first placed in
+        the dom, when its properties/attributes are changed, when the anchor element
+        resizes and when the component's update() function is invoked. Authors can use the
+        component's "auto-update-mode" attribute to "auto" which triggers additional
+        positioning checks on window resize, viewport resize and any scroll event in the
+        window.
+        <p>
+            Position checks stive to be efficient but authors should be conscious of
+            possible performance impacts of having many instances running.
+        </p>
+
+        <p>
+            It should be noted that anchored-region's method of checking position uses
+            intersection observer callbacks which avoids some expensive function calls but
+            introduces a frame delay in getting results. This causes an unavoidable 1
+            frame delay in repositioning when layouts change. Because regions positioned
+            "absolute" vs "fixed" require fewer position corrections this lag is less
+            evident in that case.
+        </p>
+    </span>
+
+    <h2>Positioning options</h2>
+    <span>
+        Authors can specify the default positions of an anchored region relative to its
+        anchor on both the horizontal and vertical axis. A "locktodefault" option forces
+        this position regardless of available space on the other side of the anchor.
+    </span>
+
     <div
-        id="viewport-default"
+        id="anchor-pos1"
         style="
-            position: relative;
-            height: 400px;
-            width: 400px;
-            background: lightgray;
-            overflow: scroll;
+            height: 160px;
+            width: 160px;
+            background: grey;
+            margin: 200px;
+            padding: 12px;
         "
     >
-        <div style="height: 1000px; width: 1000px;">
-            <button id="anchor-default" style="margin-left: 500px; margin-top: 500px;">
-                anchor
-            </button>
-            <fast-anchored-region
-                anchor="anchor-default"
-                viewport="viewport-default"
-                vertical-positioning-mode="dynamic"
-                horizontal-positioning-mode="dynamic"
-            >
-                <div style="height: 100px; width: 100px; background: yellow;"></div>
-            </fast-anchored-region>
-        </div>
+        anchor
     </div>
+    <fast-anchored-region
+        anchor="anchor-pos1"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            top/left
+        </div>
+    </fast-anchored-region>
 
-    <h2>Lock to default</h2>
+    <fast-anchored-region
+        anchor="anchor-pos1"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="right"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            top/right
+        </div>
+    </fast-anchored-region>
+    <fast-anchored-region
+        anchor="anchor-pos1"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            bottom/left
+        </div>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        anchor="anchor-pos1"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="right"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            bottom/right
+        </div>
+    </fast-anchored-region>
+
+    <h2>Inset</h2>
+    <span>
+        Setting "inset on a particular axis changes the anchor point from the outer edge,
+        to the inner edge. The anchored region always grows "away" from the edge it is
+        anchored to (a "top" oriented region would always grow upwards if it were to get
+        taller).
+    </span>
+
     <div
-        id="viewport-locked"
+        id="anchor-pos2"
         style="
-            height: 400px;
-            width: 400px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
+            height: 260px;
+            width: 260px;
+            background: grey;
+            margin: 40px 160px;
+            padding: 12px;
         "
     >
-        <div style="height: 1000px; width: 1000px;">
-            <fast-anchored-region
-                anchor="anchor-locked"
-                viewport="viewport-locked"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="bottom"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="right"
-            >
-                <div style="height: 150px; width: 150px; background: green;"></div>
-            </fast-anchored-region>
-            <div style="position: relative; height: 0; width: 0;">
-                <fast-anchored-region
-                    anchor="anchor-locked"
-                    viewport="viewport-locked"
-                    vertical-positioning-mode="locktodefault"
-                    vertical-default-position="bottom"
-                    horizontal-positioning-mode="locktodefault"
-                    horizontal-default-position="right"
-                >
-                    <div style="height: 100px; width: 100px; background: yellow;"></div>
-                </fast-anchored-region>
-            </div>
-            <fast-anchored-region
-                anchor="anchor-locked"
-                viewport="viewport-locked"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="bottom"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="right"
-            >
-                <div style="height: 50px; width: 50px; background: blue;"></div>
-            </fast-anchored-region>
-            <div></div>
-            <button id="anchor-locked" style="margin-left: 500px; margin-top: 500px;">
-                anchor
-            </button>
-        </div>
+        anchor
     </div>
+    <fast-anchored-region
+        anchor="anchor-pos2"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-inset="true"
+        vertical-inset="true"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            inset top/
+            <br />
+            inset left
+        </div>
+    </fast-anchored-region>
 
-    <h2>Scaling via update</h2>
+    <fast-anchored-region
+        anchor="anchor-pos2"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="right"
+        horizontal-inset="true"
+        vertical-inset="true"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            inset top/
+            <br />
+            inset right
+        </div>
+    </fast-anchored-region>
+    <fast-anchored-region
+        anchor="anchor-pos2"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left"
+        horizontal-inset="true"
+        vertical-inset="true"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            inset bottom/
+            <br />
+            inset left
+        </div>
+    </fast-anchored-region>
+
+    <fast-anchored-region
+        anchor="anchor-pos2"
+        vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom"
+        horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="right"
+        horizontal-inset="true"
+        vertical-inset="true"
+    >
+        <div
+            style="
+                height: 100px;
+                width: 100px;
+                background: darkblue;
+                padding: 12px;
+                border: 2px solid white;
+            "
+        >
+            inset bottom/
+            <br />
+            inset right
+        </div>
+    </fast-anchored-region>
+
+    <h2>Dynamic positioning</h2>
+    <span>
+        An anchored region can "flip" its position relative to its anchor based on
+        available space when its positioning mode is set to "dynamic".
+    </span>
+
     <div
-        id="viewport-scaling-update"
+        id="viewport-dyn1"
         style="
             height: 400px;
-            width: 400px;
+            width: 80%;
+            margin-top: 20px;
             background: lightgray;
             overflow: scroll;
             position: relative;
         "
     >
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button
-                id="anchor-scaling-update"
-                style="margin-left: 500px; margin-top: 500px;"
+            <div
+                id="anchor-dyn1"
+                style="
+                    margin-top: 450px;
+                    margin-left: 450px;
+                    height: 100px;
+                    width: 100px;
+                    background: grey;
+                    padding: 12px;
+                "
             >
                 anchor
-            </button>
+            </div>
             <fast-anchored-region
-                id="region-scaling-update"
-                anchor="anchor-scaling-update"
-                viewport="viewport-scaling-update"
+                anchor="anchor-dyn1"
+                viewport="viewport-dyn1"
                 vertical-positioning-mode="dynamic"
-                vertical-scaling="fill"
-                horizontal-positioning-mode="dynamic"
-                horizontal-scaling="fill"
+                horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="left"
+                horizontal-inset="true"
+                auto-update-mode="auto"
             >
+                <div
+                    style="
+                        height: 100px;
+                        width: 100px;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    "
+                >
+                    Dynamic vertical axis
+                </div>
+            </fast-anchored-region>
+            <fast-anchored-region
+                anchor="anchor-dyn1"
+                viewport="viewport-dyn1"
+                horizontal-positioning-mode="dynamic"
+                vertical-positioning-mode="locktodefault"
+                vertical-default-position="top"
+                vertical-inset="true"
+                auto-update-mode="auto"
+            >
+                <div
+                    style="
+                        height: 100px;
+                        width: 100px;
+                        background: darkblue;
+                        padding: 12px;
+                        border: 2px solid white;
+                    "
+                >
+                    Dynamic horizontal axis
+                </div>
+            </fast-anchored-region>
+
+            <!-- <fast-anchored-region anchor="anchor-dyn1" viewport="viewport-dyn1" vertical-positioning-mode="dynamic"
+            horizontal-positioning-mode="dynamic" horizontal-inset="true" vertical-inset="true">
+            <div style="height: 100px; width: 100px; background: darkblue; padding: 12px;border: 2px solid white;">
+                inset top/<br>inset right
+            </div>
+        </fast-anchored-region> -->
+        </div>
+
+        <!-- 
+    <h2>Manual scaling via update</h2>
+    <div id="viewport-scaling-update" style="
+            height: 400px;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
+            overflow: scroll;
+            position: relative;
+        ">
+        <div style="height: 1000px; width: 1000px; overflow: hidden;">
+            <button id="anchor-scaling-update" style="margin-left: 500px; margin-top: 500px;">
+                anchor
+            </button>
+            <fast-anchored-region id="region-scaling-update" anchor="anchor-scaling-update"
+                viewport="viewport-scaling-update" vertical-positioning-mode="dynamic" vertical-scaling="fill"
+                horizontal-positioning-mode="dynamic" horizontal-scaling="fill">
                 <div style="height: 100%; width: 100%; background: yellow;"></div>
             </fast-anchored-region>
         </div>
     </div>
 
     <h2>Inset</h2>
-    <div
-        id="viewport-inset"
-        style="
+    <div id="viewport-inset" style="
             position: relative;
             height: 400px;
-            width: 400px;
-            background: lightgray;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
             overflow: scroll;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
             <button id="anchor-inset" style="margin-left: 500px; margin-top: 500px;">
                 anchor
             </button>
-            <fast-anchored-region
-                anchor="anchor-inset"
-                viewport="viewport-inset"
-                vertical-positioning-mode="dynamic"
-                vertical-inset="true"
-                horizontal-positioning-mode="dynamic"
-                horizontal-inset="true"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="height: 100px; width: 100px; background: yellow; opacity: 0.5;"
-                ></div>
+            <fast-anchored-region anchor="anchor-inset" viewport="viewport-inset" vertical-positioning-mode="dynamic"
+                vertical-inset="true" horizontal-positioning-mode="dynamic" horizontal-inset="true"
+                auto-update-mode="auto">
+                <div style="height: 100px; width: 100px; background: yellow; opacity: 0.5;"></div>
             </fast-anchored-region>
         </div>
     </div>
 
     <h2>Thresholds</h2>
-    <div
-        id="viewport-thresholds"
-        style="
+    <div id="viewport-thresholds" style="
             position: relative;
             height: 400px;
-            width: 400px;
-            background: lightgray;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
             overflow: scroll;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
             <button id="anchor-thresholds" style="margin-left: 500px; margin-top: 500px;">
                 anchor
             </button>
-            <fast-anchored-region
-                anchor="anchor-thresholds"
-                viewport="viewport-thresholds"
-                vertical-positioning-mode="dynamic"
-                vertical-default-position="top"
-                vertical-threshold="200"
-                horizontal-positioning-mode="dynamic"
-                horizontal-default-position="left"
-                horizontal-threshold="200"
-                auto-update-mode="auto"
-            >
+            <fast-anchored-region anchor="anchor-thresholds" viewport="viewport-thresholds"
+                vertical-positioning-mode="dynamic" vertical-default-position="top" vertical-threshold="200"
+                horizontal-positioning-mode="dynamic" horizontal-default-position="left" horizontal-threshold="200"
+                auto-update-mode="auto">
                 <div style="height: 100px; width: 100px; background: yellow;"></div>
             </fast-anchored-region>
         </div>
     </div>
 
     <h2>Toggle anchor</h2>
-    <div
-        id="viewport-toggle-anchor"
-        style="
+    <div id="viewport-toggle-anchor" style="
             position: relative;
             height: 400px;
-            width: 400px;
-            background: lightgray;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
             overflow: scroll;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button
-                id="toggle-anchor-anchor1"
-                style="margin-left: 400px; margin-top: 500px;"
-            >
+            <button id="toggle-anchor-anchor1" style="margin-left: 400px; margin-top: 500px;">
                 Set anchor 1
             </button>
             <button id="toggle-anchor-anchor2">
                 Set anchor 2
             </button>
-            <fast-anchored-region
-                id="toggle-anchor-region"
-                anchor="toggle-anchor-anchor1"
-                viewport="viewport-toggle-anchor"
-                vertical-positioning-mode="dynamic"
-                horizontal-positioning-mode="dynamic"
-            >
+            <fast-anchored-region id="toggle-anchor-region" anchor="toggle-anchor-anchor1"
+                viewport="viewport-toggle-anchor" vertical-positioning-mode="dynamic"
+                horizontal-positioning-mode="dynamic">
                 <div style="height: 100px; width: 100px; background: yellow;"></div>
             </fast-anchored-region>
         </div>
     </div>
 
     <h2>Toggle positions and size</h2>
-    <div
-        id="viewport-toggle-positions"
-        style="
+    <div id="viewport-toggle-positions" style="
             position: relative;
             height: 400px;
-            width: 400px;
-            background: lightgray;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
             overflow: scroll;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button
-                id="anchor-toggle-positions"
-                style="margin-left: 400px; margin-top: 500px;"
-            >
+            <button id="anchor-toggle-positions" style="margin-left: 400px; margin-top: 500px;">
                 anchor
             </button>
-            <fast-anchored-region
-                id="toggle-positions-region"
-                anchor="anchor-toggle-positions"
-                viewport="viewport-toggle-positions"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="bottom"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="right"
-            >
-                <div
-                    id="toggle-positions-small"
-                    style="height: 50px; width: 50px; background: yellow;"
-                    hidden="true"
-                ></div>
-                <div
-                    id="toggle-positions-large"
-                    style="height: 100px; width: 100px; background: yellow;"
-                ></div>
+            <fast-anchored-region id="toggle-positions-region" anchor="anchor-toggle-positions"
+                viewport="viewport-toggle-positions" vertical-positioning-mode="locktodefault"
+                vertical-default-position="bottom" horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="right">
+                <div id="toggle-positions-small" style="height: 50px; width: 50px; background: yellow;" hidden="true">
+                </div>
+                <div id="toggle-positions-large" style="height: 100px; width: 100px; background: yellow;"></div>
             </fast-anchored-region>
             <div style="margin-top: 20px; display: flex; flex-direction: row;">
-                <button
-                    id="toggle-positions-horizontal"
-                    style="margin-left: 250px; margin-top: 120px;"
-                >
+                <button id="toggle-positions-horizontal" style="margin-left: 250px; margin-top: 120px;">
                     toggle horizontal
                 </button>
                 <button id="toggle-positions-vertical" style="margin-top: 120px;">
@@ -307,214 +575,111 @@
     </div>
 
     <h2>RTL-dynamic</h2>
-    <div
-        id="viewport-rtl-dynamic"
-        style="
+    <div id="viewport-rtl-dynamic" style="
             position: relative;
             height: 400px;
-            width: 400px;
-            background: lightgray;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
             overflow: scroll;
-        "
-        dir="rtl"
-    >
+        " dir="rtl">
         <div style="height: 1000px; width: 1000px;">
-            <fast-anchored-region
-                anchor="anchor-rtl-dynamic"
-                viewport="viewport-rtl-dynamic"
-                vertical-positioning-mode="dynamic"
-                vertical-default-position="top"
-                horizontal-positioning-mode="dynamic"
-                horizontal-default-position="left"
-            >
+            <fast-anchored-region anchor="anchor-rtl-dynamic" viewport="viewport-rtl-dynamic"
+                vertical-positioning-mode="dynamic" vertical-default-position="top"
+                horizontal-positioning-mode="dynamic" horizontal-default-position="left">
                 <div style="height: 100px; width: 100px; background: yellow;"></div>
             </fast-anchored-region>
-            <button
-                id="anchor-rtl-dynamic"
-                style="margin-right: 500px; margin-top: 500px;"
-            >
+            <button id="anchor-rtl-dynamic" style="margin-right: 500px; margin-top: 500px;">
                 anchor
             </button>
         </div>
     </div>
 
     <h2>Size to anchor</h2>
-    <div
-        id="viewport-anchor-sized"
-        style="
+    <div id="viewport-anchor-sized" style="
             position: relative;
             height: 400px;
-            width: 400px;
-            background: lightgray;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
             overflow: scroll;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px;">
-            <fast-anchored-region
-                anchor="anchor-anchor-sized"
-                viewport="viewport-anchor-sized"
-                vertical-positioning-mode="dynamic"
-                vertical-scaling="anchor"
-                horizontal-positioning-mode="dynamic"
-                horizontal-scaling="anchor"
-                horizontal-inset="true"
-            >
+            <fast-anchored-region anchor="anchor-anchor-sized" viewport="viewport-anchor-sized"
+                vertical-positioning-mode="dynamic" vertical-scaling="anchor" horizontal-positioning-mode="dynamic"
+                horizontal-scaling="anchor" horizontal-inset="true">
                 <div style="height: 100%; width: 100%; background: yellow;"></div>
             </fast-anchored-region>
-            <button
-                id="anchor-anchor-sized"
-                style="margin-left: 500px; margin-top: 500px;"
-            >
+            <button id="anchor-anchor-sized" style="margin-left: 500px; margin-top: 500px;">
                 anchor
             </button>
         </div>
     </div>
 
     <h2>RTL-fill</h2>
-    <div
-        id="viewport-rtl-fill"
-        dir="rtl"
-        style="
+    <div id="viewport-rtl-fill" dir="rtl" style="
             position: relative;
             height: 400px;
-            width: 400px;
-            background: lightgray;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
             overflow: scroll;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px;">
             <button id="anchor-rtl-fill" style="margin-right: 500px; margin-top: 500px;">
                 anchor
             </button>
-            <fast-anchored-region
-                anchor="anchor-rtl-fill"
-                viewport="viewport-rtl-fill"
-                vertical-positioning-mode="dynamic"
-                vertical-scaling="fill"
-                horizontal-positioning-mode="dynamic"
-                horizontal-scaling="fill"
-            >
+            <fast-anchored-region anchor="anchor-rtl-fill" viewport="viewport-rtl-fill"
+                vertical-positioning-mode="dynamic" vertical-scaling="fill" horizontal-positioning-mode="dynamic"
+                horizontal-scaling="fill">
                 <div style="height: 100%; width: 100%; background: yellow;"></div>
             </fast-anchored-region>
         </div>
     </div>
 
     <h2>Start & End</h2>
-    <div
-        id="viewport-se"
-        style="
+    <div id="viewport-se" style="
             position: relative;
             height: 400px;
-            width: 400px;
-            background: lightgray;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
             overflow: scroll;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px;">
             <button id="anchor-se" style="margin-left: 500px; margin-top: 500px;">
                 anchor
             </button>
-            <fast-anchored-region
-                anchor="anchor-se"
-                viewport="viewport-se"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="start"
-            >
+            <fast-anchored-region anchor="anchor-se" viewport="viewport-se" horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="start">
                 <div style="height: 100px; width: 100px; background: yellow;"></div>
             </fast-anchored-region>
 
-            <fast-anchored-region
-                anchor="anchor-se"
-                viewport="viewport-se"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="end"
-            >
+            <fast-anchored-region anchor="anchor-se" viewport="viewport-se" horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="end">
                 <div style="height: 100px; width: 100px; background: green;"></div>
             </fast-anchored-region>
         </div>
     </div>
 
     <h2>RTL-Start & End</h2>
-    <div
-        id="viewport-rtl-se"
-        dir="rtl"
-        style="
+    <div id="viewport-rtl-se" dir="rtl" style="
             position: relative;
             height: 400px;
-            width: 400px;
-            background: lightgray;
+            width: 80%;
+            margin-left: 100px; background: lightgray;
             overflow: scroll;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px;">
             <button id="anchor-rtl-se" style="margin-right: 500px; margin-top: 500px;">
                 anchor
             </button>
-            <fast-anchored-region
-                anchor="anchor-rtl-se"
-                viewport="viewport-rtl-se"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="start"
-            >
+            <fast-anchored-region anchor="anchor-rtl-se" viewport="viewport-rtl-se"
+                horizontal-positioning-mode="locktodefault" horizontal-default-position="start">
                 <div style="height: 100px; width: 100px; background: yellow;"></div>
             </fast-anchored-region>
 
-            <fast-anchored-region
-                anchor="anchor-rtl-se"
-                viewport="viewport-rtl-se"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="end"
-            >
+            <fast-anchored-region anchor="anchor-rtl-se" viewport="viewport-rtl-se"
+                horizontal-positioning-mode="locktodefault" horizontal-default-position="end">
                 <div style="height: 100px; width: 100px; background: green;"></div>
             </fast-anchored-region>
         </div>
-    </div>
-
-    <h2>Auto update auto</h2>
-    <div
-        id="viewport-auto-update-auto"
-        style="
-            height: 400px;
-            width: 400px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
-        "
-    >
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <button
-                id="anchor-auto-update-auto"
-                style="margin-left: 500px; margin-top: 500px;"
-            >
-                anchor
-            </button>
-            <fast-anchored-region
-                auto-update-mode="auto"
-                id="region-auto-update-auto"
-                anchor="anchor-auto-update-auto"
-                viewport="viewport-auto-update-auto"
-                vertical-positioning-mode="dynamic"
-                vertical-scaling="fill"
-                horizontal-positioning-mode="dynamic"
-                horizontal-scaling="fill"
-            >
-                <div style="height: 100%; width: 100%; background: yellow;"></div>
-            </fast-anchored-region>
-        </div>
+    </div> -->
     </div>
 </div>
-<fast-anchored-region
-    anchor="anchor-fixed"
-    vertical-positioning-mode="dynamic"
-    vertical-scaling="anchor"
-    vertical-inset="true"
-    horizontal-positioning-mode="locktodefault"
-    horizontal-default-position="left"
-    auto-update-mode="auto"
-    fixed-placement="true"
-    style="z-index: 11;"
->
-    <div style="height: 100%; width: 100%; background: blue; z-index: 11;">
-        outside & fixed
-    </div>
-</fast-anchored-region>

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -1,5 +1,4 @@
-<div
-    style="
+<div style="
         margin: 20px;
         position: fixed;
         height: 100px;
@@ -13,81 +12,49 @@
         grid-template-rows: 1fr;
         grid-template-columns: 1fr auto auto;
         z-index: 10;
-    "
-    id="fixed-header"
->
-    <div
-        style="
+    " id="fixed-header">
+    <div style="
             grid-column: 1 / 3;
             line-height: 60%;
             height: 50px;
             padding: 0 8px;
             white-space: nowrap;
-        "
-    >
+        ">
         <h1>
             Anchored region
         </h1>
     </div>
-    <fast-button
-        id="anchor-header-menu-fixed"
-        style="grid-row: 2; margin: 8px 10px; height: 30px; width: 200px; grid-column: 2;"
-    >
+    <fast-button id="anchor-header-menu-fixed"
+        style="grid-row: 2; margin: 8px 10px; height: 30px; width: 200px; grid-column: 2;">
         Fixed size menu
     </fast-button>
     <fast-tooltip position="top" anchor="anchor-header-menu-fixed" style="z-index: 1000;">
         This menu is of fixed height and avoids the performance cost of resizing itself.
     </fast-tooltip>
-    <fast-button
-        id="anchor-header-menu-scaling"
-        style="grid-row: 2; margin: 8px 10px; height: 30px; width: 200px; grid-column: 3;"
-    >
+    <fast-button id="anchor-header-menu-scaling"
+        style="grid-row: 2; margin: 8px 10px; height: 30px; width: 200px; grid-column: 3;">
         Scaling menu
     </fast-button>
-    <fast-tooltip
-        position="top"
-        anchor="anchor-header-menu-scaling"
-        style="z-index: 1000;"
-    >
+    <fast-tooltip position="top" anchor="anchor-header-menu-scaling" style="z-index: 1000;">
         <span style="max-width: 200px;">
             This menu scales with the parent document and gains scrollbars when it needs
             to.
         </span>
     </fast-tooltip>
-    <fast-anchored-region
-        style="display: none;"
-        id="header-menu-fixed"
-        anchor="anchor-header-menu-fixed"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="header-menu-fixed" anchor="anchor-header-menu-fixed"
+        fixed-placement="true" vertical-positioning-mode="locktodefault" vertical-default-position="bottom"
+        vertical-scaling="content" horizontal-positioning-mode="locktodefault" horizontal-default-position="left"
+        horizontal-scaling="anchor" horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none; overflow-y: auto;"
-        id="header-menu-scaling"
-        anchor="anchor-header-menu-scaling"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="fill"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none; overflow-y: auto;" id="header-menu-scaling"
+        anchor="anchor-header-menu-scaling" fixed-placement="true" vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom" vertical-scaling="fill" horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left" horizontal-scaling="anchor" horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>William Hartnell</fast-option>
             <fast-option>Patrick Troughton</fast-option>
@@ -168,97 +135,64 @@
         this position regardless of available space on the other side of the anchor.
     </span>
 
-    <div
-        id="anchor-pos1"
-        style="
+    <div id="anchor-pos1" style="
             height: 120px;
             width: 120px;
             background: grey;
             margin: 200px;
             padding: 12px;
-        "
-    >
+        ">
         anchor
     </div>
-    <fast-anchored-region
-        anchor="anchor-pos1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-pos1" vertical-positioning-mode="locktodefault" vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             top/left
         </div>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        anchor="anchor-pos1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="right"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-pos1" vertical-positioning-mode="locktodefault" vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="right" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             top/right
         </div>
     </fast-anchored-region>
-    <fast-anchored-region
-        anchor="anchor-pos1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-pos1" vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom" horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             bottom/left
         </div>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        anchor="anchor-pos1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="right"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-pos1" vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom" horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="right" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             bottom/right
         </div>
     </fast-anchored-region>
@@ -271,111 +205,72 @@
         taller).
     </span>
 
-    <div
-        id="anchor-pos2"
-        style="
+    <div id="anchor-pos2" style="
             height: 260px;
             width: 260px;
             background: grey;
             margin: 40px 160px;
             padding: 12px;
-        "
-    >
+        ">
         anchor
     </div>
-    <fast-anchored-region
-        anchor="anchor-pos2"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-inset="true"
-        vertical-inset="true"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-pos2" vertical-positioning-mode="locktodefault" vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-inset="true"
+        vertical-inset="true" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             inset top/
             <br />
             inset left
         </div>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        anchor="anchor-pos2"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="right"
-        horizontal-inset="true"
-        vertical-inset="true"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-pos2" vertical-positioning-mode="locktodefault" vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="right" horizontal-inset="true"
+        vertical-inset="true" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             inset top/
             <br />
             inset right
         </div>
     </fast-anchored-region>
-    <fast-anchored-region
-        anchor="anchor-pos2"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-inset="true"
-        vertical-inset="true"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-pos2" vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom" horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="left" horizontal-inset="true" vertical-inset="true" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             inset bottom/
             <br />
             inset left
         </div>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        anchor="anchor-pos2"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="right"
-        horizontal-inset="true"
-        vertical-inset="true"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-pos2" vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom" horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="right" horizontal-inset="true" vertical-inset="true" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             inset bottom/
             <br />
             inset right
@@ -388,70 +283,48 @@
         available space when its positioning mode is set to "dynamic".
     </span>
 
-    <div
-        id="viewport-dyn1"
-        style="
+    <div id="viewport-dyn1" style="
             height: 400px;
             width: 80%;
             margin-top: 20px;
             background: lightgray;
             overflow: scroll;
             position: relative;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <div
-                id="anchor-dyn1"
-                style="
+            <div id="anchor-dyn1" style="
                     margin-top: 450px;
                     margin-left: 450px;
                     height: 100px;
                     width: 100px;
                     background: grey;
                     padding: 12px;
-                "
-            >
+                ">
                 anchor
             </div>
-            <fast-anchored-region
-                anchor="anchor-dyn1"
-                viewport="viewport-dyn1"
-                vertical-positioning-mode="dynamic"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="left"
-                horizontal-inset="true"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
+            <fast-anchored-region anchor="anchor-dyn1" viewport="viewport-dyn1" vertical-positioning-mode="dynamic"
+                horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-inset="true"
+                auto-update-mode="auto">
+                <div style="
                         height: 100px;
                         width: 100px;
                         background: darkblue;
                         padding: 12px;
                         border: 2px solid white;
-                    "
-                >
+                    ">
                     Dynamic vertical axis
                 </div>
             </fast-anchored-region>
-            <fast-anchored-region
-                anchor="anchor-dyn1"
-                viewport="viewport-dyn1"
-                horizontal-positioning-mode="dynamic"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="top"
-                vertical-inset="true"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
+            <fast-anchored-region anchor="anchor-dyn1" viewport="viewport-dyn1" horizontal-positioning-mode="dynamic"
+                vertical-positioning-mode="locktodefault" vertical-default-position="top" vertical-inset="true"
+                auto-update-mode="auto">
+                <div style="
                         height: 100px;
                         width: 100px;
                         background: darkblue;
                         padding: 12px;
                         border: 2px solid white;
-                    "
-                >
+                    ">
                     Dynamic horizontal axis
                 </div>
             </fast-anchored-region>
@@ -468,74 +341,48 @@
         (except scaling is set to "fill" in which case a value is required).
     </span>
 
-    <div
-        id="viewport-dyn2"
-        style="
+    <div id="viewport-dyn2" style="
             height: 400px;
             width: 80%;
             margin-top: 20px;
             background: lightgray;
             overflow: scroll;
             position: relative;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <div
-                id="anchor-dyn2"
-                style="
+            <div id="anchor-dyn2" style="
                     margin-top: 450px;
                     margin-left: 450px;
                     height: 100px;
                     width: 100px;
                     background: grey;
                     padding: 12px;
-                "
-            >
+                ">
                 anchor
             </div>
-            <fast-anchored-region
-                anchor="anchor-dyn2"
-                viewport="viewport-dyn2"
-                vertical-positioning-mode="dynamic"
-                vertical-default-position="bottom"
-                vertical-threshold="110"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="left"
-                horizontal-inset="true"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
+            <fast-anchored-region anchor="anchor-dyn2" viewport="viewport-dyn2" vertical-positioning-mode="dynamic"
+                vertical-default-position="bottom" vertical-threshold="110" horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="left" horizontal-inset="true" auto-update-mode="auto">
+                <div style="
                         height: 100px;
                         width: 100px;
                         background: darkblue;
                         padding: 12px;
                         border: 2px solid white;
-                    "
-                >
+                    ">
                     Defaults to bottom
                 </div>
             </fast-anchored-region>
-            <fast-anchored-region
-                anchor="anchor-dyn2"
-                viewport="viewport-dyn2"
-                horizontal-positioning-mode="dynamic"
-                horizontal-default-position="right"
-                horizontal-threshold="110"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="top"
-                vertical-inset="true"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
+            <fast-anchored-region anchor="anchor-dyn2" viewport="viewport-dyn2" horizontal-positioning-mode="dynamic"
+                horizontal-default-position="right" horizontal-threshold="110" vertical-positioning-mode="locktodefault"
+                vertical-default-position="top" vertical-inset="true" auto-update-mode="auto">
+                <div style="
                         height: 100px;
                         width: 100px;
                         background: darkblue;
                         padding: 12px;
                         border: 2px solid white;
-                    "
-                >
+                    ">
                     defaults to right
                 </div>
             </fast-anchored-region>
@@ -549,95 +396,63 @@
         anchor and the edge of the viewport.
     </span>
 
-    <div
-        id="viewport-sz1"
-        style="
+    <div id="viewport-sz1" style="
             height: 400px;
             width: 80%;
             margin-top: 20px;
             background: lightgray;
             overflow: scroll;
             position: relative;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <div
-                id="anchor-sz1"
-                style="
+            <div id="anchor-sz1" style="
                     margin-top: 450px;
                     margin-left: 450px;
                     height: 100px;
                     width: 100px;
                     background: grey;
                     padding: 12px;
-                "
-            >
+                ">
                 anchor
             </div>
-            <fast-anchored-region
-                anchor="anchor-sz1"
-                viewport="viewport-sz1"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="top"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="left"
-            >
-                <div
-                    style="
+            <fast-anchored-region anchor="anchor-sz1" viewport="viewport-sz1" vertical-positioning-mode="locktodefault"
+                vertical-default-position="top" horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="left">
+                <div style="
                         height: 60px;
                         width: 120px;
                         background: darkblue;
                         padding: 12px;
                         border: 2px solid white;
-                    "
-                >
+                    ">
                     Size to content
                 </div>
             </fast-anchored-region>
-            <fast-anchored-region
-                anchor="anchor-sz1"
-                viewport="viewport-sz1"
-                vertical-scaling="anchor"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="top"
-                horizontal-scaling="anchor"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="right"
-            >
-                <div
-                    style="
+            <fast-anchored-region anchor="anchor-sz1" viewport="viewport-sz1" vertical-scaling="anchor"
+                vertical-positioning-mode="locktodefault" vertical-default-position="top" horizontal-scaling="anchor"
+                horizontal-positioning-mode="locktodefault" horizontal-default-position="right">
+                <div style="
                         box-sizing: border-box;
                         height: 100%;
                         width: 100%;
                         background: darkblue;
                         padding: 12px;
                         border: 2px solid white;
-                    "
-                >
+                    ">
                     Size to anchor
                 </div>
             </fast-anchored-region>
-            <fast-anchored-region
-                anchor="anchor-sz1"
-                viewport="viewport-sz1"
-                vertical-scaling="fill"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="bottom"
-                horizontal-scaling="fill"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="right"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
+            <fast-anchored-region anchor="anchor-sz1" viewport="viewport-sz1" vertical-scaling="fill"
+                vertical-positioning-mode="locktodefault" vertical-default-position="bottom" horizontal-scaling="fill"
+                horizontal-positioning-mode="locktodefault" horizontal-default-position="right" auto-update-mode="auto">
+                <div style="
                         box-sizing: border-box;
                         height: 100%;
                         width: 100%;
                         background: darkblue;
                         padding: 12px;
                         border: 2px solid white;
-                    "
-                >
+                    ">
                     Fill
                 </div>
             </fast-anchored-region>
@@ -678,50 +493,36 @@
         Authors can force position updates by calling the component's update() function.
     </span>
 
-    <div
-        id="viewport-upd1"
-        style="
+    <div id="viewport-upd1" style="
             height: 400px;
             width: 80%;
             margin-top: 20px;
             background: lightgray;
             overflow: scroll;
             position: relative;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <div
-                id="anchor-upd1"
-                style="
+            <div id="anchor-upd1" style="
                     margin-top: 450px;
                     margin-left: 450px;
                     height: 100px;
                     width: 100px;
                     background: grey;
                     padding: 12px;
-                "
-            >
+                ">
                 anchor
             </div>
-            <fast-anchored-region
-                id="region-upd1"
-                anchor="anchor-upd1"
-                viewport="viewport-upd1"
-                vertical-positioning-mode="dynamic"
-                vertical-scaling="fill"
-                horizontal-positioning-mode="dynamic"
-                horizontal-scaling="fill"
-            >
-                <div
-                    style="
+            <fast-anchored-region id="region-upd1" anchor="anchor-upd1" viewport="viewport-upd1"
+                vertical-positioning-mode="dynamic" vertical-scaling="fill" horizontal-positioning-mode="dynamic"
+                horizontal-scaling="fill">
+                <div style="
                         box-sizing: border-box;
                         height: 100%;
                         width: 100%;
                         background: darkblue;
                         padding: 12px;
                         border: 2px solid white;
-                    "
-                >
+                    ">
                     Rescaling on update()
                 </div>
             </fast-anchored-region>
@@ -734,100 +535,65 @@
         based on direction.
     </span>
 
-    <div
-        id="anchor-rtl1"
-        style="
+    <div id="anchor-rtl1" style="
             margin-top: 200px;
             margin-left: 200px;
             height: 100px;
             width: 100px;
             background: grey;
             padding: 12px;
-        "
-    >
+        ">
         anchor
     </div>
-    <fast-anchored-region
-        anchor="anchor-rtl1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="start"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-rtl1" vertical-positioning-mode="locktodefault" vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="start" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             top/start
         </div>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        anchor="anchor-rtl1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="end"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-rtl1" vertical-positioning-mode="locktodefault" vertical-default-position="top"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="end" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             top/end
         </div>
     </fast-anchored-region>
-    <fast-anchored-region
-        anchor="anchor-rtl1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="start"
-        dir="rtl"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-rtl1" vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom" horizontal-positioning-mode="locktodefault"
+        horizontal-default-position="start" dir="rtl" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             bottom/start/rtl
         </div>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        anchor="anchor-rtl1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="end"
-        dir="rtl"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
+    <fast-anchored-region anchor="anchor-rtl1" vertical-positioning-mode="locktodefault"
+        vertical-default-position="bottom" horizontal-positioning-mode="locktodefault" horizontal-default-position="end"
+        dir="rtl" auto-update-mode="auto">
+        <div style="
                 height: 100px;
                 width: 100px;
                 background: darkblue;
                 padding: 12px;
                 border: 2px solid white;
-            "
-        >
+            ">
             bottom/end/rtl
         </div>
     </fast-anchored-region>
@@ -837,27 +603,22 @@
         Test changing attributes on the fly
     </span>
 
-    <div
-        id="viewport-toggles1"
-        style="
+    <div id="viewport-toggles1" style="
             position: relative;
             height: 400px;
             margin-top: 20px;
             width: 80%;
             background: lightgray;
             overflow: scroll;
-        "
-    >
+        ">
         <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <div
-                style="
+            <div style="
                     display: grid;
                     grid-template-columns: 1fr auto 150px auto 1fr;
                     grid-template-rows: 1fr auto 1fr;
                     height: 100%;
                     width: 100%;
-                "
-            >
+                ">
                 <fast-button id="toggles1-anchor1" style="grid-column: 2; grid-row: 2;">
                     Set as anchor
                 </fast-button>
@@ -865,25 +626,17 @@
                     Set as anchor
                 </fast-button>
             </div>
-            <fast-anchored-region
-                id="toggles-region"
-                anchor="toggles1-anchor1"
-                viewport="viewport-toggles1"
-                vertical-positioning-mode="locktodefault"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="left"
-                vertical-default-position="top"
-            >
-                <div
-                    style="
+            <fast-anchored-region id="toggles-region" anchor="toggles1-anchor1" viewport="viewport-toggles1"
+                vertical-positioning-mode="locktodefault" horizontal-positioning-mode="locktodefault"
+                horizontal-default-position="left" vertical-default-position="top">
+                <div style="
                         height: 100px;
                         width: 100px;
                         background: darkblue;
                         padding: 12px;
                         border: 2px solid white;
                         box-sizing: border-box;
-                    "
-                ></div>
+                    "></div>
             </fast-anchored-region>
         </div>
     </div>
@@ -915,637 +668,449 @@
     </span>
 
     <div style="display: flex; flex-wrap: wrap;">
-        <fast-button
-            id="anchor-menu-many1"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many1" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many2"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many2" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many3"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many3" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many4"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many4" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many5"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many5" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many6"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many6" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many7"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many7" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many8"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many8" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many9"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many9" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many10"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many10" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many11"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many11" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many12"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many12" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many13"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many13" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many14"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many14" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many15"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many15" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many16"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many16" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many17"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many17" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many18"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many18" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many19"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many19" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many20"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many20" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many21"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many21" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many22"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many22" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many23"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many23" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Absolute position menu
         </fast-button>
 
-        <fast-button
-            id="anchor-menu-many24"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
+        <fast-button id="anchor-menu-many24" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
+            Fixed position menu
+        </fast-button>
+
+        <fast-button id="anchor-menu-many25" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
+            Absolute position menu
+        </fast-button>
+
+        <fast-button id="anchor-menu-many26" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
+            Fixed position menu
+        </fast-button>
+
+        <fast-button id="anchor-menu-many27" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
+            Absolute position menu
+        </fast-button>
+
+        <fast-button id="anchor-menu-many28" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
+            Fixed position menu
+        </fast-button>
+
+        <fast-button id="anchor-menu-many29" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
+            Absolute position menu
+        </fast-button>
+
+        <fast-button id="anchor-menu-many30" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
+            Fixed position menu
+        </fast-button>
+
+        <fast-button id="anchor-menu-many31" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
+            Absolute position menu
+        </fast-button>
+
+        <fast-button id="anchor-menu-many32" style="margin: 20px 20px 100px 0; height: 30px; width: 200px;">
             Fixed position menu
         </fast-button>
     </div>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many1"
-        anchor="anchor-menu-many1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many1" anchor="anchor-menu-many1"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many2"
-        anchor="anchor-menu-many2"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many2" anchor="anchor-menu-many2" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many3"
-        anchor="anchor-menu-many3"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many3" anchor="anchor-menu-many3"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many4"
-        anchor="anchor-menu-many4"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many4" anchor="anchor-menu-many4" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many5"
-        anchor="anchor-menu-many5"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many5" anchor="anchor-menu-many5"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many6"
-        anchor="anchor-menu-many6"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many6" anchor="anchor-menu-many6" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many7"
-        anchor="anchor-menu-many7"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many7" anchor="anchor-menu-many7"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many8"
-        anchor="anchor-menu-many8"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many8" anchor="anchor-menu-many8" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many9"
-        anchor="anchor-menu-many9"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many9" anchor="anchor-menu-many9"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many10"
-        anchor="anchor-menu-many10"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many10" anchor="anchor-menu-many10" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many11"
-        anchor="anchor-menu-many11"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many11" anchor="anchor-menu-many11"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many12"
-        anchor="anchor-menu-many12"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many12" anchor="anchor-menu-many12" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many13"
-        anchor="anchor-menu-many13"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many13" anchor="anchor-menu-many13"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many14"
-        anchor="anchor-menu-many14"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many14" anchor="anchor-menu-many14" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many15"
-        anchor="anchor-menu-many15"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many15" anchor="anchor-menu-many15"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many16"
-        anchor="anchor-menu-many16"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many16" anchor="anchor-menu-many16" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many17"
-        anchor="anchor-menu-many17"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many17" anchor="anchor-menu-many17"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many18"
-        anchor="anchor-menu-many18"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many18" anchor="anchor-menu-many18" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many19"
-        anchor="anchor-menu-many19"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many19" anchor="anchor-menu-many19"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many20"
-        anchor="anchor-menu-many20"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many20" anchor="anchor-menu-many20" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many21"
-        anchor="anchor-menu-many21"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many21" anchor="anchor-menu-many21"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many22"
-        anchor="anchor-menu-many22"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many22" anchor="anchor-menu-many22" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many23"
-        anchor="anchor-menu-many23"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many23" anchor="anchor-menu-many23"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>
         </fast-listbox>
     </fast-anchored-region>
 
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many24"
-        anchor="anchor-menu-many24"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
+    <fast-anchored-region style="display: none;" id="menu-many24" anchor="anchor-menu-many24" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region style="display: none;" id="menu-many25" anchor="anchor-menu-many25"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region style="display: none;" id="menu-many26" anchor="anchor-menu-many26" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region style="display: none;" id="menu-many27" anchor="anchor-menu-many27"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region style="display: none;" id="menu-many28" anchor="anchor-menu-many28" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region style="display: none;" id="menu-many29" anchor="anchor-menu-many29"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region style="display: none;" id="menu-many30" anchor="anchor-menu-many30" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region style="display: none;" id="menu-many31" anchor="anchor-menu-many31"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
+        <fast-listbox style="width: 100%;">
+            <fast-option>Yes</fast-option>
+            <fast-option>No</fast-option>
+        </fast-listbox>
+    </fast-anchored-region>
+
+    <fast-anchored-region style="display: none;" id="menu-many32" anchor="anchor-menu-many32" fixed-placement="true"
+        vertical-positioning-mode="locktodefault" vertical-default-position="bottom" vertical-scaling="content"
+        horizontal-positioning-mode="locktodefault" horizontal-default-position="left" horizontal-scaling="anchor"
+        horizontal-inset="true" auto-update-mode="auto">
         <fast-listbox style="width: 100%;">
             <fast-option>Yes</fast-option>
             <fast-option>No</fast-option>

--- a/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
@@ -16,7 +16,6 @@ import {
 
 export const TooltipStyles = css`
     :host {
-        contain: layout;
         overflow: visible;
         height: 0;
         width: 0;
@@ -35,7 +34,6 @@ export const TooltipStyles = css`
         font-family: var(--body-font);
         font-size: var(--type-ramp-base-font-size);
         line-height: var(--type-ramp-base-line-height);
-        white-space: nowrap;
         ${/* TODO: a mechanism to manage z-index across components
             https://github.com/microsoft/fast/issues/3813 */ ""}
         z-index: 10000;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -101,6 +101,7 @@ export class AnchoredRegion extends FASTElement {
     horizontalPositioningMode: AxisPositioningMode;
     horizontalScaling: AxisScalingMode;
     horizontalThreshold: number;
+    horizontalViewportLock: boolean;
     // @internal
     initialLayoutComplete: boolean;
     update: () => void;
@@ -110,6 +111,7 @@ export class AnchoredRegion extends FASTElement {
     verticalPositioningMode: AxisPositioningMode;
     verticalScaling: AxisScalingMode;
     verticalThreshold: number;
+    verticalViewportLock: boolean;
     viewport: string;
     viewportElement: HTMLElement | null;
     }

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -97,7 +97,7 @@ export class AnchoredRegion extends FASTElement {
     fixedPlacement: boolean;
     horizontalDefaultPosition: HorizontalPosition;
     horizontalInset: boolean;
-    horizontalPosition: AnchoredRegionPositionLabel;
+    horizontalPosition: AnchoredRegionPositionLabel | undefined;
     horizontalPositioningMode: AxisPositioningMode;
     horizontalScaling: AxisScalingMode;
     horizontalThreshold: number;
@@ -106,14 +106,16 @@ export class AnchoredRegion extends FASTElement {
     update: () => void;
     verticalDefaultPosition: VerticalPosition;
     verticalInset: boolean;
-    // Warning: (ae-forgotten-export) The symbol "AnchoredRegionPositionLabel" needs to be exported by the entry point index.d.ts
-    verticalPosition: AnchoredRegionPositionLabel;
+    verticalPosition: AnchoredRegionPositionLabel | undefined;
     verticalPositioningMode: AxisPositioningMode;
     verticalScaling: AxisScalingMode;
     verticalThreshold: number;
     viewport: string;
     viewportElement: HTMLElement | null;
     }
+
+// @beta
+export type AnchoredRegionPositionLabel = "start" | "insetStart" | "insetEnd" | "end";
 
 // @beta
 export const AnchoredRegionTemplate: ViewTemplate<AnchoredRegion>;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -97,8 +97,7 @@ export class AnchoredRegion extends FASTElement {
     fixedPlacement: boolean;
     horizontalDefaultPosition: HorizontalPosition;
     horizontalInset: boolean;
-    // Warning: (ae-forgotten-export) The symbol "AnchoredRegionHorizontalPositionLabel" needs to be exported by the entry point index.d.ts
-    horizontalPosition: AnchoredRegionHorizontalPositionLabel;
+    horizontalPosition: AnchoredRegionPositionLabel;
     horizontalPositioningMode: AxisPositioningMode;
     horizontalScaling: AxisScalingMode;
     horizontalThreshold: number;
@@ -107,8 +106,8 @@ export class AnchoredRegion extends FASTElement {
     update: () => void;
     verticalDefaultPosition: VerticalPosition;
     verticalInset: boolean;
-    // Warning: (ae-forgotten-export) The symbol "AnchoredRegionVerticalPositionLabel" needs to be exported by the entry point index.d.ts
-    verticalPosition: AnchoredRegionVerticalPositionLabel;
+    // Warning: (ae-forgotten-export) The symbol "AnchoredRegionPositionLabel" needs to be exported by the entry point index.d.ts
+    verticalPosition: AnchoredRegionPositionLabel;
     verticalPositioningMode: AxisPositioningMode;
     verticalScaling: AxisScalingMode;
     verticalThreshold: number;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -105,7 +105,6 @@ export class AnchoredRegion extends FASTElement {
     // @internal
     initialLayoutComplete: boolean;
     update: () => void;
-    updateAnchorOffset: (horizontalOffsetDelta: number, verticalOffsetDelta: number) => void;
     verticalDefaultPosition: VerticalPosition;
     verticalInset: boolean;
     // Warning: (ae-forgotten-export) The symbol "AnchoredRegionVerticalPositionLabel" needs to be exported by the entry point index.d.ts

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -207,12 +207,6 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 *Slots:*
 - default slot for content
 
-*functions:*
-- updateAnchorOffset = (
-    horizontalOffsetDelta: number,
-    verticalOffsetDelta: number
-) 
-
 *Events:*
 - loaded - The contents of the anchored region are loaded into the DOM.
 - positionchange - The positioning of the anchored region has changed.

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -71,29 +71,16 @@ interface Dimension {
 }
 
 /**
- * describes the possible horizontal positions of the region relative
- * to its anchor
+ * Describes the possible positions of the region relative
+ * to its anchor. Depending on the axis start = left/top, end = right/bottom
  *
  * @internal
  */
-type AnchoredRegionHorizontalPositionLabel =
-    | "left"
-    | "insetLeft"
-    | "insetRight"
-    | "right"
-    | "undefined";
-
-/**
- * describes the possible vertical positions of the region relative
- * to its anchor
- *
- * @internal
- */
-type AnchoredRegionVerticalPositionLabel =
-    | "top"
-    | "insetTop"
-    | "insetBottom"
-    | "bottom"
+type AnchoredRegionPositionLabel =
+    | "start"
+    | "insetStart"
+    | "insetEnd"
+    | "end"
     | "undefined";
 
 /**
@@ -355,12 +342,12 @@ export class AnchoredRegion extends FASTElement {
     /**
      * indicates the current horizontal position of the region
      */
-    public verticalPosition: AnchoredRegionVerticalPositionLabel;
+    public verticalPosition: AnchoredRegionPositionLabel;
 
     /**
      * indicates the current vertical position of the region
      */
-    public horizontalPosition: AnchoredRegionHorizontalPositionLabel;
+    public horizontalPosition: AnchoredRegionPositionLabel;
 
     /**
      * values to be applied to the component's transform on render
@@ -755,12 +742,11 @@ export class AnchoredRegion extends FASTElement {
     private updateLayout = (): void => {
         this.pendingLayoutUpdate = false;
 
-        let desiredVerticalPosition: AnchoredRegionVerticalPositionLabel = "undefined";
-        let desiredHorizontalPosition: AnchoredRegionHorizontalPositionLabel =
-            "undefined";
+        let desiredVerticalPosition: AnchoredRegionPositionLabel = "undefined";
+        let desiredHorizontalPosition: AnchoredRegionPositionLabel = "undefined";
 
         if (this.horizontalPositioningMode !== "uncontrolled") {
-            const horizontalOptions: AnchoredRegionHorizontalPositionLabel[] = this.getHorizontalPositioningOptions();
+            const horizontalOptions: AnchoredRegionPositionLabel[] = this.getHorizontalPositioningOptions();
 
             if (this.horizontalDefaultPosition !== "unset") {
                 let dirCorrectedHorizontalDefaultPosition: string = this
@@ -794,14 +780,14 @@ export class AnchoredRegion extends FASTElement {
                 switch (dirCorrectedHorizontalDefaultPosition) {
                     case "left":
                         desiredHorizontalPosition = this.horizontalInset
-                            ? "insetLeft"
-                            : "left";
+                            ? "insetStart"
+                            : "start";
                         break;
 
                     case "right":
                         desiredHorizontalPosition = this.horizontalInset
-                            ? "insetRight"
-                            : "right";
+                            ? "insetEnd"
+                            : "end";
                         break;
                 }
             }
@@ -828,17 +814,17 @@ export class AnchoredRegion extends FASTElement {
         }
 
         if (this.verticalPositioningMode !== "uncontrolled") {
-            const verticalOptions: AnchoredRegionVerticalPositionLabel[] = this.getVerticalPositioningOptions();
+            const verticalOptions: AnchoredRegionPositionLabel[] = this.getVerticalPositioningOptions();
             if (this.verticalDefaultPosition !== "unset") {
                 switch (this.verticalDefaultPosition) {
                     case "top":
-                        desiredVerticalPosition = this.verticalInset ? "insetTop" : "top";
+                        desiredVerticalPosition = this.verticalInset
+                            ? "insetStart"
+                            : "start";
                         break;
 
                     case "bottom":
-                        desiredVerticalPosition = this.verticalInset
-                            ? "insetBottom"
-                            : "bottom";
+                        desiredVerticalPosition = this.verticalInset ? "insetEnd" : "end";
                         break;
                 }
             }
@@ -906,15 +892,15 @@ export class AnchoredRegion extends FASTElement {
      *  to the root element
      */
     private updateRegionStyle = (): void => {
-        this.classList.toggle("top", this.verticalPosition === "top");
-        this.classList.toggle("bottom", this.verticalPosition === "bottom");
-        this.classList.toggle("inset-top", this.verticalPosition === "insetTop");
-        this.classList.toggle("inset-bottom", this.verticalPosition === "insetBottom");
+        this.classList.toggle("top", this.verticalPosition === "start");
+        this.classList.toggle("bottom", this.verticalPosition === "end");
+        this.classList.toggle("inset-top", this.verticalPosition === "insetStart");
+        this.classList.toggle("inset-bottom", this.verticalPosition === "insetEnd");
 
-        this.classList.toggle("left", this.horizontalPosition === "left");
-        this.classList.toggle("right", this.horizontalPosition === "right");
-        this.classList.toggle("inset-left", this.horizontalPosition === "insetLeft");
-        this.classList.toggle("inset-right", this.horizontalPosition === "insetRight");
+        this.classList.toggle("left", this.horizontalPosition === "start");
+        this.classList.toggle("right", this.horizontalPosition === "end");
+        this.classList.toggle("inset-left", this.horizontalPosition === "insetStart");
+        this.classList.toggle("inset-right", this.horizontalPosition === "insetEnd");
 
         this.style.position = this.fixedPlacement ? "fixed" : "absolute";
 
@@ -928,7 +914,7 @@ export class AnchoredRegion extends FASTElement {
      * Get horizontal positioning state based on desired position
      */
     private setHorizontalPosition = (
-        desiredHorizontalPosition: AnchoredRegionHorizontalPositionLabel,
+        desiredHorizontalPosition: AnchoredRegionPositionLabel,
         nextPositionerDimension: Dimension
     ): void => {
         if (this.regionRect === undefined || this.anchorRect === undefined) {
@@ -951,20 +937,20 @@ export class AnchoredRegion extends FASTElement {
         }
 
         switch (desiredHorizontalPosition) {
-            case "left":
+            case "start":
                 this.translateX = this.baseHorizontalOffset - nextRegionWidth;
                 break;
 
-            case "insetLeft":
+            case "insetStart":
                 this.translateX =
                     this.baseHorizontalOffset - nextRegionWidth + this.anchorRect.width;
                 break;
 
-            case "insetRight":
+            case "insetEnd":
                 this.translateX = this.baseHorizontalOffset;
                 break;
 
-            case "right":
+            case "end":
                 this.translateX = this.baseHorizontalOffset + this.anchorRect.width;
                 break;
         }
@@ -976,7 +962,7 @@ export class AnchoredRegion extends FASTElement {
      * Get vertical positioning state based on desired position
      */
     private setVerticalPosition = (
-        desiredVerticalPosition: AnchoredRegionVerticalPositionLabel,
+        desiredVerticalPosition: AnchoredRegionPositionLabel,
         nextPositionerDimension: Dimension
     ): void => {
         if (this.regionRect === undefined || this.anchorRect === undefined) {
@@ -999,20 +985,20 @@ export class AnchoredRegion extends FASTElement {
         }
 
         switch (desiredVerticalPosition) {
-            case "top":
+            case "start":
                 this.translateY = this.baseVerticalOffset - nextRegionHeight;
                 break;
 
-            case "insetTop":
+            case "insetStart":
                 this.translateY =
                     this.baseVerticalOffset - nextRegionHeight + this.anchorRect.height;
                 break;
 
-            case "insetBottom":
+            case "insetEnd":
                 this.translateY = this.baseVerticalOffset;
                 break;
 
-            case "bottom":
+            case "end":
                 this.translateY = this.baseVerticalOffset + this.anchorRect.height;
                 break;
         }
@@ -1023,42 +1009,40 @@ export class AnchoredRegion extends FASTElement {
     /**
      *  Get available Horizontal positions based on positioning mode
      */
-    private getHorizontalPositioningOptions = (): AnchoredRegionHorizontalPositionLabel[] => {
+    private getHorizontalPositioningOptions = (): AnchoredRegionPositionLabel[] => {
         if (this.horizontalInset) {
-            return ["insetLeft", "insetRight"];
+            return ["insetStart", "insetEnd"];
         }
-        return ["left", "right"];
+        return ["start", "end"];
     };
 
     /**
      * Get available Vertical positions based on positioning mode
      */
-    private getVerticalPositioningOptions = (): AnchoredRegionVerticalPositionLabel[] => {
+    private getVerticalPositioningOptions = (): AnchoredRegionPositionLabel[] => {
         if (this.verticalInset) {
-            return ["insetTop", "insetBottom"];
+            return ["insetStart", "insetEnd"];
         }
-        return ["top", "bottom"];
+        return ["start", "end"];
     };
 
     /**
      *  Get the width available for a particular horizontal position
      */
-    private getAvailableWidth = (
-        positionOption: AnchoredRegionHorizontalPositionLabel
-    ): number => {
+    private getAvailableWidth = (positionOption: AnchoredRegionPositionLabel): number => {
         if (this.viewportRect !== undefined && this.anchorRect !== undefined) {
             const spaceLeft: number = this.anchorRect.left - this.viewportRect.left;
             const spaceRight: number =
                 this.viewportRect.right - (this.anchorRect.left + this.anchorRect.width);
 
             switch (positionOption) {
-                case "left":
+                case "start":
                     return spaceLeft;
-                case "insetLeft":
+                case "insetStart":
                     return spaceLeft + this.anchorRect.width;
-                case "insetRight":
+                case "insetEnd":
                     return spaceRight + this.anchorRect.width;
-                case "right":
+                case "end":
                     return spaceRight;
             }
         }
@@ -1070,7 +1054,7 @@ export class AnchoredRegion extends FASTElement {
      *  Get the height available for a particular vertical position
      */
     private getAvailableHeight = (
-        positionOption: AnchoredRegionVerticalPositionLabel
+        positionOption: AnchoredRegionPositionLabel
     ): number => {
         if (this.viewportRect !== undefined && this.anchorRect !== undefined) {
             const spaceAbove: number = this.anchorRect.top - this.viewportRect.top;
@@ -1078,13 +1062,13 @@ export class AnchoredRegion extends FASTElement {
                 this.viewportRect.bottom - (this.anchorRect.top + this.anchorRect.height);
 
             switch (positionOption) {
-                case "top":
+                case "start":
                     return spaceAbove;
-                case "insetTop":
+                case "insetStart":
                     return spaceAbove + this.anchorRect.height;
-                case "insetBottom":
+                case "insetEnd":
                     return spaceBelow + this.anchorRect.height;
-                case "bottom":
+                case "end":
                     return spaceBelow;
             }
         }
@@ -1095,8 +1079,8 @@ export class AnchoredRegion extends FASTElement {
      * Get region dimensions
      */
     private getNextRegionDimension = (
-        desiredHorizontalPosition: AnchoredRegionHorizontalPositionLabel,
-        desiredVerticalPosition: AnchoredRegionVerticalPositionLabel
+        desiredHorizontalPosition: AnchoredRegionPositionLabel,
+        desiredVerticalPosition: AnchoredRegionPositionLabel
     ): Dimension => {
         const newRegionDimension: Dimension = {
             height: this.regionRect !== undefined ? this.regionRect.height : 0,

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -60,7 +60,19 @@ export type VerticalPosition = "top" | "bottom" | "unset";
  *
  * @beta
  */
-export type AutoUpdateMode = "anchor" | "auto";
+export type AutoUpdateMode = "anchor" | "auto"
+
+/**
+ * Describes the possible positions of the region relative
+ * to its anchor. Depending on the axis start = left/top, end = right/bottom
+ *
+ * @beta
+ */
+ export type AnchoredRegionPositionLabel =
+ | "start"
+ | "insetStart"
+ | "insetEnd"
+ | "end";
 
 /**
  * @internal
@@ -69,18 +81,6 @@ interface Dimension {
     height: number;
     width: number;
 }
-
-/**
- * Describes the possible positions of the region relative
- * to its anchor. Depending on the axis start = left/top, end = right/bottom
- *
- * @internal
- */
-type AnchoredRegionPositionLabel =
-    | "start"
-    | "insetStart"
-    | "insetEnd"
-    | "end";
 
 /**
  * An anchored region Custom HTML Element.
@@ -889,10 +889,6 @@ export class AnchoredRegion extends FASTElement {
         }
 
         if (positionChanged) {
-            // do a position check to ensure we're in the right spot
-            // temporary until method for recalculating offsets on position changes improved
-            this.requestPositionUpdates();
-
             // emit change event
             this.$emit("positionchange", this, { bubbles: false });
         }
@@ -970,7 +966,7 @@ export class AnchoredRegion extends FASTElement {
     };
 
     /**
-     * Get vertical positioning state based on desired position
+     * Set vertical positioning state based on desired position
      */
     private setVerticalPosition = (
         desiredVerticalPosition: AnchoredRegionPositionLabel | undefined,

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -97,13 +97,6 @@ type AnchoredRegionVerticalPositionLabel =
     | "undefined";
 
 /**
- * describes possible transform origin settings
- *
- * @internal
- */
-type Location = "top" | "left" | "right" | "bottom";
-
-/**
  * An anchored region Custom HTML Element.
  *
  * @beta
@@ -376,7 +369,7 @@ export class AnchoredRegion extends FASTElement {
     private translateY: number;
 
     /**
-     * the span in pixels of the selected position on each axis
+     * the span to be applied to the region on each axis
      */
     private regionWidth: string;
     private regionHeight: string;
@@ -389,8 +382,6 @@ export class AnchoredRegion extends FASTElement {
     private viewportRect: ClientRect | DOMRect | null;
     private anchorRect: ClientRect | DOMRect | null;
     private regionRect: ClientRect | DOMRect | null;
-
-    private regionDimension: Dimension;
 
     /**
      * base offsets between the positioner's base position and the anchor's
@@ -444,7 +435,7 @@ export class AnchoredRegion extends FASTElement {
      * update position
      */
     public update = (): void => {
-        if (this.viewportRect === null || this.regionDimension === null) {
+        if (this.viewportRect === null || this.regionRect === null) {
             this.requestLayoutUpdate();
             return;
         }
@@ -538,7 +529,6 @@ export class AnchoredRegion extends FASTElement {
         this.viewportRect = null;
         this.regionRect = null;
         this.anchorRect = null;
-        this.regionDimension = { height: 0, width: 0 };
 
         this.verticalPosition = "undefined";
         this.horizontalPosition = "undefined";
@@ -692,9 +682,6 @@ export class AnchoredRegion extends FASTElement {
             this.anchorRect = anchorEntry.boundingClientRect;
             this.viewportRect = viewportEntry.boundingClientRect;
 
-            this.handleRegionIntersection(regionEntry);
-            this.handleAnchorIntersection(anchorEntry);
-
             return true;
         }
 
@@ -717,24 +704,6 @@ export class AnchoredRegion extends FASTElement {
             return true;
         }
         return false;
-    };
-
-    /**
-     *  Update data based on anchor intersections
-     */
-    private handleAnchorIntersection = (
-        anchorEntry: IntersectionObserverEntry
-    ): void => {};
-
-    /**
-     *  Update data based on positioner intersections
-     */
-    private handleRegionIntersection = (regionEntry: IntersectionObserverEntry): void => {
-        const regionRect: ClientRect | DOMRect = regionEntry.boundingClientRect;
-        this.regionDimension = {
-            height: regionRect.height,
-            width: regionRect.width,
-        };
     };
 
     /**
@@ -829,7 +798,9 @@ export class AnchoredRegion extends FASTElement {
             const horizontalThreshold: number =
                 this.horizontalThreshold !== undefined
                     ? this.horizontalThreshold
-                    : this.regionDimension.width;
+                    : this.regionRect !== null
+                    ? this.regionRect.width
+                    : 0;
 
             if (
                 desiredHorizontalPosition === "undefined" ||
@@ -864,7 +835,9 @@ export class AnchoredRegion extends FASTElement {
             const verticalThreshold: number =
                 this.verticalThreshold !== undefined
                     ? this.verticalThreshold
-                    : this.regionDimension.height;
+                    : this.regionRect !== null
+                    ? this.regionRect.height
+                    : 0;
 
             if (
                 desiredVerticalPosition === "undefined" ||
@@ -1186,8 +1159,8 @@ export class AnchoredRegion extends FASTElement {
         desiredVerticalPosition: AnchoredRegionVerticalPositionLabel
     ): Dimension => {
         const newRegionDimension: Dimension = {
-            height: this.regionDimension.height,
-            width: this.regionDimension.width,
+            height: this.regionRect !== null ? this.regionRect.height : 0,
+            width: this.regionRect !== null ? this.regionRect.width : 0,
         };
 
         if (this.horizontalScaling === "fill") {

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -242,23 +242,23 @@ export class Tooltip extends FASTElement {
      * @internal
      */
     public handlePositionChange = (ev: Event): void => {
-        this.classList.toggle("top", this.region.verticalPosition === "top");
-        this.classList.toggle("bottom", this.region.verticalPosition === "bottom");
-        this.classList.toggle("inset-top", this.region.verticalPosition === "insetTop");
+        this.classList.toggle("top", this.region.verticalPosition === "start");
+        this.classList.toggle("bottom", this.region.verticalPosition === "end");
+        this.classList.toggle("inset-top", this.region.verticalPosition === "insetStart");
         this.classList.toggle(
             "inset-bottom",
-            this.region.verticalPosition === "insetBottom"
+            this.region.verticalPosition === "insetEnd"
         );
 
-        this.classList.toggle("left", this.region.horizontalPosition === "left");
-        this.classList.toggle("right", this.region.horizontalPosition === "right");
+        this.classList.toggle("left", this.region.horizontalPosition === "start");
+        this.classList.toggle("right", this.region.horizontalPosition === "end");
         this.classList.toggle(
             "inset-left",
-            this.region.horizontalPosition === "insetLeft"
+            this.region.horizontalPosition === "insetStart"
         );
         this.classList.toggle(
             "inset-right",
-            this.region.horizontalPosition === "insetRight"
+            this.region.horizontalPosition === "insetEnd"
         );
     };
 


### PR DESCRIPTION
## 📖 Description

This change modifies anchored region to use transforms for positioning rather than top/right/bottom/left.  This drastically improves performance, makes the scaling experience better by getting rid of elements being anchored to the reverse edge and makes the math a bit simpler too.

I also removed the updateAnchorOffset() call from the api as it seemed extraneous (this change would be part of a version bump).

The storybook sample page has also been beefed up to provide clearer examples and some explanations.  It has way more auto-tracking regions active than I'd expect to see in a page so how it performs is a point of interest.  Note that you can scroll to the bottom and click to open a bunch of sample menus - does having many open have a noticable impact on perf while scrolling/resizing?

![image](https://user-images.githubusercontent.com/7649425/115426347-44c75a00-a1b5-11eb-84af-92940816799a.png)

I'm still working on samples and opportunities to further optimize the code.

### 🎫 Issues

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan
Need to add playwright testing to anchored region.

## ✅ Checklist

### General
- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ x] I have added a new component
- [ ] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
