### PR TITLE
feat(design-system): better integrate with DI and enforce constraints

### DIFF
--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -752,9 +752,7 @@ export interface DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {
 export type DerivedDesignTokenValue<T> = T extends Function ? never : (target: HTMLElement) => T;
 
 // @alpha (undocumented)
-export class DesignSystem {
-    // (undocumented)
-    applyTo(element: HTMLElement): Container;
+export interface DesignSystem {
     // (undocumented)
     register(...params: any[]): this;
     // (undocumented)
@@ -762,6 +760,13 @@ export class DesignSystem {
     // (undocumented)
     withPrefix(prefix: string): this;
 }
+
+// @alpha (undocumented)
+export const DesignSystem: Readonly<{
+    tagFor(type: Constructable): string;
+    responsibleFor(element: HTMLElement): DesignSystem;
+    getOrCreate(element?: HTMLElement): DesignSystem;
+}>;
 
 // @public
 export interface DesignSystemConsumer {

--- a/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
@@ -5,6 +5,25 @@ import { uniqueElementName } from "../fixture";
 import { DesignSystem, DesignSystemRegistrationContext } from "./design-system";
 
 describe("DesignSystem", () => {
+    it("Should return the same instance for the same element", () => {
+        const host = document.createElement("div");
+        const ds1 = DesignSystem.getOrCreate(host);
+        const ds2 = DesignSystem.getOrCreate(host);
+
+        expect(ds1).to.equal(ds2);
+    });
+
+    it("Should find the responsible design system for an element in the hierarchy", () => {
+        const host = document.createElement("div");
+        const child = document.createElement("div");
+        host.appendChild(child);
+
+        const ds1 = DesignSystem.getOrCreate(host);
+        const ds2 = DesignSystem.responsibleFor(child);
+
+        expect(ds1).to.equal(ds2);
+    });
+
     it("Should initialize with a default prefix of 'fast'", () => {
         const host = document.createElement("div");
         let prefix = '';

--- a/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
@@ -1,53 +1,64 @@
 import type { Constructable } from "@microsoft/fast-element";
 import { expect } from "chai";
-import type { Container } from "../di";
+import { Container, DI } from "../di";
 import { uniqueElementName } from "../fixture";
 import { DesignSystem, DesignSystemRegistrationContext } from "./design-system";
 
 describe("DesignSystem", () => {
     it("Should initialize with a default prefix of 'fast'", () => {
         const host = document.createElement("div");
-        const container = new DesignSystem().applyTo(host);
+        let prefix = '';
 
-        expect(container.get(DesignSystemRegistrationContext).elementPrefix).to.equal(
-            "fast"
-        );
+        DesignSystem.getOrCreate(host)
+            .register({
+                register(container: Container) {
+                    prefix = container.get(DesignSystemRegistrationContext).elementPrefix;
+                }
+            });
+
+        expect(prefix).to.equal("fast");
     });
 
     it("Should initialize with a provided prefix", () => {
         const host = document.createElement("div");
-        const container = new DesignSystem().withPrefix("custom").applyTo(host);
+        let prefix = '';
 
-        expect(container.get(DesignSystemRegistrationContext).elementPrefix).to.equal(
-            "custom"
-        );
+        DesignSystem.getOrCreate(host)
+            .withPrefix("custom")
+            .register({
+                register(container: Container) {
+                    prefix = container.get(DesignSystemRegistrationContext).elementPrefix;
+                }
+            });
+
+        expect(prefix).to.equal("custom");
     });
 
-    it("Should apply registries to the container", () => {
+    it("Should apply registries to the container associated with the host", () => {
         let capturedContainer: Container | null = null;
         const host = document.createElement("div");
-        const container = new DesignSystem()
+
+        DesignSystem.getOrCreate(host)
             .register({
                 register(container: Container) {
                     capturedContainer = container;
                 },
-            })
-            .applyTo(host);
+            });
 
-        expect(capturedContainer).to.equal(container);
+        const container = DI.getOrCreateDOMContainer(host);
+        expect(container).equals(capturedContainer);
     });
 
     it("Should provide a way for registries to define elements", () => {
         let capturedDefine: any;
         const host = document.createElement("div");
-        new DesignSystem()
+        DesignSystem.getOrCreate(host)
             .register({
                 register(container: Container) {
                     capturedDefine = container.get(DesignSystemRegistrationContext)
                         .tryDefineElement;
                 },
-            })
-            .applyTo(host);
+            });
 
         expect(capturedDefine).to.not.be.null;
     });
@@ -55,35 +66,34 @@ describe("DesignSystem", () => {
     it("Should provide a way for registries to get the default prefix", () => {
         let capturePrefix: string | null = null;
         const host = document.createElement("div");
-        new DesignSystem()
+        DesignSystem.getOrCreate(host)
             .withPrefix("custom")
             .register({
                 register(container: Container) {
                     capturePrefix = container.get(DesignSystemRegistrationContext)
                         .elementPrefix;
                 },
-            })
-            .applyTo(host);
+            });
 
         expect(capturePrefix).to.equal("custom");
     });
 
-    it("Should register elements when applied", () => {
+    it("Should register elements", () => {
         const elementName = uniqueElementName();
         const customElement = class extends HTMLElement {};
         const host = document.createElement("div");
-        const system = new DesignSystem().register({
-            register(container: Container) {
-                const context = container.get(DesignSystemRegistrationContext);
-                context.tryDefineElement(elementName, customElement, x =>
-                    x.defineElement()
-                );
-            },
-        });
 
         expect(customElements.get(elementName)).to.be.undefined;
 
-        system.applyTo(host);
+        DesignSystem.getOrCreate(host)
+            .register({
+                register(container: Container) {
+                    const context = container.get(DesignSystemRegistrationContext);
+                    context.tryDefineElement(elementName, customElement, x =>
+                        x.defineElement()
+                    );
+                },
+            });
 
         expect(customElements.get(elementName)).to.equal(customElement);
     });
@@ -93,7 +103,7 @@ describe("DesignSystem", () => {
         const elementName2 = uniqueElementName();
         const host = document.createElement("div");
         let capturedType: Constructable | null = null;
-        const system = new DesignSystem()
+        DesignSystem.getOrCreate(host)
             .withElementDisambiguation((name, type, existingType) => {
                 capturedType = existingType;
                 return elementName2;
@@ -119,8 +129,7 @@ describe("DesignSystem", () => {
                         );
                     },
                 }
-            )
-            .applyTo(host);
+            );
 
         expect(capturedType).to.not.be.null;
         expect(customElements.get(elementName)).to.not.be.undefined;
@@ -131,28 +140,31 @@ describe("DesignSystem", () => {
         const elementName = uniqueElementName();
         const customElement = class extends HTMLElement {};
         const host = document.createElement("div");
-        const system = new DesignSystem().register(
-            {
-                register(container: Container) {
-                    const context = container.get(DesignSystemRegistrationContext);
-                    context.tryDefineElement(elementName, customElement, x =>
-                        x.defineElement()
-                    );
-                },
-            },
-            {
-                register(container: Container) {
-                    const context = container.get(DesignSystemRegistrationContext);
-                    context.tryDefineElement(
-                        elementName,
-                        class extends HTMLElement {},
-                        x => x.defineElement()
-                    );
-                },
-            }
-        );
+        const system = DesignSystem.getOrCreate(host);
 
-        expect(() => system.applyTo(host)).not.to.throw();
+        expect(() => {
+            system.register(
+                {
+                    register(container: Container) {
+                        const context = container.get(DesignSystemRegistrationContext);
+                        context.tryDefineElement(elementName, customElement, x =>
+                            x.defineElement()
+                        );
+                    },
+                },
+                {
+                    register(container: Container) {
+                        const context = container.get(DesignSystemRegistrationContext);
+                        context.tryDefineElement(
+                            elementName,
+                            class extends HTMLElement {},
+                            x => x.defineElement()
+                        );
+                    },
+                }
+            );
+        }).not.to.throw();
+
         expect(customElements.get(elementName)).to.equal(customElement);
     });
 });

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -2,15 +2,22 @@
 import { css, DOM, FASTElement, Observable } from "@microsoft/fast-element";
 import { expect } from "chai";
 import { DesignSystem } from "../design-system";
+import { uniqueElementName } from "../fixture";
 import { FoundationElement } from "../foundation-element";
 import { DesignToken } from "./design-token";
 
-new DesignSystem().register(
-    FoundationElement.compose({ type: class extends FoundationElement { }, baseName: "custom-element" })()
-).applyTo(document.body)
+const elementName = uniqueElementName();
+
+DesignSystem.getOrCreate()
+    .register(
+        FoundationElement.compose({ 
+            type: class extends FoundationElement { }, 
+            baseName: elementName 
+        })()
+    );
 
 function addElement(parent = document.body): FASTElement & HTMLElement {
-    const el = document.createElement("fast-custom-element") as any;
+    const el = document.createElement(`fast-${elementName}`) as any;
     parent.appendChild(el);
     return el;
 }

--- a/packages/web-components/fast-foundation/src/fixture.ts
+++ b/packages/web-components/fast-foundation/src/fixture.ts
@@ -6,7 +6,7 @@ import {
     ViewTemplate,
 } from "@microsoft/fast-element";
 import { DesignSystem, DesignSystemRegistrationContext } from "./design-system";
-import type { Registry } from "./di";
+import { DI, Registry } from "./di";
 import type {
     FoundationElement,
     FoundationElementDefinition,
@@ -155,16 +155,14 @@ export async function fixture<TElement = HTMLElement>(
 
     if (Array.isArray(templateNameOrRegistry)) {
         const first = templateNameOrRegistry[0];
-        const container = (options.designSystem || new DesignSystem())
-            .register(templateNameOrRegistry)
-            .applyTo(parent);
-
+        (options.designSystem || DesignSystem.getOrCreate(parent)).register(
+            templateNameOrRegistry
+        );
+        const container = DI.getOrCreateDOMContainer(parent);
         const context = container.get(DesignSystemRegistrationContext);
         const elementName = `${context.elementPrefix}-${first.definition.baseName}`;
         const html = `<${elementName}></${elementName}>`;
         templateNameOrRegistry = new ViewTemplate(html, []);
-    } else if (options.designSystem) {
-        options.designSystem.applyTo(parent);
     }
 
     const view = templateNameOrRegistry.create();

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
@@ -132,7 +132,8 @@ describe("FoundationElement", () => {
             });
 
             const host = document.createElement("div");
-            const container = new DesignSystem().register(myElement()).applyTo(host);
+            DesignSystem.getOrCreate(host).register(myElement());
+            const container = DI.getOrCreateDOMContainer(host);
 
             const fullName = `fast-${baseName}`;
             const presentation = container.get<DefaultComponentPresentation>(
@@ -171,7 +172,8 @@ describe("FoundationElement", () => {
             });
 
             const host = document.createElement("div");
-            const container = new DesignSystem().register(myElement()).applyTo(host);
+            DesignSystem.getOrCreate(host).register(myElement());
+            const container = DI.getOrCreateDOMContainer(host);
 
             const presentation = container.get<DefaultComponentPresentation>(
                 ComponentPresentation.keyFrom(fullName)
@@ -200,9 +202,9 @@ describe("FoundationElement", () => {
             };
 
             const host = document.createElement("div");
-            const container = new DesignSystem()
-                .register(myElement(overrides))
-                .applyTo(host);
+            DesignSystem.getOrCreate(host)
+                .register(myElement(overrides));
+            const container = DI.getOrCreateDOMContainer(host);
 
             const originalFullName = `fast-${originalName}`;
             const overrideFullName = `my-${overrideName}`;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR removes the ability to create a `DesignSystem` outright and replaces it with a factory function. The reasons for this are:

* Ensure that only one `DesignSystem` can exists on a single HTMLElement.
* Integrate the `DesignSystem` with the DI Container hierarchy.

As a side-effect of this, the `DesignSystem` now knows it's host element, so there's no reason for for a special `apply` call. That has now been removed and elements are defined as part of the call to `register`. 

The changes should improve ergonomics overall, reduce bugs, and enable lazy registration of components to a design system.

### 🎫 Issues

No related issues. I realized this design flaw the other day and wanted to address it before the next release.

## 👩‍💻 Reviewer Notes

Most API and behavior changes were made in the `design-system.ts` file. Everything else is just fixing up dependent code to use the changed APIs. The bulk of that was updates to tests.

## 📑 Test Plan

I've added a couple of new tests for the new APIs. Otherwise, the tests were updated to use the APIs and continue to assert the original behavior, as desired.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

As a follow up to this PR, I'll be making updates to the `ComponentPresentation` API to fast-path template and styles lookup for cases where a given component is only defined with one set of templates or styles. Some improvements to the APIs will likely mirror the `DesignSystem` API changes as well.