### PR TITLE
feat: adds the ability for an arbitrary Design Token value to control emission to CSS

### DIFF
--- a/change/@microsoft-fast-foundation-82d4edb4-882b-4a0b-9cf3-c7eb71edc72b.json
+++ b/change/@microsoft-fast-foundation-82d4edb4-882b-4a0b-9cf3-c7eb71edc72b.json
@@ -1,0 +1,6 @@
+{
+  "type": "minor",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -819,7 +819,9 @@ export interface DesignSystemRegistrationContext {
 export const DesignSystemRegistrationContext: InterfaceSymbol<DesignSystemRegistrationContext>;
 
 // @alpha
-export interface DesignToken<T> extends CSSDirective {
+export interface DesignToken<T extends {
+    createCSS?(): string;
+}> extends CSSDirective {
     addCustomPropertyFor(element: HTMLElement & FASTElement): this;
     readonly cssCustomProperty: string;
     deleteValueFor(element: HTMLElement): this;
@@ -2197,7 +2199,7 @@ export function whitespaceFilter(value: Node, index: number, array: Node[]): boo
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/design-token/design-token.d.ts:54:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
+// dist/dts/design-token/design-token.d.ts:56:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
 // dist/dts/di/di.d.ts:204:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-foundation/src/design-token/README.md
+++ b/packages/web-components/fast-foundation/src/design-token/README.md
@@ -57,19 +57,42 @@ fillColor.withDefault("#FFFFFF");
 A Design Token can be made available in CSS through CSS custom properties. The custom property value will be set to the token's value for the supplied target element.
 
 ```ts
-fillColor.addCustomPropertyFor(descendent); // --background-color: #FFFFFF;
+fillColor.addCustomPropertyFor(descendent); // --fill-color: #FFFFFF;
 ```
 
 If the value of the token *changes* for the target element, the CSS custom property will be updated to the new value:
 
 ```ts
-fillColor.setValueFor(descendent, "#F7F7F7"); // --background-color: #F7F7F7;
+fillColor.setValueFor(descendent, "#F7F7F7"); // --fill-color: #F7F7F7;
 ```
 
 The CSS custom property can also be removed through a parallel method:
 
 ```ts
 fillColor.removeCustomPropertyFor(descendent);
+```
+
+#### Values with a 'createCSS' method
+It is sometimes useful to be able to set a token to a complex object but still use that value in CSS. If a DesignToken is assigned a value with a `createCSS` method on it, the product of that method will be used when emitting to a CSS custom property instead of the Design Token value itself:
+
+```ts
+interface RGBColor {
+    r: number;
+    g: number;
+    b: number;
+    createCSS(): string;
+}
+const fancyFillColor = DesignToken.create<RGBColor>("fancy-fill-color");
+const value = {
+    r: 255,
+    g: 0,
+    b: 0,
+    createCSS: function () {
+        return `rgb(${this.r}, ${this.g}, ${this.b})`;
+    }
+}
+fancyFillColor.setValueFor(descendent, value)
+fancyFillColor.addCustomPropertyFor(descendent); // --fancy-fill-color: rgb(255, 0, 0);
 ```
 
 ## Using Design Tokens in CSS

--- a/packages/web-components/fast-foundation/src/design-token/README.md
+++ b/packages/web-components/fast-foundation/src/design-token/README.md
@@ -87,7 +87,7 @@ const value = {
     r: 255,
     g: 0,
     b: 0,
-    createCSS: function () {
+    createCSS() {
         return `rgb(${this.r}, ${this.g}, ${this.b})`;
     }
 }

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -567,6 +567,19 @@ describe("A DesignToken", () => {
 
                 removeElement(parent);
             })
+        });
+
+        describe("to values with a 'createCSS' method", () => {
+            it("should emit the product of 'createCSS' to CSS", () => {
+                const target = addElement();
+                const token = DesignToken.create<{ createCSS: () => string}>("test");
+                token.setValueFor(target, { createCSS: () => "12"})
+
+                token.addCustomPropertyFor(target);
+
+                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
+                removeElement(target);
+            })
         })
     });
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR enhances Design Token values with the ability to control their own emission to CSS. This is useful when the token value is a structure that does not emit to a valid CSS value. When emitting to CSS, any DesignToken value that has a `createCSS` method will get the product of that function assigned to the custom property value, instead of the DesignToken itself.

See https://github.com/microsoft/fast/compare/users/nirice/add-createCSS-to-design-token-value?expand=1#diff-dc910e98f1afc7f4cc970daabfbd4de573f06b5ca8e82507e225a322a64759df for usage example.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->