### PR TITLE
feat: encapsulate and optimize ComponentPresentation resolution

### DIFF
--- a/change/@microsoft-fast-components-0e27942e-3b81-4a7a-bd6c-031a14017a89.json
+++ b/change/@microsoft-fast-components-0e27942e-3b81-4a7a-bd6c-031a14017a89.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "fix(fast-components): update rollup index to use the new DS API",
+  "packageName": "@microsoft/fast-components",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-components-11d3d100-a9cd-47cf-adda-e2b76137e8fa.json
+++ b/change/@microsoft-fast-components-11d3d100-a9cd-47cf-adda-e2b76137e8fa.json
@@ -1,0 +1,6 @@
+{
+  "type": "minor",
+  "packageName": "@microsoft/fast-components",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-components-a2550851-d95a-44e8-b894-b6522374a1f3.json
+++ b/change/@microsoft-fast-components-a2550851-d95a-44e8-b894-b6522374a1f3.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "update components to extend FoundationElement",
+  "packageName": "@microsoft/fast-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-components-be84dce5-5d4e-43bc-967f-c015c3e94c62.json
+++ b/change/@microsoft-fast-components-be84dce5-5d4e-43bc-967f-c015c3e94c62.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "packageName": "@microsoft/fast-components",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-components-c60516f0-c41a-446e-9895-7cf69c4e4cf6.json
+++ b/change/@microsoft-fast-components-c60516f0-c41a-446e-9895-7cf69c4e4cf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "update name casing for style exports to lowercase as they are functions",
+  "packageName": "@microsoft/fast-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-37087d28-3565-4060-bb9e-7b328baa9aea.json
+++ b/change/@microsoft-fast-foundation-37087d28-3565-4060-bb9e-7b328baa9aea.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix incorrect name for select tests",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-foundation-6fc300e8-5aea-4f33-bde6-b229bbb15761.json
+++ b/change/@microsoft-fast-foundation-6fc300e8-5aea-4f33-bde6-b229bbb15761.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat(design-system): better integrate with DI and enforce constraints",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-a1f17588-3819-4e5d-bd7b-0551b59828a9.json
+++ b/change/@microsoft-fast-foundation-a1f17588-3819-4e5d-bd7b-0551b59828a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "update components to extend FoundationElement",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-deafb619-c242-42d8-a45d-7b2cbca0327e.json
+++ b/change/@microsoft-fast-foundation-deafb619-c242-42d8-a45d-7b2cbca0327e.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat: encapsulate and optimize ComponentPresentation resolution",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-tooling-react-f402f65f-d3f7-4bd8-be9b-6b6e55c2a7ec.json
+++ b/change/@microsoft-fast-tooling-react-f402f65f-d3f7-4bd8-be9b-6b6e55c2a7ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update fast-tooling references to web components",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.tsx
@@ -1,27 +1,27 @@
 /** @jsx h */ /* Note: Set the JSX pragma to the wrapped version of createElement */
 import h from "../../utilities/web-components/pragma"; /* Note: Import wrapped createElement. */
-
+import {
+    fastCheckbox,
+    fastNumberField,
+    fastOption,
+    fastSelect,
+    fastTextField,
+} from "@microsoft/fast-components";
+import { FASTColorPicker } from "@microsoft/fast-tooling/dist/esm/web-components";
 import React from "react";
 import {
     RenderRefControlConfig,
     RenderSelectControlConfig,
 } from "./control.css.utilities.props";
-import {
-    FASTCheckbox,
-    FASTNumberField,
-    FASTOption,
-    FASTSelect,
-    FASTTextField,
-} from "@microsoft/fast-components";
-import { FASTColorPicker } from "@microsoft/fast-tooling/dist/esm/web-components";
+
 /**
  * Ensure tree-shaking doesn't remove these components from the bundle.
  */
-FASTCheckbox;
-FASTNumberField;
-FASTOption;
-FASTSelect;
-FASTTextField;
+fastCheckbox;
+fastNumberField;
+fastOption;
+fastSelect;
+fastTextField;
 FASTColorPicker;
 
 export function renderDefault(config: RenderRefControlConfig): React.ReactNode {

--- a/packages/web-components/fast-components/.storybook/preview.js
+++ b/packages/web-components/fast-components/.storybook/preview.js
@@ -1,4 +1,7 @@
 import "../src/design-system-provider";
+import * as FAST from "../src/index-rollup";
+
+FAST;
 
 const withThemeProvider = Story => `
   <fast-design-system-provider id="root-provider" use-defaults>

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -6,13 +6,13 @@
 
 import { Accordion } from '@microsoft/fast-foundation';
 import { AccordionItem } from '@microsoft/fast-foundation';
-import { Anchor } from '@microsoft/fast-foundation';
+import { Anchor as Anchor_2 } from '@microsoft/fast-foundation';
 import { AnchoredRegion } from '@microsoft/fast-foundation';
 import { Badge } from '@microsoft/fast-foundation';
 import { BaseProgress } from '@microsoft/fast-foundation';
 import { Breadcrumb } from '@microsoft/fast-foundation';
 import { BreadcrumbItem } from '@microsoft/fast-foundation';
-import { Button } from '@microsoft/fast-foundation';
+import { Button as Button_2 } from '@microsoft/fast-foundation';
 import { Checkbox } from '@microsoft/fast-foundation';
 import { ColorRGBA64 } from '@microsoft/fast-colors';
 import { Combobox } from '@microsoft/fast-foundation';
@@ -22,27 +22,27 @@ import { DataGridRow } from '@microsoft/fast-foundation';
 import { DesignSystemProvider } from '@microsoft/fast-foundation';
 import { Dialog } from '@microsoft/fast-foundation';
 import { Direction } from '@microsoft/fast-web-utilities';
-import { Disclosure } from '@microsoft/fast-foundation';
+import { Disclosure as Disclosure_2 } from '@microsoft/fast-foundation';
 import { Divider } from '@microsoft/fast-foundation';
 import { Flipper } from '@microsoft/fast-foundation';
-import { HorizontalScroll } from '@microsoft/fast-foundation';
+import { HorizontalScroll as HorizontalScroll_2 } from '@microsoft/fast-foundation';
 import { Listbox } from '@microsoft/fast-foundation';
 import { ListboxOption } from '@microsoft/fast-foundation';
 import { Menu } from '@microsoft/fast-foundation';
 import { MenuItem } from '@microsoft/fast-foundation';
-import { NumberField } from '@microsoft/fast-foundation';
+import { NumberField as NumberField_2 } from '@microsoft/fast-foundation';
 import { Radio } from '@microsoft/fast-foundation';
 import { RadioGroup } from '@microsoft/fast-foundation';
 import { Select } from '@microsoft/fast-foundation';
 import { Skeleton } from '@microsoft/fast-foundation';
 import { Slider } from '@microsoft/fast-foundation';
-import { SliderLabel } from '@microsoft/fast-foundation';
+import { SliderLabel as SliderLabel_2 } from '@microsoft/fast-foundation';
 import { Switch } from '@microsoft/fast-foundation';
 import { Tab } from '@microsoft/fast-foundation';
 import { TabPanel } from '@microsoft/fast-foundation';
 import { Tabs } from '@microsoft/fast-foundation';
-import { TextArea } from '@microsoft/fast-foundation';
-import { TextField } from '@microsoft/fast-foundation';
+import { TextArea as TextArea_2 } from '@microsoft/fast-foundation';
+import { TextField as TextField_2 } from '@microsoft/fast-foundation';
 import { Tooltip } from '@microsoft/fast-foundation';
 import { TreeItem } from '@microsoft/fast-foundation';
 import { TreeView } from '@microsoft/fast-foundation';
@@ -208,37 +208,62 @@ export const accentForegroundRest: SwatchRecipe;
 export const accentForegroundRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
 
 // @public
-export const AccordionItemStyles: import("@microsoft/fast-element").ElementStyles;
+export const AccordionItemStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const AccordionStyles: import("@microsoft/fast-element").ElementStyles;
+export const AccordionStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+
+// Warning: (ae-internal-missing-underscore) The name "Anchor" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export class Anchor extends Anchor_2 {
+    // @public
+    appearance: AnchorAppearance;
+    // (undocumented)
+    appearanceChanged(oldValue: AnchorAppearance, newValue: AnchorAppearance): void;
+    // (undocumented)
+    connectedCallback(): void;
+    defaultSlottedContentChanged(oldValue: any, newValue: any): void;
+}
 
 // @public
 export type AnchorAppearance = ButtonAppearance | "hypertext";
 
 // @public
-export const AnchoredRegionStyles: import("@microsoft/fast-element").ElementStyles;
+export const AnchoredRegionStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const AnchorStyles: import("@microsoft/fast-element").ElementStyles;
+export const AnchorStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const BadgeStyles: import("@microsoft/fast-element").ElementStyles;
+export const BadgeStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+
+// Warning: (ae-internal-missing-underscore) The name "Button" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export class Button extends Button_2 {
+    // @public
+    appearance: ButtonAppearance;
+    // (undocumented)
+    connectedCallback(): void;
+    // @public
+    defaultSlottedContentChanged(oldValue: any, newValue: any): void;
+}
 
 // @public
 export type ButtonAppearance = "accent" | "lightweight" | "neutral" | "outline" | "stealth";
 
 // @public
-export const ButtonStyles: import("@microsoft/fast-element").ElementStyles;
+export const ButtonStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export const CardStyles: import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const CheckboxStyles: import("@microsoft/fast-element").ElementStyles;
+export const CheckboxStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const ComboboxStyles: import("@microsoft/fast-element").ElementStyles;
+export const ComboboxStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export function createColorPalette(baseColor: any): string[];
@@ -253,7 +278,23 @@ export const DataGridRowStyles: import("@microsoft/fast-element").ElementStyles;
 export const DataGridStyles: import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const DialogStyles: import("@microsoft/fast-element").ElementStyles;
+export const DialogStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+
+// Warning: (ae-internal-missing-underscore) The name "Disclosure" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export class Disclosure extends Disclosure_2 {
+    // @public
+    appearance: DisclosureAppearance;
+    // (undocumented)
+    appearanceChanged(oldValue: DisclosureAppearance, newValue: DisclosureAppearance): void;
+    // (undocumented)
+    get disclosureHeight(): number;
+    // @override
+    protected onToggle(): void;
+    // @override
+    protected setup(): void;
+    }
 
 // @public
 export type DisclosureAppearance = "accent" | "lightweight";
@@ -262,50 +303,117 @@ export type DisclosureAppearance = "accent" | "lightweight";
 export const DisclosureStyles: import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const DividerStyles: import("@microsoft/fast-element").ElementStyles;
+export const DividerStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export class FASTAccordion extends Accordion {
-}
+export const fastAccordion: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Accordion, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Accordion, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Accordion>;
 
 // @public
-export class FASTAccordionItem extends AccordionItem {
-}
+export const fastAccordionItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<AccordionItem, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<AccordionItem, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof AccordionItem>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "fastAnchor" is marked as @public, but its signature references "Anchor" which is marked as @internal
+//
 // @public
-export class FASTAnchor extends Anchor {
-    appearance: AnchorAppearance;
-    // (undocumented)
-    appearanceChanged(oldValue: AnchorAppearance, newValue: AnchorAppearance): void;
-    // (undocumented)
-    connectedCallback(): void;
-    // @internal
-    defaultSlottedContentChanged(oldValue: any, newValue: any): void;
-}
+export const fastAnchor: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Anchor_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Anchor_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}, typeof Anchor>;
 
 // @beta
-export class FASTAnchoredRegion extends AnchoredRegion {
-}
+export const fastAnchoredRegion: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<AnchoredRegion, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<AnchoredRegion, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof AnchoredRegion>;
 
 // @public
-export class FASTBadge extends Badge {
-}
+export const fastBadge: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Badge, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Badge, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Badge>;
 
 // @public
-export class FASTBreadcrumb extends Breadcrumb {
-}
+export const fastBreadcrumb: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Breadcrumb, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Breadcrumb, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Breadcrumb>;
 
 // @public
-export class FASTBreadcrumbItem extends BreadcrumbItem {
-}
+export const fastBreadcrumbItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BreadcrumbItem, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BreadcrumbItem, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}, typeof BreadcrumbItem>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "fastButton" is marked as @public, but its signature references "Button" which is marked as @internal
+//
 // @public
-export class FASTButton extends Button {
-    appearance: ButtonAppearance;
-    // (undocumented)
-    connectedCallback(): void;
-    defaultSlottedContentChanged(oldValue: any, newValue: any): void;
-}
+export const fastButton: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Button_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Button_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}, typeof Button>;
 
 // @public
 export class FASTCard extends DesignSystemProvider implements Pick<FASTDesignSystem, "backgroundColor" | "neutralPalette"> {
@@ -321,12 +429,26 @@ export class FASTCard extends DesignSystemProvider implements Pick<FASTDesignSys
 }
 
 // @public
-export class FASTCheckbox extends Checkbox {
-}
+export const fastCheckbox: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Checkbox, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Checkbox, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Checkbox>;
 
 // @public
-export class FASTCombobox extends Combobox {
-}
+export const fastCombobox: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Combobox, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Combobox, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Combobox>;
 
 // @public
 export class FASTDataGrid extends DataGrid {
@@ -545,137 +667,342 @@ export class FASTDesignSystemProvider extends DesignSystemProvider implements FA
 }
 
 // @public
-export class FASTDialog extends Dialog {
-}
+export const fastDialog: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Dialog, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Dialog, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Dialog>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "fastDisclosure" is marked as @public, but its signature references "Disclosure" which is marked as @internal
+//
+// @public
+export const fastDisclosure: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Disclosure_2, any>;
+    styles: import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Disclosure_2, any>;
+    styles: import("@microsoft/fast-element").ElementStyles;
+}, typeof Disclosure>;
 
 // @public
-export class FASTDisclosure extends Disclosure {
-    appearance: DisclosureAppearance;
-    // (undocumented)
-    appearanceChanged(oldValue: DisclosureAppearance, newValue: DisclosureAppearance): void;
-    // (undocumented)
-    get disclosureHeight(): number;
-    // @override
-    protected onToggle(): void;
-    // @override
-    protected setup(): void;
-    }
+export const fastDivider: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Divider, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Divider, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Divider>;
 
 // @public
-export class FASTDivider extends Divider {
-}
+export const fastFlipper: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Flipper, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Flipper, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Flipper>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "fastHorizontalScroll" is marked as @public, but its signature references "HorizontalScroll" which is marked as @internal
+//
+// @public
+export const fastHorizontalScroll: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<HorizontalScroll_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<HorizontalScroll_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof HorizontalScroll>;
 
 // @public
-export class FASTFlipper extends Flipper {
-}
+export const fastListbox: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Listbox, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Listbox, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Listbox>;
 
 // @public
-export class FASTHorizontalScroll extends HorizontalScroll {
-    // (undocumented)
+export const fastMenu: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Menu, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Menu, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Menu>;
+
+// @public
+export const fastMenuItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<MenuItem, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<MenuItem, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof MenuItem>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "fastNumberField" is marked as @public, but its signature references "NumberField" which is marked as @internal
+//
+// @public
+export const fastNumberField: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<NumberField_2, any>;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<NumberField_2, any>;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}, typeof NumberField>;
+
+// @public
+export const fastOption: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<ListboxOption, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<ListboxOption, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof ListboxOption>;
+
+// @public
+export const fastProgress: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, defintion: any) => import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, defintion: any) => import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof BaseProgress>;
+
+// @public
+export const fastProgressRing: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
+    styles: (context: any, defintion: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
+    styles: (context: any, defintion: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof BaseProgress>;
+
+// @public
+export const fastRadio: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Radio, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Radio, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Radio>;
+
+// @public
+export const fastRadioGroup: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<RadioGroup, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<RadioGroup, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof RadioGroup>;
+
+// @public
+export const fastSelect: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Select, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Select, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Select>;
+
+// @public
+export const fastSkeleton: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Skeleton, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Skeleton, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Skeleton>;
+
+// @public
+export const fastSlider: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Slider, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Slider, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Slider>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "fastSliderLabel" is marked as @public, but its signature references "SliderLabel" which is marked as @internal
+//
+// @public
+export const fastSliderLabel: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<SliderLabel_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<SliderLabel_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof SliderLabel>;
+
+// @public
+export const fastSwitch: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Switch, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Switch, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Switch>;
+
+// @public
+export const fastTab: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Tab, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Tab, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Tab>;
+
+// @public
+export const fastTabPanel: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TabPanel, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TabPanel, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof TabPanel>;
+
+// @public
+export const fastTabs: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Tabs, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Tabs, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Tabs>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "fastTextArea" is marked as @public, but its signature references "TextArea" which is marked as @internal
+//
+// @public
+export const fastTextArea: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TextArea_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TextArea_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}, typeof TextArea>;
+
+// Warning: (ae-incompatible-release-tags) The symbol "fastTextField" is marked as @public, but its signature references "TextField" which is marked as @internal
+//
+// @public
+export const fastTextField: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TextField_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TextField_2, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    shadowOptions: {
+        delegatesFocus: true;
+    };
+}, typeof TextField>;
+
+// @public
+export const fastTooltip: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<any, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<any, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof Tooltip>;
+
+// @public
+export const fastTreeItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TreeItem, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TreeItem, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof TreeItem>;
+
+// @public
+export const fastTreeView: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TreeView, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TreeView, any>;
+    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+}, typeof TreeView>;
+
+// @public
+export const FlipperStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+
+// Warning: (ae-internal-missing-underscore) The name "HorizontalScroll" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export class HorizontalScroll extends HorizontalScroll_2 {
+    // @public (undocumented)
     connectedCallback(): void;
 }
-
-// @public
-export class FASTListbox extends Listbox {
-}
-
-// @public
-export class FASTMenu extends Menu {
-}
-
-// @public
-export class FASTMenuItem extends MenuItem {
-}
-
-// @public
-export class FASTNumberField extends NumberField {
-    appearance: NumberFieldAppearance;
-    // @internal (undocumented)
-    connectedCallback(): void;
-}
-
-// @public
-export class FASTOption extends ListboxOption {
-}
-
-// @public
-export class FASTProgress extends BaseProgress {
-}
-
-// @public
-export class FASTProgressRing extends BaseProgress {
-}
-
-// @public
-export class FASTRadio extends Radio {
-}
-
-// @public
-export class FASTRadioGroup extends RadioGroup {
-}
-
-// @public
-export class FASTSelect extends Select {
-}
-
-// @public
-export class FASTSkeleton extends Skeleton {
-}
-
-// @public
-export class FASTSlider extends Slider {
-}
-
-// @public
-export class FASTSliderLabel extends SliderLabel {
-    // (undocumented)
-    protected sliderOrientationChanged(): void;
-}
-
-// @public
-export class FASTSwitch extends Switch {
-}
-
-// @public
-export class FASTTab extends Tab {
-}
-
-// @public
-export class FASTTabPanel extends TabPanel {
-}
-
-// @public
-export class FASTTabs extends Tabs {
-}
-
-// @public
-export class FASTTextArea extends TextArea {
-    appearance: TextAreaAppearance;
-    // @internal (undocumented)
-    connectedCallback(): void;
-}
-
-// @public
-export class FASTTextField extends TextField {
-    appearance: TextFieldAppearance;
-    // @internal (undocumented)
-    connectedCallback(): void;
-}
-
-// @public
-export class FASTTooltip extends Tooltip {
-}
-
-// @public
-export class FASTTreeItem extends TreeItem {
-}
-
-// @public
-export class FASTTreeView extends TreeView {
-}
-
-// @public
-export const FlipperStyles: import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export const inlineEndBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
@@ -687,13 +1014,13 @@ export const inlineStartBehavior: import("@microsoft/fast-foundation").CSSCustom
 export function isDarkMode(designSystem: FASTDesignSystem): boolean;
 
 // @public
-export const ListboxStyles: import("@microsoft/fast-element").ElementStyles;
+export const ListboxStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const MenuItemStyles: import("@microsoft/fast-element").ElementStyles;
+export const MenuItemStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const MenuStyles: import("@microsoft/fast-element").ElementStyles;
+export const MenuStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralContrastFill" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1083,14 +1410,24 @@ export const neutralOutlineRest: SwatchRecipe;
 // @public
 export const neutralOutlineRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
 
+// Warning: (ae-internal-missing-underscore) The name "NumberField" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export class NumberField extends NumberField_2 {
+    // @public
+    appearance: NumberFieldAppearance;
+    // (undocumented)
+    connectedCallback(): void;
+}
+
 // @public
 export type NumberFieldAppearance = "filled" | "outline";
 
 // @public
-export const NumberFieldStyles: import("@microsoft/fast-element").ElementStyles;
+export const NumberFieldStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const OptionStyles: import("@microsoft/fast-element").ElementStyles;
+export const OptionStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export type Palette = Swatch[];
@@ -1112,28 +1449,36 @@ export enum PaletteType {
 export const parseColorString: (color: string) => ColorRGBA64;
 
 // @public
-export const ProgressRingStyles: import("@microsoft/fast-element").ElementStyles;
+export const ProgressRingStyles: (context: any, defintion: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const ProgressStyles: import("@microsoft/fast-element").ElementStyles;
+export const ProgressStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const RadioGroupStyles: import("@microsoft/fast-element").ElementStyles;
+export const RadioGroupStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const RadioStyles: import("@microsoft/fast-element").ElementStyles;
+export const RadioStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const SelectStyles: import("@microsoft/fast-element").ElementStyles;
+export const SelectStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const SkeletonStyles: import("@microsoft/fast-element").ElementStyles;
+export const SkeletonStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+
+// Warning: (ae-internal-missing-underscore) The name "SliderLabel" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export class SliderLabel extends SliderLabel_2 {
+    // (undocumented)
+    protected sliderOrientationChanged(): void;
+}
 
 // @public
-export const SliderLabelStyles: import("@microsoft/fast-element").ElementStyles;
+export const SliderLabelStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const SliderStyles: import("@microsoft/fast-element").ElementStyles;
+export const SliderStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export enum StandardLuminance {
@@ -1144,34 +1489,54 @@ export enum StandardLuminance {
 }
 
 // @public
-export const SwitchStyles: import("@microsoft/fast-element").ElementStyles;
+export const SwitchStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TabPanelStyles: import("@microsoft/fast-element").ElementStyles;
+export const TabPanelStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TabsStyles: import("@microsoft/fast-element").ElementStyles;
+export const TabsStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TabStyles: import("@microsoft/fast-element").ElementStyles;
+export const TabStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+
+// Warning: (ae-internal-missing-underscore) The name "TextArea" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export class TextArea extends TextArea_2 {
+    // @public
+    appearance: TextAreaAppearance;
+    // (undocumented)
+    connectedCallback(): void;
+}
 
 // @public
 export type TextAreaAppearance = "filled" | "outline";
 
 // @public
-export const TextAreaStyles: import("@microsoft/fast-element").ElementStyles;
+export const TextAreaStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+
+// Warning: (ae-internal-missing-underscore) The name "TextField" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal (undocumented)
+export class TextField extends TextField_2 {
+    // @public
+    appearance: TextFieldAppearance;
+    // (undocumented)
+    connectedCallback(): void;
+}
 
 // @public
 export type TextFieldAppearance = "filled" | "outline";
 
 // @public
-export const TextFieldStyles: import("@microsoft/fast-element").ElementStyles;
+export const TextFieldStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TreeItemStyles: import("@microsoft/fast-element").ElementStyles;
+export const TreeItemStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TreeViewStyles: import("@microsoft/fast-element").ElementStyles;
+export const TreeViewStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -462,7 +462,7 @@ export class FASTDataGridCell extends DataGridCell {
 export class FASTDataGridRow extends DataGridRow {
 }
 
-// @public
+// @public @deprecated
 export interface FASTDesignSystem {
     accentBaseColor: string;
     // (undocumented)
@@ -586,7 +586,7 @@ export interface FASTDesignSystem {
     typeRampPlus6LineHeight: string;
 }
 
-// @public
+// @public @deprecated
 export const fastDesignSystemDefaults: FASTDesignSystem;
 
 // @public

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -208,10 +208,10 @@ export const accentForegroundRest: SwatchRecipe;
 export const accentForegroundRestBehavior: import("@microsoft/fast-foundation").CSSCustomPropertyBehavior;
 
 // @public
-export const AccordionItemStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const accordionItemStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const AccordionStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const accordionStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "Anchor" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -230,13 +230,13 @@ export class Anchor extends Anchor_2 {
 export type AnchorAppearance = ButtonAppearance | "hypertext";
 
 // @public
-export const AnchoredRegionStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const anchoredRegionStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const AnchorStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const anchorStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const BadgeStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const badgeStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "Button" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -254,16 +254,16 @@ export class Button extends Button_2 {
 export type ButtonAppearance = "accent" | "lightweight" | "neutral" | "outline" | "stealth";
 
 // @public
-export const ButtonStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const buttonStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export const CardStyles: import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const CheckboxStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const checkboxStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const ComboboxStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const comboboxStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export function createColorPalette(baseColor: any): string[];
@@ -278,7 +278,7 @@ export const DataGridRowStyles: import("@microsoft/fast-element").ElementStyles;
 export const DataGridStyles: import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const DialogStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const dialogStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "Disclosure" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -300,10 +300,10 @@ export class Disclosure extends Disclosure_2 {
 export type DisclosureAppearance = "accent" | "lightweight";
 
 // @public
-export const DisclosureStyles: import("@microsoft/fast-element").ElementStyles;
+export const disclosureStyles: import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const DividerStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const dividerStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export const fastAccordion: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
@@ -994,7 +994,7 @@ export const fastTreeView: (overrideDefinition?: import("@microsoft/fast-foundat
 }, typeof TreeView>;
 
 // @public
-export const FlipperStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const flipperStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "HorizontalScroll" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1014,13 +1014,13 @@ export const inlineStartBehavior: import("@microsoft/fast-foundation").CSSCustom
 export function isDarkMode(designSystem: FASTDesignSystem): boolean;
 
 // @public
-export const ListboxStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const listboxStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const MenuItemStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const menuItemStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const MenuStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const menuStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "neutralContrastFill" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1424,10 +1424,10 @@ export class NumberField extends NumberField_2 {
 export type NumberFieldAppearance = "filled" | "outline";
 
 // @public
-export const NumberFieldStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const numberFieldStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const OptionStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const optionStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export type Palette = Swatch[];
@@ -1449,22 +1449,22 @@ export enum PaletteType {
 export const parseColorString: (color: string) => ColorRGBA64;
 
 // @public
-export const ProgressRingStyles: (context: any, defintion: any) => import("@microsoft/fast-element").ElementStyles;
+export const progressRingStyles: (context: any, defintion: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const ProgressStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const progressStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const RadioGroupStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const radioGroupStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const RadioStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const radioStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const SelectStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const selectStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const SkeletonStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const skeletonStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "SliderLabel" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1475,10 +1475,10 @@ export class SliderLabel extends SliderLabel_2 {
 }
 
 // @public
-export const SliderLabelStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const sliderLabelStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const SliderStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const sliderStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export enum StandardLuminance {
@@ -1489,16 +1489,16 @@ export enum StandardLuminance {
 }
 
 // @public
-export const SwitchStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const switchStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TabPanelStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const tabPanelStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TabsStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const tabsStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TabStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const tabStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "TextArea" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1514,7 +1514,7 @@ export class TextArea extends TextArea_2 {
 export type TextAreaAppearance = "filled" | "outline";
 
 // @public
-export const TextAreaStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const textAreaStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "TextField" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1530,13 +1530,13 @@ export class TextField extends TextField_2 {
 export type TextFieldAppearance = "filled" | "outline";
 
 // @public
-export const TextFieldStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const textFieldStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TreeItemStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const treeItemStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const TreeViewStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+export const treeViewStyles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
 
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
@@ -16,7 +16,8 @@ import {
 } from "../styles/recipes";
 import { heightNumber } from "../styles/size";
 
-export const AccordionItemStyles = css`
+export const accordionItemStyles = (context, definition) =>
+    css`
     ${display("flex")} :host {
         box-sizing: border-box;
         font-family: var(--body-font);
@@ -130,19 +131,19 @@ export const AccordionItemStyles = css`
         z-index: 2;
     }
 `.withBehaviors(
-    accentFillRestBehavior,
-    neutralDividerRestBehavior,
-    neutralForegroundActiveBehavior,
-    neutralForegroundFocusBehavior,
-    neutralForegroundHoverBehavior,
-    neutralForegroundRestBehavior,
-    neutralFocusBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
+        accentFillRestBehavior,
+        neutralDividerRestBehavior,
+        neutralForegroundActiveBehavior,
+        neutralForegroundFocusBehavior,
+        neutralForegroundHoverBehavior,
+        neutralForegroundRestBehavior,
+        neutralFocusBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
             .button:${focusVisible}::before {
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${SystemColors.Highlight};
             }
         `
-    )
-);
+        )
+    );

--- a/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
@@ -6,6 +6,15 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    density,
+    designUnit,
+    focusOutlineWidth,
+    outlineWidth,
+    typeRampMinus1FontSize,
+    typeRampMinus1LineHeight,
+} from "../design-tokens";
+import {
     accentFillRestBehavior,
     neutralDividerRestBehavior,
     neutralFocusBehavior,
@@ -20,16 +29,16 @@ export const accordionItemStyles = (context, definition) =>
     css`
     ${display("flex")} :host {
         box-sizing: border-box;
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         flex-direction: column;
-        font-size: var(--type-ramp-minus-1-font-size);
-        line-height: var(--type-ramp-minus-1-line-height);
-        border-bottom: calc(var(--outline-width) * 1px) solid var(--neutral-divider-rest);
+        font-size: ${typeRampMinus1FontSize};
+        line-height: ${typeRampMinus1LineHeight};
+        border-bottom: calc(${outlineWidth} * 1px) solid var(--neutral-divider-rest);
     }
     
     .region {
         display: none;
-        padding: calc((6 + (var(--design-unit) * 2 * var(--density))) * 1px);
+        padding: calc((6 + (${designUnit} * 2 * ${density})) * 1px);
     }
 
     .heading {
@@ -46,7 +55,7 @@ export const accordionItemStyles = (context, definition) =>
         grid-column: 2;
         grid-row: 1;
         outline: none;
-        padding: 0 calc((6 + (var(--design-unit) * 2 * var(--density))) * 1px);
+        padding: 0 calc((6 + (${designUnit} * 2 * ${density})) * 1px);
         text-align: left;
         height: calc(${heightNumber} * 1px);
         color: ${neutralForegroundRestBehavior.var};
@@ -75,8 +84,8 @@ export const accordionItemStyles = (context, definition) =>
 
     .button:${focusVisible}::before {
         outline: none;
-        border: calc(var(--outline-width) * 1px) solid ${neutralFocusBehavior.var};
-        box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px)
+        border: calc(${outlineWidth} * 1px) solid ${neutralFocusBehavior.var};
+        box-shadow: 0 0 0 calc((${focusOutlineWidth} - ${outlineWidth}) * 1px)
             ${neutralFocusBehavior.var};
     }
 
@@ -117,7 +126,7 @@ export const accordionItemStyles = (context, definition) =>
     .start {
         display: flex;
         align-items: center;
-        padding-inline-start: calc(var(--design-unit) * 1px);
+        padding-inline-start: calc(${designUnit} * 1px);
         justify-content: center;
         grid-column: 1;
         z-index: 2;
@@ -142,7 +151,7 @@ export const accordionItemStyles = (context, definition) =>
             css`
             .button:${focusVisible}::before {
                 border-color: ${SystemColors.Highlight};
-                box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${SystemColors.Highlight};
+                box-shadow: 0 0 0 calc((${focusOutlineWidth} - ${outlineWidth}) * 1px) ${SystemColors.Highlight};
             }
         `
         )

--- a/packages/web-components/fast-components/src/accordion-item/index.ts
+++ b/packages/web-components/fast-components/src/accordion-item/index.ts
@@ -1,25 +1,23 @@
-import { customElement } from "@microsoft/fast-element";
 import {
     AccordionItem,
-    AccordionItemTemplate as template,
+    accordionItemTemplate as template,
 } from "@microsoft/fast-foundation";
-import { AccordionItemStyles as styles } from "./accordion-item.styles";
+import { accordionItemStyles as styles } from "./accordion-item.styles";
 
 /**
  * The FAST Accordion Item Element. Implements {@link @microsoft/fast-foundation#AccordionItem},
- * {@link @microsoft/fast-foundation#AccordionItemTemplate}
+ * {@link @microsoft/fast-foundation#accordionItemTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-accordion-item\>
  */
-@customElement({
-    name: "fast-accordion-item",
+export const fastAccordionItem = AccordionItem.compose({
+    baseName: "accordion-item",
     template,
     styles,
-})
-export class FASTAccordionItem extends AccordionItem {}
+});
 
 /**
  * Styles for AccordionItem

--- a/packages/web-components/fast-components/src/accordion-item/index.ts
+++ b/packages/web-components/fast-components/src/accordion-item/index.ts
@@ -23,4 +23,4 @@ export const fastAccordionItem = AccordionItem.compose({
  * Styles for AccordionItem
  * @public
  */
-export const AccordionItemStyles = styles;
+export const accordionItemStyles = styles;

--- a/packages/web-components/fast-components/src/accordion/accordion.styles.ts
+++ b/packages/web-components/fast-components/src/accordion/accordion.styles.ts
@@ -1,6 +1,12 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 import {
+    bodyFont,
+    outlineWidth,
+    typeRampMinus1FontSize,
+    typeRampMinus1LineHeight,
+} from "../design-tokens";
+import {
     neutralDividerRestBehavior,
     neutralForegroundRestBehavior,
 } from "../styles/recipes";
@@ -10,11 +16,11 @@ export const accordionStyles = (context, definition) =>
         ${display("flex")} :host {
             box-sizing: border-box;
             flex-direction: column;
-            font-family: var(--body-font);
-            font-size: var(--type-ramp-minus-1-font-size);
-            line-height: var(--type-ramp-minus-1-line-height);
+            font-family: ${bodyFont};
+            font-size: ${typeRampMinus1FontSize};
+            line-height: ${typeRampMinus1LineHeight};
             color: ${neutralForegroundRestBehavior.var};
-            border-top: calc(var(--outline-width) * 1px) solid
+            border-top: calc(${outlineWidth} * 1px) solid
                 ${neutralDividerRestBehavior.var};
         }
     `.withBehaviors(neutralDividerRestBehavior, neutralForegroundRestBehavior);

--- a/packages/web-components/fast-components/src/accordion/accordion.styles.ts
+++ b/packages/web-components/fast-components/src/accordion/accordion.styles.ts
@@ -5,15 +5,16 @@ import {
     neutralForegroundRestBehavior,
 } from "../styles/recipes";
 
-export const AccordionStyles = css`
-    ${display("flex")} :host {
-        box-sizing: border-box;
-        flex-direction: column;
-        font-family: var(--body-font);
-        font-size: var(--type-ramp-minus-1-font-size);
-        line-height: var(--type-ramp-minus-1-line-height);
-        color: ${neutralForegroundRestBehavior.var};
-        border-top: calc(var(--outline-width) * 1px) solid
-            ${neutralDividerRestBehavior.var};
-    }
-`.withBehaviors(neutralDividerRestBehavior, neutralForegroundRestBehavior);
+export const accordionStyles = (context, definition) =>
+    css`
+        ${display("flex")} :host {
+            box-sizing: border-box;
+            flex-direction: column;
+            font-family: var(--body-font);
+            font-size: var(--type-ramp-minus-1-font-size);
+            line-height: var(--type-ramp-minus-1-line-height);
+            color: ${neutralForegroundRestBehavior.var};
+            border-top: calc(var(--outline-width) * 1px) solid
+                ${neutralDividerRestBehavior.var};
+        }
+    `.withBehaviors(neutralDividerRestBehavior, neutralForegroundRestBehavior);

--- a/packages/web-components/fast-components/src/accordion/index.ts
+++ b/packages/web-components/fast-components/src/accordion/index.ts
@@ -1,24 +1,22 @@
-import { customElement } from "@microsoft/fast-element";
-import { Accordion, AccordionTemplate as template } from "@microsoft/fast-foundation";
-import { AccordionStyles as styles } from "./accordion.styles";
+import { Accordion, accordionTemplate as template } from "@microsoft/fast-foundation";
+import { accordionStyles as styles } from "./accordion.styles";
 
 export * from "../accordion-item/index";
 
 /**
  * The FAST Accordion Element. Implements {@link @microsoft/fast-foundation#Accordion},
- * {@link @microsoft/fast-foundation#AccordionTemplate}
+ * {@link @microsoft/fast-foundation#accordionTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-accordion\>
  */
-@customElement({
-    name: "fast-accordion",
+export const fastAccordion = Accordion.compose({
+    baseName: "accordion",
     template,
     styles,
-})
-export class FASTAccordion extends Accordion {}
+});
 
 /**
  * Styles for Accordion

--- a/packages/web-components/fast-components/src/accordion/index.ts
+++ b/packages/web-components/fast-components/src/accordion/index.ts
@@ -22,4 +22,4 @@ export const fastAccordion = Accordion.compose({
  * Styles for Accordion
  * @public
  */
-export const AccordionStyles = styles;
+export const accordionStyles = styles;

--- a/packages/web-components/fast-components/src/anchor/anchor.styles.ts
+++ b/packages/web-components/fast-components/src/anchor/anchor.styles.ts
@@ -9,12 +9,13 @@ import {
 } from "../styles/index";
 import { appearanceBehavior } from "../utilities/behaviors";
 
-export const AnchorStyles = css`
-    ${BaseButtonStyles}
-`.withBehaviors(
-    appearanceBehavior("accent", AccentButtonStyles),
-    appearanceBehavior("hypertext", HypertextStyles),
-    appearanceBehavior("lightweight", LightweightButtonStyles),
-    appearanceBehavior("outline", OutlineButtonStyles),
-    appearanceBehavior("stealth", StealthButtonStyles)
-);
+export const anchorStyles = (context, definition) =>
+    css`
+        ${BaseButtonStyles}
+    `.withBehaviors(
+        appearanceBehavior("accent", AccentButtonStyles),
+        appearanceBehavior("hypertext", HypertextStyles),
+        appearanceBehavior("lightweight", LightweightButtonStyles),
+        appearanceBehavior("outline", OutlineButtonStyles),
+        appearanceBehavior("stealth", StealthButtonStyles)
+    );

--- a/packages/web-components/fast-components/src/anchor/index.ts
+++ b/packages/web-components/fast-components/src/anchor/index.ts
@@ -1,7 +1,10 @@
-import { attr, customElement } from "@microsoft/fast-element";
-import { Anchor, AnchorTemplate as template } from "@microsoft/fast-foundation";
+import { attr } from "@microsoft/fast-element";
+import {
+    Anchor as FoundationAnchor,
+    anchorTemplate as template,
+} from "@microsoft/fast-foundation";
 import { ButtonAppearance } from "../button";
-import { AnchorStyles as styles } from "./anchor.styles";
+import { anchorStyles as styles } from "./anchor.styles";
 
 /**
  * Types of anchor appearance.
@@ -10,25 +13,10 @@ import { AnchorStyles as styles } from "./anchor.styles";
 export type AnchorAppearance = ButtonAppearance | "hypertext";
 
 /**
- * The FAST Anchor Element. Implements {@link @microsoft/fast-foundation#Anchor},
- * {@link @microsoft/fast-foundation#AnchorTemplate}
- *
- *
- * @public
- * @remarks
- * HTML Element: \<fast-anchor\>
- *
- * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ * The FAST components version of Anchor
+ * @internal
  */
-@customElement({
-    name: "fast-anchor",
-    template,
-    styles,
-    shadowOptions: {
-        delegatesFocus: true,
-    },
-})
-export class FASTAnchor extends Anchor {
+export class Anchor extends FoundationAnchor {
     /**
      * The appearance the anchor should have.
      *
@@ -79,3 +67,23 @@ export class FASTAnchor extends Anchor {
  * @public
  */
 export const AnchorStyles = styles;
+
+/**
+ * The FAST Anchor Element. Implements {@link @microsoft/fast-foundation#Anchor},
+ * {@link @microsoft/fast-foundation#anchorTemplate}
+ *
+ *
+ * @public
+ * @remarks
+ * HTML Element: \<fast-anchor\>
+ *
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ */
+export const fastAnchor = Anchor.compose({
+    baseName: "anchor",
+    template,
+    styles,
+    shadowOptions: {
+        delegatesFocus: true,
+    },
+});

--- a/packages/web-components/fast-components/src/anchor/index.ts
+++ b/packages/web-components/fast-components/src/anchor/index.ts
@@ -66,7 +66,7 @@ export class Anchor extends FoundationAnchor {
  * Styles for Anchor
  * @public
  */
-export const AnchorStyles = styles;
+export const anchorStyles = styles;
 
 /**
  * The FAST Anchor Element. Implements {@link @microsoft/fast-foundation#Anchor},

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
@@ -1,8 +1,8 @@
 import { Direction, RtlScrollConverter } from "@microsoft/fast-web-utilities";
 import addons from "@storybook/addons";
 import { STORY_RENDERED } from "@storybook/core-events";
+import { AnchoredRegion as FoundationAnchoredRegion } from "@microsoft/fast-foundation";
 import AnchoredRegionTemplate from "./fixtures/base.html";
-import type { FASTAnchoredRegion } from "./index";
 import "./index";
 
 let scalingViewportPreviousXValue: number = 250;
@@ -67,14 +67,14 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
 
         const regionScalingUpdate = document.getElementById(
             "region-scaling-update"
-        ) as FASTAnchoredRegion;
+        ) as FoundationAnchoredRegion;
         document
             .getElementById("viewport-scaling-update")!
             .addEventListener("scroll", () => regionScalingUpdate.update());
 
         const regionScalingOffset = document.getElementById(
             "region-scaling-offset"
-        ) as FASTAnchoredRegion;
+        ) as FoundationAnchoredRegion;
         document
             .getElementById("viewport-scaling-offset")
             ?.addEventListener("scroll", (e: MouseEvent) => {

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.styles.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.styles.ts
@@ -1,6 +1,6 @@
 import { css } from "@microsoft/fast-element";
 
-export const AnchoredRegionStyles = css`
+export const anchoredRegionStyles = (context, definition) => css`
     :host {
         contain: layout;
         display: block;

--- a/packages/web-components/fast-components/src/anchored-region/index.ts
+++ b/packages/web-components/fast-components/src/anchored-region/index.ts
@@ -1,25 +1,23 @@
-import { customElement } from "@microsoft/fast-element";
 import {
     AnchoredRegion,
-    AnchoredRegionTemplate as template,
+    anchoredRegionTemplate as template,
 } from "@microsoft/fast-foundation";
-import { AnchoredRegionStyles as styles } from "./anchored-region.styles";
+import { anchoredRegionStyles as styles } from "./anchored-region.styles";
 
 /**
  * The FAST AnchoredRegion Element. Implements {@link @microsoft/fast-foundation#AnchoredRegion},
- * {@link @microsoft/fast-foundation#AnchoredRegionTemplate}
+ * {@link @microsoft/fast-foundation#anchoredRegionTemplate}
  *
  *
  * @beta
  * @remarks
  * HTML Element: \<fast-anchored-region\>
  */
-@customElement({
-    name: "fast-anchored-region",
+export const fastAnchoredRegion = AnchoredRegion.compose({
+    baseName: "anchored-region",
     template,
     styles,
-})
-export class FASTAnchoredRegion extends AnchoredRegion {}
+});
 
 /**
  * Styles for AnchoredRegion

--- a/packages/web-components/fast-components/src/anchored-region/index.ts
+++ b/packages/web-components/fast-components/src/anchored-region/index.ts
@@ -23,4 +23,4 @@ export const fastAnchoredRegion = AnchoredRegion.compose({
  * Styles for AnchoredRegion
  * @public
  */
-export const AnchoredRegionStyles = styles;
+export const anchoredRegionStyles = styles;

--- a/packages/web-components/fast-components/src/badge/badge.styles.ts
+++ b/packages/web-components/fast-components/src/badge/badge.styles.ts
@@ -2,7 +2,8 @@ import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 import { accentForegroundRestBehavior, heightNumber } from "../styles/index";
 
-export const BadgeStyles = css`
+export const badgeStyles = (context, definition) =>
+    css`
     ${display("inline-block")} :host {
         box-sizing: border-box;
         font-family: var(--body-font);

--- a/packages/web-components/fast-components/src/badge/badge.styles.ts
+++ b/packages/web-components/fast-components/src/badge/badge.styles.ts
@@ -1,19 +1,26 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
+import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    typeRampMinus1FontSize,
+    typeRampMinus1LineHeight,
+} from "../design-tokens";
 import { accentForegroundRestBehavior, heightNumber } from "../styles/index";
 
 export const badgeStyles = (context, definition) =>
     css`
     ${display("inline-block")} :host {
         box-sizing: border-box;
-        font-family: var(--body-font);
-        font-size: var(--type-ramp-minus-1-font-size);
-        line-height: var(--type-ramp-minus-1-line-height);
+        font-family: ${bodyFont};
+        font-size: ${typeRampMinus1FontSize};
+        line-height: ${typeRampMinus1LineHeight};
     }
 
     .control {
-        border-radius: calc(var(--corner-radius) * 1px);
-        padding: calc(var(--design-unit) * 0.5px) calc(var(--design-unit) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
+        padding: calc(${designUnit} * 0.5px) calc(${designUnit} * 1px);
         color: ${accentForegroundRestBehavior.var};
         font-weight: 600;
     }
@@ -24,11 +31,11 @@ export const badgeStyles = (context, definition) =>
 
     :host([circular]) .control {
         border-radius: 100px;
-        padding: 0 calc(var(--design-unit) * 1px);
+        padding: 0 calc(${designUnit} * 1px);
         ${
             /* Need to work with Brian on width and height here */ ""
-        } height: calc((${heightNumber} - (var(--design-unit) * 3)) * 1px);
-        min-width: calc((${heightNumber} - (var(--design-unit) * 3)) * 1px);
+        } height: calc((${heightNumber} - (${designUnit} * 3)) * 1px);
+        min-width: calc((${heightNumber} - (${designUnit} * 3)) * 1px);
         display: flex;
         align-items: center;
         justify-content: center;

--- a/packages/web-components/fast-components/src/badge/index.ts
+++ b/packages/web-components/fast-components/src/badge/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Badge, BadgeTemplate as template } from "@microsoft/fast-foundation";
-import { BadgeStyles as styles } from "./badge.styles";
+import { Badge, badgeTemplate as template } from "@microsoft/fast-foundation";
+import { badgeStyles as styles } from "./badge.styles";
 
 /**
  * The FAST Badge Element. Implements {@link @microsoft/fast-foundation#Badge},
- * {@link @microsoft/fast-foundation#BadgeTemplate}
+ * {@link @microsoft/fast-foundation#badgeTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-badge\>
  */
-@customElement({
-    name: "fast-badge",
+export const fastBadge = Badge.compose({
+    baseName: "badge",
     template,
     styles,
-})
-export class FASTBadge extends Badge {}
+});
 
 /**
  * Styles for Badge

--- a/packages/web-components/fast-components/src/badge/index.ts
+++ b/packages/web-components/fast-components/src/badge/index.ts
@@ -20,4 +20,4 @@ export const fastBadge = Badge.compose({
  * Styles for Badge
  * @public
  */
-export const BadgeStyles = styles;
+export const badgeStyles = styles;

--- a/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.styles.ts
@@ -6,6 +6,13 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    focusOutlineWidth,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentForegroundActiveBehavior,
     accentForegroundHoverBehavior,
     accentForegroundRestBehavior,
@@ -18,10 +25,10 @@ export const breadcrumbItemStyles = (context, definition) =>
     ${display("inline-flex")} :host {
         background: transparent;
         box-sizing: border-box;
-        font-family: var(--body-font);
-        font-size: var(--type-ramp-base-font-size);
+        font-family: ${bodyFont};
+        font-size: ${typeRampBaseFontSize};
         fill: currentColor;
-        line-height: var(--type-ramp-base-line-height);
+        line-height: ${typeRampBaseLineHeight};
         min-width: calc(${heightNumber} * 1px);
         outline: none;
     }
@@ -63,7 +70,7 @@ export const breadcrumbItemStyles = (context, definition) =>
     .control .content::before {
         content: "";
         display: block;
-        height: calc(var(--outline-width) * 1px);
+        height: calc(${outlineWidth} * 1px);
         left: 0;
         position: absolute;
         right: 0;
@@ -81,7 +88,7 @@ export const breadcrumbItemStyles = (context, definition) =>
 
     .control:${focusVisible} .content::before {
         background: ${neutralForegroundRestBehavior.var};
-        height: calc(var(--focus-outline-width) * 1px);
+        height: calc(${focusOutlineWidth} * 1px);
     }
 
     .control:not([href]) {

--- a/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.styles.ts
@@ -4,16 +4,17 @@ import {
     focusVisible,
     forcedColorsStylesheetBehavior,
 } from "@microsoft/fast-foundation";
+import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
     accentForegroundActiveBehavior,
     accentForegroundHoverBehavior,
     accentForegroundRestBehavior,
-    neutralForegroundRestBehavior,
     heightNumber,
+    neutralForegroundRestBehavior,
 } from "../styles/index";
-import { SystemColors } from "@microsoft/fast-web-utilities";
 
-export const BreadcrumbItemStyles = css`
+export const breadcrumbItemStyles = (context, definition) =>
+    css`
     ${display("inline-flex")} :host {
         background: transparent;
         box-sizing: border-box;
@@ -113,16 +114,16 @@ export const BreadcrumbItemStyles = css`
         margin-inline-start: 6px;
     }
 `.withBehaviors(
-    accentForegroundRestBehavior,
-    accentForegroundHoverBehavior,
-    accentForegroundActiveBehavior,
-    accentForegroundHoverBehavior,
-    neutralForegroundRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            .control:hover .content::before {
-                background: ${SystemColors.LinkText};
-            }
-        `
-    )
-);
+        accentForegroundRestBehavior,
+        accentForegroundHoverBehavior,
+        accentForegroundActiveBehavior,
+        accentForegroundHoverBehavior,
+        neutralForegroundRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                .control:hover .content::before {
+                    background: ${SystemColors.LinkText};
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/breadcrumb-item/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/index.ts
@@ -1,25 +1,23 @@
-import { customElement } from "@microsoft/fast-element";
 import {
     BreadcrumbItem,
-    BreadcrumbItemTemplate as template,
+    breadcrumbItemTemplate as template,
 } from "@microsoft/fast-foundation";
-import { BreadcrumbItemStyles as styles } from "./breadcrumb-item.styles";
+import { breadcrumbItemStyles as styles } from "./breadcrumb-item.styles";
 
 /**
  * The FAST BreadcrumbItem Element. Implements {@link @microsoft/fast-foundation#BreadcrumbItem},
- * {@link @microsoft/fast-foundation#BreadcrumbItemTemplate}
+ * {@link @microsoft/fast-foundation#breadcrumbItemTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-breadcrumb-item\>
  */
-@customElement({
-    name: "fast-breadcrumb-item",
+export const fastBreadcrumbItem = BreadcrumbItem.compose({
+    baseName: "breadcrumb-item",
     template,
     styles,
     shadowOptions: {
         delegatesFocus: true,
     },
-})
-export class FASTBreadcrumbItem extends BreadcrumbItem {}
+});

--- a/packages/web-components/fast-components/src/breadcrumb/breadcrumb.styles.ts
+++ b/packages/web-components/fast-components/src/breadcrumb/breadcrumb.styles.ts
@@ -1,12 +1,13 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
+import { bodyFont, typeRampBaseFontSize, typeRampBaseLineHeight } from "../design-tokens";
 
 export const breadcrumbStyles = (context, definition) => css`
     ${display("inline-block")} :host {
         box-sizing: border-box;
-        font-family: var(--body-font);
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-family: ${bodyFont};
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
     }
 
     .list {

--- a/packages/web-components/fast-components/src/breadcrumb/breadcrumb.styles.ts
+++ b/packages/web-components/fast-components/src/breadcrumb/breadcrumb.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 
-export const BreadcrumbStyles = css`
+export const breadcrumbStyles = (context, definition) => css`
     ${display("inline-block")} :host {
         box-sizing: border-box;
         font-family: var(--body-font);

--- a/packages/web-components/fast-components/src/breadcrumb/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb/index.ts
@@ -1,19 +1,17 @@
-import { customElement } from "@microsoft/fast-element";
-import { Breadcrumb, BreadcrumbTemplate as template } from "@microsoft/fast-foundation";
-import { BreadcrumbStyles as styles } from "./breadcrumb.styles";
+import { Breadcrumb, breadcrumbTemplate as template } from "@microsoft/fast-foundation";
+import { breadcrumbStyles as styles } from "./breadcrumb.styles";
 
 /**
  * The FAST Breadcrumb Element. Implements {@link @microsoft/fast-foundation#Breadcrumb},
- * {@link @microsoft/fast-foundation#BreadcrumbTemplate}
+ * {@link @microsoft/fast-foundation#breadcrumbTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-breadcrumb\>
  */
-@customElement({
-    name: "fast-breadcrumb",
+export const fastBreadcrumb = Breadcrumb.compose({
+    baseName: "breadcrumb",
     template,
     styles,
-})
-export class FASTBreadcrumb extends Breadcrumb {}
+});

--- a/packages/web-components/fast-components/src/button/button.styles.ts
+++ b/packages/web-components/fast-components/src/button/button.styles.ts
@@ -8,11 +8,12 @@ import {
 } from "../styles/index";
 import { appearanceBehavior } from "../utilities/behaviors";
 
-export const ButtonStyles = css`
-    ${BaseButtonStyles}
-`.withBehaviors(
-    appearanceBehavior("accent", AccentButtonStyles),
-    appearanceBehavior("lightweight", LightweightButtonStyles),
-    appearanceBehavior("outline", OutlineButtonStyles),
-    appearanceBehavior("stealth", StealthButtonStyles)
-);
+export const buttonStyles = (context, definition) =>
+    css`
+        ${BaseButtonStyles}
+    `.withBehaviors(
+        appearanceBehavior("accent", AccentButtonStyles),
+        appearanceBehavior("lightweight", LightweightButtonStyles),
+        appearanceBehavior("outline", OutlineButtonStyles),
+        appearanceBehavior("stealth", StealthButtonStyles)
+    );

--- a/packages/web-components/fast-components/src/button/index.ts
+++ b/packages/web-components/fast-components/src/button/index.ts
@@ -79,4 +79,4 @@ export const fastButton = Button.compose({
  * Styles for Button
  * @public
  */
-export const ButtonStyles = styles;
+export const buttonStyles = styles;

--- a/packages/web-components/fast-components/src/button/index.ts
+++ b/packages/web-components/fast-components/src/button/index.ts
@@ -1,6 +1,9 @@
-import { attr, customElement } from "@microsoft/fast-element";
-import { Button, ButtonTemplate as template } from "@microsoft/fast-foundation";
-import { ButtonStyles as styles } from "./button.styles";
+import { attr } from "@microsoft/fast-element";
+import {
+    Button as FoundationButton,
+    buttonTemplate as template,
+} from "@microsoft/fast-foundation";
+import { buttonStyles as styles } from "./button.styles";
 
 /**
  * Types of button appearance.
@@ -14,25 +17,9 @@ export type ButtonAppearance =
     | "stealth";
 
 /**
- * The FAST Button Element. Implements {@link @microsoft/fast-foundation#Button},
- * {@link @microsoft/fast-foundation#ButtonTemplate}
- *
- *
- * @public
- * @remarks
- * HTML Element: \<fast-button\>
- *
- * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ * @internal
  */
-@customElement({
-    name: "fast-button",
-    template,
-    styles,
-    shadowOptions: {
-        delegatesFocus: true,
-    },
-})
-export class FASTButton extends Button {
+export class Button extends FoundationButton {
     /**
      * The appearance the button should have.
      *
@@ -67,6 +54,26 @@ export class FASTButton extends Button {
         }
     }
 }
+
+/**
+ * The FAST Button Element. Implements {@link @microsoft/fast-foundation#Button},
+ * {@link @microsoft/fast-foundation#buttonTemplate}
+ *
+ *
+ * @public
+ * @remarks
+ * HTML Element: \<fast-button\>
+ *
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ */
+export const fastButton = Button.compose({
+    baseName: "button",
+    template,
+    styles,
+    shadowOptions: {
+        delegatesFocus: true,
+    },
+});
 
 /**
  * Styles for Button

--- a/packages/web-components/fast-components/src/card/card.styles.ts
+++ b/packages/web-components/fast-components/src/card/card.styles.ts
@@ -1,6 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import { cornerRadius } from "../design-tokens";
 import { elevation } from "../styles/index";
 
 export const CardStyles = css`
@@ -12,7 +13,7 @@ export const CardStyles = css`
         width: var(--card-width, 100%);
         box-sizing: border-box;
         background: var(--background-color);
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
         ${elevation}
     }
 `.withBehaviors(

--- a/packages/web-components/fast-components/src/checkbox/checkbox.stories.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.stories.ts
@@ -1,14 +1,16 @@
 import addons from "@storybook/addons";
 import { STORY_RENDERED } from "@storybook/core-events";
+import { Checkbox as FoundationCheckbox } from "@microsoft/fast-foundation";
 import Examples from "./fixtures/base.html";
 import "./index";
-import { FASTCheckbox } from "./index";
 
 addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
     if (name.toLowerCase().startsWith("checkbox")) {
-        document.querySelectorAll(".flag-indeterminate").forEach((el: FASTCheckbox) => {
-            el.indeterminate = true;
-        });
+        document
+            .querySelectorAll(".flag-indeterminate")
+            .forEach((el: FoundationCheckbox) => {
+                el.indeterminate = true;
+            });
     }
 });
 

--- a/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
@@ -7,6 +7,15 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
@@ -28,7 +37,7 @@ export const checkboxStyles = (context, definition) =>
     ${display("inline-flex")} :host {
         align-items: center;
         outline: none;
-        margin: calc(var(--design-unit) * 1px) 0;
+        margin: calc(${designUnit} * 1px) 0;
         ${
             /*
              * Chromium likes to select label text or the default slot when
@@ -39,26 +48,26 @@ export const checkboxStyles = (context, definition) =>
 
     .control {
         position: relative;
-        width: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
-        height: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
+        width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
+        height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         box-sizing: border-box;
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${outlineWidth} * 1px) solid ${neutralOutlineRestBehavior.var};
         background: ${neutralFillInputRestBehavior.var};
         outline: none;
         cursor: pointer;
     }
 
     .label {
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         color: ${neutralForegroundRestBehavior.var};
         ${
             /* Need to discuss with Brian how HorizontalSpacingNumber can work. https://github.com/microsoft/fast/issues/2766 */ ""
-        } padding-inline-start: calc(var(--design-unit) * 2px + 2px);
-        margin-inline-end: calc(var(--design-unit) * 2px + 2px);
+        } padding-inline-start: calc(${designUnit} * 2px + 2px);
+        margin-inline-end: calc(${designUnit} * 2px + 2px);
         cursor: pointer;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
     }
 
     .label__hidden {
@@ -76,7 +85,7 @@ export const checkboxStyles = (context, definition) =>
     }
 
     .indeterminate-indicator {
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
         background: ${accentForegroundCutRestBehavior.var};
         position: absolute;
         top: 50%;
@@ -106,17 +115,17 @@ export const checkboxStyles = (context, definition) =>
 
     :host([aria-checked="true"]) .control {
         background: ${accentFillRestBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
+        border: calc(${outlineWidth} * 1px) solid ${accentFillRestBehavior.var};
     }
 
     :host([aria-checked="true"]:not([disabled])) .control:hover {
         background: ${accentFillHoverBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${accentFillHoverBehavior.var};
+        border: calc(${outlineWidth} * 1px) solid ${accentFillHoverBehavior.var};
     }
 
     :host([aria-checked="true"]:not([disabled])) .control:active {
         background: ${accentFillActiveBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${accentFillActiveBehavior.var};
+        border: calc(${outlineWidth} * 1px) solid ${accentFillActiveBehavior.var};
     }
 
     :host([aria-checked="true"]:${focusVisible}:not([disabled])) .control {
@@ -140,7 +149,7 @@ export const checkboxStyles = (context, definition) =>
     }
 
     :host([disabled]) {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 `.withBehaviors(
         accentFillActiveBehavior,

--- a/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
+++ b/packages/web-components/fast-components/src/checkbox/checkbox.styles.ts
@@ -23,7 +23,8 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const CheckboxStyles = css`
+export const checkboxStyles = (context, definition) =>
+    css`
     ${display("inline-flex")} :host {
         align-items: center;
         outline: none;
@@ -142,21 +143,21 @@ export const CheckboxStyles = css`
         opacity: var(--disabled-opacity);
     }
 `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    accentForegroundCutRestBehavior,
-    neutralFillInputActiveBehavior,
-    neutralFillInputHoverBehavior,
-    neutralFillInputRestBehavior,
-    neutralFocusBehavior,
-    neutralFocusInnerAccentBehavior,
-    neutralForegroundRestBehavior,
-    neutralOutlineActiveBehavior,
-    neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        accentForegroundCutRestBehavior,
+        neutralFillInputActiveBehavior,
+        neutralFillInputHoverBehavior,
+        neutralFillInputRestBehavior,
+        neutralFocusBehavior,
+        neutralFocusInnerAccentBehavior,
+        neutralForegroundRestBehavior,
+        neutralOutlineActiveBehavior,
+        neutralOutlineHoverBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
             .control {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.FieldText};
@@ -218,5 +219,5 @@ export const CheckboxStyles = css`
                 fill: ${SystemColors.GrayText};
             }
         `
-    )
-);
+        )
+    );

--- a/packages/web-components/fast-components/src/checkbox/index.ts
+++ b/packages/web-components/fast-components/src/checkbox/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Checkbox, CheckboxTemplate as template } from "@microsoft/fast-foundation";
-import { CheckboxStyles as styles } from "./checkbox.styles";
+import { Checkbox, checkboxTemplate as template } from "@microsoft/fast-foundation";
+import { checkboxStyles as styles } from "./checkbox.styles";
 
 /**
  * The FAST Checkbox Element. Implements {@link @microsoft/fast-foundation#Checkbox},
- * {@link @microsoft/fast-foundation#CheckboxTemplate}
+ * {@link @microsoft/fast-foundation#checkboxTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-checkbox\>
  */
-@customElement({
-    name: "fast-checkbox",
+export const fastCheckbox = Checkbox.compose({
+    baseName: "checkbox",
     template,
     styles,
-})
-export class FASTCheckbox extends Checkbox {}
+});
 
 /**
  * Styles for Checkbox

--- a/packages/web-components/fast-components/src/checkbox/index.ts
+++ b/packages/web-components/fast-components/src/checkbox/index.ts
@@ -20,4 +20,4 @@ export const fastCheckbox = Checkbox.compose({
  * Styles for Checkbox
  * @public
  */
-export const CheckboxStyles = styles;
+export const checkboxStyles = styles;

--- a/packages/web-components/fast-components/src/color-vNext/README.md
+++ b/packages/web-components/fast-components/src/color-vNext/README.md
@@ -1,0 +1,28 @@
+# FAST Color Recipes
+
+Color recipes are named colors who's value is algorithmically defined from a variety of inputs. `@microsoft/fast-components` relies on these recipes heavily to achieve expressive theming options while maintaining color accessability targets.
+
+
+## Swatch
+A Swatch is a representation of a color that has a `relativeLuminance` value and a method to convert the swatch to a color string. It is used by recipes to determine which colors to use for UI.
+
+### SwatchRGB
+A concrete implementation of `Swatch`, it is a swatch with red, green, and blue 64bit color channels .
+
+**Example: Creating a SwatchRGB**
+```ts
+import { SwatchRGB } from "@microsoft/fast-components";
+
+const red = new SwatchRGB(1, 0, 0);
+```
+
+## Palette
+A palette is a collection `Swatch` instances, ordered by relative luminance, and provides mechanisms to safely retrieve swatches by index and by target contrast ratios. It also contains a `source` color, which is the color from which the palette is 
+
+### PaletteRGB
+An implementation of `Palette` of `SwatchRGB` instances. 
+
+```ts
+// Create a palette from the red swatch
+const palette = PaletteRGB.from(red):
+```

--- a/packages/web-components/fast-components/src/color-vNext/palette.ts
+++ b/packages/web-components/fast-components/src/color-vNext/palette.ts
@@ -1,0 +1,145 @@
+import {
+    clamp,
+    ComponentStateColorPalette,
+    parseColorHexRGB,
+} from "@microsoft/fast-colors";
+import { Swatch, SwatchRGB } from "./swatch";
+import { binarySearch } from "./utilities/binary-search";
+import { directionByIsDark } from "./utilities/direction-by-is-dark";
+import { contrast, RelativeLuminance } from "./utilities/relative-luminance";
+
+/**
+ * A collection of {@link Swatch} instances
+ * @public
+ */
+export interface Palette<T extends Swatch = Swatch> {
+    readonly source: T;
+    readonly swatches: ReadonlyArray<T>;
+
+    /**
+     * Returns a swatch from the palette that most closely matches
+     * the contrast ratio provided to a provided reference.
+     */
+    colorContrast(
+        reference: Swatch,
+        contrast: number,
+        initialIndex?: number,
+        direction?: 1 | -1
+    ): Swatch;
+
+    /**
+     * Returns the index of the palette that most closely matches
+     * the relativeLuminance of the provided swatch
+     */
+    closestIndexOf(reference: RelativeLuminance): number;
+
+    /**
+     * Gets a swatch by index. Index is clamped to the limits
+     * of the palette so a Swatch will always be returned.
+     */
+    get(index: number): T;
+}
+
+/**
+ * A {@link Palette} representing RGB swatch values.
+ * @public
+ */
+export class PaletteRGB implements Palette<SwatchRGB> {
+    /**
+     * {@inheritdoc Palette.source}
+     */
+    public readonly source: SwatchRGB;
+    public readonly swatches: ReadonlyArray<SwatchRGB>;
+    private lastIndex: number;
+    private reversedSwatches: ReadonlyArray<SwatchRGB>;
+    /**
+     *
+     * @param source - The source color for the palette
+     * @param swatches - All swatches in the palette
+     */
+    constructor(source: SwatchRGB, swatches: ReadonlyArray<SwatchRGB>) {
+        this.source = source;
+        this.swatches = swatches;
+
+        this.reversedSwatches = Object.freeze([...this.swatches].reverse());
+        this.lastIndex = this.swatches.length - 1;
+    }
+
+    /**
+     * {@inheritdoc Palette.colorContrast}
+     */
+    public colorContrast(
+        reference: Swatch,
+        contrastTarget: number,
+        initialSearchIndex?: number,
+        direction?: 1 | -1
+    ): SwatchRGB {
+        if (initialSearchIndex === undefined) {
+            initialSearchIndex = this.closestIndexOf(reference);
+        }
+
+        let source: ReadonlyArray<SwatchRGB> = this.swatches;
+        const endSearchIndex = this.lastIndex;
+        let startSearchIndex = initialSearchIndex;
+
+        if (direction === undefined) {
+            direction = directionByIsDark(reference);
+        }
+
+        const condition = (value: SwatchRGB) =>
+            contrast(reference, value) >= contrastTarget;
+
+        if (direction === -1) {
+            source = this.reversedSwatches;
+            startSearchIndex = endSearchIndex - startSearchIndex;
+        }
+
+        return binarySearch(source, condition, startSearchIndex, endSearchIndex);
+    }
+
+    /**
+     * {@inheritdoc Palette.get}
+     */
+    public get(index: number): SwatchRGB {
+        return this.swatches[index] || this.swatches[clamp(index, 0, this.lastIndex)];
+    }
+
+    /**
+     * {@inheritdoc Palette.closestIndexOf}
+     */
+    public closestIndexOf(reference: Swatch): number {
+        const index = this.swatches.indexOf(reference as SwatchRGB);
+
+        if (index !== -1) {
+            return index;
+        }
+
+        const closest = this.swatches.reduce((previous, next) =>
+            Math.abs(next.relativeLuminance - reference.relativeLuminance) <
+            Math.abs(previous.relativeLuminance - reference.relativeLuminance)
+                ? next
+                : previous
+        );
+
+        return this.swatches.indexOf(closest);
+    }
+
+    /**
+     * Create a color palette from a provided swatch
+     * @param source - The source swatch to create a palette from
+     * @returns
+     */
+    static from(source: SwatchRGB) {
+        return new PaletteRGB(
+            source,
+            Object.freeze(
+                new ComponentStateColorPalette({
+                    baseColor: source,
+                }).palette.map(x => {
+                    const _x = parseColorHexRGB(x.toStringHexRGB())!;
+                    return new SwatchRGB(_x.r, _x.g, _x.b);
+                })
+            )
+        );
+    }
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/accent-fill.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/accent-fill.ts
@@ -1,0 +1,60 @@
+import { inRange } from "lodash";
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+import { isDark } from "../utilities/is-dark";
+
+/**
+ * @internal
+ */
+export function accentFill(
+    palette: Palette,
+    neutralPalette: Palette,
+    reference: Swatch,
+    textColor: Swatch,
+    contrastTarget: number,
+    hoverDelta: number,
+    activeDelta: number,
+    focusDelta: number,
+    selectedDelta: number,
+    neutralFillRestDelta: number,
+    neutralFillHoverDelta: number,
+    neutralFillActiveDelta: number
+) {
+    const accent = palette.source;
+    const referenceIndex = neutralPalette.closestIndexOf(reference);
+    const swapThreshold = Math.max(
+        neutralFillRestDelta,
+        neutralFillHoverDelta,
+        neutralFillActiveDelta
+    );
+    const direction = referenceIndex >= swapThreshold ? -1 : 1;
+    const paletteLength = palette.swatches.length;
+    const maxIndex = paletteLength - 1;
+    const accentIndex = palette.closestIndexOf(accent);
+    let accessibleOffset = 0;
+
+    while (
+        accessibleOffset < direction * hoverDelta &&
+        inRange(accentIndex + accessibleOffset + direction, 0, paletteLength) &&
+        textColor.contrast(palette.get(accentIndex + accessibleOffset + direction)) >=
+            contrastTarget &&
+        inRange(accentIndex + accessibleOffset + direction + direction, 0, maxIndex)
+    ) {
+        accessibleOffset += direction;
+    }
+
+    const hoverIndex = accentIndex + accessibleOffset;
+    const restIndex = hoverIndex + direction * -1 * hoverDelta;
+    const activeIndex = restIndex + direction * activeDelta;
+    const focusIndex = restIndex + direction * focusDelta;
+    const selectedIndex =
+        restIndex + (isDark(reference) ? selectedDelta * -1 : selectedDelta);
+
+    return {
+        rest: palette.get(restIndex),
+        hover: palette.get(hoverIndex),
+        active: palette.get(activeIndex),
+        focus: palette.get(focusIndex),
+        selected: palette.get(selectedIndex),
+    };
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/accent-foreground-cut.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/accent-foreground-cut.ts
@@ -1,0 +1,9 @@
+import { Swatch } from "../swatch";
+import { black, white } from "../utilities/color-constants";
+
+/**
+ * @internal
+ */
+export function accentForegroundCut(reference: Swatch, contrastTarget: number) {
+    return reference.contrast(white) >= contrastTarget ? white : black;
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/accent-foreground.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/accent-foreground.ts
@@ -1,0 +1,56 @@
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+import { directionByIsDark } from "../utilities/direction-by-is-dark";
+
+/**
+ * @internal
+ */
+export function accentForeground(
+    palette: Palette,
+    reference: Swatch,
+    contrastTarget: number,
+    restDelta: number,
+    hoverDelta: number,
+    activeDelta: number,
+    focusDelta: number
+) {
+    const accent = palette.source;
+    const accentIndex = palette.closestIndexOf(accent);
+    const direction = directionByIsDark(reference);
+    const startIndex =
+        accentIndex +
+        (direction === 1
+            ? Math.min(restDelta, hoverDelta)
+            : Math.max(direction * restDelta, direction * hoverDelta));
+    const accessibleSwatch = palette.colorContrast(
+        reference,
+        contrastTarget,
+        startIndex,
+        direction
+    );
+    const accessibleIndex1 = palette.closestIndexOf(accessibleSwatch);
+    const accessibleIndex2 =
+        accessibleIndex1 + direction * Math.abs(restDelta - hoverDelta);
+    const indexOneIsRestState =
+        direction === 1
+            ? restDelta < hoverDelta
+            : direction * restDelta > direction * hoverDelta;
+
+    let restIndex: number;
+    let hoverIndex: number;
+
+    if (indexOneIsRestState) {
+        restIndex = accessibleIndex1;
+        hoverIndex = accessibleIndex2;
+    } else {
+        restIndex = accessibleIndex2;
+        hoverIndex = accessibleIndex1;
+    }
+
+    return {
+        rest: palette.get(restIndex),
+        hover: palette.get(hoverIndex),
+        active: palette.get(restIndex + direction * activeDelta),
+        focus: palette.get(restIndex + direction * focusDelta),
+    };
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-divider.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-divider.ts
@@ -1,0 +1,17 @@
+import { Swatch } from "../swatch";
+import { Palette } from "../palette";
+import { directionByIsDark } from "../utilities/direction-by-is-dark";
+
+/**
+ * The neutralDivider color recipe
+ * @param palette - The palette to operate on
+ * @param reference - The reference color
+ * @param delta - The offset from the reference
+ *
+ * @internal
+ */
+export function neutralDivider(palette: Palette, reference: Swatch, delta: number) {
+    return palette.get(
+        palette.closestIndexOf(reference) + directionByIsDark(reference) * delta
+    );
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill-card.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill-card.ts
@@ -1,0 +1,11 @@
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+
+/**
+ * @internal
+ */
+export function neutralFillCard(palette: Palette, reference: Swatch, delta: number) {
+    const referenceIndex = palette.closestIndexOf(reference);
+
+    return palette.get(referenceIndex - (referenceIndex < delta ? delta * -1 : delta));
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill-input.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill-input.ts
@@ -1,0 +1,27 @@
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+import { directionByIsDark } from "../utilities/direction-by-is-dark";
+
+/**
+ * @internal
+ */
+export function neutralFillInput(
+    palette: Palette,
+    reference: Swatch,
+    restDelta: number,
+    hoverDelta: number,
+    activeDelta: number,
+    focusDelta: number,
+    selectedDelta: number
+) {
+    const direction = directionByIsDark(reference);
+    const referenceIndex = palette.closestIndexOf(reference);
+
+    return {
+        rest: palette.get(referenceIndex - direction * restDelta),
+        hover: palette.get(referenceIndex - direction * hoverDelta),
+        active: palette.get(referenceIndex - direction * activeDelta),
+        focus: palette.get(referenceIndex - direction * focusDelta),
+        selected: palette.get(referenceIndex - direction * selectedDelta),
+    };
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill-stealth.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill-stealth.ts
@@ -1,0 +1,41 @@
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+
+/**
+ * @internal
+ */
+export function neutralFillStealth(
+    palette: Palette,
+    reference: Swatch,
+    restDelta: number,
+    hoverDelta: number,
+    activeDelta: number,
+    focusDelta: number,
+    selectedDelta: number,
+    fillRestDelta: number,
+    fillHoverDelta: number,
+    fillActiveDelta: number,
+    fillFocusDelta: number
+) {
+    const swapThreshold = Math.max(
+        restDelta,
+        hoverDelta,
+        activeDelta,
+        focusDelta,
+        fillRestDelta,
+        fillHoverDelta,
+        fillActiveDelta,
+        fillFocusDelta
+    );
+
+    const referenceIndex = palette.closestIndexOf(reference);
+    const direction: 1 | -1 = referenceIndex >= swapThreshold ? -1 : 1;
+
+    return {
+        rest: palette.get(referenceIndex + direction * restDelta),
+        hover: palette.get(referenceIndex + direction * hoverDelta),
+        active: palette.get(referenceIndex + direction * activeDelta),
+        focus: palette.get(referenceIndex + direction * focusDelta),
+        selected: palette.get(referenceIndex + direction * selectedDelta),
+    };
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill-toggle.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill-toggle.ts
@@ -1,0 +1,41 @@
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+import { directionByIsDark } from "../utilities/direction-by-is-dark";
+
+/**
+ * @internal
+ */
+export function neutralFillToggle(
+    palette: Palette,
+    reference: Swatch,
+    restDelta: number,
+    hoverDelta: number,
+    activeDelta: number,
+    focusDelta: number
+) {
+    const direction = directionByIsDark(reference);
+    const accessibleIndex = palette.closestIndexOf(palette.colorContrast(reference, 4.5));
+    const accessibleIndex2 =
+        accessibleIndex + direction * Math.abs(restDelta - hoverDelta);
+    const indexOneIsRest =
+        direction === 1
+            ? restDelta < hoverDelta
+            : direction * restDelta > direction * hoverDelta;
+    let restIndex: number;
+    let hoverIndex: number;
+
+    if (indexOneIsRest) {
+        restIndex = accessibleIndex;
+        hoverIndex = accessibleIndex2;
+    } else {
+        restIndex = accessibleIndex2;
+        hoverIndex = accessibleIndex;
+    }
+
+    return {
+        rest: palette.get(restIndex),
+        hover: palette.get(hoverIndex),
+        active: palette.get(restIndex + direction * activeDelta),
+        focus: palette.get(restIndex + direction * focusDelta),
+    };
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-fill.ts
@@ -1,0 +1,34 @@
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+
+/**
+ *
+ * @param palette - The palette to operate on
+ * @param reference - The reference color to calculate a color for
+ * @param delta - The offset from the reference's location
+ * @param threshold - Determines if a lighter or darker color than the reference will be picked.
+ * @returns
+ *
+ * @internal
+ */
+export function neutralFill(
+    palette: Palette,
+    reference: Swatch,
+    restDelta: number,
+    hoverDelta: number,
+    activeDelta: number,
+    focusDelta: number,
+    selectedDelta: number
+) {
+    const referenceIndex = palette.closestIndexOf(reference);
+    const threshold = Math.max(restDelta, hoverDelta, activeDelta, focusDelta);
+    const direction = referenceIndex >= threshold ? -1 : 1;
+
+    return {
+        rest: palette.get(referenceIndex + direction * restDelta),
+        hover: palette.get(referenceIndex + direction * hoverDelta),
+        active: palette.get(referenceIndex + direction * activeDelta),
+        focus: palette.get(referenceIndex + direction * focusDelta),
+        selected: palette.get(referenceIndex + direction * selectedDelta),
+    };
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-focus.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-focus.ts
@@ -1,0 +1,9 @@
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+
+/**
+ * @internal
+ */
+export function neutralFocus(palette: Palette, reference: Swatch) {
+    return palette.colorContrast(reference, 3.5);
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-foreground-hint.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-foreground-hint.ts
@@ -1,0 +1,13 @@
+import { Swatch } from "../swatch";
+import { Palette } from "../palette";
+
+/**
+ * The neutralForegroundHint color recipe
+ * @param palette - The palette to operate on
+ * @param reference - The reference color
+ *
+ * @internal
+ */
+export function neutralForegroundHint(palette: Palette, reference: Swatch) {
+    return palette.colorContrast(reference, 4.5);
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-foreground.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-foreground.ts
@@ -1,0 +1,9 @@
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+
+/**
+ * @internal
+ */
+export function neutralForeground(palette: Palette, reference: Swatch) {
+    return palette.colorContrast(reference, 14);
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-layer-card.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-layer-card.ts
@@ -1,0 +1,17 @@
+import { Palette } from "../palette";
+import { SwatchRGB } from "../swatch";
+
+/**
+ * @internal
+ */
+export function neutralLayerCard(
+    palette: Palette,
+    relativeLuminance: number,
+    cardDelta: number
+) {
+    return palette.get(
+        palette.closestIndexOf(
+            new SwatchRGB(relativeLuminance, relativeLuminance, relativeLuminance)
+        ) - cardDelta
+    );
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-layer-floating.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-layer-floating.ts
@@ -1,0 +1,16 @@
+import { Palette } from "../palette";
+import { neutralLayerCard } from "./neutral-layer-card";
+
+/**
+ * @internal
+ */
+export function neutralLayerFloating(
+    palette: Palette,
+    relativeLuminance: number,
+    cardDelta: number
+) {
+    const cardIndex = palette.closestIndexOf(
+        neutralLayerCard(palette, relativeLuminance, cardDelta)
+    );
+    return palette.get(cardIndex - cardDelta);
+}

--- a/packages/web-components/fast-components/src/color-vNext/recipes/neutral-outline.ts
+++ b/packages/web-components/fast-components/src/color-vNext/recipes/neutral-outline.ts
@@ -1,0 +1,30 @@
+import { Palette } from "../palette";
+import { Swatch } from "../swatch";
+import { directionByIsDark } from "../utilities/direction-by-is-dark";
+
+/**
+ * @internal
+ */
+export function neutralOutline(
+    palette: Palette,
+    reference: Swatch,
+    restDelta: number,
+    hoverDelta: number,
+    activeDelta: number,
+    focusDelta: number
+) {
+    const referenceIndex = palette.closestIndexOf(reference);
+    const direction = directionByIsDark(reference);
+
+    const restIndex = referenceIndex + direction * restDelta;
+    const hoverIndex = restIndex + direction * (hoverDelta - restDelta);
+    const activeIndex = restIndex + direction * (activeDelta - restDelta);
+    const focusIndex = restIndex + direction * (focusDelta - restDelta);
+
+    return {
+        rest: palette.get(restIndex),
+        hover: palette.get(hoverIndex),
+        active: palette.get(activeIndex),
+        focus: palette.get(focusIndex),
+    };
+}

--- a/packages/web-components/fast-components/src/color-vNext/swatch.ts
+++ b/packages/web-components/fast-components/src/color-vNext/swatch.ts
@@ -1,0 +1,33 @@
+import { ColorRGBA64, rgbToRelativeLuminance } from "@microsoft/fast-colors";
+import { contrast, RelativeLuminance } from "./utilities/relative-luminance";
+
+/**
+ * Represents a color in a {@link Palette}
+ * @public
+ */
+export interface Swatch extends RelativeLuminance {
+    toColorString(): string;
+    contrast(target: RelativeLuminance): number;
+}
+
+/**
+ * A RGB implementation of {@link Swatch}
+ * @public
+ */
+export class SwatchRGB extends ColorRGBA64 implements Swatch {
+    readonly relativeLuminance: number;
+
+    /**
+     *
+     * @param red - Red channel expressed as a number between 0 and 1
+     * @param green - Green channel expressed as a number between 0 and 1
+     * @param blue - Blue channel expressed as a number between 0 and 1
+     */
+    constructor(red: number, green: number, blue: number) {
+        super(red, green, blue, 1);
+        this.relativeLuminance = rgbToRelativeLuminance(this);
+    }
+
+    public toColorString = this.toStringHexRGB;
+    public contrast = contrast.bind(null, this);
+}

--- a/packages/web-components/fast-components/src/color-vNext/utilities/binary-search.ts
+++ b/packages/web-components/fast-components/src/color-vNext/utilities/binary-search.ts
@@ -1,0 +1,31 @@
+/**
+ * @internal
+ */
+export function binarySearch<T>(
+    valuesToSearch: T[] | ReadonlyArray<T>,
+    searchCondition: (value: T) => boolean,
+    startIndex: number = 0,
+    endIndex: number = valuesToSearch.length - 1
+): T {
+    if (endIndex === startIndex) {
+        return valuesToSearch[startIndex];
+    }
+
+    const middleIndex: number = Math.floor((endIndex - startIndex) / 2) + startIndex;
+
+    // Check to see if this passes on the item in the center of the array
+    // if it does check the previous values
+    return searchCondition(valuesToSearch[middleIndex])
+        ? binarySearch(
+              valuesToSearch,
+              searchCondition,
+              startIndex,
+              middleIndex // include this index because it passed the search condition
+          )
+        : binarySearch(
+              valuesToSearch,
+              searchCondition,
+              middleIndex + 1, // exclude this index because it failed the search condition
+              endIndex
+          );
+}

--- a/packages/web-components/fast-components/src/color-vNext/utilities/color-constants.ts
+++ b/packages/web-components/fast-components/src/color-vNext/utilities/color-constants.ts
@@ -1,0 +1,10 @@
+import { SwatchRGB } from "../swatch";
+
+/**
+ * @internal
+ */
+export const white = new SwatchRGB(1, 1, 1);
+/**
+ * @internal
+ */
+export const black = new SwatchRGB(0, 0, 0);

--- a/packages/web-components/fast-components/src/color-vNext/utilities/direction-by-is-dark.ts
+++ b/packages/web-components/fast-components/src/color-vNext/utilities/direction-by-is-dark.ts
@@ -1,0 +1,9 @@
+import { Swatch } from "../swatch";
+import { isDark } from "./is-dark";
+
+/**
+ * @internal
+ */
+export function directionByIsDark(color: Swatch): 1 | -1 {
+    return isDark(color) ? -1 : 1;
+}

--- a/packages/web-components/fast-components/src/color-vNext/utilities/is-dark.ts
+++ b/packages/web-components/fast-components/src/color-vNext/utilities/is-dark.ts
@@ -1,0 +1,20 @@
+import { Swatch } from "../swatch";
+
+/*
+ * A color is in "dark" if there is more contrast between #000000 and a reference
+ * color than #FFFFFF and the reference color. That threshold can be expressed as a relative luminance
+ * using the contrast formula as (1 + 0.5) / (R + 0.05) === (R + 0.05) / (0 + 0.05),
+ * which reduces to the following, where 'R' is the relative luminance of the reference color
+ */
+const target = (-0.1 + Math.sqrt(0.21)) / 2;
+
+/**
+ * Determines if a color should be considered Dark Mode
+ * @param color - The color to check to mode of
+ * @returns boolean
+ *
+ * @internal
+ */
+export function isDark(color: Swatch): boolean {
+    return color.relativeLuminance <= target;
+}

--- a/packages/web-components/fast-components/src/color-vNext/utilities/relative-luminance.ts
+++ b/packages/web-components/fast-components/src/color-vNext/utilities/relative-luminance.ts
@@ -1,0 +1,19 @@
+/**
+ * @public
+ */
+export interface RelativeLuminance {
+    /**
+     * A number between 0 and 1, calculated by {@link https://www.w3.org/WAI/GL/wiki/Relative_luminance}
+     */
+    readonly relativeLuminance: number;
+}
+
+/**
+ * @internal
+ */
+export function contrast(a: RelativeLuminance, b: RelativeLuminance): number {
+    const L1 = a.relativeLuminance > b.relativeLuminance ? a : b;
+    const L2 = a.relativeLuminance > b.relativeLuminance ? b : a;
+
+    return (L1.relativeLuminance + 0.05) / (L2.relativeLuminance + 0.05);
+}

--- a/packages/web-components/fast-components/src/color/accent-fill.spec.ts
+++ b/packages/web-components/fast-components/src/color/accent-fill.spec.ts
@@ -1,11 +1,11 @@
 import { expect } from "chai";
 import { FASTDesignSystem, fastDesignSystemDefaults } from "../fast-design-system";
 import {
-    accentBaseColor,
     accentPalette as getAccentPalette,
     neutralPalette as getNeutralPalette,
 } from "../fast-design-system";
 import {
+    accentFill,
     accentFillActive,
     accentFillHover,
     accentFillLargeActive,
@@ -17,6 +17,12 @@ import {
 } from "./accent-fill";
 import { findClosestSwatchIndex, Palette } from "./palette";
 import { contrast, Swatch } from "./common";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
+import { neutralBaseColor, accentBaseColor } from "./color-constants";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
+import { accentFill as accentFillNew } from "../color-vNext/recipes/accent-fill";
+import { accentForegroundCut as accentForegroundCutNew  } from '../color-vNext/recipes/accent-foreground-cut';
 import { accentForegroundCut } from "./accent-foreground-cut";
 
 describe("accentFill", (): void => {
@@ -25,7 +31,7 @@ describe("accentFill", (): void => {
 
     const accentIndex: number = findClosestSwatchIndex(
         getAccentPalette,
-        accentBaseColor(fastDesignSystemDefaults)
+        accentBaseColor
     )(fastDesignSystemDefaults);
 
     it("should operate on design system defaults", (): void => {
@@ -90,3 +96,43 @@ describe("accentFill", (): void => {
         });
     });
 });
+describe("ensure parity between old and new recipe implementation", () => {
+    const neutralColor = (parseColorHexRGB(neutralBaseColor)!)
+    const neutralPalette = PaletteRGB.from(new SwatchRGB(neutralColor.r, neutralColor.g, neutralColor.b));
+    const accentColor = (parseColorHexRGB(accentBaseColor)!)
+    const accentPalette = PaletteRGB.from(new SwatchRGB(accentColor.r, accentColor.g, accentColor.b));
+    neutralPalette.swatches.forEach(( newSwatch, index ) => {
+        const {
+            accentFillHoverDelta,
+            accentFillActiveDelta,
+            accentFillFocusDelta,
+            accentFillSelectedDelta,
+            neutralFillRestDelta,
+            neutralFillHoverDelta,
+            neutralFillActiveDelta,
+        } = fastDesignSystemDefaults;
+           
+        const oldValues = accentFill({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]});
+        const textColor = accentForegroundCutNew(accentPalette.source, 4.5);
+        const newValues = accentFillNew(
+            accentPalette,
+            neutralPalette,
+            newSwatch, 
+            textColor, 
+            4.5, 
+            accentFillHoverDelta, 
+            accentFillActiveDelta, 
+            accentFillFocusDelta, 
+            accentFillSelectedDelta,
+            neutralFillRestDelta,
+            neutralFillHoverDelta,
+            neutralFillActiveDelta
+            )
+
+            for (let key in oldValues) {
+                it(`${newSwatch.toColorString()}old value for ${key} at ${oldValues[key]} should be equal to new value`, () => {
+                    expect(oldValues[key]).to.equal(newValues[key].toColorString().toUpperCase())
+                } ) 
+            }
+    })
+})

--- a/packages/web-components/fast-components/src/color/accent-foreground-cut.spec.ts
+++ b/packages/web-components/fast-components/src/color/accent-foreground-cut.spec.ts
@@ -1,7 +1,12 @@
+import { parseColorHexRGB } from "@microsoft/fast-colors";
 import { expect } from "chai";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
 import { FASTDesignSystem, fastDesignSystemDefaults } from "../fast-design-system";
 import { accentForegroundCut, accentForegroundCutLarge } from "./accent-foreground-cut";
+import { neutralBaseColor, accentBaseColor } from "./color-constants";
 import { Swatch } from "./common";
+import { accentForegroundCut as accentForegroundCutNew } from "../color-vNext/recipes/accent-foreground-cut";
 
 describe("Cut text", (): void => {
     it("should return white by by default", (): void => {
@@ -28,3 +33,19 @@ describe("Cut text", (): void => {
         ).to.equal("#000000");
     });
 });
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(accentBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    it(
+        `should be the same for ${palette.source}`,
+        () => {
+            expect(
+                accentForegroundCut(
+                    { ...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.accentBaseColor }
+                )
+            ).to.be.equal(
+                accentForegroundCutNew(palette.source, 4.5).toColorString().toUpperCase()
+            )
+        }
+    )
+})

--- a/packages/web-components/fast-components/src/color/accent-foreground.spec.ts
+++ b/packages/web-components/fast-components/src/color/accent-foreground.spec.ts
@@ -12,9 +12,14 @@ import {
     accentForegroundLargeHover,
     accentForegroundLargeRest,
     accentForegroundRest,
+    accentForeground
 } from "./accent-foreground";
 import { Palette } from "./palette";
 import { contrast, Swatch } from "./common";
+import { accentBaseColor, neutralBaseColor } from "./color-constants";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
+import { accentForeground as accentForegroundNew } from "../color-vNext/recipes/accent-foreground";
 
 describe("accentForeground", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);
@@ -119,5 +124,42 @@ describe("accentForeground", (): void => {
                 });
             }
         );
+    });
+});
+
+describe("ensure parity between old and new recipe implementation", () => {
+    const neutralBase = parseColorHexRGB(neutralBaseColor)!;
+    const accentBase = parseColorHexRGB(accentBaseColor)!;
+
+    const neutralPalette = PaletteRGB.from(new SwatchRGB(neutralBase.r, neutralBase.g, neutralBase.b));
+    const accentPalette = PaletteRGB.from(new SwatchRGB(accentBase.r, accentBase.g, accentBase.b));
+    
+    neutralPalette.swatches.forEach((newSwatch, index) => {
+        const {
+            accentForegroundRestDelta,
+            accentForegroundFocusDelta,
+            accentForegroundActiveDelta,
+            accentForegroundHoverDelta
+        } = fastDesignSystemDefaults;
+        const oldValues = accentForeground({
+            ...fastDesignSystemDefaults,
+            backgroundColor: fastDesignSystemDefaults.neutralPalette[index],
+        });
+        const newValues = accentForegroundNew(
+            accentPalette,
+            newSwatch,
+            4.5,
+            accentForegroundRestDelta,
+            accentForegroundHoverDelta,
+            accentForegroundActiveDelta,
+            accentForegroundFocusDelta,
+        );
+        it(`should be the same for ${newSwatch}`, () => {
+            for (let key in newValues) {
+                expect(oldValues[key]).to.equal(
+                    newValues[key].toColorString().toUpperCase()
+                );
+            }
+        });
     });
 });

--- a/packages/web-components/fast-components/src/color/accent-foreground.ts
+++ b/packages/web-components/fast-components/src/color/accent-foreground.ts
@@ -66,7 +66,6 @@ function accentForegroundAlgorithm(
             designSystem // Pass the design system
         );
 
-        // One of these will be rest, the other will be hover. Depends on the offsets and the direction.
         const accessibleIndex1: number = findSwatchIndex(
             accentPalette,
             accessibleSwatch

--- a/packages/web-components/fast-components/src/color/neutral-divider.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-divider.spec.ts
@@ -1,5 +1,10 @@
+import { ColorRGBA64, parseColorHexRGB } from "@microsoft/fast-colors";
 import { expect } from "chai";
+import { PaletteRGB } from "../color-vNext/palette";
+import { neutralDivider } from "../color-vNext/recipes/neutral-divider";
+import { SwatchRGB } from "../color-vNext/swatch";
 import { fastDesignSystemDefaults } from "../fast-design-system";
+import { neutralBaseColor } from "./color-constants";
 import { neutralDividerRest } from "./neutral-divider";
 
 describe("neutralDividerRest", (): void => {
@@ -11,3 +16,16 @@ describe("neutralDividerRest", (): void => {
         expect(typeof neutralDividerRest(() => "#FFF")).to.equal("function");
     });
 });
+
+
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    palette.swatches.forEach(( newSwatch, index ) => {
+        it(`should be the same for ${newSwatch}`, () => {
+            expect(neutralDivider(palette, newSwatch, fastDesignSystemDefaults.neutralDividerRestDelta).toColorString().toUpperCase()).to.equal(
+                neutralDividerRest({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]})
+            )
+        })
+    })
+})

--- a/packages/web-components/fast-components/src/color/neutral-fill-card.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill-card.spec.ts
@@ -1,6 +1,11 @@
+import { parseColorHexRGB } from "@microsoft/fast-colors";
 import { expect } from "chai";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
 import { FASTDesignSystem, fastDesignSystemDefaults } from "../fast-design-system";
+import { neutralBaseColor } from "./color-constants";
 import { neutralFillCard } from "./neutral-fill-card";
+import { neutralFillCard as neutralFillCardNew } from "../color-vNext/recipes/neutral-fill-card"
 
 describe("neutralFillCard", (): void => {
     it("should operate on design system defaults", (): void => {
@@ -42,3 +47,15 @@ describe("neutralFillCard", (): void => {
         ).to.equal(fastDesignSystemDefaults.neutralPalette[1]);
     });
 });
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    const { neutralFillCardDelta } = fastDesignSystemDefaults;
+    palette.swatches.forEach(( newSwatch, index ) => {
+            it(`should be the same for ${newSwatch}`, () => {
+                expect(
+                    neutralFillCard({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]})
+                ).to.be.equal(neutralFillCardNew( palette, newSwatch, neutralFillCardDelta).toColorString().toUpperCase())
+        });
+    })
+})

--- a/packages/web-components/fast-components/src/color/neutral-fill-input.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill-input.spec.ts
@@ -1,9 +1,13 @@
+import { parseColorHexRGB } from "@microsoft/fast-colors";
 import { expect } from "chai";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
 import { FASTDesignSystem, fastDesignSystemDefaults } from "../fast-design-system";
 import {
     accentPalette as getAccentPalette,
     neutralPalette as getNeutralPalette,
 } from "../fast-design-system";
+import { neutralBaseColor } from "./color-constants";
 import { clamp, FillSwatchFamily, Swatch } from "./common";
 import {
     neutralFillInput,
@@ -14,6 +18,7 @@ import {
     neutralFillInputSelected,
 } from "./neutral-fill-input";
 import { isDarkMode, Palette } from "./palette";
+import { neutralFillInput as neutralFillInputNew } from "../color-vNext/recipes/neutral-fill-input";
 
 describe("neutralFillInput", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);
@@ -128,3 +133,31 @@ describe("neutralFillInput", (): void => {
         });
     });
 });
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    palette.swatches.forEach(( newSwatch, index ) => {
+        const {
+            neutralFillInputRestDelta,
+            neutralFillInputHoverDelta,
+            neutralFillInputActiveDelta,
+            neutralFillInputFocusDelta,
+            neutralFillInputSelectedDelta
+        } = fastDesignSystemDefaults;
+        const oldValues = neutralFillInput({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]});
+        const newValues = neutralFillInputNew(
+            palette,
+            newSwatch,
+            neutralFillInputRestDelta,
+            neutralFillInputHoverDelta,
+            neutralFillInputActiveDelta,
+            neutralFillInputFocusDelta,
+            neutralFillInputSelectedDelta
+        );
+            it(`should be the same for ${newSwatch}`, () => {
+                for (let key in oldValues) {
+                    expect(oldValues[key]).to.equal(newValues[key].toColorString().toUpperCase())
+                }
+        });
+    })
+})

--- a/packages/web-components/fast-components/src/color/neutral-fill-stealth.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill-stealth.spec.ts
@@ -14,6 +14,11 @@ import {
 } from "./neutral-fill-stealth";
 import { Palette } from "./palette";
 import { FillSwatchFamily, Swatch } from "./common";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
+import { neutralBaseColor } from "./color-constants";
+import { neutralFillStealth as neutralFillStealthNew } from "../color-vNext/recipes/neutral-fill-stealth";
 
 describe("neutralFillStealth", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);
@@ -110,3 +115,39 @@ describe("neutralFillStealth", (): void => {
         });
     });
 });
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    palette.swatches.forEach(( newSwatch, index ) => {
+        const {
+            neutralFillStealthRestDelta,
+            neutralFillStealthHoverDelta,
+            neutralFillStealthActiveDelta,
+            neutralFillStealthFocusDelta,
+            neutralFillStealthSelectedDelta,
+            neutralFillRestDelta,
+            neutralFillHoverDelta,
+            neutralFillActiveDelta,
+            neutralFillFocusDelta
+        } = fastDesignSystemDefaults;
+        const oldValues = neutralFillStealth({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]});
+        const newValues = neutralFillStealthNew(
+            palette,
+            newSwatch,
+            neutralFillStealthRestDelta,
+            neutralFillStealthHoverDelta,
+            neutralFillStealthActiveDelta,
+            neutralFillStealthFocusDelta,
+            neutralFillStealthSelectedDelta,
+            neutralFillRestDelta,
+            neutralFillHoverDelta,
+            neutralFillActiveDelta,
+            neutralFillFocusDelta
+        );
+            it(`should be the same for ${newSwatch}`, () => {
+                for (let key in oldValues) {
+                    expect(oldValues[key]).to.equal(newValues[key].toColorString().toUpperCase())
+                }
+        });
+    })
+})

--- a/packages/web-components/fast-components/src/color/neutral-fill-toggle.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill-toggle.spec.ts
@@ -1,0 +1,30 @@
+import { parseColorHexRGB } from "@microsoft/fast-colors";
+import { expect } from "chai";
+import { PaletteRGB } from "../color-vNext/palette";
+import { neutralFillToggle as neutralFillToggleNew } from "../color-vNext/recipes/neutral-fill-toggle";
+import { SwatchRGB } from "../color-vNext/swatch";
+import { fastDesignSystemDefaults } from "../fast-design-system";
+import { neutralBaseColor } from "./color-constants";
+import { neutralFillToggle } from "./neutral-fill-toggle";
+
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    palette.swatches.forEach(( newSwatch, index ) => {
+        const { neutralFillToggleHoverDelta, neutralFillToggleActiveDelta, neutralFillToggleFocusDelta} = fastDesignSystemDefaults;
+        const oldValues = neutralFillToggle({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]});
+        const newValues = neutralFillToggleNew(
+            palette,
+            newSwatch,
+            0,
+            neutralFillToggleHoverDelta,
+            neutralFillToggleActiveDelta,
+            neutralFillToggleFocusDelta,
+        );
+            it(`should be the same for ${newSwatch}`, () => {
+                for (let key in oldValues) {
+                    expect(oldValues[key]).to.equal(newValues[key].toColorString().toUpperCase())
+                }
+        });
+    })
+})

--- a/packages/web-components/fast-components/src/color/neutral-fill.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-fill.spec.ts
@@ -14,6 +14,11 @@ import {
 } from "./neutral-fill";
 import { Palette } from "./palette";
 import { FillSwatchFamily, Swatch } from "./common";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
+import { neutralBaseColor } from "./color-constants";
+import { SwatchRGB } from "../color-vNext/swatch";
+import { PaletteRGB } from "../color-vNext/palette";
+import { neutralFill as neutralFillNew } from "../color-vNext/recipes/neutral-fill"
 
 describe("neutralFill", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);
@@ -98,3 +103,17 @@ describe("neutralFill", (): void => {
         });
     });
 });
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    palette.swatches.forEach(( newSwatch, index ) => {
+        const { neutralFillRestDelta, neutralFillHoverDelta, neutralFillActiveDelta, neutralFillFocusDelta, neutralFillSelectedDelta } = fastDesignSystemDefaults;
+        const oldValues = neutralFill({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]});
+        const newValues = neutralFillNew(palette, newSwatch, neutralFillRestDelta, neutralFillHoverDelta, neutralFillActiveDelta, neutralFillFocusDelta, neutralFillSelectedDelta );
+            it(`should be the same for ${newSwatch}`, () => {
+                for (let key in oldValues) {
+                    expect(oldValues[key]).to.equal(newValues[key].toColorString().toUpperCase())
+                }
+        });
+    })
+})

--- a/packages/web-components/fast-components/src/color/neutral-focus.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-focus.spec.ts
@@ -2,6 +2,11 @@ import { expect } from "chai";
 import { FASTDesignSystem, fastDesignSystemDefaults } from "../fast-design-system";
 import { neutralFocus } from "./neutral-focus";
 import { contrast } from "./common";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
+import { neutralBaseColor } from "./color-constants";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
+import { neutralFocus as neutralFocusNew } from "../color-vNext/recipes/neutral-focus";
 
 describe("neutralFocus", (): void => {
     it("should return a string when invoked with an object", (): void => {
@@ -16,3 +21,13 @@ describe("neutralFocus", (): void => {
         expect(contrast(neutralFocus({} as FASTDesignSystem), "#FFF")).to.be.gte(3.5);
     });
 });
+
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    palette.swatches.forEach(( newSwatch, index ) => {
+            it(`should be the same for ${newSwatch}`, () => {
+                expect(neutralFocus({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]})).to.be.equal(neutralFocusNew( palette, newSwatch).toColorString().toUpperCase())
+        });
+    })
+})

--- a/packages/web-components/fast-components/src/color/neutral-foreground-hint.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-foreground-hint.spec.ts
@@ -10,6 +10,11 @@ import {
 } from "./neutral-foreground-hint";
 import { Palette } from "./palette";
 import { contrast, Swatch, SwatchRecipe } from "./common";
+import { parseColorHexRGB } from "@microsoft/fast-colors";
+import { neutralBaseColor } from "./color-constants";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
+import { neutralForegroundHint as neutralForegroundHintNew } from "../color-vNext/recipes/neutral-foreground-hint";
 
 describe("neutralForegroundHint", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);
@@ -69,3 +74,15 @@ describe("neutralForegroundHint", (): void => {
         });
     });
 });
+
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    palette.swatches.forEach(( newSwatch, index ) => {
+        it(`should be the same for ${newSwatch}`, () => {
+            expect(neutralForegroundHintNew(palette, newSwatch).toColorString().toUpperCase()).to.equal(
+                neutralForegroundHint({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]})
+            )
+        })
+    })
+})

--- a/packages/web-components/fast-components/src/color/neutral-foreground.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-foreground.spec.ts
@@ -1,11 +1,16 @@
+import { parseColorHexRGB } from "@microsoft/fast-colors";
 import { expect } from "chai";
+import { PaletteRGB } from "../color-vNext/palette";
+import { neutralForeground } from "../color-vNext/recipes/neutral-foreground";
+import { SwatchRGB } from "../color-vNext/swatch";
 import { fastDesignSystemDefaults } from "../fast-design-system";
+import { neutralBaseColor } from "./color-constants";
+import { contrast } from "./common";
 import {
     neutralForegroundActive,
     neutralForegroundHover,
-    neutralForegroundRest,
+    neutralForegroundRest
 } from "./neutral-foreground";
-import { contrast } from "./common";
 
 describe("neutralForeground", (): void => {
     it("should return a string when invoked with an object", (): void => {
@@ -125,3 +130,13 @@ describe("neutralForeground", (): void => {
         ).to.be.gte(14);
     });
 });
+
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    palette.swatches.forEach(( newSwatch, index ) => {
+            it(`should be the same for ${newSwatch}`, () => {
+                expect(neutralForegroundRest({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]})).to.be.equal(neutralForeground( palette, newSwatch).toColorString().toUpperCase())
+        });
+    })
+})

--- a/packages/web-components/fast-components/src/color/neutral-foreground.ts
+++ b/packages/web-components/fast-components/src/color/neutral-foreground.ts
@@ -4,6 +4,7 @@ import {
     neutralForegroundHoverDelta,
     neutralPalette,
 } from "../fast-design-system";
+import { accessibleAlgorithm } from "./accessible-recipe";
 import {
     colorRecipeFactory,
     SwatchFamilyResolver,
@@ -11,7 +12,6 @@ import {
     SwatchFamilyType,
     SwatchRecipe,
 } from "./common";
-import { accessibleAlgorithm } from "./accessible-recipe";
 
 /**
  * @internal

--- a/packages/web-components/fast-components/src/color/neutral-layer.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-layer.spec.ts
@@ -10,6 +10,16 @@ import {
     neutralLayerL4,
     StandardLuminance,
 } from "./neutral-layer";
+import {
+    neutralLayerFloating as neutralLayerFloatingNew
+} from '../color-vNext/recipes/neutral-layer-floating';
+import {
+    neutralLayerCard as neutralLayerCardNew
+} from '../color-vNext/recipes/neutral-layer-card';
+import { parseColorHexRGB } from "@microsoft/fast-colors";
+import { neutralBaseColor } from "./color-constants";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
 
 const lightModeDesignSystem: FASTDesignSystem = Object.assign(
     {},
@@ -159,6 +169,13 @@ describe("neutralLayer", (): void => {
             expect(color).not.to.equal(neutralLayerFloating(fastDesignSystemDefaults));
             expect(fastDesignSystemDefaults.neutralPalette.includes(color)).to.be.ok;
         });
+        
+        it("should have a new implementation that matches the old implementation", () => {
+             const color = (parseColorHexRGB(neutralBaseColor)!)
+            const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+            expect(neutralLayerFloating(lightModeDesignSystem)).to.equal(neutralLayerFloatingNew(palette, StandardLuminance.LightMode, lightModeDesignSystem.neutralFillCardDelta).toColorString().toUpperCase())
+            expect(neutralLayerFloating(darkModeDesignSystem)).to.equal(neutralLayerFloatingNew(palette, StandardLuminance.DarkMode, lightModeDesignSystem.neutralFillCardDelta).toColorString().toUpperCase())
+        })
     });
     describe("neutralLayerCardContainer", (): void => {
         it("should return a color from the neutral palette", (): void => {
@@ -195,5 +212,11 @@ describe("neutralLayer", (): void => {
             expect(color).not.to.equal(neutralLayerCard(fastDesignSystemDefaults));
             expect(fastDesignSystemDefaults.neutralPalette.includes(color)).to.be.ok;
         });
+        it("should have a new implementation that matches the old implementation", () => {
+             const color = (parseColorHexRGB(neutralBaseColor)!)
+            const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+            expect(neutralLayerCard(lightModeDesignSystem)).to.equal(neutralLayerCardNew(palette, StandardLuminance.LightMode, lightModeDesignSystem.neutralFillCardDelta).toColorString().toUpperCase())
+            expect(neutralLayerCard(darkModeDesignSystem)).to.equal(neutralLayerCardNew(palette, StandardLuminance.DarkMode, lightModeDesignSystem.neutralFillCardDelta).toColorString().toUpperCase())
+        })
     });
 });

--- a/packages/web-components/fast-components/src/color/neutral-outline.spec.ts
+++ b/packages/web-components/fast-components/src/color/neutral-outline.spec.ts
@@ -1,4 +1,4 @@
-import { isColorStringHexRGB } from "@microsoft/fast-colors";
+import { isColorStringHexRGB, parseColorHexRGB } from "@microsoft/fast-colors";
 import { expect } from "chai";
 import { FASTDesignSystem, fastDesignSystemDefaults } from "../fast-design-system";
 import {
@@ -14,6 +14,10 @@ import {
 } from "./neutral-outline";
 import { Palette } from "./palette";
 import { Swatch, SwatchFamily } from "./common";
+import { neutralBaseColor } from "./color-constants";
+import { PaletteRGB } from "../color-vNext/palette";
+import { SwatchRGB } from "../color-vNext/swatch";
+import { neutralOutline as neutralOutlineNew } from "../color-vNext/recipes/neutral-outline"
 
 describe("neutralOutline", (): void => {
     const neutralPalette: Palette = getNeutralPalette(fastDesignSystemDefaults);
@@ -98,3 +102,25 @@ describe("neutralOutline", (): void => {
         });
     });
 });
+
+describe("ensure parity between old and new recipe implementation", () => {
+    const color = (parseColorHexRGB(neutralBaseColor)!)
+    const palette = PaletteRGB.from(new SwatchRGB(color.r, color.g, color.b));
+    palette.swatches.forEach(( newSwatch, index ) => {
+        const { neutralOutlineRestDelta, neutralOutlineHoverDelta, neutralOutlineFocusDelta, neutralOutlineActiveDelta } = fastDesignSystemDefaults;
+        const oldValues = neutralOutline({...fastDesignSystemDefaults, backgroundColor: fastDesignSystemDefaults.neutralPalette[index]});
+        const newValues = neutralOutlineNew(
+            palette,
+            newSwatch,
+            neutralOutlineRestDelta,
+            neutralOutlineHoverDelta,
+            neutralOutlineActiveDelta,
+            neutralOutlineFocusDelta,
+        );
+            it(`should be the same for ${newSwatch}`, () => {
+                for (let key in oldValues) {
+                    expect(oldValues[key]).to.equal(newValues[key].toColorString().toUpperCase())
+                }
+        });
+    })
+})

--- a/packages/web-components/fast-components/src/combobox/combobox.styles.ts
+++ b/packages/web-components/fast-components/src/combobox/combobox.styles.ts
@@ -1,9 +1,9 @@
 import { css } from "@microsoft/fast-element";
 import { disabledCursor, focusVisible } from "@microsoft/fast-foundation";
-import { SelectStyles } from "../select/select.styles";
+import { selectStyles } from "../select/select.styles";
 
-export const ComboboxStyles = css`
-    ${SelectStyles}
+export const comboboxStyles = (context, definition) => css`
+    ${selectStyles(context, definition)}
 
     :host(:empty) .listbox {
         display: none;

--- a/packages/web-components/fast-components/src/combobox/combobox.styles.ts
+++ b/packages/web-components/fast-components/src/combobox/combobox.styles.ts
@@ -1,5 +1,10 @@
 import { css } from "@microsoft/fast-element";
 import { disabledCursor, focusVisible } from "@microsoft/fast-foundation";
+import {
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
 import { selectStyles } from "../select/select.styles";
 
 export const comboboxStyles = (context, definition) => css`
@@ -20,9 +25,9 @@ export const comboboxStyles = (context, definition) => css`
         background: transparent;
         border: none;
         color: inherit;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
-        height: calc(100% - (var(--outline-width) * 1px));
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
+        height: calc(100% - (${outlineWidth} * 1px));
         margin: auto 0;
         width: 100%;
     }

--- a/packages/web-components/fast-components/src/combobox/index.ts
+++ b/packages/web-components/fast-components/src/combobox/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Combobox, ComboboxTemplate as template } from "@microsoft/fast-foundation";
-import { ComboboxStyles as styles } from "./combobox.styles";
+import { Combobox, comboboxTemplate as template } from "@microsoft/fast-foundation";
+import { comboboxStyles as styles } from "./combobox.styles";
 
 /**
- * The FAST Combobox Custom Element. Implements {@link @microsoft/fast-foundation#Combobox|Combobox},
- * {@link @microsoft/fast-foundation#ComboboxTemplate|ComboboxTemplate}
+ * The FAST Combobox Custom Element. Implements {@link @microsoft/fast-foundation#Combobox},
+ * {@link @microsoft/fast-foundation#comboboxTemplate}
  *
  * @public
  * @remarks
  * HTML Element: \<fast-combobox\>
  *
  */
-@customElement({
-    name: "fast-combobox",
+export const fastCombobox = Combobox.compose({
+    baseName: "combobox",
     template,
     styles,
-})
-export class FASTCombobox extends Combobox {}
+});
 
 /**
  * Styles for combobox

--- a/packages/web-components/fast-components/src/combobox/index.ts
+++ b/packages/web-components/fast-components/src/combobox/index.ts
@@ -20,4 +20,4 @@ export const fastCombobox = Combobox.compose({
  * Styles for combobox
  * @public
  */
-export const ComboboxStyles = styles;
+export const comboboxStyles = styles;

--- a/packages/web-components/fast-components/src/custom-elements.ts
+++ b/packages/web-components/fast-components/src/custom-elements.ts
@@ -1,0 +1,40 @@
+/**
+ * Export all custom element definitions
+ */
+export { fastAccordion, fastAccordionItem } from "./accordion/index";
+export { fastAnchor } from "./anchor/index";
+export { fastAnchoredRegion } from "./anchored-region/index";
+export { fastBadge } from "./badge/index";
+export { fastBreadcrumb } from "./breadcrumb/index";
+export { fastBreadcrumbItem } from "./breadcrumb-item/index";
+export { fastButton } from "./button/index";
+// export * from "./card/index";
+export { fastCheckbox } from "./checkbox/index";
+export { fastCombobox } from "./combobox/index";
+// export * from "./data-grid/index";
+// export * from "./design-system-provider/index";
+export { fastDialog } from "./dialog/index";
+export { fastDisclosure } from "./disclosure/index";
+export { fastDivider } from "./divider/index";
+export { fastFlipper } from "./flipper/index";
+export { fastHorizontalScroll } from "./horizontal-scroll/index";
+export { fastListbox } from "./listbox/index";
+export { fastOption } from "./listbox-option/index";
+export { fastMenu } from "./menu/index";
+export { fastMenuItem } from "./menu-item/index";
+export { fastNumberField } from "./number-field/index";
+export { fastProgress } from "./progress/index";
+export { fastProgressRing } from "./progress-ring/index";
+export { fastRadio } from "./radio/index";
+export { fastRadioGroup } from "./radio-group/index";
+export { fastSelect } from "./select/index";
+export { fastSkeleton } from "./skeleton/index";
+export { fastSlider } from "./slider/index";
+export { fastSliderLabel } from "./slider-label/index";
+export { fastSwitch } from "./switch/index";
+export { fastTabs, fastTab, fastTabPanel } from "./tabs/index";
+export { fastTextArea } from "./text-area/index";
+export { fastTextField } from "./text-field/index";
+export { fastTooltip } from "./tooltip/index";
+export { fastTreeView } from "./tree-view/index";
+export { fastTreeItem } from "./tree-item/index";

--- a/packages/web-components/fast-components/src/data-grid/data-grid-cell.styles.ts
+++ b/packages/web-components/fast-components/src/data-grid/data-grid-cell.styles.ts
@@ -6,20 +6,28 @@ import {
     neutralForegroundActiveBehavior,
     neutralForegroundRestBehavior,
 } from "../styles/recipes";
+import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
 
 export const DataGridCellStyles = css`
     :host {
-        padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 3px);
+        padding: calc(${designUnit} * 1px) calc(${designUnit} * 3px);
         color: ${neutralForegroundRestBehavior.var};
         box-sizing: border-box;
-        font-family: var(--body-font);
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-family: ${bodyFont};
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
         font-weight: 400;
-        border: transparent calc(var(--outline-width) * 1px) solid;
+        border: transparent calc(${outlineWidth} * 1px) solid;
         overflow: hidden;
         white-space: nowrap;
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
     }
 
     :host(.column-header) {
@@ -27,7 +35,7 @@ export const DataGridCellStyles = css`
     }
 
     :host(:${focusVisible}) {
-        border: ${neutralFocusBehavior.var} calc(var(--outline-width) * 1px) solid;
+        border: ${neutralFocusBehavior.var} calc(${outlineWidth} * 1px) solid;
         color: ${neutralForegroundActiveBehavior.var};
     }
 

--- a/packages/web-components/fast-components/src/data-grid/data-grid-row.styles.ts
+++ b/packages/web-components/fast-components/src/data-grid/data-grid-row.styles.ts
@@ -1,5 +1,6 @@
 import { css } from "@microsoft/fast-element";
 import { forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
+import { outlineWidth } from "../design-tokens";
 import { neutralDividerRestBehavior, neutralFillRestBehavior } from "../styles/recipes";
 
 export const DataGridRowStyles = css`
@@ -8,7 +9,7 @@ export const DataGridRowStyles = css`
         padding: 1px 0;
         box-sizing: border-box;
         width: 100%;
-        border-bottom: calc(var(--outline-width) * 1px) solid var(--neutral-divider-rest);
+        border-bottom: calc(${outlineWidth} * 1px) solid var(--neutral-divider-rest);
     }
 
     :host(.header) {

--- a/packages/web-components/fast-components/src/data-grid/index.ts
+++ b/packages/web-components/fast-components/src/data-grid/index.ts
@@ -1,11 +1,11 @@
 import { customElement, ViewTemplate } from "@microsoft/fast-element";
 import {
-    DataGrid,
-    createDataGridTemplate,
-    DataGridRow,
-    createDataGridRowTemplate,
-    DataGridCell,
     createDataGridCellTemplate,
+    createDataGridRowTemplate,
+    createDataGridTemplate,
+    DataGrid,
+    DataGridCell,
+    DataGridRow,
 } from "@microsoft/fast-foundation";
 import { DataGridStyles as gridStyles } from "./data-grid.styles";
 import { DataGridRowStyles as rowStyles } from "./data-grid-row.styles";

--- a/packages/web-components/fast-components/src/design-tokens.ts
+++ b/packages/web-components/fast-components/src/design-tokens.ts
@@ -1,0 +1,186 @@
+import { DesignToken } from "@microsoft/fast-foundation";
+import { Direction } from "@microsoft/fast-web-utilities";
+
+const { create } = DesignToken;
+
+export const accentFillRestDelta = create<number>("accent-fill-rest-delta").withDefault(
+    0
+);
+export const accentFillHoverDelta = create<number>("accent-fill-hover-delta").withDefault(
+    4
+);
+export const accentFillActiveDelta = create<number>(
+    "accent-fill-active-delta"
+).withDefault(-5);
+export const accentFillFocusDelta = create<number>("accent-fill-focus-delta").withDefault(
+    0
+);
+export const accentFillSelectedDelta = create<number>(
+    "accent-fill-selected-delta"
+).withDefault(12);
+
+export const accentForegroundRestDelta = create<number>(
+    "accent-foreground-rest-delta"
+).withDefault(0);
+export const accentForegroundHoverDelta = create<number>(
+    "accent-foreground-hover-delta"
+).withDefault(6);
+export const accentForegroundActiveDelta = create<number>(
+    "accent-foreground-active-delta"
+).withDefault(-4);
+export const accentForegroundFocusDelta = create<number>(
+    "accent-foreground-focus-delta"
+).withDefault(0);
+
+export const bodyFont = create<string>("body-font").withDefault("Segoe UI, sans-serif");
+export const baseHeightMultiplier = create<number>("base-height-multiplier").withDefault(
+    10
+);
+export const baseHorizontalSpacingMultiplier = create<number>(
+    "base-horizontal-spacing-multiplier"
+).withDefault(3);
+export const baseLayerLuminance = create<number>("base-layer-luminance").withDefault(1);
+export const cornerRadius = create<number>("corner-radius").withDefault(3);
+export const density = create<number>("density").withDefault(0);
+export const designUnit = create<number>("design-unit").withDefault(4);
+export const direction = create<Direction>("direction").withDefault(Direction.ltr);
+export const disabledOpacity = create<number>("disabled-opacity").withDefault(0.3);
+export const focusOutlineWidth = create<number>("focus-outline-width").withDefault(2);
+
+export const neutralDividerRestDelta = create<number>(
+    "neutral-divider-rest-delta"
+).withDefault(8);
+
+export const neutralFillActiveDelta = create<number>(
+    "neutral-fill-active-delta"
+).withDefault(5);
+export const neutralFillCardDelta = create<number>("neutral-fill-card-delta").withDefault(
+    3
+);
+export const neutralFillFocusDelta = create<number>(
+    "neutral-fill-focus-delta"
+).withDefault(0);
+export const neutralFillHoverDelta = create<number>(
+    "neutral-fill-hover-delta"
+).withDefault(10);
+export const neutralFillInputActiveDelta = create<number>(
+    "neutral-fill-input-active-delta"
+).withDefault(0);
+export const neutralFillInputFocusDelta = create<number>(
+    "neutral-fill-input-focus-delta"
+).withDefault(0);
+export const neutralFillInputHoverDelta = create<number>(
+    "neutral-fill-input-hover-delta"
+).withDefault(0);
+export const neutralFillInputRestDelta = create<number>(
+    "neutral-fill-input-rest-delta"
+).withDefault(0);
+export const neutralFillInputSelectedDelta = create<number>(
+    "neutral-fill-input-selected-delta"
+).withDefault(0);
+export const neutralFillRestDelta = create<number>("neutral-fill-rest-delta").withDefault(
+    7
+);
+export const neutralFillSelectedDelta = create<number>(
+    "neutral-fill-selected-delta"
+).withDefault(7);
+export const neutralFillStealthActiveDelta = create<number>(
+    "neutral-fill-stealth-active-delta"
+).withDefault(3);
+export const neutralFillStealthFocusDelta = create<number>(
+    "neutral-fill-stealth-focus-delta"
+).withDefault(0);
+export const neutralFillStealthHoverDelta = create<number>(
+    "neutral-fill-stealth-hover-delta"
+).withDefault(5);
+export const neutralFillStealthRestDelta = create<number>(
+    "neutral-fill-stealth-rest-delta"
+).withDefault(0);
+export const neutralFillStealthSelectedDelta = create<number>(
+    "neutral-fill-stealth-selected-delta"
+).withDefault(7);
+export const neutralFillToggleActiveDelta = create<number>(
+    "neutral-fill-toggle-active-delta"
+).withDefault(-5);
+export const neutralFillToggleFocusDelta = create<number>(
+    "neutral-fill-toggle-focus-delta"
+).withDefault(0);
+export const neutralFillToggleHoverDelta = create<number>(
+    "neutral-fill-toggle-hover-delta"
+).withDefault(8);
+export const neutralForegroundActiveDelta = create<number>(
+    "neutral-foreground-active-delta"
+).withDefault(0);
+export const neutralForegroundFocusDelta = create<number>(
+    "neutral-foreground-focus-delta"
+).withDefault(0);
+export const neutralForegroundHoverDelta = create<number>(
+    "neutral-foreground-hover-delta"
+).withDefault(0);
+export const neutralOutlineActiveDelta = create<number>(
+    "neutral-outline-active-delta"
+).withDefault(16);
+export const neutralOutlineFocusDelta = create<number>(
+    "neutral-outline-focus-delta"
+).withDefault(25);
+export const neutralOutlineHoverDelta = create<number>(
+    "neutral-outline-hover-delta"
+).withDefault(40);
+export const neutralOutlineRestDelta = create<number>(
+    "neutral-outline-rest-delta"
+).withDefault(25);
+export const outlineWidth = create<number>("outline-width").withDefault(1);
+export const typeRampBaseFontSize = create<string>(
+    "type-ramp-base-font-size"
+).withDefault("14px");
+export const typeRampBaseLineHeight = create<string>(
+    "type-ramp-base-line-height"
+).withDefault("20px");
+export const typeRampMinus1FontSize = create<string>(
+    "type-ramp-minus1-font-size"
+).withDefault("12px");
+export const typeRampMinus1LineHeight = create<string>(
+    "type-ramp-minus1-line-height"
+).withDefault("16px");
+export const typeRampMinus2FontSize = create<string>(
+    "type-ramp-minus2-font-size"
+).withDefault("10px");
+export const typeRampMinus2LineHeight = create<string>(
+    "type-ramp-minus2-line-height"
+).withDefault("16px");
+export const typeRampPlus1FontSize = create<string>(
+    "type-ramp-plus1-font-size"
+).withDefault("16px");
+export const typeRampPlus1LineHeight = create<string>(
+    "type-ramp-plus1-line-height"
+).withDefault("24px");
+export const typeRampPlus2FontSize = create<string>(
+    "type-ramp-plus2-font-size"
+).withDefault("20px");
+export const typeRampPlus2LineHeight = create<string>(
+    "type-ramp-plus2-line-height"
+).withDefault("28px");
+export const typeRampPlus3FontSize = create<string>(
+    "type-ramp-plus3-font-size"
+).withDefault("28px");
+export const typeRampPlus3LineHeight = create<string>(
+    "type-ramp-plus3-line-height"
+).withDefault("36px");
+export const typeRampPlus4FontSize = create<string>(
+    "type-ramp-plus4-font-size"
+).withDefault("34px");
+export const typeRampPlus4LineHeight = create<string>(
+    "type-ramp-plus4-line-height"
+).withDefault("44px");
+export const typeRampPlus5FontSize = create<string>(
+    "type-ramp-plus5-font-size"
+).withDefault("46px");
+export const typeRampPlus5LineHeight = create<string>(
+    "type-ramp-plus5-line-height"
+).withDefault("56px");
+export const typeRampPlus6FontSize = create<string>(
+    "type-ramp-plus6-font-size"
+).withDefault("60px");
+export const typeRampPlus6LineHeight = create<string>(
+    "type-ramp-plus6-line-height"
+).withDefault("72px");

--- a/packages/web-components/fast-components/src/dialog/dialog.styles.ts
+++ b/packages/web-components/fast-components/src/dialog/dialog.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { elevation } from "../styles/elevation";
 
-export const DialogStyles = css`
+export const dialogStyles = (context, definition) => css`
     :host([hidden]) {
         display: none;
     }

--- a/packages/web-components/fast-components/src/dialog/dialog.styles.ts
+++ b/packages/web-components/fast-components/src/dialog/dialog.styles.ts
@@ -1,4 +1,5 @@
 import { css } from "@microsoft/fast-element";
+import { cornerRadius, outlineWidth } from "../design-tokens";
 import { elevation } from "../styles/elevation";
 
 export const dialogStyles = (context, definition) => css`
@@ -42,7 +43,7 @@ export const dialogStyles = (context, definition) => css`
         height: var(--dialog-height);
         background-color: var(--background-color);
         z-index: 1;
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid transparent;
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${outlineWidth} * 1px) solid transparent;
     }
 `;

--- a/packages/web-components/fast-components/src/dialog/index.ts
+++ b/packages/web-components/fast-components/src/dialog/index.ts
@@ -20,4 +20,4 @@ export const fastDialog = Dialog.compose({
  * Styles for Dialog
  * @public
  */
-export const DialogStyles = styles;
+export const dialogStyles = styles;

--- a/packages/web-components/fast-components/src/dialog/index.ts
+++ b/packages/web-components/fast-components/src/dialog/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Dialog, DialogTemplate as template } from "@microsoft/fast-foundation";
-import { DialogStyles as styles } from "./dialog.styles";
+import { Dialog, dialogTemplate as template } from "@microsoft/fast-foundation";
+import { dialogStyles as styles } from "./dialog.styles";
 
 /**
  * The FAST Dialog Element. Implements {@link @microsoft/fast-foundation#Dialog},
- * {@link @microsoft/fast-foundation#DialogTemplate}
+ * {@link @microsoft/fast-foundation#dialogTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-dialog\>
  */
-@customElement({
-    name: "fast-dialog",
+export const fastDialog = Dialog.compose({
+    baseName: "dialog",
     template,
     styles,
-})
-export class FASTDialog extends Dialog {}
+});
 
 /**
  * Styles for Dialog

--- a/packages/web-components/fast-components/src/disclosure/disclosure.styles.ts
+++ b/packages/web-components/fast-components/src/disclosure/disclosure.styles.ts
@@ -9,7 +9,7 @@ import {
     accentForegroundRestBehavior,
 } from "../styles/recipes";
 
-export const DisclosureStyles = css`
+export const disclosureStyles = css`
     .disclosure {
         transition: height 0.35s;
     }

--- a/packages/web-components/fast-components/src/disclosure/disclosure.styles.ts
+++ b/packages/web-components/fast-components/src/disclosure/disclosure.styles.ts
@@ -1,5 +1,11 @@
 import { css } from "@microsoft/fast-element";
 import {
+    bodyFont,
+    cornerRadius,
+    outlineWidth,
+    typeRampBaseFontSize,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
@@ -25,9 +31,9 @@ export const disclosureStyles = css`
     :host([appearance="accent"]) .invoker {
         background: ${accentFillRestBehavior.var};
         color: ${accentForegroundCutRestBehavior.var};
-        font-family: var(--body-font);
-        font-size: var(--type-ramp-base-font-size);
-        border-radius: calc(var(--corner-radius) * 1px);
+        font-family: ${bodyFont};
+        font-size: ${typeRampBaseFontSize};
+        border-radius: calc(${cornerRadius} * 1px);
         outline: none;
         cursor: pointer;
         margin: 16px 0;
@@ -46,8 +52,7 @@ export const disclosureStyles = css`
     :host([appearance="lightweight"]) .invoker {
         background: transparent;
         color: ${accentForegroundRestBehavior.var};
-        border-bottom: calc(var(--outline-width) * 1px) solid
-            var(--accent-foreground-rest);
+        border-bottom: calc(${outlineWidth} * 1px) solid var(--accent-foreground-rest);
         cursor: pointer;
         width: max-content;
         margin: 16px 0;

--- a/packages/web-components/fast-components/src/disclosure/index.ts
+++ b/packages/web-components/fast-components/src/disclosure/index.ts
@@ -1,6 +1,9 @@
-import { attr, customElement } from "@microsoft/fast-element";
-import { Disclosure, DisclosureTemplate as template } from "@microsoft/fast-foundation";
-import { DisclosureStyles as styles } from "./disclosure.styles";
+import { attr } from "@microsoft/fast-element";
+import {
+    Disclosure as FoundationDisclosure,
+    disclosureTemplate as template,
+} from "@microsoft/fast-foundation";
+import { disclosureStyles as styles } from "./disclosure.styles";
 /**
  * Types of anchor appearance.
  * @public
@@ -8,21 +11,9 @@ import { DisclosureStyles as styles } from "./disclosure.styles";
 export type DisclosureAppearance = "accent" | "lightweight";
 
 /**
- * The FAST Disclosure Element. Implements {@link @microsoft/fast-foundation#Disclosure},
- * {@link @microsoft/fast-foundation#DisclosureTemplate}
- *
- *
- * @public
- * @remarks
- * HTML Element: \<fast-Disclosure\>
- *
+ * @internal
  */
-@customElement({
-    name: "fast-disclosure",
-    template,
-    styles,
-})
-export class FASTDisclosure extends Disclosure {
+export class Disclosure extends FoundationDisclosure {
     /**
      * Disclosure default height
      */
@@ -91,3 +82,19 @@ export class FASTDisclosure extends Disclosure {
  * @public
  */
 export const DisclosureStyles = styles;
+
+/**
+ * The FAST Disclosure Element. Implements {@link @microsoft/fast-foundation#Disclosure},
+ * {@link @microsoft/fast-foundation#disclosureTemplate}
+ *
+ *
+ * @public
+ * @remarks
+ * HTML Element: \<fast-Disclosure\>
+ *
+ */
+export const fastDisclosure = Disclosure.compose({
+    baseName: "disclosure",
+    template,
+    styles,
+});

--- a/packages/web-components/fast-components/src/disclosure/index.ts
+++ b/packages/web-components/fast-components/src/disclosure/index.ts
@@ -81,7 +81,7 @@ export class Disclosure extends FoundationDisclosure {
  * Styles for Disclosure
  * @public
  */
-export const DisclosureStyles = styles;
+export const disclosureStyles = styles;
 
 /**
  * The FAST Disclosure Element. Implements {@link @microsoft/fast-foundation#Disclosure},

--- a/packages/web-components/fast-components/src/divider/divider.styles.ts
+++ b/packages/web-components/fast-components/src/divider/divider.styles.ts
@@ -2,13 +2,14 @@ import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 import { neutralDividerRestBehavior } from "../styles/index";
 
-export const DividerStyles = css`
-    ${display("block")} :host {
-        box-sizing: content-box;
-        height: 0;
-        margin: calc(var(--design-unit) * 1px) 0;
-        border: none;
-        border-top: calc(var(--outline-width) * 1px) solid
-            ${neutralDividerRestBehavior.var};
-    }
-`.withBehaviors(neutralDividerRestBehavior);
+export const dividerStyles = (context, definition) =>
+    css`
+        ${display("block")} :host {
+            box-sizing: content-box;
+            height: 0;
+            margin: calc(var(--design-unit) * 1px) 0;
+            border: none;
+            border-top: calc(var(--outline-width) * 1px) solid
+                ${neutralDividerRestBehavior.var};
+        }
+    `.withBehaviors(neutralDividerRestBehavior);

--- a/packages/web-components/fast-components/src/divider/divider.styles.ts
+++ b/packages/web-components/fast-components/src/divider/divider.styles.ts
@@ -1,5 +1,6 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
+import { designUnit, outlineWidth } from "../design-tokens";
 import { neutralDividerRestBehavior } from "../styles/index";
 
 export const dividerStyles = (context, definition) =>
@@ -7,9 +8,9 @@ export const dividerStyles = (context, definition) =>
         ${display("block")} :host {
             box-sizing: content-box;
             height: 0;
-            margin: calc(var(--design-unit) * 1px) 0;
+            margin: calc(${designUnit} * 1px) 0;
             border: none;
-            border-top: calc(var(--outline-width) * 1px) solid
+            border-top: calc(${outlineWidth} * 1px) solid
                 ${neutralDividerRestBehavior.var};
         }
     `.withBehaviors(neutralDividerRestBehavior);

--- a/packages/web-components/fast-components/src/divider/index.ts
+++ b/packages/web-components/fast-components/src/divider/index.ts
@@ -20,4 +20,4 @@ export const fastDivider = Divider.compose({
  * Styles for Divider
  * @public
  */
-export const DividerStyles = styles;
+export const dividerStyles = styles;

--- a/packages/web-components/fast-components/src/divider/index.ts
+++ b/packages/web-components/fast-components/src/divider/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Divider, DividerTemplate as template } from "@microsoft/fast-foundation";
-import { DividerStyles as styles } from "./divider.styles";
+import { Divider, dividerTemplate as template } from "@microsoft/fast-foundation";
+import { dividerStyles as styles } from "./divider.styles";
 
 /**
  * The FAST Divider Element. Implements {@link @microsoft/fast-foundation#Divider},
- * {@link @microsoft/fast-foundation#DividerTemplate}
+ * {@link @microsoft/fast-foundation#dividerTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-divider\>
  */
-@customElement({
-    name: "fast-divider",
+export const fastDivider = Divider.compose({
+    baseName: "divider",
     template,
     styles,
-})
-export class FASTDivider extends Divider {}
+});
 
 /**
  * Styles for Divider

--- a/packages/web-components/fast-components/src/fast-design-system.ts
+++ b/packages/web-components/fast-components/src/fast-design-system.ts
@@ -4,11 +4,15 @@ import {
     neutralPalette as defaultNeutralPalette,
 } from "./default-palette";
 
+/**
+ * @deprecated - use DesignTokens
+ */
 export type DesignSystemResolver<T, Y = FASTDesignSystem> = (d: Y) => T;
 
 /**
  * Defines the properties in the FAST Design System
  * @public
+ * @deprecated - use DesignTokens
  */
 export interface FASTDesignSystem {
     /**
@@ -199,6 +203,7 @@ export interface FASTDesignSystem {
 /**
  * The default values for {@link FASTDesignSystem}
  * @public
+ * @deprecated - Use DesignTokens
  */
 export const fastDesignSystemDefaults: FASTDesignSystem = {
     typeRampMinus2FontSize: "10px",

--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -19,7 +19,8 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const FlipperStyles = css`
+export const flipperStyles = (context, definition) =>
+    css`
     ${display("inline-flex")} :host {
         width: calc(${heightNumber} * 1px);
         height: calc(${heightNumber} * 1px);
@@ -98,17 +99,17 @@ export const FlipperStyles = css`
         border: 0;
     }
 `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    accentForegroundCutRestBehavior,
-    neutralFillStealthRestBehavior,
-    neutralFocusBehavior,
-    neutralFocusInnerAccentBehavior,
-    neutralForegroundRestBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        accentForegroundCutRestBehavior,
+        neutralFillStealthRestBehavior,
+        neutralFocusBehavior,
+        neutralFocusInnerAccentBehavior,
+        neutralForegroundRestBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
             :host {
                 background: ${SystemColors.Canvas};
             }
@@ -152,5 +153,5 @@ export const FlipperStyles = css`
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
         `
-    )
-);
+        )
+    );

--- a/packages/web-components/fast-components/src/flipper/flipper.styles.ts
+++ b/packages/web-components/fast-components/src/flipper/flipper.styles.ts
@@ -6,6 +6,7 @@ import {
     forcedColorsStylesheetBehavior,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import { disabledOpacity, focusOutlineWidth, outlineWidth } from "../design-tokens";
 import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
@@ -39,7 +40,7 @@ export const flipperStyles = (context, definition) =>
     :host::before {
         content: "";
         background: ${accentFillRestBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
+        border: calc(${outlineWidth} * 1px) solid ${accentFillRestBehavior.var};
         border-radius: 50%;
         position: absolute;
         top: 0;
@@ -61,7 +62,7 @@ export const flipperStyles = (context, definition) =>
     }
 
     :host([disabled]) {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
         cursor: ${disabledCursor};
         fill: currentcolor;
         color: ${neutralForegroundRestBehavior.var};
@@ -71,7 +72,7 @@ export const flipperStyles = (context, definition) =>
     :host([disabled]:hover)::before,
     :host([disabled]:active)::before {
         background: ${neutralFillStealthRestBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
+        border: calc(${outlineWidth} * 1px) solid ${neutralOutlineRestBehavior.var};
     }
 
     :host(:hover)::before {
@@ -89,9 +90,9 @@ export const flipperStyles = (context, definition) =>
     }
 
     :host(:${focusVisible})::before {
-        box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${
-            neutralFocusInnerAccentBehavior.var
-        };
+        box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) inset ${
+        neutralFocusInnerAccentBehavior.var
+    };
         border-color: ${neutralFocusBehavior.var};
     }
 

--- a/packages/web-components/fast-components/src/flipper/index.ts
+++ b/packages/web-components/fast-components/src/flipper/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Flipper, FlipperTemplate as template } from "@microsoft/fast-foundation";
-import { FlipperStyles as styles } from "./flipper.styles";
+import { Flipper, flipperTemplate as template } from "@microsoft/fast-foundation";
+import { flipperStyles as styles } from "./flipper.styles";
 
 /**
  * The FAST Flipper Element. Implements {@link @microsoft/fast-foundation#Flipper},
- * {@link @microsoft/fast-foundation#FlipperTemplate}
+ * {@link @microsoft/fast-foundation#flipperTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-flipper\>
  */
-@customElement({
-    name: "fast-flipper",
+export const fastFlipper = Flipper.compose({
+    baseName: "flipper",
     template,
     styles,
-})
-export class FASTFlipper extends Flipper {}
+});
 
 /**
  * Styles for Flipper

--- a/packages/web-components/fast-components/src/flipper/index.ts
+++ b/packages/web-components/fast-components/src/flipper/index.ts
@@ -20,4 +20,4 @@ export const fastFlipper = Flipper.compose({
  * Styles for Flipper
  * @public
  */
-export const FlipperStyles = styles;
+export const flipperStyles = styles;

--- a/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.styles.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.styles.ts
@@ -98,7 +98,7 @@ export const ActionsStyles = css`
  * Styles handling the scroll container and content
  * @public
  */
-export const HorizontalScrollStyles = css`
+export const horizontalScrollStyles = (context, definition) => css`
     ${display("block")} :host {
         --scroll-align: center;
         --scroll-item-spacing: 5px;

--- a/packages/web-components/fast-components/src/horizontal-scroll/index.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/index.ts
@@ -1,28 +1,16 @@
-import { customElement } from "@microsoft/fast-element";
 import {
-    HorizontalScroll,
-    HorizontalScrollTemplate as template,
+    HorizontalScroll as FoundationHorizontalScroll,
+    horizontalScrollTemplate as template,
 } from "@microsoft/fast-foundation";
 import {
     ActionsStyles,
-    HorizontalScrollStyles as styles,
+    horizontalScrollStyles as styles,
 } from "./horizontal-scroll.styles";
 
 /**
- * The FAST HorizontalScroll Element. Implements {@link @microsoft/fast-foundation#HorizontalScroll},
- * {@link @microsoft/fast-foundation#HorizontalScrollTemplate}
- *
- *
- * @public
- * @remarks
- * HTML Element: \<fast-horizontal-scroll\>
+ * @internal
  */
-@customElement({
-    name: "fast-horizontal-scroll",
-    template,
-    styles,
-})
-export class FASTHorizontalScroll extends HorizontalScroll {
+export class HorizontalScroll extends FoundationHorizontalScroll {
     /**
      * @public
      */
@@ -34,3 +22,18 @@ export class FASTHorizontalScroll extends HorizontalScroll {
         }
     }
 }
+
+/**
+ * The FAST HorizontalScroll Element. Implements {@link @microsoft/fast-foundation#HorizontalScroll},
+ * {@link @microsoft/fast-foundation#horizontalScrollTemplate}
+ *
+ *
+ * @public
+ * @remarks
+ * HTML Element: \<fast-horizontal-scroll\>
+ */
+export const fastHorizontalScroll = HorizontalScroll.compose({
+    baseName: "horizontal-scroll",
+    template,
+    styles,
+});

--- a/packages/web-components/fast-components/src/index-rollup.ts
+++ b/packages/web-components/fast-components/src/index-rollup.ts
@@ -1,3 +1,4 @@
+// TODO: Is exporting Foundation still necessary with the updated API's?
+// export * from "@microsoft/fast-element";
+// export * from "@microsoft/fast-foundation";
 export * from "./index";
-export * from "@microsoft/fast-element";
-export * from "@microsoft/fast-foundation";

--- a/packages/web-components/fast-components/src/index-rollup.ts
+++ b/packages/web-components/fast-components/src/index-rollup.ts
@@ -1,4 +1,17 @@
 // TODO: Is exporting Foundation still necessary with the updated API's?
 // export * from "@microsoft/fast-element";
-// export * from "@microsoft/fast-foundation";
+import { DesignSystem } from "@microsoft/fast-foundation";
+import * as fastComponents from "./custom-elements";
+
 export * from "./index";
+
+/**
+ * TODO rename this to FASTDesignSystem when {@link @FASTDesignSystem} interface is removed.
+ */
+export const fastDesignSystem = new DesignSystem();
+
+Object.values(fastComponents).forEach(definition => {
+    fastDesignSystem.register(definition());
+});
+
+fastDesignSystem.applyTo(document.body);

--- a/packages/web-components/fast-components/src/index-rollup.ts
+++ b/packages/web-components/fast-components/src/index-rollup.ts
@@ -8,10 +8,6 @@ export * from "./index";
 /**
  * TODO rename this to FASTDesignSystem when {@link @FASTDesignSystem} interface is removed.
  */
-export const fastDesignSystem = new DesignSystem();
-
-Object.values(fastComponents).forEach(definition => {
-    fastDesignSystem.register(definition());
-});
-
-fastDesignSystem.applyTo(document.body);
+export const fastDesignSystem = DesignSystem.getOrCreate().register(
+    ...Object.values(fastComponents).map(definition => definition())
+);

--- a/packages/web-components/fast-components/src/index.ts
+++ b/packages/web-components/fast-components/src/index.ts
@@ -1,3 +1,8 @@
+/**
+ * Export all custom element definitions.
+ */
+export * from "./custom-elements";
+
 export * from "./accordion/index";
 export * from "./anchor/index";
 export * from "./anchored-region/index";

--- a/packages/web-components/fast-components/src/listbox-option/index.ts
+++ b/packages/web-components/fast-components/src/listbox-option/index.ts
@@ -1,13 +1,12 @@
-import { customElement } from "@microsoft/fast-element";
 import {
     ListboxOption,
-    ListboxOptionTemplate as template,
+    listboxOptionTemplate as template,
 } from "@microsoft/fast-foundation";
-import { OptionStyles as styles } from "./listbox-option.styles";
+import { optionStyles as styles } from "./listbox-option.styles";
 
 /**
  * The FAST option Custom Element. Implements {@link @microsoft/fast-foundation#ListboxOption}
- * {@link @microsoft/fast-foundation#ListboxOptionTemplate}
+ * {@link @microsoft/fast-foundation#listboxOptionTemplate}
  *
  *
  * @public
@@ -15,12 +14,11 @@ import { OptionStyles as styles } from "./listbox-option.styles";
  * HTML Element: \<fast-option\>
  *
  */
-@customElement({
-    name: "fast-option",
+export const fastOption = ListboxOption.compose({
+    baseName: "option",
     template,
     styles,
-})
-export class FASTOption extends ListboxOption {}
+});
 
 /**
  * Styles for Option

--- a/packages/web-components/fast-components/src/listbox-option/index.ts
+++ b/packages/web-components/fast-components/src/listbox-option/index.ts
@@ -24,4 +24,4 @@ export const fastOption = ListboxOption.compose({
  * Styles for Option
  * @public
  */
-export const OptionStyles = styles;
+export const optionStyles = styles;

--- a/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
+++ b/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
@@ -23,7 +23,8 @@ import {
 } from "../styles/recipes";
 import { heightNumber } from "../styles/size";
 
-export const OptionStyles = css`
+export const optionStyles = (context, definition) =>
+    css`
     ${display("inline-flex")} :host {
         align-items: center;
         font-family: var(--body-font);
@@ -112,41 +113,41 @@ export const OptionStyles = css`
     }
 
 `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillSelectedBehavior,
-    accentForegroundCutRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            :host {
-                border-color: transparent;
-                forced-color-adjust: none;
-                color: ${SystemColors.ButtonText};
-                fill: currentcolor;
-            }
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillSelectedBehavior,
+        accentForegroundCutRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                :host {
+                    border-color: transparent;
+                    forced-color-adjust: none;
+                    color: ${SystemColors.ButtonText};
+                    fill: currentcolor;
+                }
 
-            :host(:not([aria-selected="true"]):hover),
-            :host([aria-selected="true"]) {
-                background: ${SystemColors.Highlight};
-                color: ${SystemColors.HighlightText};
-            }
+                :host(:not([aria-selected="true"]):hover),
+                :host([aria-selected="true"]) {
+                    background: ${SystemColors.Highlight};
+                    color: ${SystemColors.HighlightText};
+                }
 
-            :host([disabled]),
-            :host([disabled]:not([aria-selected="true"]):hover) {
-                background: ${SystemColors.Canvas};
-                color: ${SystemColors.GrayText};
-                fill: currentcolor;
-                opacity: 1;
-            }
-        `
-    ),
-    neutralFillHoverBehavior,
-    neutralFillStealthHoverBehavior,
-    neutralFillStealthRestBehavior,
-    neutralFillStealthSelectedBehavior,
-    neutralFocusBehavior,
-    neutralFocusInnerAccentBehavior,
-    neutralForegroundHoverBehavior,
-    neutralForegroundRestBehavior,
-    neutralLayerL1Behavior
-);
+                :host([disabled]),
+                :host([disabled]:not([aria-selected="true"]):hover) {
+                    background: ${SystemColors.Canvas};
+                    color: ${SystemColors.GrayText};
+                    fill: currentcolor;
+                    opacity: 1;
+                }
+            `
+        ),
+        neutralFillHoverBehavior,
+        neutralFillStealthHoverBehavior,
+        neutralFillStealthRestBehavior,
+        neutralFillStealthSelectedBehavior,
+        neutralFocusBehavior,
+        neutralFocusInnerAccentBehavior,
+        neutralForegroundHoverBehavior,
+        neutralForegroundRestBehavior,
+        neutralLayerL1Behavior
+    );

--- a/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
+++ b/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
@@ -7,6 +7,15 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    focusOutlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillSelectedBehavior,
@@ -27,28 +36,28 @@ export const optionStyles = (context, definition) =>
     css`
     ${display("inline-flex")} :host {
         align-items: center;
-        font-family: var(--body-font);
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--focus-outline-width) * 1px) solid transparent;
+        font-family: ${bodyFont};
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${focusOutlineWidth} * 1px) solid transparent;
         box-sizing: border-box;
         color: ${neutralForegroundRestBehavior.var};
         cursor: pointer;
         fill: currentcolor;
-        font-size: var(--type-ramp-base-font-size);
+        font-size: ${typeRampBaseFontSize};
         height: calc(${heightNumber} * 1px);
-        line-height: var(--type-ramp-base-line-height);
-        margin: 0 calc(var(--design-unit) * 1px);
+        line-height: ${typeRampBaseLineHeight};
+        margin: 0 calc(${designUnit} * 1px);
         outline: none;
         overflow: hidden;
-        padding: 0 calc(var(--design-unit) * 2.25px);
+        padding: 0 calc(${designUnit} * 2.25px);
         user-select: none;
         white-space: nowrap;
     }
 
     :host(:${focusVisible}) {
-        box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${
-            neutralFocusInnerAccentBehavior.var
-        };
+        box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) inset ${
+        neutralFocusInnerAccentBehavior.var
+    };
         border-color: ${neutralFocusBehavior.var};
         background: ${accentFillHoverBehavior.var};
         color: ${accentForegroundCutRestBehavior.var};
@@ -76,7 +85,7 @@ export const optionStyles = (context, definition) =>
 
     :host([disabled]) {
         cursor: ${disabledCursor};
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 
     :host([disabled]:hover) {
@@ -100,8 +109,8 @@ export const optionStyles = (context, definition) =>
         ${
             /* Glyph size and margin-left is temporary - replace when adaptive typography is figured out */ ""
         }
-        height: calc(var(--design-unit) * 4px);
-        width: calc(var(--design-unit) * 4px);
+        height: calc(${designUnit} * 4px);
+        width: calc(${designUnit} * 4px);
     }
 
     ::slotted([slot="end"]) {

--- a/packages/web-components/fast-components/src/listbox/index.ts
+++ b/packages/web-components/fast-components/src/listbox/index.ts
@@ -1,10 +1,9 @@
-import { customElement } from "@microsoft/fast-element";
-import { Listbox, ListboxTemplate as template } from "@microsoft/fast-foundation";
-import { ListboxStyles as styles } from "./listbox.styles";
+import { Listbox, listboxTemplate as template } from "@microsoft/fast-foundation";
+import { listboxStyles as styles } from "./listbox.styles";
 
 /**
  * The FAST listbox Custom Element. Implements, {@link @microsoft/fast-foundation#Listbox}
- * {@link @microsoft/fast-foundation#ListboxTemplate}
+ * {@link @microsoft/fast-foundation#listboxTemplate}
  *
  *
  * @public
@@ -12,12 +11,11 @@ import { ListboxStyles as styles } from "./listbox.styles";
  * HTML Element: \<fast-listbox\>
  *
  */
-@customElement({
-    name: "fast-listbox",
+export const fastListbox = Listbox.compose({
+    baseName: "listbox",
     template,
     styles,
-})
-export class FASTListbox extends Listbox {}
+});
 
 /**
  * Styles for Listbox

--- a/packages/web-components/fast-components/src/listbox/index.ts
+++ b/packages/web-components/fast-components/src/listbox/index.ts
@@ -21,4 +21,4 @@ export const fastListbox = Listbox.compose({
  * Styles for Listbox
  * @public
  */
-export const ListboxStyles = styles;
+export const listboxStyles = styles;

--- a/packages/web-components/fast-components/src/listbox/listbox.styles.ts
+++ b/packages/web-components/fast-components/src/listbox/listbox.styles.ts
@@ -6,6 +6,12 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    cornerRadius,
+    designUnit,
+    focusOutlineWidth,
+    outlineWidth,
+} from "../design-tokens";
+import {
     neutralFocusBehavior,
     neutralLayerFloatingBehavior,
     neutralOutlineFocusBehavior,
@@ -16,12 +22,11 @@ export const listboxStyles = (context, definition) =>
     css`
         ${display("inline-flex")} :host {
             background: ${neutralLayerFloatingBehavior.var};
-            border: calc(var(--outline-width) * 1px) solid
-                ${neutralOutlineRestBehavior.var};
-            border-radius: calc(var(--corner-radius) * 1px);
+            border: calc(${outlineWidth} * 1px) solid ${neutralOutlineRestBehavior.var};
+            border-radius: calc(${cornerRadius} * 1px);
             box-sizing: border-box;
             flex-direction: column;
-            padding: calc(var(--design-unit) * 1px) 0;
+            padding: calc(${designUnit} * 1px) 0;
         }
 
         :host(:focus-within:not([disabled])) {
@@ -34,7 +39,7 @@ export const listboxStyles = (context, definition) =>
             :host(:${focusVisible}) ::slotted([aria-selected="true"][role="option"]) {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.ButtonText};
-                box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${SystemColors.HighlightText};
+                box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) inset ${SystemColors.HighlightText};
                 color: ${SystemColors.HighlightText};
                 fill: currentcolor;
             }
@@ -42,7 +47,7 @@ export const listboxStyles = (context, definition) =>
             :host(:${focusVisible}) ::slotted([aria-selected="true"][role="option"]) {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.ButtonText};
-                box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${SystemColors.HighlightText};
+                box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) inset ${SystemColors.HighlightText};
                 color: ${SystemColors.HighlightText};
                 fill: currentcolor;
             }

--- a/packages/web-components/fast-components/src/listbox/listbox.styles.ts
+++ b/packages/web-components/fast-components/src/listbox/listbox.styles.ts
@@ -12,23 +12,25 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/recipes";
 
-export const ListboxStyles = css`
-    ${display("inline-flex")} :host {
-        background: ${neutralLayerFloatingBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
-        box-sizing: border-box;
-        flex-direction: column;
-        padding: calc(var(--design-unit) * 1px) 0;
-    }
+export const listboxStyles = (context, definition) =>
+    css`
+        ${display("inline-flex")} :host {
+            background: ${neutralLayerFloatingBehavior.var};
+            border: calc(var(--outline-width) * 1px) solid
+                ${neutralOutlineRestBehavior.var};
+            border-radius: calc(var(--corner-radius) * 1px);
+            box-sizing: border-box;
+            flex-direction: column;
+            padding: calc(var(--design-unit) * 1px) 0;
+        }
 
-    :host(:focus-within:not([disabled])) {
-        border-color: ${neutralFocusBehavior.var};
-        box-shadow: 0 0 0 1px ${neutralFocusBehavior.var} inset;
-    }
-`.withBehaviors(
-    forcedColorsStylesheetBehavior(
-        css`
+        :host(:focus-within:not([disabled])) {
+            border-color: ${neutralFocusBehavior.var};
+            box-shadow: 0 0 0 1px ${neutralFocusBehavior.var} inset;
+        }
+    `.withBehaviors(
+        forcedColorsStylesheetBehavior(
+            css`
             :host(:${focusVisible}) ::slotted([aria-selected="true"][role="option"]) {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.ButtonText};
@@ -45,8 +47,8 @@ export const ListboxStyles = css`
                 fill: currentcolor;
             }
         `
-    ),
-    neutralLayerFloatingBehavior,
-    neutralOutlineRestBehavior,
-    neutralOutlineFocusBehavior
-);
+        ),
+        neutralLayerFloatingBehavior,
+        neutralOutlineRestBehavior,
+        neutralOutlineFocusBehavior
+    );

--- a/packages/web-components/fast-components/src/menu-item/index.ts
+++ b/packages/web-components/fast-components/src/menu-item/index.ts
@@ -20,4 +20,4 @@ export const fastMenuItem = MenuItem.compose({
  * Styles for MenuItem
  * @public
  */
-export const MenuItemStyles = styles;
+export const menuItemStyles = styles;

--- a/packages/web-components/fast-components/src/menu-item/index.ts
+++ b/packages/web-components/fast-components/src/menu-item/index.ts
@@ -1,24 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { MenuItem, createMenuItemTemplate } from "@microsoft/fast-foundation";
-import { MenuItemStyles as styles } from "./menu-item.styles";
-
-const template = createMenuItemTemplate("fast");
+import { MenuItem, menuItemTemplate as template } from "@microsoft/fast-foundation";
+import { menuItemStyles as styles } from "./menu-item.styles";
 
 /**
  * The FAST Menu Item Element. Implements {@link @microsoft/fast-foundation#MenuItem},
- * {@link @microsoft/fast-foundation#MenuItemTemplate}
+ * {@link @microsoft/fast-foundation#menuItemTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-menu-item\>
  */
-@customElement({
-    name: "fast-menu-item",
+export const fastMenuItem = MenuItem.compose({
+    baseName: "menu-item",
     template,
     styles,
-})
-export class FASTMenuItem extends MenuItem {}
+});
 
 /**
  * Styles for MenuItem

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -18,7 +18,8 @@ import {
     neutralLayerL3Behavior,
 } from "../styles/index";
 
-export const MenuItemStyles = css`
+export const menuItemStyles = (context, definition) =>
+    css`
     ${display("grid")} :host {
         contain: layout;
         overflow: visible;
@@ -227,15 +228,15 @@ export const MenuItemStyles = css`
         pointer-events: none;
     }
 `.withBehaviors(
-    accentFillRestBehavior,
-    neutralFillStealthRestBehavior,
-    neutralFocusBehavior,
-    neutralForegroundHoverBehavior,
-    neutralForegroundRestBehavior,
-    neutralLayerL2Behavior,
-    neutralLayerL3Behavior,
-    forcedColorsStylesheetBehavior(
-        css`
+        accentFillRestBehavior,
+        neutralFillStealthRestBehavior,
+        neutralFocusBehavior,
+        neutralForegroundHoverBehavior,
+        neutralForegroundRestBehavior,
+        neutralLayerL2Behavior,
+        neutralLayerL3Behavior,
+        forcedColorsStylesheetBehavior(
+            css`
             :host {
                 border-color: transparent;
                 color: ${SystemColors.ButtonText};
@@ -322,24 +323,24 @@ export const MenuItemStyles = css`
                 background: ${SystemColors.Highlight};
             }
         `
-    ),
+        ),
 
-    new DirectionalStyleSheetBehavior(
-        css`
-            .expand-collapse-glyph {
-                transform: rotate(0deg);
-            }
-            :host([expanded="true"]) .expand-collapse-glyph {
-                transform: rotate(45deg);
-            }
-        `,
-        css`
-            .expand-collapse-glyph {
-                transform: rotate(180deg);
-            }
-            :host([expanded="true"]) .expand-collapse-glyph {
-                transform: rotate(135deg);
-            }
-        `
-    )
-);
+        new DirectionalStyleSheetBehavior(
+            css`
+                .expand-collapse-glyph {
+                    transform: rotate(0deg);
+                }
+                :host([expanded="true"]) .expand-collapse-glyph {
+                    transform: rotate(45deg);
+                }
+            `,
+            css`
+                .expand-collapse-glyph {
+                    transform: rotate(180deg);
+                }
+                :host([expanded="true"]) .expand-collapse-glyph {
+                    transform: rotate(135deg);
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -8,6 +8,16 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    focusOutlineWidth,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillRestBehavior,
     heightNumber,
     neutralFillStealthRestBehavior,
@@ -23,7 +33,7 @@ export const menuItemStyles = (context, definition) =>
     ${display("grid")} :host {
         contain: layout;
         overflow: visible;
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         outline: none;
         box-sizing: border-box;
         height: calc(${heightNumber} * 1px);
@@ -32,15 +42,15 @@ export const menuItemStyles = (context, definition) =>
         justify-items: center;
         align-items: center;
         padding: 0;
-        margin: 0 calc(var(--design-unit) * 1px);
+        margin: 0 calc(${designUnit} * 1px);
         white-space: nowrap;
         color: ${neutralForegroundRestBehavior.var};
         fill: currentcolor;
         cursor: pointer;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--focus-outline-width) * 1px) solid transparent;
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${focusOutlineWidth} * 1px) solid transparent;
     }
 
     :host(:${focusVisible}) {
@@ -63,7 +73,7 @@ export const menuItemStyles = (context, definition) =>
 
     :host([disabled]) {
         cursor: ${disabledCursor};
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 
     :host([disabled]:hover) {
@@ -174,9 +184,7 @@ export const menuItemStyles = (context, definition) =>
 
     :host .checkbox,
     :host .radio {
-        border: calc(var(--outline-width) * 1px) solid ${
-            neutralForegroundRestBehavior.var
-        };
+        border: calc(${outlineWidth} * 1px) solid ${neutralForegroundRestBehavior.var};
     }
 
     :host([aria-checked="true"]) .checkbox,
@@ -186,7 +194,7 @@ export const menuItemStyles = (context, definition) =>
     }
 
     :host .checkbox {
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
     }
 
     :host .radio {
@@ -266,7 +274,7 @@ export const menuItemStyles = (context, definition) =>
             :host(:${focusVisible}) {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.ButtonText};
-                box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${SystemColors.HighlightText};
+                box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) inset ${SystemColors.HighlightText};
                 color: ${SystemColors.HighlightText};
                 fill: currentcolor;
             }

--- a/packages/web-components/fast-components/src/menu/index.ts
+++ b/packages/web-components/fast-components/src/menu/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Menu, MenuTemplate as template } from "@microsoft/fast-foundation";
-import { MenuStyles as styles } from "./menu.styles";
+import { Menu, menuTemplate as template } from "@microsoft/fast-foundation";
+import { menuStyles as styles } from "./menu.styles";
 
 /**
  * The FAST Menu Element. Implements {@link @microsoft/fast-foundation#Menu},
- * {@link @microsoft/fast-foundation#MenuTemplate}
+ * {@link @microsoft/fast-foundation#menuTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-menu\>
  */
-@customElement({
-    name: "fast-menu",
+export const fastMenu = Menu.compose({
+    baseName: "menu",
     template,
     styles,
-})
-export class FASTMenu extends Menu {}
+});
 
 /**
  * Styles for Menu

--- a/packages/web-components/fast-components/src/menu/index.ts
+++ b/packages/web-components/fast-components/src/menu/index.ts
@@ -20,4 +20,4 @@ export const fastMenu = Menu.compose({
  * Styles for Menu
  * @public
  */
-export const MenuStyles = styles;
+export const menuStyles = styles;

--- a/packages/web-components/fast-components/src/menu/menu.styles.ts
+++ b/packages/web-components/fast-components/src/menu/menu.styles.ts
@@ -1,6 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import { cornerRadius, designUnit, outlineWidth } from "../design-tokens";
 import {
     elevation,
     neutralDividerRestBehavior,
@@ -12,18 +13,18 @@ export const menuStyles = (context, definition) =>
         ${display("block")} :host {
             --elevation: 11;
             background: ${neutralLayerFloatingBehavior.var};
-            border: calc(var(--outline-width) * 1px) solid transparent;
+            border: calc(${outlineWidth} * 1px) solid transparent;
             ${elevation}
             margin: 0;
-            border-radius: calc(var(--corner-radius) * 1px);
-            padding: calc(var(--design-unit) * 1px) 0;
+            border-radius: calc(${cornerRadius} * 1px);
+            padding: calc(${designUnit} * 1px) 0;
             max-width: 368px;
             min-width: 64px;
         }
 
         :host([slot="submenu"]) {
             width: max-content;
-            margin: 0 calc(var(--design-unit) * 1px);
+            margin: 0 calc(${designUnit} * 1px);
         }
 
         ::slotted(hr) {
@@ -31,7 +32,7 @@ export const menuStyles = (context, definition) =>
             height: 0;
             margin: 0;
             border: none;
-            border-top: calc(var(--outline-width) * 1px) solid var(--neutral-divider-rest);
+            border-top: calc(${outlineWidth} * 1px) solid var(--neutral-divider-rest);
         }
     `.withBehaviors(
         neutralLayerFloatingBehavior,

--- a/packages/web-components/fast-components/src/menu/menu.styles.ts
+++ b/packages/web-components/fast-components/src/menu/menu.styles.ts
@@ -7,40 +7,41 @@ import {
     neutralLayerFloatingBehavior,
 } from "../styles/index";
 
-export const MenuStyles = css`
-    ${display("block")} :host {
-        --elevation: 11;
-        background: ${neutralLayerFloatingBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid transparent;
-        ${elevation}
-        margin: 0;
-        border-radius: calc(var(--corner-radius) * 1px);
-        padding: calc(var(--design-unit) * 1px) 0;
-        max-width: 368px;
-        min-width: 64px;
-    }
+export const menuStyles = (context, definition) =>
+    css`
+        ${display("block")} :host {
+            --elevation: 11;
+            background: ${neutralLayerFloatingBehavior.var};
+            border: calc(var(--outline-width) * 1px) solid transparent;
+            ${elevation}
+            margin: 0;
+            border-radius: calc(var(--corner-radius) * 1px);
+            padding: calc(var(--design-unit) * 1px) 0;
+            max-width: 368px;
+            min-width: 64px;
+        }
 
-    :host([slot="submenu"]) {
-        width: max-content;
-        margin: 0 calc(var(--design-unit) * 1px);
-    }
+        :host([slot="submenu"]) {
+            width: max-content;
+            margin: 0 calc(var(--design-unit) * 1px);
+        }
 
-    ::slotted(hr) {
-        box-sizing: content-box;
-        height: 0;
-        margin: 0;
-        border: none;
-        border-top: calc(var(--outline-width) * 1px) solid var(--neutral-divider-rest);
-    }
-`.withBehaviors(
-    neutralLayerFloatingBehavior,
-    neutralDividerRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            :host {
-                background: ${SystemColors.Canvas};
-                border-color: ${SystemColors.CanvasText};
-            }
-        `
-    )
-);
+        ::slotted(hr) {
+            box-sizing: content-box;
+            height: 0;
+            margin: 0;
+            border: none;
+            border-top: calc(var(--outline-width) * 1px) solid var(--neutral-divider-rest);
+        }
+    `.withBehaviors(
+        neutralLayerFloatingBehavior,
+        neutralDividerRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                :host {
+                    background: ${SystemColors.Canvas};
+                    border-color: ${SystemColors.CanvasText};
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/number-field/index.ts
+++ b/packages/web-components/fast-components/src/number-field/index.ts
@@ -1,6 +1,9 @@
-import { attr, customElement } from "@microsoft/fast-element";
-import { NumberField, NumberFieldTemplate as template } from "@microsoft/fast-foundation";
-import { NumberFieldStyles as styles } from "./number-field.styles";
+import { attr } from "@microsoft/fast-element";
+import {
+    NumberField as FoundationNumberField,
+    numberFieldTemplate as template,
+} from "@microsoft/fast-foundation";
+import { numberFieldStyles as styles } from "./number-field.styles";
 
 /**
  * Number field appearances
@@ -9,25 +12,9 @@ import { NumberFieldStyles as styles } from "./number-field.styles";
 export type NumberFieldAppearance = "filled" | "outline";
 
 /**
- * The FAST Number Field Custom Element. Implements {@link @microsoft/fast-foundation#NumberField},
- * {@link @microsoft/fast-foundation#NumberFieldTemplate}
- *
- *
- * @public
- * @remarks
- * HTML Element: \<fast-number-field\>
- *
- * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ * @internal
  */
-@customElement({
-    name: "fast-number-field",
-    shadowOptions: {
-        delegatesFocus: true,
-    },
-    styles,
-    template,
-})
-export class FASTNumberField extends NumberField {
+export class NumberField extends FoundationNumberField {
     /**
      * The appearance of the element.
      *
@@ -55,3 +42,23 @@ export class FASTNumberField extends NumberField {
  * @public
  */
 export const NumberFieldStyles = styles;
+
+/**
+ * The FAST Number Field Custom Element. Implements {@link @microsoft/fast-foundation#NumberField},
+ * {@link @microsoft/fast-foundation#numberFieldTemplate}
+ *
+ *
+ * @public
+ * @remarks
+ * HTML Element: \<fast-number-field\>
+ *
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ */
+export const fastNumberField = NumberField.compose({
+    baseName: "number-field",
+    styles,
+    template,
+    shadowOptions: {
+        delegatesFocus: true,
+    },
+});

--- a/packages/web-components/fast-components/src/number-field/index.ts
+++ b/packages/web-components/fast-components/src/number-field/index.ts
@@ -41,7 +41,7 @@ export class NumberField extends FoundationNumberField {
  * Styles for NumberField
  * @public
  */
-export const NumberFieldStyles = styles;
+export const numberFieldStyles = styles;
 
 /**
  * The FAST Number Field Custom Element. Implements {@link @microsoft/fast-foundation#NumberField},

--- a/packages/web-components/fast-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/fast-components/src/number-field/number-field.styles.ts
@@ -7,6 +7,15 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
@@ -23,7 +32,7 @@ import {
 export const numberFieldStyles = (context, definition) =>
     css`
     ${display("inline-block")} :host {
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         outline: none;
         user-select: none;
     }
@@ -35,8 +44,8 @@ export const numberFieldStyles = (context, definition) =>
         flex-direction: row;
         color: ${neutralForegroundRestBehavior.var};
         background: ${neutralFillInputRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${outlineWidth} * 1px) solid ${accentFillRestBehavior.var};
         height: calc(${heightNumber} * 1px);
     }
 
@@ -51,9 +60,9 @@ export const numberFieldStyles = (context, definition) =>
         margin-top: auto;
         margin-bottom: auto;
         border: none;
-        padding: 0 calc(var(--design-unit) * 2px + 1px);
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        padding: 0 calc(${designUnit} * 2px + 1px);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
     }
 
     .control:hover,
@@ -71,8 +80,8 @@ export const numberFieldStyles = (context, definition) =>
         display: block;
         color: ${neutralForegroundRestBehavior.var};
         cursor: pointer;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
         margin-bottom: 4px;
     }
 
@@ -160,7 +169,7 @@ export const numberFieldStyles = (context, definition) =>
     }
 
     :host([disabled]) {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 
     :host([disabled]) .control {

--- a/packages/web-components/fast-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/fast-components/src/number-field/number-field.styles.ts
@@ -20,7 +20,8 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const NumberFieldStyles = css`
+export const numberFieldStyles = (context, definition) =>
+    css`
     ${display("inline-block")} :host {
         font-family: var(--body-font);
         outline: none;
@@ -166,46 +167,46 @@ export const NumberFieldStyles = css`
         border-color: ${neutralOutlineRestBehavior.var};
     }
 `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    neutralFillHoverBehavior,
-    neutralFillInputHoverBehavior,
-    neutralFillInputRestBehavior,
-    neutralFillRestBehavior,
-    neutralFocusBehavior,
-    neutralForegroundRestBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            .root,
-            :host([appearance="filled"]) .root {
-                forced-color-adjust: none;
-                background: ${SystemColors.Field};
-                border-color: ${SystemColors.FieldText};
-            }
-            :host(:hover:not([disabled])) .root,
-            :host([appearance="filled"]:hover:not([disabled])) .root,
-            :host([appearance="filled"]:hover) .root {
-                background: ${SystemColors.Field};
-                border-color: ${SystemColors.Highlight};
-            }
-            .start,
-            .end {
-                fill: currentcolor;
-            }
-            :host([disabled]) {
-                opacity: 1;
-            }
-            :host([disabled]) .root,
-            :host([appearance="filled"]:hover[disabled]) .root {
-                border-color: ${SystemColors.GrayText};
-                background: ${SystemColors.Field};
-            }
-            :host(:focus-within:enabled) .root {
-                border-color: ${SystemColors.Highlight};
-                box-shadow: 0 0 0 1px ${SystemColors.Highlight} inset;
-            }
-        `
-    )
-);
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        neutralFillHoverBehavior,
+        neutralFillInputHoverBehavior,
+        neutralFillInputRestBehavior,
+        neutralFillRestBehavior,
+        neutralFocusBehavior,
+        neutralForegroundRestBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                .root,
+                :host([appearance="filled"]) .root {
+                    forced-color-adjust: none;
+                    background: ${SystemColors.Field};
+                    border-color: ${SystemColors.FieldText};
+                }
+                :host(:hover:not([disabled])) .root,
+                :host([appearance="filled"]:hover:not([disabled])) .root,
+                :host([appearance="filled"]:hover) .root {
+                    background: ${SystemColors.Field};
+                    border-color: ${SystemColors.Highlight};
+                }
+                .start,
+                .end {
+                    fill: currentcolor;
+                }
+                :host([disabled]) {
+                    opacity: 1;
+                }
+                :host([disabled]) .root,
+                :host([appearance="filled"]:hover[disabled]) .root {
+                    border-color: ${SystemColors.GrayText};
+                    background: ${SystemColors.Field};
+                }
+                :host(:focus-within:enabled) .root {
+                    border-color: ${SystemColors.Highlight};
+                    box-shadow: 0 0 0 1px ${SystemColors.Highlight} inset;
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/progress-ring/index.ts
+++ b/packages/web-components/fast-components/src/progress-ring/index.ts
@@ -1,25 +1,23 @@
-import { customElement } from "@microsoft/fast-element";
 import {
-    BaseProgress,
-    ProgressRingTemplate as template,
+    BaseProgress as Progress,
+    progressRingTemplate as template,
 } from "@microsoft/fast-foundation";
-import { ProgressRingStyles as styles } from "./progress-ring.styles";
+import { progressRingStyles as styles } from "./progress-ring.styles";
 
 /**
  * The FAST Progress Ring Element. Implements {@link @microsoft/fast-foundation#BaseProgress},
- * {@link @microsoft/fast-foundation#ProgressRingTemplate}
+ * {@link @microsoft/fast-foundation#progressRingTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-progress-ring\>
  */
-@customElement({
-    name: "fast-progress-ring",
+export const fastProgressRing = Progress.compose({
+    baseName: "progress-ring",
     template,
     styles,
-})
-export class FASTProgressRing extends BaseProgress {}
+});
 
 /**
  * Styles for ProgressRing

--- a/packages/web-components/fast-components/src/progress-ring/index.ts
+++ b/packages/web-components/fast-components/src/progress-ring/index.ts
@@ -23,4 +23,4 @@ export const fastProgressRing = Progress.compose({
  * Styles for ProgressRing
  * @public
  */
-export const ProgressRingStyles = styles;
+export const progressRingStyles = styles;

--- a/packages/web-components/fast-components/src/progress-ring/progress-ring.styles.ts
+++ b/packages/web-components/fast-components/src/progress-ring/progress-ring.styles.ts
@@ -8,89 +8,90 @@ import {
     neutralForegroundHintBehavior,
 } from "../styles";
 
-export const ProgressRingStyles = css`
-    ${display("flex")} :host {
-        align-items: center;
-        outline: none;
-        height: calc(${heightNumber} * 1px);
-        width: calc(${heightNumber} * 1px);
-        margin: calc(${heightNumber} * 1px) 0;
-    }
-
-    .progress {
-        height: 100%;
-        width: 100%;
-    }
-
-    .background {
-        stroke: ${neutralFillRestBehavior.var};
-        fill: none;
-        stroke-width: 2px;
-    }
-
-    .determinate {
-        stroke: ${accentForegroundRestBehavior.var};
-        fill: none;
-        stroke-width: 2px;
-        stroke-linecap: round;
-        transform-origin: 50% 50%;
-        transform: rotate(-90deg);
-        transition: all 0.2s ease-in-out;
-    }
-
-    .indeterminate-indicator-1 {
-        stroke: ${accentForegroundRestBehavior.var};
-        fill: none;
-        stroke-width: 2px;
-        stroke-linecap: round;
-        transform-origin: 50% 50%;
-        transform: rotate(-90deg);
-        transition: all 0.2s ease-in-out;
-        animation: spin-infinite 2s linear infinite;
-    }
-
-    :host([paused]) .indeterminate-indicator-1 {
-        animation-play-state: paused;
-        stroke: ${neutralFillRestBehavior.var};
-    }
-
-    :host([paused]) .determinate {
-        stroke: ${neutralForegroundHintBehavior.var};
-    }
-
-    @keyframes spin-infinite {
-        0% {
-            stroke-dasharray: 0.01px 43.97px;
-            transform: rotate(0deg);
+export const progressRingStyles = (context, defintion) =>
+    css`
+        ${display("flex")} :host {
+            align-items: center;
+            outline: none;
+            height: calc(${heightNumber} * 1px);
+            width: calc(${heightNumber} * 1px);
+            margin: calc(${heightNumber} * 1px) 0;
         }
-        50% {
-            stroke-dasharray: 21.99px 21.99px;
-            transform: rotate(450deg);
+
+        .progress {
+            height: 100%;
+            width: 100%;
         }
-        100% {
-            stroke-dasharray: 0.01px 43.97px;
-            transform: rotate(1080deg);
+
+        .background {
+            stroke: ${neutralFillRestBehavior.var};
+            fill: none;
+            stroke-width: 2px;
         }
-    }
-`.withBehaviors(
-    accentForegroundRestBehavior,
-    neutralFillRestBehavior,
-    neutralForegroundHintBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            .indeterminate-indicator-1,
-            .determinate {
-                stroke: ${SystemColors.FieldText};
+
+        .determinate {
+            stroke: ${accentForegroundRestBehavior.var};
+            fill: none;
+            stroke-width: 2px;
+            stroke-linecap: round;
+            transform-origin: 50% 50%;
+            transform: rotate(-90deg);
+            transition: all 0.2s ease-in-out;
+        }
+
+        .indeterminate-indicator-1 {
+            stroke: ${accentForegroundRestBehavior.var};
+            fill: none;
+            stroke-width: 2px;
+            stroke-linecap: round;
+            transform-origin: 50% 50%;
+            transform: rotate(-90deg);
+            transition: all 0.2s ease-in-out;
+            animation: spin-infinite 2s linear infinite;
+        }
+
+        :host([paused]) .indeterminate-indicator-1 {
+            animation-play-state: paused;
+            stroke: ${neutralFillRestBehavior.var};
+        }
+
+        :host([paused]) .determinate {
+            stroke: ${neutralForegroundHintBehavior.var};
+        }
+
+        @keyframes spin-infinite {
+            0% {
+                stroke-dasharray: 0.01px 43.97px;
+                transform: rotate(0deg);
             }
-            .background {
-                stroke: ${SystemColors.Field};
+            50% {
+                stroke-dasharray: 21.99px 21.99px;
+                transform: rotate(450deg);
             }
-            :host([paused]) .indeterminate-indicator-1 {
-                stroke: ${SystemColors.Field};
+            100% {
+                stroke-dasharray: 0.01px 43.97px;
+                transform: rotate(1080deg);
             }
-            :host([paused]) .determinate {
-                stroke: ${SystemColors.GrayText};
-            }
-        `
-    )
-);
+        }
+    `.withBehaviors(
+        accentForegroundRestBehavior,
+        neutralFillRestBehavior,
+        neutralForegroundHintBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                .indeterminate-indicator-1,
+                .determinate {
+                    stroke: ${SystemColors.FieldText};
+                }
+                .background {
+                    stroke: ${SystemColors.Field};
+                }
+                :host([paused]) .indeterminate-indicator-1 {
+                    stroke: ${SystemColors.Field};
+                }
+                :host([paused]) .determinate {
+                    stroke: ${SystemColors.GrayText};
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/progress/index.ts
+++ b/packages/web-components/fast-components/src/progress/index.ts
@@ -1,22 +1,23 @@
-import { customElement } from "@microsoft/fast-element";
-import { BaseProgress, ProgressTemplate as template } from "@microsoft/fast-foundation";
-import { ProgressStyles as styles } from "./progress.styles";
+import {
+    BaseProgress as Progress,
+    progressTemplate as template,
+} from "@microsoft/fast-foundation";
+import { progressStyles as styles } from "./progress.styles";
 
 /**
  * The FAST Progress Element. Implements {@link @microsoft/fast-foundation#BaseProgress},
- * {@link @microsoft/fast-foundation#ProgressTemplate}
+ * {@link @microsoft/fast-foundation#progressTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-progress\>
  */
-@customElement({
-    name: "fast-progress",
+export const fastProgress = Progress.compose({
+    baseName: "progress",
     template,
     styles,
-})
-export class FASTProgress extends BaseProgress {}
+});
 
 /**
  * Styles for Progress

--- a/packages/web-components/fast-components/src/progress/index.ts
+++ b/packages/web-components/fast-components/src/progress/index.ts
@@ -23,4 +23,4 @@ export const fastProgress = Progress.compose({
  * Styles for Progress
  * @public
  */
-export const ProgressStyles = styles;
+export const progressStyles = styles;

--- a/packages/web-components/fast-components/src/progress/progress.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress.styles.ts
@@ -1,6 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import { designUnit } from "../design-tokens";
 import {
     accentForegroundRestBehavior,
     neutralFillRestBehavior,
@@ -12,13 +13,13 @@ export const progressStyles = (context, definition) =>
         ${display("flex")} :host {
             align-items: center;
             outline: none;
-            height: calc(var(--design-unit) * 1px);
-            margin: calc(var(--design-unit) * 1px) 0;
+            height: calc(${designUnit} * 1px);
+            margin: calc(${designUnit} * 1px) 0;
         }
 
         .progress {
             background-color: ${neutralFillRestBehavior.var};
-            border-radius: calc(var(--design-unit) * 1px);
+            border-radius: calc(${designUnit} * 1px);
             width: 100%;
             height: 100%;
             display: flex;
@@ -28,7 +29,7 @@ export const progressStyles = (context, definition) =>
 
         .determinate {
             background-color: ${accentForegroundRestBehavior.var};
-            border-radius: calc(var(--design-unit) * 1px);
+            border-radius: calc(${designUnit} * 1px);
             height: 100%;
             transition: all 0.2s ease-in-out;
             display: flex;
@@ -36,7 +37,7 @@ export const progressStyles = (context, definition) =>
 
         .indeterminate {
             height: 100%;
-            border-radius: calc(var(--design-unit) * 1px);
+            border-radius: calc(${designUnit} * 1px);
             display: flex;
             width: 100%;
             position: relative;
@@ -48,7 +49,7 @@ export const progressStyles = (context, definition) =>
             opacity: 0;
             height: 100%;
             background-color: ${accentForegroundRestBehavior.var};
-            border-radius: calc(var(--design-unit) * 1px);
+            border-radius: calc(${designUnit} * 1px);
             animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
             width: 40%;
             animation: indeterminate-1 2s infinite;
@@ -59,7 +60,7 @@ export const progressStyles = (context, definition) =>
             opacity: 0;
             height: 100%;
             background-color: ${accentForegroundRestBehavior.var};
-            border-radius: calc(var(--design-unit) * 1px);
+            border-radius: calc(${designUnit} * 1px);
             animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
             width: 60%;
             animation: indeterminate-2 2s infinite;

--- a/packages/web-components/fast-components/src/progress/progress.styles.ts
+++ b/packages/web-components/fast-components/src/progress/progress.styles.ts
@@ -7,130 +7,131 @@ import {
     neutralForegroundHintBehavior,
 } from "../styles";
 
-export const ProgressStyles = css`
-    ${display("flex")} :host {
-        align-items: center;
-        outline: none;
-        height: calc(var(--design-unit) * 1px);
-        margin: calc(var(--design-unit) * 1px) 0;
-    }
-
-    .progress {
-        background-color: ${neutralFillRestBehavior.var};
-        border-radius: calc(var(--design-unit) * 1px);
-        width: 100%;
-        height: 100%;
-        display: flex;
-        align-items: center;
-        position: relative;
-    }
-
-    .determinate {
-        background-color: ${accentForegroundRestBehavior.var};
-        border-radius: calc(var(--design-unit) * 1px);
-        height: 100%;
-        transition: all 0.2s ease-in-out;
-        display: flex;
-    }
-
-    .indeterminate {
-        height: 100%;
-        border-radius: calc(var(--design-unit) * 1px);
-        display: flex;
-        width: 100%;
-        position: relative;
-        overflow: hidden;
-    }
-
-    .indeterminate-indicator-1 {
-        position: absolute;
-        opacity: 0;
-        height: 100%;
-        background-color: ${accentForegroundRestBehavior.var};
-        border-radius: calc(var(--design-unit) * 1px);
-        animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
-        width: 40%;
-        animation: indeterminate-1 2s infinite;
-    }
-
-    .indeterminate-indicator-2 {
-        position: absolute;
-        opacity: 0;
-        height: 100%;
-        background-color: ${accentForegroundRestBehavior.var};
-        border-radius: calc(var(--design-unit) * 1px);
-        animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
-        width: 60%;
-        animation: indeterminate-2 2s infinite;
-    }
-
-    :host([paused]) .indeterminate-indicator-1,
-    :host([paused]) .indeterminate-indicator-2 {
-        animation-play-state: paused;
-        background-color: ${neutralFillRestBehavior.var};
-    }
-
-    :host([paused]) .determinate {
-        background-color: ${neutralForegroundHintBehavior.var};
-    }
-
-    @keyframes indeterminate-1 {
-        0% {
-            opacity: 1;
-            transform: translateX(-100%);
+export const progressStyles = (context, definition) =>
+    css`
+        ${display("flex")} :host {
+            align-items: center;
+            outline: none;
+            height: calc(var(--design-unit) * 1px);
+            margin: calc(var(--design-unit) * 1px) 0;
         }
-        70% {
-            opacity: 1;
-            transform: translateX(300%);
+
+        .progress {
+            background-color: ${neutralFillRestBehavior.var};
+            border-radius: calc(var(--design-unit) * 1px);
+            width: 100%;
+            height: 100%;
+            display: flex;
+            align-items: center;
+            position: relative;
         }
-        70.01% {
+
+        .determinate {
+            background-color: ${accentForegroundRestBehavior.var};
+            border-radius: calc(var(--design-unit) * 1px);
+            height: 100%;
+            transition: all 0.2s ease-in-out;
+            display: flex;
+        }
+
+        .indeterminate {
+            height: 100%;
+            border-radius: calc(var(--design-unit) * 1px);
+            display: flex;
+            width: 100%;
+            position: relative;
+            overflow: hidden;
+        }
+
+        .indeterminate-indicator-1 {
+            position: absolute;
             opacity: 0;
+            height: 100%;
+            background-color: ${accentForegroundRestBehavior.var};
+            border-radius: calc(var(--design-unit) * 1px);
+            animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+            width: 40%;
+            animation: indeterminate-1 2s infinite;
         }
-        100% {
-            opacity: 0;
-            transform: translateX(300%);
-        }
-    }
 
-    @keyframes indeterminate-2 {
-        0% {
+        .indeterminate-indicator-2 {
+            position: absolute;
             opacity: 0;
-            transform: translateX(-150%);
+            height: 100%;
+            background-color: ${accentForegroundRestBehavior.var};
+            border-radius: calc(var(--design-unit) * 1px);
+            animation-timing-function: cubic-bezier(0.4, 0, 0.6, 1);
+            width: 60%;
+            animation: indeterminate-2 2s infinite;
         }
-        29.99% {
-            opacity: 0;
+
+        :host([paused]) .indeterminate-indicator-1,
+        :host([paused]) .indeterminate-indicator-2 {
+            animation-play-state: paused;
+            background-color: ${neutralFillRestBehavior.var};
         }
-        30% {
-            opacity: 1;
-            transform: translateX(-150%);
+
+        :host([paused]) .determinate {
+            background-color: ${neutralForegroundHintBehavior.var};
         }
-        100% {
-            transform: translateX(166.66%);
-            opacity: 1;
-        }
-    }
-`.withBehaviors(
-    accentForegroundRestBehavior,
-    neutralFillRestBehavior,
-    neutralForegroundHintBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            .progress {
-                forced-color-adjust: none;
-                background-color: ${SystemColors.Field};
-                box-shadow: 0 0 0 1px inset ${SystemColors.FieldText};
+
+        @keyframes indeterminate-1 {
+            0% {
+                opacity: 1;
+                transform: translateX(-100%);
             }
-            .determinate,
-            .indeterminate-indicator-1,
-            .indeterminate-indicator-2 {
-                forced-color-adjust: none;
-                background-color: ${SystemColors.FieldText};
+            70% {
+                opacity: 1;
+                transform: translateX(300%);
             }
-            :host([paused]) .determinate,
-            :host([paused]) .indeterminate-indicator-1,
-            :host([paused]) .indeterminate-indicator-2 {
-                background-color: ${SystemColors.GrayText};
+            70.01% {
+                opacity: 0;
             }
-        `
-    )
-);
+            100% {
+                opacity: 0;
+                transform: translateX(300%);
+            }
+        }
+
+        @keyframes indeterminate-2 {
+            0% {
+                opacity: 0;
+                transform: translateX(-150%);
+            }
+            29.99% {
+                opacity: 0;
+            }
+            30% {
+                opacity: 1;
+                transform: translateX(-150%);
+            }
+            100% {
+                transform: translateX(166.66%);
+                opacity: 1;
+            }
+        }
+    `.withBehaviors(
+        accentForegroundRestBehavior,
+        neutralFillRestBehavior,
+        neutralForegroundHintBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                .progress {
+                    forced-color-adjust: none;
+                    background-color: ${SystemColors.Field};
+                    box-shadow: 0 0 0 1px inset ${SystemColors.FieldText};
+                }
+                .determinate,
+                .indeterminate-indicator-1,
+                .indeterminate-indicator-2 {
+                    forced-color-adjust: none;
+                    background-color: ${SystemColors.FieldText};
+                }
+                :host([paused]) .determinate,
+                :host([paused]) .indeterminate-indicator-1,
+                :host([paused]) .indeterminate-indicator-2 {
+                    background-color: ${SystemColors.GrayText};
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/radio-group/index.ts
+++ b/packages/web-components/fast-components/src/radio-group/index.ts
@@ -20,4 +20,4 @@ export const fastRadioGroup = RadioGroup.compose({
  * Styles for RadioGroup
  * @public
  */
-export const RadioGroupStyles = styles;
+export const radioGroupStyles = styles;

--- a/packages/web-components/fast-components/src/radio-group/index.ts
+++ b/packages/web-components/fast-components/src/radio-group/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { RadioGroup, RadioGroupTemplate as template } from "@microsoft/fast-foundation";
-import { RadioGroupStyles as styles } from "./radio-group.styles";
+import { RadioGroup, radioGroupTemplate as template } from "@microsoft/fast-foundation";
+import { radioGroupStyles as styles } from "./radio-group.styles";
 
 /**
  * The FAST Radio Group Element. Implements {@link @microsoft/fast-foundation#RadioGroup},
- * {@link @microsoft/fast-foundation#RadioGroupTemplate}
+ * {@link @microsoft/fast-foundation#radioGroupTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-radio-group\>
  */
-@customElement({
-    name: "fast-radio-group",
+export const fastRadioGroup = RadioGroup.compose({
+    baseName: "radio-group",
     template,
     styles,
-})
-export class FASTRadioGroup extends RadioGroup {}
+});
 
 /**
  * Styles for RadioGroup

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 
-export const RadioGroupStyles = css`
+export const radioGroupStyles = (context, definition) => css`
     ${display("flex")} :host {
         align-items: flex-start;
         margin: calc(var(--design-unit) * 1px) 0;

--- a/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
+++ b/packages/web-components/fast-components/src/radio-group/radio-group.styles.ts
@@ -1,10 +1,11 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
+import { designUnit } from "../design-tokens";
 
 export const radioGroupStyles = (context, definition) => css`
     ${display("flex")} :host {
         align-items: flex-start;
-        margin: calc(var(--design-unit) * 1px) 0;
+        margin: calc(${designUnit} * 1px) 0;
         flex-direction: column;
     }
     .positioning-region {

--- a/packages/web-components/fast-components/src/radio/index.ts
+++ b/packages/web-components/fast-components/src/radio/index.ts
@@ -20,4 +20,4 @@ export const fastRadio = Radio.compose({
  * Styles for Radio
  * @public
  */
-export const RadioStyles = styles;
+export const radioStyles = styles;

--- a/packages/web-components/fast-components/src/radio/index.ts
+++ b/packages/web-components/fast-components/src/radio/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Radio, RadioTemplate as template } from "@microsoft/fast-foundation";
-import { RadioStyles as styles } from "./radio.styles";
+import { Radio, radioTemplate as template } from "@microsoft/fast-foundation";
+import { radioStyles as styles } from "./radio.styles";
 
 /**
  * The FAST Radio Element. Implements {@link @microsoft/fast-foundation#Radio},
- * {@link @microsoft/fast-foundation#RadioTemplate}
+ * {@link @microsoft/fast-foundation#radioTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-radio\>
  */
-@customElement({
-    name: "fast-radio",
+export const fastRadio = Radio.compose({
+    baseName: "radio",
     template,
     styles,
-})
-export class FASTRadio extends Radio {}
+});
 
 /**
  * Styles for Radio

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -22,7 +22,8 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const RadioStyles = css`
+export const radioStyles = (context, definition) =>
+    css`
     ${display("inline-flex")} :host {
         --input-size: calc((${heightNumber} / 2) + var(--design-unit));
         align-items: center;
@@ -140,20 +141,20 @@ export const RadioStyles = css`
         opacity: var(--disabled-opacity);
     }
 `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    accentForegroundCutRestBehavior,
-    neutralFillInputActiveBehavior,
-    neutralFillInputHoverBehavior,
-    neutralFillInputRestBehavior,
-    neutralFocusBehavior,
-    neutralForegroundRestBehavior,
-    neutralOutlineActiveBehavior,
-    neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        accentForegroundCutRestBehavior,
+        neutralFillInputActiveBehavior,
+        neutralFillInputHoverBehavior,
+        neutralFillInputRestBehavior,
+        neutralFocusBehavior,
+        neutralForegroundRestBehavior,
+        neutralOutlineActiveBehavior,
+        neutralOutlineHoverBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
             .control,
             :host([checked]:not([disabled])) .control {
                 forced-color-adjust: none;
@@ -204,5 +205,5 @@ export const RadioStyles = css`
                 background: ${SystemColors.GrayText};
             }
         `
-    )
-);
+        )
+    );

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -7,6 +7,14 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    designUnit,
+    disabledOpacity,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
@@ -25,10 +33,10 @@ import {
 export const radioStyles = (context, definition) =>
     css`
     ${display("inline-flex")} :host {
-        --input-size: calc((${heightNumber} / 2) + var(--design-unit));
+        --input-size: calc((${heightNumber} / 2) + ${designUnit});
         align-items: center;
         outline: none;
-        margin: calc(var(--design-unit) * 1px) 0;
+        margin: calc(${designUnit} * 1px) 0;
         ${
             /*
              * Chromium likes to select label text or the default slot when
@@ -42,26 +50,26 @@ export const radioStyles = (context, definition) =>
 
     .control {
         position: relative;
-        width: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
-        height: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
+        width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
+        height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         box-sizing: border-box;
         border-radius: 999px;
-        border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
+        border: calc(${outlineWidth} * 1px) solid ${neutralOutlineRestBehavior.var};
         background: ${neutralFillInputRestBehavior.var};
         outline: none;
         cursor: pointer;
     }
 
     .label {
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         color: ${neutralForegroundRestBehavior.var};
         ${
             /* Need to discuss with Brian how HorizontalSpacingNumber can work. https://github.com/microsoft/fast/issues/2766 */ ""
-        } padding-inline-start: calc(var(--design-unit) * 2px + 2px);
-        margin-inline-end: calc(var(--design-unit) * 2px + 2px);
+        } padding-inline-start: calc(${designUnit} * 2px + 2px);
+        margin-inline-end: calc(${designUnit} * 2px + 2px);
         cursor: pointer;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
     }
 
     .label__hidden {
@@ -106,17 +114,17 @@ export const radioStyles = (context, definition) =>
 
     :host([aria-checked="true"]) .control {
         background: ${accentFillRestBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
+        border: calc(${outlineWidth} * 1px) solid ${accentFillRestBehavior.var};
     }
 
     :host([aria-checked="true"]:not([disabled])) .control:hover {
         background: ${accentFillHoverBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${accentFillHoverBehavior.var};
+        border: calc(${outlineWidth} * 1px) solid ${accentFillHoverBehavior.var};
     }
 
     :host([aria-checked="true"]:not([disabled])) .control:active {
         background: ${accentFillActiveBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${accentFillActiveBehavior.var};
+        border: calc(${outlineWidth} * 1px) solid ${accentFillActiveBehavior.var};
     }
 
     :host([aria-checked="true"]:${focusVisible}:not([disabled])) .control {
@@ -138,7 +146,7 @@ export const radioStyles = (context, definition) =>
     }
 
     :host([disabled]) {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 `.withBehaviors(
         accentFillActiveBehavior,

--- a/packages/web-components/fast-components/src/select/index.ts
+++ b/packages/web-components/fast-components/src/select/index.ts
@@ -12,7 +12,7 @@ import { selectStyles as styles } from "./select.styles";
  *
  */
 export const fastSelect = Select.compose({
-    baseName: "fast",
+    baseName: "select",
     template,
     styles,
 });
@@ -21,4 +21,4 @@ export const fastSelect = Select.compose({
  * Styles for Select
  * @public
  */
-export const SelectStyles = styles;
+export const selectStyles = styles;

--- a/packages/web-components/fast-components/src/select/index.ts
+++ b/packages/web-components/fast-components/src/select/index.ts
@@ -1,10 +1,9 @@
-import { customElement } from "@microsoft/fast-element";
-import { Select, SelectTemplate as template } from "@microsoft/fast-foundation";
-import { SelectStyles as styles } from "./select.styles";
+import { Select, selectTemplate as template } from "@microsoft/fast-foundation";
+import { selectStyles as styles } from "./select.styles";
 
 /**
  * The FAST select Custom Element. Implements, {@link @microsoft/fast-foundation#Select}
- * {@link @microsoft/fast-foundation#SelectTemplate}
+ * {@link @microsoft/fast-foundation#selectTemplate}
  *
  *
  * @public
@@ -12,12 +11,11 @@ import { SelectStyles as styles } from "./select.styles";
  * HTML Element: \<fast-select\>
  *
  */
-@customElement({
-    name: "fast-select",
+export const fastSelect = Select.compose({
+    baseName: "fast",
     template,
     styles,
-})
-export class FASTSelect extends Select {}
+});
 
 /**
  * Styles for Select

--- a/packages/web-components/fast-components/src/select/select.styles.ts
+++ b/packages/web-components/fast-components/src/select/select.styles.ts
@@ -25,7 +25,8 @@ import {
 } from "../styles/recipes";
 import { heightNumber } from "../styles/size";
 
-export const SelectStyles = css`
+export const selectStyles = (context, definition) =>
+    css`
     ${display("inline-flex")} :host {
         --elevation: 14;
         background: ${neutralFillInputRestBehavior.var};
@@ -188,13 +189,13 @@ export const SelectStyles = css`
     }
 
 `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    accentForegroundCutRestBehavior,
-    accentForegroundFocusBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        accentForegroundCutRestBehavior,
+        accentForegroundFocusBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
             :host(:not([disabled]):hover),
             :host(:not([disabled]):active) {
                 border-color: ${SystemColors.Highlight};
@@ -253,13 +254,13 @@ export const SelectStyles = css`
                 fill: currentcolor;
             }
         `
-    ),
-    neutralFillInputActiveBehavior,
-    neutralFillInputHoverBehavior,
-    neutralFillInputRestBehavior,
-    neutralFocusBehavior,
-    neutralFocusInnerAccentBehavior,
-    neutralForegroundRestBehavior,
-    neutralLayerFloatingBehavior,
-    neutralOutlineRestBehavior
-);
+        ),
+        neutralFillInputActiveBehavior,
+        neutralFillInputHoverBehavior,
+        neutralFillInputRestBehavior,
+        neutralFocusBehavior,
+        neutralFocusInnerAccentBehavior,
+        neutralForegroundRestBehavior,
+        neutralLayerFloatingBehavior,
+        neutralOutlineRestBehavior
+    );

--- a/packages/web-components/fast-components/src/select/select.styles.ts
+++ b/packages/web-components/fast-components/src/select/select.styles.ts
@@ -6,6 +6,16 @@ import {
     forcedColorsStylesheetBehavior,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    focusOutlineWidth,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
 import { elevation } from "../styles/elevation";
 import {
     accentFillActiveBehavior,
@@ -30,11 +40,11 @@ export const selectStyles = (context, definition) =>
     ${display("inline-flex")} :host {
         --elevation: 14;
         background: ${neutralFillInputRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${outlineWidth} * 1px) solid ${accentFillRestBehavior.var};
         box-sizing: border-box;
         color: ${neutralForegroundRestBehavior.var};
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         height: calc(${heightNumber} * 1px);
         position: relative;
         user-select: none;
@@ -46,14 +56,14 @@ export const selectStyles = (context, definition) =>
     .listbox {
         ${elevation}
         background: ${neutralLayerFloatingBehavior.var};
-        border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
+        border: calc(${outlineWidth} * 1px) solid ${neutralOutlineRestBehavior.var};
+        border-radius: calc(${cornerRadius} * 1px);
         box-sizing: border-box;
         display: inline-flex;
         flex-direction: column;
         left: 0;
         max-height: calc(var(--max-height) - (${heightNumber} * 1px));
-        padding: calc(var(--design-unit) * 1px) 0;
+        padding: calc(${designUnit} * 1px) 0;
         overflow-y: auto;
         position: absolute;
         width: 100%;
@@ -69,11 +79,11 @@ export const selectStyles = (context, definition) =>
         box-sizing: border-box;
         cursor: pointer;
         display: flex;
-        font-size: var(--type-ramp-base-font-size);
+        font-size: ${typeRampBaseFontSize};
         font-family: inherit;
-        line-height: var(--type-ramp-base-line-height);
+        line-height: ${typeRampBaseLineHeight};
         min-height: 100%;
-        padding: 0 calc(var(--design-unit) * 2.25px);
+        padding: 0 calc(${designUnit} * 2.25px);
         width: 100%;
     }
 
@@ -84,15 +94,13 @@ export const selectStyles = (context, definition) =>
 
     :host(:${focusVisible}) {
         border-color: ${neutralFocusBehavior.var};
-        box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) ${
-            neutralFocusBehavior.var
-        };
+        box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) ${neutralFocusBehavior.var};
     }
 
     :host(:${focusVisible}) ::slotted([aria-selected="true"][role="option"]:not([disabled])) {
-        box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${
-            neutralFocusInnerAccentBehavior.var
-        };
+        box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) inset ${
+        neutralFocusInnerAccentBehavior.var
+    };
         border-color: ${neutralFocusBehavior.var};
         background: ${accentFillHoverBehavior.var};
         color: ${accentForegroundCutRestBehavior.var};
@@ -100,7 +108,7 @@ export const selectStyles = (context, definition) =>
 
     :host([disabled]) {
         cursor: ${disabledCursor};
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 
     :host([disabled]) .control {
@@ -178,8 +186,8 @@ export const selectStyles = (context, definition) =>
         ${`` /* Glyph size is temporary - replace when glyph-size var is added */}
         fill: currentcolor;
         height: 1em;
-        min-height: calc(var(--design-unit) * 4px);
-        min-width: calc(var(--design-unit) * 4px);
+        min-height: calc(${designUnit} * 4px);
+        min-width: calc(${designUnit} * 4px);
         width: 1em;
     }
 
@@ -203,7 +211,7 @@ export const selectStyles = (context, definition) =>
 
             :host(:not([disabled]):${focusVisible}) {
                 background-color: ${SystemColors.ButtonFace};
-                box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) ${SystemColors.Highlight};
+                box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) ${SystemColors.Highlight};
                 color: ${SystemColors.ButtonText};
                 fill: currentcolor;
                 forced-color-adjust: none;
@@ -240,7 +248,7 @@ export const selectStyles = (context, definition) =>
             :host(:${focusVisible}) ::slotted([aria-selected="true"][role="option"]:not([disabled])) {
                 background: ${SystemColors.Highlight};
                 border-color: ${SystemColors.ButtonText};
-                box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${SystemColors.HighlightText};
+                box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) inset ${SystemColors.HighlightText};
                 color: ${SystemColors.HighlightText};
                 fill: currentcolor;
             }

--- a/packages/web-components/fast-components/src/skeleton/index.ts
+++ b/packages/web-components/fast-components/src/skeleton/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Skeleton, SkeletonTemplate as template } from "@microsoft/fast-foundation";
-import { SkeletonStyles as styles } from "./skeleton.styles";
+import { Skeleton, skeletonTemplate as template } from "@microsoft/fast-foundation";
+import { skeletonStyles as styles } from "./skeleton.styles";
 
 /**
  * The FAST Skeleton Element. Implements {@link @microsoft/fast-foundation#Skeleton},
- * {@link @microsoft/fast-foundation#SkeletonTemplate}
+ * {@link @microsoft/fast-foundation#skeletonTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-skeleton\>
  */
-@customElement({
-    name: "fast-skeleton",
+export const fastSkeleton = Skeleton.compose({
+    baseName: "skeleton",
     template,
     styles,
-})
-export class FASTSkeleton extends Skeleton {}
+});
 
 /**
  * Styles for Skeleton

--- a/packages/web-components/fast-components/src/skeleton/index.ts
+++ b/packages/web-components/fast-components/src/skeleton/index.ts
@@ -20,4 +20,4 @@ export const fastSkeleton = Skeleton.compose({
  * Styles for Skeleton
  * @public
  */
-export const SkeletonStyles = styles;
+export const skeletonStyles = styles;

--- a/packages/web-components/fast-components/src/skeleton/skeleton.styles.ts
+++ b/packages/web-components/fast-components/src/skeleton/skeleton.styles.ts
@@ -3,6 +3,7 @@ import { forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import { display } from "@microsoft/fast-foundation";
 import { neutralFillRestBehavior } from "../styles";
+import { cornerRadius } from "../design-tokens";
 
 export const skeletonStyles = (context, definition) =>
     css`
@@ -22,7 +23,7 @@ export const skeletonStyles = (context, definition) =>
         }
 
         :host([shape="rect"]) {
-            border-radius: calc(var(--corner-radius) * 1px);
+            border-radius: calc(${cornerRadius} * 1px);
         }
 
         :host([shape="circle"]) {

--- a/packages/web-components/fast-components/src/skeleton/skeleton.styles.ts
+++ b/packages/web-components/fast-components/src/skeleton/skeleton.styles.ts
@@ -4,93 +4,97 @@ import { SystemColors } from "@microsoft/fast-web-utilities";
 import { display } from "@microsoft/fast-foundation";
 import { neutralFillRestBehavior } from "../styles";
 
-export const SkeletonStyles = css`
-    ${display("block")} :host {
-        --skeleton-fill-default: #e1dfdd;
-        overflow: hidden;
-        width: 100%;
-        position: relative;
-        background-color: var(--skeleton-fill, var(--skeleton-fill-default));
-        --skeleton-animation-gradient-default: linear-gradient(
-            270deg,
-            var(--skeleton-fill, var(--skeleton-fill-default)) 0%,
-            #f3f2f1 51.13%,
-            var(--skeleton-fill, var(--skeleton-fill-default)) 100%
-        );
-        --skeleton-animation-timing-default: ease-in-out;
-    }
-
-    :host([shape="rect"]) {
-        border-radius: calc(var(--corner-radius) * 1px);
-    }
-
-    :host([shape="circle"]) {
-        border-radius: 100%;
-        overflow: hidden;
-    }
-
-    object {
-        position: absolute;
-        width: 100%;
-        height: auto;
-        z-index: 2;
-    }
-
-    object img {
-        width: 100%;
-        height: auto;
-    }
-
-    ${display("block")} span.shimmer {
-        position: absolute;
-        width: 100%;
-        height: 100%;
-        background-image: var(
-            --skeleton-animation-gradient,
-            var(--skeleton-animation-gradient-default)
-        );
-        background-size: 0px 0px / 90% 100%;
-        background-repeat: no-repeat;
-        background-color: var(--skeleton-animation-fill, ${neutralFillRestBehavior.var});
-        animation: shimmer 2s infinite;
-        animation-timing-function: var(
-            --skeleton-animation-timing,
-            var(--skeleton-timing-default)
-        );
-        animation-direction: normal;
-        z-index: 1;
-    }
-
-    ::slotted(svg) {
-        z-index: 2;
-    }
-
-    ::slotted(.pattern) {
-        width: 100%;
-        height: 100%;
-    }
-
-    @keyframes shimmer {
-        0% {
-            transform: translateX(-100%);
+export const skeletonStyles = (context, definition) =>
+    css`
+        ${display("block")} :host {
+            --skeleton-fill-default: #e1dfdd;
+            overflow: hidden;
+            width: 100%;
+            position: relative;
+            background-color: var(--skeleton-fill, var(--skeleton-fill-default));
+            --skeleton-animation-gradient-default: linear-gradient(
+                270deg,
+                var(--skeleton-fill, var(--skeleton-fill-default)) 0%,
+                #f3f2f1 51.13%,
+                var(--skeleton-fill, var(--skeleton-fill-default)) 100%
+            );
+            --skeleton-animation-timing-default: ease-in-out;
         }
-        100% {
-            transform: translateX(100%);
-        }
-    }
-`.withBehaviors(
-    neutralFillRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            :host {
-                forced-color-adjust: none;
-                background-color: ${SystemColors.ButtonFace};
-                box-shadow: 0 0 0 1px ${SystemColors.ButtonText};
-            }
 
-            ${display("block")} span.shimmer {
-                display: none;
+        :host([shape="rect"]) {
+            border-radius: calc(var(--corner-radius) * 1px);
+        }
+
+        :host([shape="circle"]) {
+            border-radius: 100%;
+            overflow: hidden;
+        }
+
+        object {
+            position: absolute;
+            width: 100%;
+            height: auto;
+            z-index: 2;
+        }
+
+        object img {
+            width: 100%;
+            height: auto;
+        }
+
+        ${display("block")} span.shimmer {
+            position: absolute;
+            width: 100%;
+            height: 100%;
+            background-image: var(
+                --skeleton-animation-gradient,
+                var(--skeleton-animation-gradient-default)
+            );
+            background-size: 0px 0px / 90% 100%;
+            background-repeat: no-repeat;
+            background-color: var(
+                --skeleton-animation-fill,
+                ${neutralFillRestBehavior.var}
+            );
+            animation: shimmer 2s infinite;
+            animation-timing-function: var(
+                --skeleton-animation-timing,
+                var(--skeleton-timing-default)
+            );
+            animation-direction: normal;
+            z-index: 1;
+        }
+
+        ::slotted(svg) {
+            z-index: 2;
+        }
+
+        ::slotted(.pattern) {
+            width: 100%;
+            height: 100%;
+        }
+
+        @keyframes shimmer {
+            0% {
+                transform: translateX(-100%);
             }
-        `
-    )
-);
+            100% {
+                transform: translateX(100%);
+            }
+        }
+    `.withBehaviors(
+        neutralFillRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                :host {
+                    forced-color-adjust: none;
+                    background-color: ${SystemColors.ButtonFace};
+                    box-shadow: 0 0 0 1px ${SystemColors.ButtonText};
+                }
+
+                ${display("block")} span.shimmer {
+                    display: none;
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/slider-label/index.ts
+++ b/packages/web-components/fast-components/src/slider-label/index.ts
@@ -1,27 +1,18 @@
-import { customElement } from "@microsoft/fast-element";
-import { SliderLabel, SliderLabelTemplate as template } from "@microsoft/fast-foundation";
+import {
+    SliderLabel as FoundationSliderLabel,
+    sliderLabelTemplate as template,
+} from "@microsoft/fast-foundation";
 import { Orientation } from "@microsoft/fast-web-utilities";
 import {
     horizontalSliderStyles,
-    SliderLabelStyles as styles,
+    sliderLabelStyles as styles,
     verticalSliderStyles,
 } from "./slider-label.styles";
 
 /**
- * The FAST Slider Label Custom Element. Implements {@link @microsoft/fast-foundation#(SliderLabel:class)},
- * {@link @microsoft/fast-foundation#SliderLabelTemplate}
- *
- *
- * @public
- * @remarks
- * HTML Element: \<fast-slider-label\>
+ * @internal
  */
-@customElement({
-    name: "fast-slider-label",
-    template,
-    styles,
-})
-export class FASTSliderLabel extends SliderLabel {
+export class SliderLabel extends FoundationSliderLabel {
     protected sliderOrientationChanged(): void {
         if (this.sliderOrientation === Orientation.horizontal) {
             this.$fastController.addStyles(horizontalSliderStyles);
@@ -32,6 +23,22 @@ export class FASTSliderLabel extends SliderLabel {
         }
     }
 }
+
+/**
+ * The FAST Slider Label Custom Element. Implements {@link @microsoft/fast-foundation#(SliderLabel:class)},
+ * {@link @microsoft/fast-foundation#sliderLabelTemplate}
+ *
+ *
+ * @public
+ * @remarks
+ * HTML Element: \<fast-slider-label\>
+ */
+
+export const fastSliderLabel = SliderLabel.compose({
+    baseName: "slider-label",
+    template,
+    styles,
+});
 
 /**
  * Styles for SliderLabel

--- a/packages/web-components/fast-components/src/slider-label/index.ts
+++ b/packages/web-components/fast-components/src/slider-label/index.ts
@@ -44,4 +44,4 @@ export const fastSliderLabel = SliderLabel.compose({
  * Styles for SliderLabel
  * @public
  */
-export const SliderLabelStyles = styles;
+export const sliderLabelStyles = styles;

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -1,6 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import { bodyFont, designUnit, disabledOpacity } from "../design-tokens";
 import {
     heightNumber,
     neutralForegroundRestBehavior,
@@ -12,7 +13,7 @@ export const horizontalSliderStyles = css`
         align-self: start;
         grid-row: 2;
         margin-top: -2px;
-        height: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
+        height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         width: auto;
     }
     .container {
@@ -30,7 +31,7 @@ export const verticalSliderStyles = css`
         grid-column: 2;
         margin-left: 2px;
         height: auto;
-        width: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
+        width: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
     }
     .container {
         grid-template-columns: auto auto;
@@ -43,7 +44,7 @@ export const verticalSliderStyles = css`
         align-self: center;
     }
     .label {
-        margin-left: calc((var(--design-unit) / 2) * 3px);
+        margin-left: calc((${designUnit} / 2) * 3px);
         align-self: center;
     }
 `;
@@ -51,7 +52,7 @@ export const verticalSliderStyles = css`
 export const sliderLabelStyles = (context, definition) =>
     css`
         ${display("block")} :host {
-            font-family: var(--body-font);
+            // font-family: ${bodyFont};
             color: ${neutralForegroundRestBehavior.var};
             fill: currentcolor;
         }
@@ -70,13 +71,13 @@ export const sliderLabelStyles = (context, definition) =>
             max-width: 30px;
         }
         .mark {
-            width: calc((var(--design-unit) / 4) * 1px);
+            width: calc((${designUnit} / 4) * 1px);
             height: calc(${heightNumber} * 0.25 * 1px);
             background: ${neutralOutlineRestBehavior.var};
             justify-self: center;
         }
         :host(.disabled) {
-            opacity: var(--disabled-opacity);
+            opacity: ${disabledOpacity};
         }
     `.withBehaviors(
         neutralForegroundRestBehavior,

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -52,7 +52,7 @@ export const verticalSliderStyles = css`
 export const sliderLabelStyles = (context, definition) =>
     css`
         ${display("block")} :host {
-            // font-family: ${bodyFont};
+            font-family: ${bodyFont};
             color: ${neutralForegroundRestBehavior.var};
             fill: currentcolor;
         }

--- a/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
+++ b/packages/web-components/fast-components/src/slider-label/slider-label.styles.ts
@@ -48,54 +48,55 @@ export const verticalSliderStyles = css`
     }
 `;
 
-export const SliderLabelStyles = css`
-    ${display("block")} :host {
-        font-family: var(--body-font);
-        color: ${neutralForegroundRestBehavior.var};
-        fill: currentcolor;
-    }
-    .root {
-        position: absolute;
-        display: grid;
-    }
-    .container {
-        display: grid;
-        justify-self: center;
-    }
-    .label {
-        justify-self: center;
-        align-self: center;
-        white-space: nowrap;
-        max-width: 30px;
-    }
-    .mark {
-        width: calc((var(--design-unit) / 4) * 1px);
-        height: calc(${heightNumber} * 0.25 * 1px);
-        background: ${neutralOutlineRestBehavior.var};
-        justify-self: center;
-    }
-    :host(.disabled) {
-        opacity: var(--disabled-opacity);
-    }
-`.withBehaviors(
-    neutralForegroundRestBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            .mark {
-                forced-color-adjust: none;
-                background: ${SystemColors.FieldText};
-            }
-            :host(.disabled) {
-                forced-color-adjust: none;
-                opacity: 1;
-            }
-            :host(.disabled) .label {
-                color: ${SystemColors.GrayText};
-            }
-            :host(.disabled) .mark {
-                background: ${SystemColors.GrayText};
-            }
-        `
-    )
-);
+export const sliderLabelStyles = (context, definition) =>
+    css`
+        ${display("block")} :host {
+            font-family: var(--body-font);
+            color: ${neutralForegroundRestBehavior.var};
+            fill: currentcolor;
+        }
+        .root {
+            position: absolute;
+            display: grid;
+        }
+        .container {
+            display: grid;
+            justify-self: center;
+        }
+        .label {
+            justify-self: center;
+            align-self: center;
+            white-space: nowrap;
+            max-width: 30px;
+        }
+        .mark {
+            width: calc((var(--design-unit) / 4) * 1px);
+            height: calc(${heightNumber} * 0.25 * 1px);
+            background: ${neutralOutlineRestBehavior.var};
+            justify-self: center;
+        }
+        :host(.disabled) {
+            opacity: var(--disabled-opacity);
+        }
+    `.withBehaviors(
+        neutralForegroundRestBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                .mark {
+                    forced-color-adjust: none;
+                    background: ${SystemColors.FieldText};
+                }
+                :host(.disabled) {
+                    forced-color-adjust: none;
+                    opacity: 1;
+                }
+                :host(.disabled) .label {
+                    color: ${SystemColors.GrayText};
+                }
+                :host(.disabled) .mark {
+                    background: ${SystemColors.GrayText};
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/slider/index.ts
+++ b/packages/web-components/fast-components/src/slider/index.ts
@@ -20,4 +20,4 @@ export const fastSlider = Slider.compose({
  * Styles for Slider
  * @public
  */
-export const SliderStyles = styles;
+export const sliderStyles = styles;

--- a/packages/web-components/fast-components/src/slider/index.ts
+++ b/packages/web-components/fast-components/src/slider/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Slider, SliderTemplate as template } from "@microsoft/fast-foundation";
-import { SliderStyles as styles } from "./slider.styles";
+import { Slider, sliderTemplate as template } from "@microsoft/fast-foundation";
+import { sliderStyles as styles } from "./slider.styles";
 
 /**
  * The FAST Slider Custom Element. Implements {@link @microsoft/fast-foundation#(Slider:class)},
- * {@link @microsoft/fast-foundation#SliderTemplate}
+ * {@link @microsoft/fast-foundation#sliderTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-slider\>
  */
-@customElement({
-    name: "fast-slider",
+export const fastSlider = Slider.compose({
+    baseName: "slider",
     template,
     styles,
-})
-export class FASTSlider extends Slider {}
+});
 
 /**
  * Styles for Slider

--- a/packages/web-components/fast-components/src/slider/slider.stories.ts
+++ b/packages/web-components/fast-components/src/slider/slider.stories.ts
@@ -1,7 +1,7 @@
 import addons from "@storybook/addons";
 import { STORY_RENDERED } from "@storybook/core-events";
+import type { Slider as FoundationSlider } from "@microsoft/fast-foundation";
 import Examples from "./fixtures/base.html";
-import type { FASTSlider } from "./index";
 import "./index";
 
 function valueTextFormatter(value: string): string {
@@ -11,7 +11,7 @@ function valueTextFormatter(value: string): string {
 addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
     if (name.toLowerCase().endsWith("slider")) {
         ["switcher", "switcher2", "slider1"].forEach(x => {
-            const slider = document.getElementById(x) as FASTSlider;
+            const slider = document.getElementById(x) as FoundationSlider;
             slider.valueTextFormatter = valueTextFormatter;
         });
     }

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -16,7 +16,8 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const SliderStyles = css`
+export const sliderStyles = (context, definition) =>
+    css`
     :host([hidden]) {
         display: none;
     }
@@ -116,14 +117,14 @@ export const SliderStyles = css`
         opacity: var(--disabled-opacity);
     }
 `.withBehaviors(
-    neutralFocusBehavior,
-    neutralForegroundActiveBehavior,
-    neutralForegroundHoverBehavior,
-    neutralForegroundRestBehavior,
-    neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
+        neutralFocusBehavior,
+        neutralForegroundActiveBehavior,
+        neutralForegroundHoverBehavior,
+        neutralForegroundRestBehavior,
+        neutralOutlineHoverBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
             .thumb-cursor {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.FieldText};
@@ -155,5 +156,5 @@ export const SliderStyles = css`
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};    
             }
         `
-    )
-);
+        )
+    );

--- a/packages/web-components/fast-components/src/slider/slider.styles.ts
+++ b/packages/web-components/fast-components/src/slider/slider.styles.ts
@@ -6,6 +6,7 @@ import {
     forcedColorsStylesheetBehavior,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import { cornerRadius, density, designUnit, disabledOpacity } from "../design-tokens";
 import {
     heightNumber,
     neutralFocusBehavior,
@@ -23,17 +24,17 @@ export const sliderStyles = (context, definition) =>
     }
 
     ${display("inline-grid")} :host {
-        --thumb-size: calc(${heightNumber} * 0.5 - var(--design-unit));
+        --thumb-size: calc(${heightNumber} * 0.5 - ${designUnit});
         --thumb-translate: calc(var(--thumb-size) * 0.5);
-        --track-overhang: calc((var(--design-unit) / 2) * -1);
-        --track-width: var(--design-unit);
+        --track-overhang: calc((${designUnit} / 2) * -1);
+        --track-width: ${designUnit};
         --fast-slider-height: calc(var(--thumb-size) * 10);
         align-items: center;
         width: 100%;
-        margin: calc(var(--design-unit) * 1px) 0;
+        margin: calc(${designUnit} * 1px) 0;
         user-select: none;
         box-sizing: border-box;
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
         outline: none;
         cursor: pointer;
     }
@@ -68,7 +69,7 @@ export const sliderStyles = (context, definition) =>
         width: calc(var(--thumb-size) * 1px);
         height: calc(var(--thumb-size) * 1px);
         background: ${neutralForegroundRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
     }
     .thumb-cursor:hover {
         background: ${neutralForegroundHoverBehavior.var};
@@ -90,31 +91,31 @@ export const sliderStyles = (context, definition) =>
         right: calc(var(--track-overhang) * 1px);
         left: calc(var(--track-overhang) * 1px);
         align-self: start;
-        margin-top: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
+        margin-top: calc((${designUnit} + calc(${density} + 2)) * 1px);
         height: calc(var(--track-width) * 1px);
     }
     :host([orientation="vertical"]) .track {
         top: calc(var(--track-overhang) * 1px);
         bottom: calc(var(--track-overhang) * 1px);
         width: calc(var(--track-width) * 1px);
-        margin-inline-start: calc((var(--design-unit) + calc(var(--density) + 2)) * 1px);
+        margin-inline-start: calc((${designUnit} + calc(${density} + 2)) * 1px);
         height: 100%;
     }
     .track {
         background: ${neutralOutlineRestBehavior.var};
         position: absolute;
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
     }
     :host([orientation="vertical"]) {
         height: calc(var(--fast-slider-height) * 1px);
         min-height: calc(var(--thumb-size) * 1px);
-        min-width: calc(var(--design-unit) * 20px);
+        min-width: calc(${designUnit} * 20px);
     }
     :host([disabled]), :host([readonly]) {
         cursor: ${disabledCursor};
     }
     :host([disabled]) {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 `.withBehaviors(
         neutralFocusBehavior,

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -25,21 +25,32 @@ import {
     neutralFocusInnerAccentBehavior,
     neutralForegroundRestBehavior,
 } from "../recipes";
+import {
+    bodyFont,
+    cornerRadius,
+    density,
+    designUnit,
+    disabledOpacity,
+    focusOutlineWidth,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../../design-tokens";
 
 /**
  * @internal
  */
 export const BaseButtonStyles = css`
     ${display("inline-flex")} :host {
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         outline: none;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
         height: calc(${heightNumber} * 1px);
         min-width: calc(${heightNumber} * 1px);
         background-color: ${neutralFillRestBehavior.var};
         color: ${neutralForegroundRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
         fill: currentcolor;
         cursor: pointer;
     }
@@ -52,11 +63,11 @@ export const BaseButtonStyles = css`
         display: inline-flex;
         justify-content: center;
         align-items: center;
-        padding: 0 calc((10 + (var(--design-unit) * 2 * var(--density))) * 1px);
+        padding: 0 calc((10 + (${designUnit} * 2 * ${density})) * 1px);
         white-space: nowrap;
         outline: none;
         text-decoration: none;
-        border: calc(var(--outline-width) * 1px) solid transparent;
+        border: calc(${outlineWidth} * 1px) solid transparent;
         color: inherit;
         border-radius: inherit;
         fill: inherit;
@@ -75,10 +86,10 @@ export const BaseButtonStyles = css`
     }
 
     .control:${focusVisible} {
-        border: calc(var(--outline-width) * 1px) solid ${neutralFocusBehavior.var};
-        box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${
-            neutralFocusBehavior.var
-        };
+        border: calc(${outlineWidth} * 1px) solid ${neutralFocusBehavior.var};
+        box-shadow: 0 0 0 calc((${focusOutlineWidth} - ${outlineWidth}) * 1px) ${
+    neutralFocusBehavior.var
+};
     }
 
     .control::-moz-focus-inner {
@@ -86,7 +97,7 @@ export const BaseButtonStyles = css`
     }
 
     :host([disabled]) {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
         background-color: ${neutralFillRestBehavior.var};
         cursor: ${disabledCursor};
     }
@@ -141,7 +152,7 @@ export const BaseButtonStyles = css`
               forced-color-adjust: none;
               background-color: ${SystemColors.Highlight};
               border-color: ${SystemColors.ButtonText};
-              box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${SystemColors.ButtonText};
+              box-shadow: 0 0 0 calc((${focusOutlineWidth} - ${outlineWidth}) * 1px) ${SystemColors.ButtonText};
               color: ${SystemColors.HighlightText};
             }
     
@@ -196,7 +207,7 @@ export const AccentButtonStyles = css`
     }
 
     :host([appearance="accent"]) .control:${focusVisible} {
-        box-shadow: 0 0 0 calc(var(--focus-outline-width) * 1px) inset ${neutralFocusInnerAccentBehavior.var};
+        box-shadow: 0 0 0 calc(${focusOutlineWidth} * 1px) inset ${neutralFocusInnerAccentBehavior.var};
     }
 
     :host([appearance="accent"][disabled]) {
@@ -284,7 +295,7 @@ export const HypertextStyles = css`
     :host([appearance="hypertext"]) .control:visited {
         background: transparent;
         color: ${accentForegroundRestBehavior.var};
-        border-bottom: calc(var(--outline-width) * 1px) solid ${accentForegroundRestBehavior.var};
+        border-bottom: calc(${outlineWidth} * 1px) solid ${accentForegroundRestBehavior.var};
     }
 
     :host([appearance="hypertext"]) .control:hover {
@@ -296,8 +307,8 @@ export const HypertextStyles = css`
     }
 
     :host([appearance="hypertext"]) .control:${focusVisible} {
-        border-bottom: calc(var(--focus-outline-width) * 1px) solid ${neutralFocusBehavior.var};
-        margin-bottom: calc(calc(var(--outline-width) - var(--focus-outline-width)) * 1px);
+        border-bottom: calc(${focusOutlineWidth} * 1px) solid ${neutralFocusBehavior.var};
+        margin-bottom: calc(calc(${outlineWidth} - ${focusOutlineWidth}) * 1px);
     }
 `.withBehaviors(
     accentForegroundRestBehavior,
@@ -353,7 +364,7 @@ export const LightweightButtonStyles = css`
     :host([appearance="lightweight"]) .content::before {
         content: "";
         display: block;
-        height: calc(var(--outline-width) * 1px);
+        height: calc(${outlineWidth} * 1px);
         position: absolute;
         top: calc(1em + 4px);
         width: 100%;
@@ -369,7 +380,7 @@ export const LightweightButtonStyles = css`
 
     :host([appearance="lightweight"]) .control:${focusVisible} .content::before {
         background: ${neutralForegroundRestBehavior.var};
-        height: calc(var(--focus-outline-width) * 1px);
+        height: calc(${focusOutlineWidth} * 1px);
     }
 
     :host([appearance="lightweight"][disabled]) .content::before {
@@ -440,7 +451,7 @@ export const OutlineButtonStyles = css`
     }
 
     :host([appearance="outline"]) .control:${focusVisible} {
-        box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${neutralFocusBehavior.var};
+        box-shadow: 0 0 0 calc((${focusOutlineWidth} - ${outlineWidth}) * 1px) ${neutralFocusBehavior.var};
         border-color: ${neutralFocusBehavior.var};
     }
 
@@ -461,7 +472,7 @@ export const OutlineButtonStyles = css`
               forced-color-adjust: none;
               background-color: ${SystemColors.Highlight};
               border-color: ${SystemColors.ButtonText};
-              box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px) ${SystemColors.ButtonText};
+              box-shadow: 0 0 0 calc((${focusOutlineWidth} - ${outlineWidth}) * 1px) ${SystemColors.ButtonText};
               color: ${SystemColors.HighlightText};
               fill: currentColor;
             }

--- a/packages/web-components/fast-components/src/styles/size.ts
+++ b/packages/web-components/fast-components/src/styles/size.ts
@@ -1,7 +1,33 @@
+import { Behavior, css, CSSDirective, FASTElement } from "@microsoft/fast-element";
+import { baseHeightMultiplier, density, designUnit } from "../design-tokens";
+
 /**
  * A formula to retrieve the control height.
  * Use this as the value of any CSS property that
  * accepts a pixel size.
+ *
+ * TODO: refactor with https://github.com/microsoft/fast/issues/4633
  */
-export const heightNumber =
-    "(var(--base-height-multiplier) + var(--density)) * var(--design-unit)";
+class HeightNumber extends CSSDirective implements Behavior {
+    private behaviors: Behavior[] = [
+        baseHeightMultiplier.createBehavior(),
+        density.createBehavior(),
+        designUnit.createBehavior(),
+    ].filter(x => x !== void 0) as Behavior[];
+    createCSS() {
+        return `(${baseHeightMultiplier.createCSS()} + ${density.createCSS()}) * ${designUnit.createCSS()}`;
+    }
+    createBehavior() {
+        return this;
+    }
+
+    bind(element: FASTElement) {
+        element.$fastController.addBehaviors(this.behaviors);
+    }
+
+    unbind(element: FASTElement) {
+        element.$fastController.removeBehaviors(this.behaviors);
+    }
+}
+
+export const heightNumber = new HeightNumber();

--- a/packages/web-components/fast-components/src/switch/index.ts
+++ b/packages/web-components/fast-components/src/switch/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Switch, SwitchTemplate as template } from "@microsoft/fast-foundation";
-import { SwitchStyles as styles } from "./switch.styles";
+import { Switch, switchTemplate as template } from "@microsoft/fast-foundation";
+import { switchStyles as styles } from "./switch.styles";
 
 /**
  * The FAST Switch Custom Element. Implements {@link @microsoft/fast-foundation#Switch},
- * {@link @microsoft/fast-foundation#SwitchTemplate}
+ * {@link @microsoft/fast-foundation#switchTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-switch\>
  */
-@customElement({
-    name: "fast-switch",
+export const fastSwitch = Switch.compose({
+    baseName: "switch",
     template,
     styles,
-})
-export class FASTSwitch extends Switch {}
+});
 
 /**
  * Styles for Switch

--- a/packages/web-components/fast-components/src/switch/index.ts
+++ b/packages/web-components/fast-components/src/switch/index.ts
@@ -20,4 +20,4 @@ export const fastSwitch = Switch.compose({
  * Styles for Switch
  * @public
  */
-export const SwitchStyles = styles;
+export const switchStyles = styles;

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -8,6 +8,15 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
@@ -32,8 +41,8 @@ export const switchStyles = (context, definition) =>
     ${display("inline-flex")} :host {
         align-items: center;
         outline: none;
-        font-family: var(--body-font);
-        margin: calc(var(--design-unit) * 1px) 0;
+        font-family: ${bodyFont};
+        margin: calc(${designUnit} * 1px) 0;
         ${
             /*
              * Chromium likes to select label text or the default slot when
@@ -43,7 +52,7 @@ export const switchStyles = (context, definition) =>
     }
 
     :host([disabled]) {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 
     :host([disabled]) .label,
@@ -58,10 +67,10 @@ export const switchStyles = (context, definition) =>
         outline: none;
         box-sizing: border-box;
         width: calc(${heightNumber} * 1px);
-        height: calc((${heightNumber} / 2 + var(--design-unit)) * 1px);
+        height: calc((${heightNumber} / 2 + ${designUnit}) * 1px);
         background: ${neutralFillInputRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid ${neutralOutlineRestBehavior.var};
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${outlineWidth} * 1px) solid ${neutralOutlineRestBehavior.var};
     }
 
     .switch:hover {
@@ -94,15 +103,15 @@ export const switchStyles = (context, definition) =>
         top: 5px;
         bottom: 5px;
         background: ${neutralForegroundRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
         transition: all 0.2s ease-in-out;
     }
 
     .status-message {
         color: ${neutralForegroundRestBehavior.var};
         cursor: pointer;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
     }
 
     :host([disabled]) .status-message,
@@ -115,9 +124,9 @@ export const switchStyles = (context, definition) =>
 
         ${
             /* Need to discuss with Brian how HorizontalSpacingNumber can work. https://github.com/microsoft/fast/issues/2766 */ ""
-        } margin-inline-end: calc(var(--design-unit) * 2px + 2px);
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        } margin-inline-end: calc(${designUnit} * 2px + 2px);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
         cursor: pointer;
     }
 
@@ -129,7 +138,7 @@ export const switchStyles = (context, definition) =>
     ::slotted(*) {
         ${
             /* Need to discuss with Brian how HorizontalSpacingNumber can work. https://github.com/microsoft/fast/issues/2766 */ ""
-        } margin-inline-start: calc(var(--design-unit) * 2px + 2px);
+        } margin-inline-start: calc(${designUnit} * 2px + 2px);
     }
 
     :host([aria-checked="true"]) .checked-indicator {

--- a/packages/web-components/fast-components/src/switch/switch.styles.ts
+++ b/packages/web-components/fast-components/src/switch/switch.styles.ts
@@ -23,7 +23,8 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const SwitchStyles = css`
+export const switchStyles = (context, definition) =>
+    css`
     :host([hidden]) {
         display: none;
     }
@@ -173,20 +174,20 @@ export const SwitchStyles = css`
         display: block;
     }
 `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    accentForegroundCutRestBehavior,
-    neutralFillInputActiveBehavior,
-    neutralFillInputHoverBehavior,
-    neutralFillInputRestBehavior,
-    neutralFocusBehavior,
-    neutralForegroundRestBehavior,
-    neutralOutlineActiveBehavior,
-    neutralOutlineHoverBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        accentForegroundCutRestBehavior,
+        neutralFillInputActiveBehavior,
+        neutralFillInputHoverBehavior,
+        neutralFillInputRestBehavior,
+        neutralFocusBehavior,
+        neutralForegroundRestBehavior,
+        neutralOutlineActiveBehavior,
+        neutralOutlineHoverBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
             .checked-indicator,
             :host(:not([disabled])) .switch:active .checked-indicator {
                 forced-color-adjust: none;
@@ -234,29 +235,29 @@ export const SwitchStyles = css`
                 border-color: ${SystemColors.GrayText};
             }
         `
-    ),
-    new DirectionalStyleSheetBehavior(
-        css`
-            .checked-indicator {
-                left: 5px;
-                right: calc(((${heightNumber} / 2) + 1) * 1px);
-            }
+        ),
+        new DirectionalStyleSheetBehavior(
+            css`
+                .checked-indicator {
+                    left: 5px;
+                    right: calc(((${heightNumber} / 2) + 1) * 1px);
+                }
 
-            :host([aria-checked="true"]) .checked-indicator {
-                left: calc(((${heightNumber} / 2) + 1) * 1px);
-                right: 5px;
-            }
-        `,
-        css`
-            .checked-indicator {
-                right: 5px;
-                left: calc(((${heightNumber} / 2) + 1) * 1px);
-            }
+                :host([aria-checked="true"]) .checked-indicator {
+                    left: calc(((${heightNumber} / 2) + 1) * 1px);
+                    right: 5px;
+                }
+            `,
+            css`
+                .checked-indicator {
+                    right: 5px;
+                    left: calc(((${heightNumber} / 2) + 1) * 1px);
+                }
 
-            :host([aria-checked="true"]) .checked-indicator {
-                right: calc(((${heightNumber} / 2) + 1) * 1px);
-                left: 5px;
-            }
-        `
-    )
-);
+                :host([aria-checked="true"]) .checked-indicator {
+                    right: calc(((${heightNumber} / 2) + 1) * 1px);
+                    left: 5px;
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/tab-panel/index.ts
+++ b/packages/web-components/fast-components/src/tab-panel/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { TabPanel, TabPanelTemplate as template } from "@microsoft/fast-foundation";
-import { TabPanelStyles as styles } from "./tab-panel.styles";
+import { TabPanel, tabPanelTemplate as template } from "@microsoft/fast-foundation";
+import { tabPanelStyles as styles } from "./tab-panel.styles";
 
 /**
  * The FAST Tab Panel Custom Element. Implements {@link @microsoft/fast-foundation#TabPanel},
- * {@link @microsoft/fast-foundation#TabPanelTemplate}
+ * {@link @microsoft/fast-foundation#tabPanelTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-tab-panel\>
  */
-@customElement({
-    name: "fast-tab-panel",
+export const fastTabPanel = TabPanel.compose({
+    baseName: "tab-panel",
     template,
     styles,
-})
-export class FASTTabPanel extends TabPanel {}
+});
 
 /**
  * Styles for TabPanel

--- a/packages/web-components/fast-components/src/tab-panel/index.ts
+++ b/packages/web-components/fast-components/src/tab-panel/index.ts
@@ -20,4 +20,4 @@ export const fastTabPanel = TabPanel.compose({
  * Styles for TabPanel
  * @public
  */
-export const TabPanelStyles = styles;
+export const tabPanelStyles = styles;

--- a/packages/web-components/fast-components/src/tab-panel/tab-panel.styles.ts
+++ b/packages/web-components/fast-components/src/tab-panel/tab-panel.styles.ts
@@ -1,11 +1,17 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
+import {
+    density,
+    designUnit,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
 
 export const tabPanelStyles = (context, definition) => css`
     ${display("flex")} :host {
         box-sizing: border-box;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
-        padding: 0 calc((6 + (var(--design-unit) * 2 * var(--density))) * 1px);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
+        padding: 0 calc((6 + (${designUnit} * 2 * ${density})) * 1px);
     }
 `;

--- a/packages/web-components/fast-components/src/tab-panel/tab-panel.styles.ts
+++ b/packages/web-components/fast-components/src/tab-panel/tab-panel.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 
-export const TabPanelStyles = css`
+export const tabPanelStyles = (context, definition) => css`
     ${display("flex")} :host {
         box-sizing: border-box;
         font-size: var(--type-ramp-base-font-size);

--- a/packages/web-components/fast-components/src/tab/index.ts
+++ b/packages/web-components/fast-components/src/tab/index.ts
@@ -1,22 +1,20 @@
-import { customElement } from "@microsoft/fast-element";
-import { Tab, TabTemplate as template } from "@microsoft/fast-foundation";
-import { TabStyles as styles } from "./tab.styles";
+import { Tab, tabTemplate as template } from "@microsoft/fast-foundation";
+import { tabStyles as styles } from "./tab.styles";
 
 /**
  * The FAST Tab Custom Element. Implements {@link @microsoft/fast-foundation#Tab},
- * {@link @microsoft/fast-foundation#TabTemplate}
+ * {@link @microsoft/fast-foundation#tabTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-tab\>
  */
-@customElement({
-    name: "fast-tab",
+export const fastTab = Tab.compose({
+    baseName: "tab",
     template,
     styles,
-})
-export class FASTTab extends Tab {}
+});
 
 /**
  * Styles for Tab

--- a/packages/web-components/fast-components/src/tab/index.ts
+++ b/packages/web-components/fast-components/src/tab/index.ts
@@ -20,4 +20,4 @@ export const fastTab = Tab.compose({
  * Styles for Tab
  * @public
  */
-export const TabStyles = styles;
+export const tabStyles = styles;

--- a/packages/web-components/fast-components/src/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tab/tab.styles.ts
@@ -25,7 +25,8 @@ import {
     neutralForegroundRestBehavior,
 } from "../styles";
 
-export const TabStyles = css`
+export const tabStyles = (context, definition) =>
+    css`
     ${display("inline-flex")} :host {
         box-sizing: border-box;
         font-family: var(--body-font);
@@ -112,23 +113,23 @@ export const TabStyles = css`
     :host(.vertical:hover[aria-selected="true"]) {
     }
 `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    accentForegroundActiveBehavior,
-    accentForegroundHoverBehavior,
-    accentForegroundRestBehavior,
-    neutralFillActiveBehavior,
-    neutralFillHoverBehavior,
-    neutralFillRestBehavior,
-    neutralFillStealthRestBehavior,
-    neutralFocusBehavior,
-    neutralForegroundHintBehavior,
-    neutralForegroundActiveBehavior,
-    neutralForegroundHoverBehavior,
-    neutralForegroundRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        accentForegroundActiveBehavior,
+        accentForegroundHoverBehavior,
+        accentForegroundRestBehavior,
+        neutralFillActiveBehavior,
+        neutralFillHoverBehavior,
+        neutralFillRestBehavior,
+        neutralFillStealthRestBehavior,
+        neutralFocusBehavior,
+        neutralForegroundHintBehavior,
+        neutralForegroundActiveBehavior,
+        neutralForegroundHoverBehavior,
+        neutralForegroundRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
             :host {
                 forced-color-adjust: none;
                 border-color: transparent;
@@ -152,5 +153,5 @@ export const TabStyles = css`
                 box-shadow: none;
             }
         `
-    )
-);
+        )
+    );

--- a/packages/web-components/fast-components/src/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tab/tab.styles.ts
@@ -7,6 +7,16 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    focusOutlineWidth,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
@@ -29,15 +39,15 @@ export const tabStyles = (context, definition) =>
     css`
     ${display("inline-flex")} :host {
         box-sizing: border-box;
-        font-family: var(--body-font);
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-family: ${bodyFont};
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
         height: calc(${heightNumber} * 1px);
-        padding: calc(var(--design-unit) * 5px) calc(var(--design-unit) * 4px);
+        padding: calc(${designUnit} * 5px) calc(${designUnit} * 4px);
         color: ${neutralForegroundHintBehavior.var};
         fill: currentcolor;
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid transparent;
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${outlineWidth} * 1px) solid transparent;
         align-items: center;
         justify-content: center;
         grid-row: 1;
@@ -56,7 +66,7 @@ export const tabStyles = (context, definition) =>
 
     :host([disabled]) {
         cursor: ${disabledCursor};
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 
     :host([disabled]:hover) {
@@ -84,8 +94,8 @@ export const tabStyles = (context, definition) =>
 
     :host(:${focusVisible}) {
         outline: none;
-        border: calc(var(--outline-width) * 1px) solid ${neutralFocusBehavior.var};
-        box-shadow: 0 0 0 calc((var(--focus-outline-width) - var(--outline-width)) * 1px)
+        border: calc(${outlineWidth} * 1px) solid ${neutralFocusBehavior.var};
+        box-shadow: 0 0 0 calc((${focusOutlineWidth} - ${outlineWidth}) * 1px)
             ${neutralFocusBehavior.var};
     }
 

--- a/packages/web-components/fast-components/src/tabs/index.ts
+++ b/packages/web-components/fast-components/src/tabs/index.ts
@@ -1,22 +1,21 @@
-import { customElement } from "@microsoft/fast-element";
-import { Tabs, TabsTemplate as template } from "@microsoft/fast-foundation";
-import { TabsStyles as styles } from "./tabs.styles";
+import { Tabs, tabsTemplate as template } from "@microsoft/fast-foundation";
+import { tabsStyles as styles } from "./tabs.styles";
 
 /**
  * The FAST Tabs Custom Element. Implements {@link @microsoft/fast-foundation#Tabs},
- * {@link @microsoft/fast-foundation#TabsTemplate}
+ * {@link @microsoft/fast-foundation#tabsTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-tabs\>
  */
-@customElement({
-    name: "fast-tabs",
+export const fastTabs = Tabs.compose({
+    baseName: "tabs",
     template,
     styles,
-})
-export class FASTTabs extends Tabs {}
+});
+
 export * from "../tab";
 export * from "../tab-panel";
 /**

--- a/packages/web-components/fast-components/src/tabs/index.ts
+++ b/packages/web-components/fast-components/src/tabs/index.ts
@@ -22,4 +22,4 @@ export * from "../tab-panel";
  * Styles for Tabs
  * @public
  */
-export const TabsStyles = styles;
+export const tabsStyles = styles;

--- a/packages/web-components/fast-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tabs.styles.ts
@@ -7,112 +7,113 @@ import {
     neutralForegroundRestBehavior,
 } from "../styles/index";
 
-export const TabsStyles = css`
-    ${display("grid")} :host {
-        box-sizing: border-box;
-        font-family: var(--body-font);
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
-        color: ${neutralForegroundRestBehavior.var};
-        grid-template-columns: auto 1fr auto;
-        grid-template-rows: auto 1fr;
-    }
+export const tabsStyles = (context, definition) =>
+    css`
+        ${display("grid")} :host {
+            box-sizing: border-box;
+            font-family: var(--body-font);
+            font-size: var(--type-ramp-base-font-size);
+            line-height: var(--type-ramp-base-line-height);
+            color: ${neutralForegroundRestBehavior.var};
+            grid-template-columns: auto 1fr auto;
+            grid-template-rows: auto 1fr;
+        }
 
-    .tablist {
-        display: grid;
-        grid-template-rows: auto auto;
-        grid-template-columns: auto;
-        position: relative;
-        width: max-content;
-        align-self: end;
-        padding: calc(var(--design-unit) * 4px) calc(var(--design-unit) * 4px) 0;
-        box-sizing: border-box;
-    }
+        .tablist {
+            display: grid;
+            grid-template-rows: auto auto;
+            grid-template-columns: auto;
+            position: relative;
+            width: max-content;
+            align-self: end;
+            padding: calc(var(--design-unit) * 4px) calc(var(--design-unit) * 4px) 0;
+            box-sizing: border-box;
+        }
 
-    .start,
-    .end {
-        align-self: center;
-    }
+        .start,
+        .end {
+            align-self: center;
+        }
 
-    .activeIndicator {
-        grid-row: 2;
-        grid-column: 1;
-        width: 100%;
-        height: 5px;
-        justify-self: center;
-        background: ${accentFillRestBehavior.var};
-        margin-top: 10px;
-        border-radius: calc(var(--corner-radius) * 1px) calc(var(--corner-radius) * 1px) 0
-            0;
-    }
+        .activeIndicator {
+            grid-row: 2;
+            grid-column: 1;
+            width: 100%;
+            height: 5px;
+            justify-self: center;
+            background: ${accentFillRestBehavior.var};
+            margin-top: 10px;
+            border-radius: calc(var(--corner-radius) * 1px)
+                calc(var(--corner-radius) * 1px) 0 0;
+        }
 
-    .activeIndicatorTransition {
-        transition: transform 0.2s ease-in-out;
-    }
+        .activeIndicatorTransition {
+            transition: transform 0.2s ease-in-out;
+        }
 
-    .tabpanel {
-        grid-row: 2;
-        grid-column-start: 1;
-        grid-column-end: 4;
-        position: relative;
-    }
+        .tabpanel {
+            grid-row: 2;
+            grid-column-start: 1;
+            grid-column-end: 4;
+            position: relative;
+        }
 
-    :host([orientation="vertical"]) {
-        grid-template-rows: auto 1fr auto;
-        grid-template-columns: auto 1fr;
-    }
+        :host([orientation="vertical"]) {
+            grid-template-rows: auto 1fr auto;
+            grid-template-columns: auto 1fr;
+        }
 
-    :host([orientation="vertical"]) .tablist {
-        grid-row-start: 2;
-        grid-row-end: 2;
-        display: grid;
-        grid-template-rows: auto;
-        grid-template-columns: auto 1fr;
-        position: relative;
-        width: max-content;
-        justify-self: end;
-        width: 100%;
-        padding: calc((${heightNumber} - var(--design-unit)) * 1px)
-            calc(var(--design-unit) * 4px)
-            calc((${heightNumber} - var(--design-unit)) * 1px) 0;
-    }
+        :host([orientation="vertical"]) .tablist {
+            grid-row-start: 2;
+            grid-row-end: 2;
+            display: grid;
+            grid-template-rows: auto;
+            grid-template-columns: auto 1fr;
+            position: relative;
+            width: max-content;
+            justify-self: end;
+            width: 100%;
+            padding: calc((${heightNumber} - var(--design-unit)) * 1px)
+                calc(var(--design-unit) * 4px)
+                calc((${heightNumber} - var(--design-unit)) * 1px) 0;
+        }
 
-    :host([orientation="vertical"]) .tabpanel {
-        grid-column: 2;
-        grid-row-start: 1;
-        grid-row-end: 4;
-    }
+        :host([orientation="vertical"]) .tabpanel {
+            grid-column: 2;
+            grid-row-start: 1;
+            grid-row-end: 4;
+        }
 
-    :host([orientation="vertical"]) .end {
-        grid-row: 3;
-    }
+        :host([orientation="vertical"]) .end {
+            grid-row: 3;
+        }
 
-    :host([orientation="vertical"]) .activeIndicator {
-        grid-column: 1;
-        grid-row: 1;
-        width: 5px;
-        height: 100%;
-        margin-inline-end: 10px;
-        align-self: center;
-        background: ${accentFillRestBehavior.var};
-        margin-top: 0;
-        border-radius: 0 calc(var(--corner-radius) * 1px) calc(var(--corner-radius) * 1px)
-            0;
-    }
+        :host([orientation="vertical"]) .activeIndicator {
+            grid-column: 1;
+            grid-row: 1;
+            width: 5px;
+            height: 100%;
+            margin-inline-end: 10px;
+            align-self: center;
+            background: ${accentFillRestBehavior.var};
+            margin-top: 0;
+            border-radius: 0 calc(var(--corner-radius) * 1px)
+                calc(var(--corner-radius) * 1px) 0;
+        }
 
-    :host([orientation="vertical"]) .activeIndicatorTransition {
-        transition: transform 0.2s linear;
-    }
-`.withBehaviors(
-    accentFillRestBehavior,
-    neutralForegroundRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            .activeIndicator,
-            :host([orientation="vertical"]) .activeIndicator {
-                forced-color-adjust: none;
-                background: ${SystemColors.Highlight};
-            }
-        `
-    )
-);
+        :host([orientation="vertical"]) .activeIndicatorTransition {
+            transition: transform 0.2s linear;
+        }
+    `.withBehaviors(
+        accentFillRestBehavior,
+        neutralForegroundRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                .activeIndicator,
+                :host([orientation="vertical"]) .activeIndicator {
+                    forced-color-adjust: none;
+                    background: ${SystemColors.Highlight};
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tabs.styles.ts
@@ -2,6 +2,13 @@ import { css } from "@microsoft/fast-element";
 import { display, forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillRestBehavior,
     heightNumber,
     neutralForegroundRestBehavior,
@@ -11,9 +18,9 @@ export const tabsStyles = (context, definition) =>
     css`
         ${display("grid")} :host {
             box-sizing: border-box;
-            font-family: var(--body-font);
-            font-size: var(--type-ramp-base-font-size);
-            line-height: var(--type-ramp-base-line-height);
+            font-family: ${bodyFont};
+            font-size: ${typeRampBaseFontSize};
+            line-height: ${typeRampBaseLineHeight};
             color: ${neutralForegroundRestBehavior.var};
             grid-template-columns: auto 1fr auto;
             grid-template-rows: auto 1fr;
@@ -26,7 +33,7 @@ export const tabsStyles = (context, definition) =>
             position: relative;
             width: max-content;
             align-self: end;
-            padding: calc(var(--design-unit) * 4px) calc(var(--design-unit) * 4px) 0;
+            padding: calc(${designUnit} * 4px) calc(${designUnit} * 4px) 0;
             box-sizing: border-box;
         }
 
@@ -43,8 +50,7 @@ export const tabsStyles = (context, definition) =>
             justify-self: center;
             background: ${accentFillRestBehavior.var};
             margin-top: 10px;
-            border-radius: calc(var(--corner-radius) * 1px)
-                calc(var(--corner-radius) * 1px) 0 0;
+            border-radius: calc(${cornerRadius} * 1px) calc(${cornerRadius} * 1px) 0 0;
         }
 
         .activeIndicatorTransition {
@@ -73,9 +79,8 @@ export const tabsStyles = (context, definition) =>
             width: max-content;
             justify-self: end;
             width: 100%;
-            padding: calc((${heightNumber} - var(--design-unit)) * 1px)
-                calc(var(--design-unit) * 4px)
-                calc((${heightNumber} - var(--design-unit)) * 1px) 0;
+            padding: calc((${heightNumber} - ${designUnit}) * 1px)
+                calc(${designUnit} * 4px) calc((${heightNumber} - ${designUnit}) * 1px) 0;
         }
 
         :host([orientation="vertical"]) .tabpanel {
@@ -97,8 +102,7 @@ export const tabsStyles = (context, definition) =>
             align-self: center;
             background: ${accentFillRestBehavior.var};
             margin-top: 0;
-            border-radius: 0 calc(var(--corner-radius) * 1px)
-                calc(var(--corner-radius) * 1px) 0;
+            border-radius: 0 calc(${cornerRadius} * 1px) calc(${cornerRadius} * 1px) 0;
         }
 
         :host([orientation="vertical"]) .activeIndicatorTransition {

--- a/packages/web-components/fast-components/src/text-area/index.ts
+++ b/packages/web-components/fast-components/src/text-area/index.ts
@@ -61,4 +61,4 @@ export const fastTextArea = TextArea.compose({
  * Styles for TextArea
  * @public
  */
-export const TextAreaStyles = styles;
+export const textAreaStyles = styles;

--- a/packages/web-components/fast-components/src/text-area/index.ts
+++ b/packages/web-components/fast-components/src/text-area/index.ts
@@ -1,6 +1,9 @@
-import { attr, customElement } from "@microsoft/fast-element";
-import { TextAreaTemplate as template, TextArea } from "@microsoft/fast-foundation";
-import { TextAreaStyles as styles } from "./text-area.styles";
+import { attr } from "@microsoft/fast-element";
+import {
+    TextArea as FoundationTextArea,
+    textAreaTemplate as template,
+} from "@microsoft/fast-foundation";
+import { textAreaStyles as styles } from "./text-area.styles";
 
 /**
  * Text area appearances
@@ -9,25 +12,9 @@ import { TextAreaStyles as styles } from "./text-area.styles";
 export type TextAreaAppearance = "filled" | "outline";
 
 /**
- * The FAST Text Area Custom Element. Implements {@link @microsoft/fast-foundation#TextArea},
- * {@link @microsoft/fast-foundation#TextAreaTemplate}
- *
- *
- * @public
- * @remarks
- * HTML Element: \<fast-text-area\>
- *
- * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ * @internal
  */
-@customElement({
-    name: "fast-text-area",
-    template,
-    styles,
-    shadowOptions: {
-        delegatesFocus: true,
-    },
-})
-export class FASTTextArea extends TextArea {
+export class TextArea extends FoundationTextArea {
     /**
      * The appearance of the element.
      *
@@ -49,6 +36,26 @@ export class FASTTextArea extends TextArea {
         }
     }
 }
+
+/**
+ * The FAST Text Area Custom Element. Implements {@link @microsoft/fast-foundation#TextArea},
+ * {@link @microsoft/fast-foundation#textAreaTemplate}
+ *
+ *
+ * @public
+ * @remarks
+ * HTML Element: \<fast-text-area\>
+ *
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ */
+export const fastTextArea = TextArea.compose({
+    baseName: "text-area",
+    template,
+    styles,
+    shadowOptions: {
+        delegatesFocus: true,
+    },
+});
 
 /**
  * Styles for TextArea

--- a/packages/web-components/fast-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/fast-components/src/text-area/text-area.styles.ts
@@ -20,7 +20,8 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const TextAreaStyles = css`
+export const textAreaStyles = (context, definition) =>
+    css`
     ${display("inline-block")} :host {
         font-family: var(--body-font);
         outline: none;
@@ -112,22 +113,22 @@ export const TextAreaStyles = css`
         border-color: ${neutralOutlineRestBehavior.var};
     }
  `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    neutralFillHoverBehavior,
-    neutralFillInputActiveBehavior,
-    neutralFillInputHoverBehavior,
-    neutralFillInputRestBehavior,
-    neutralFillRestBehavior,
-    neutralFocusBehavior,
-    neutralForegroundRestBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            :host([disabled]) {
-                opacity: 1;
-            }
-        `
-    )
-);
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        neutralFillHoverBehavior,
+        neutralFillInputActiveBehavior,
+        neutralFillInputHoverBehavior,
+        neutralFillInputRestBehavior,
+        neutralFillRestBehavior,
+        neutralFocusBehavior,
+        neutralForegroundRestBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                :host([disabled]) {
+                    opacity: 1;
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/text-area/text-area.styles.ts
+++ b/packages/web-components/fast-components/src/text-area/text-area.styles.ts
@@ -6,6 +6,15 @@ import {
     forcedColorsStylesheetBehavior,
 } from "@microsoft/fast-foundation";
 import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
@@ -23,7 +32,7 @@ import {
 export const textAreaStyles = (context, definition) =>
     css`
     ${display("inline-block")} :host {
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         outline: none;
         user-select: none;
     }
@@ -33,13 +42,13 @@ export const textAreaStyles = (context, definition) =>
         position: relative;
         color: ${neutralForegroundRestBehavior.var};
         background: ${neutralFillInputRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${outlineWidth} * 1px) solid ${accentFillRestBehavior.var};
         height: calc(${heightNumber} * 2px);
         font: inherit;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
-        padding: calc(var(--design-unit) * 2px + 1px);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
+        padding: calc(${designUnit} * 2px + 1px);
         width: 100%;
         resize: none;
     }
@@ -90,8 +99,8 @@ export const textAreaStyles = (context, definition) =>
         display: block;
         color: ${neutralForegroundRestBehavior.var};
         cursor: pointer;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
         margin-bottom: 4px;
     }
 
@@ -107,7 +116,7 @@ export const textAreaStyles = (context, definition) =>
         cursor: ${disabledCursor};
     }
     :host([disabled]) {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
     :host([disabled]) .control {
         border-color: ${neutralOutlineRestBehavior.var};

--- a/packages/web-components/fast-components/src/text-field/index.ts
+++ b/packages/web-components/fast-components/src/text-field/index.ts
@@ -1,6 +1,9 @@
-import { attr, customElement } from "@microsoft/fast-element";
-import { TextFieldTemplate as template, TextField } from "@microsoft/fast-foundation";
-import { TextFieldStyles as styles } from "./text-field.styles";
+import { attr } from "@microsoft/fast-element";
+import {
+    TextField as FoundationTextField,
+    textFieldTemplate as template,
+} from "@microsoft/fast-foundation";
+import { textFieldStyles as styles } from "./text-field.styles";
 
 /**
  * Text field appearances
@@ -9,25 +12,9 @@ import { TextFieldStyles as styles } from "./text-field.styles";
 export type TextFieldAppearance = "filled" | "outline";
 
 /**
- * The FAST Text Field Custom Element. Implements {@link @microsoft/fast-foundation#TextField},
- * {@link @microsoft/fast-foundation#TextFieldTemplate}
- *
- *
- * @public
- * @remarks
- * HTML Element: \<fast-text-field\>
- *
- * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ * @internal
  */
-@customElement({
-    name: "fast-text-field",
-    template,
-    styles,
-    shadowOptions: {
-        delegatesFocus: true,
-    },
-})
-export class FASTTextField extends TextField {
+export class TextField extends FoundationTextField {
     /**
      * The appearance of the element.
      *
@@ -49,6 +36,26 @@ export class FASTTextField extends TextField {
         }
     }
 }
+
+/**
+ * The FAST Text Field Custom Element. Implements {@link @microsoft/fast-foundation#TextField},
+ * {@link @microsoft/fast-foundation#textFieldTemplate}
+ *
+ *
+ * @public
+ * @remarks
+ * HTML Element: \<fast-text-field\>
+ *
+ * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
+ */
+export const fastTextField = TextField.compose({
+    baseName: "text-field",
+    template,
+    styles,
+    shadowOptions: {
+        delegatesFocus: true,
+    },
+});
 
 /**
  * Styles for TextField

--- a/packages/web-components/fast-components/src/text-field/index.ts
+++ b/packages/web-components/fast-components/src/text-field/index.ts
@@ -61,4 +61,4 @@ export const fastTextField = TextField.compose({
  * Styles for TextField
  * @public
  */
-export const TextFieldStyles = styles;
+export const textFieldStyles = styles;

--- a/packages/web-components/fast-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.styles.ts
@@ -20,7 +20,8 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const TextFieldStyles = css`
+export const textFieldStyles = (context, definition) =>
+    css`
     ${display("inline-block")} :host {
         font-family: var(--body-font);
         outline: none;
@@ -136,46 +137,46 @@ export const TextFieldStyles = css`
         border-color: ${neutralOutlineRestBehavior.var};
     }
 `.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    neutralFillHoverBehavior,
-    neutralFillInputHoverBehavior,
-    neutralFillInputRestBehavior,
-    neutralFillRestBehavior,
-    neutralFocusBehavior,
-    neutralForegroundRestBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            .root,
-            :host([appearance="filled"]) .root {
-                forced-color-adjust: none;
-                background: ${SystemColors.Field};
-                border-color: ${SystemColors.FieldText};
-            }
-            :host(:hover:not([disabled])) .root,
-            :host([appearance="filled"]:hover:not([disabled])) .root,
-            :host([appearance="filled"]:hover) .root {
-                background: ${SystemColors.Field};
-                border-color: ${SystemColors.Highlight};
-            }
-            .start,
-            .end {
-                fill: currentcolor;
-            }
-            :host([disabled]) {
-                opacity: 1;
-            }
-            :host([disabled]) .root,
-            :host([appearance="filled"]:hover[disabled]) .root {
-                border-color: ${SystemColors.GrayText};
-                background: ${SystemColors.Field};
-            }
-            :host(:focus-within:enabled) .root {
-                border-color: ${SystemColors.Highlight};
-                box-shadow: 0 0 0 1px ${SystemColors.Highlight} inset;
-            }
-        `
-    )
-);
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        neutralFillHoverBehavior,
+        neutralFillInputHoverBehavior,
+        neutralFillInputRestBehavior,
+        neutralFillRestBehavior,
+        neutralFocusBehavior,
+        neutralForegroundRestBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                .root,
+                :host([appearance="filled"]) .root {
+                    forced-color-adjust: none;
+                    background: ${SystemColors.Field};
+                    border-color: ${SystemColors.FieldText};
+                }
+                :host(:hover:not([disabled])) .root,
+                :host([appearance="filled"]:hover:not([disabled])) .root,
+                :host([appearance="filled"]:hover) .root {
+                    background: ${SystemColors.Field};
+                    border-color: ${SystemColors.Highlight};
+                }
+                .start,
+                .end {
+                    fill: currentcolor;
+                }
+                :host([disabled]) {
+                    opacity: 1;
+                }
+                :host([disabled]) .root,
+                :host([appearance="filled"]:hover[disabled]) .root {
+                    border-color: ${SystemColors.GrayText};
+                    background: ${SystemColors.Field};
+                }
+                :host(:focus-within:enabled) .root {
+                    border-color: ${SystemColors.Highlight};
+                    box-shadow: 0 0 0 1px ${SystemColors.Highlight} inset;
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.styles.ts
@@ -7,6 +7,15 @@ import {
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
@@ -23,7 +32,7 @@ import {
 export const textFieldStyles = (context, definition) =>
     css`
     ${display("inline-block")} :host {
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         outline: none;
         user-select: none;
     }
@@ -35,8 +44,8 @@ export const textFieldStyles = (context, definition) =>
         flex-direction: row;
         color: ${neutralForegroundRestBehavior.var};
         background: ${neutralFillInputRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid ${accentFillRestBehavior.var};
+        border-radius: calc(${cornerRadius} * 1px);
+        border: calc(${outlineWidth} * 1px) solid ${accentFillRestBehavior.var};
         height: calc(${heightNumber} * 1px);
     }
 
@@ -51,9 +60,9 @@ export const textFieldStyles = (context, definition) =>
         margin-top: auto;
         margin-bottom: auto;
         border: none;
-        padding: 0 calc(var(--design-unit) * 2px + 1px);
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        padding: 0 calc(${designUnit} * 2px + 1px);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
     }
 
     .control:hover,
@@ -67,8 +76,8 @@ export const textFieldStyles = (context, definition) =>
         display: block;
         color: ${neutralForegroundRestBehavior.var};
         cursor: pointer;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
         margin-bottom: 4px;
     }
 
@@ -130,7 +139,7 @@ export const textFieldStyles = (context, definition) =>
     }
 
     :host([disabled]) {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
     }
 
     :host([disabled]) .control {

--- a/packages/web-components/fast-components/src/tooltip/index.ts
+++ b/packages/web-components/fast-components/src/tooltip/index.ts
@@ -1,23 +1,17 @@
-import { customElement } from "@microsoft/fast-element";
-import { createTooltipTemplate, Tooltip } from "@microsoft/fast-foundation";
-import { TooltipStyles as styles } from "./tooltip.styles";
-import { FASTAnchoredRegion } from "../anchored-region";
-
-// prevent tree shaking
-FASTAnchoredRegion;
+import { tooltipTemplate as template, Tooltip } from "@microsoft/fast-foundation";
+import { tooltipStyles as styles } from "./tooltip.styles";
 
 /**
  * The FAST Tooltip Custom Element. Implements {@link @microsoft/fast-foundation#Tooltip},
- * {@link @microsoft/fast-foundation#createTooltipTemplate}
+ * {@link @microsoft/fast-foundation#tooltipTemplate}
  *
  *
  * @public
  * @remarks
  * HTML Element: \<fast-tooltip\>
  */
-@customElement({
-    name: "fast-tooltip",
-    template: createTooltipTemplate("fast"),
+export const fastTooltip = Tooltip.compose({
+    baseName: "tooltip",
+    template,
     styles,
-})
-export class FASTTooltip extends Tooltip {}
+});

--- a/packages/web-components/fast-components/src/tooltip/tooltip.stories.ts
+++ b/packages/web-components/fast-components/src/tooltip/tooltip.stories.ts
@@ -1,7 +1,7 @@
 import { STORY_RENDERED } from "@storybook/core-events";
 import addons from "@storybook/addons";
+import type { Tooltip as FoundationTooltip } from "@microsoft/fast-foundation";
 import TooltipTemplate from "./fixtures/base.html";
-import type { FASTTooltip } from "./index";
 import "../button";
 import "./index";
 
@@ -9,7 +9,7 @@ function onShowClick(): void {
     for (let i = 1; i <= 4; i++) {
         const tooltipInstance = document.getElementById(
             `tooltip-show-${i}`
-        ) as FASTTooltip;
+        ) as FoundationTooltip;
         tooltipInstance.visible = !tooltipInstance.visible;
     }
 }
@@ -21,7 +21,7 @@ function onAnchorMouseEnter(e: MouseEvent): void {
 
     const tooltipInstance = document.getElementById(
         "tooltip-anchor-switch"
-    ) as FASTTooltip;
+    ) as FoundationTooltip;
     tooltipInstance.anchorElement = e.target as HTMLElement;
 }
 

--- a/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
@@ -14,78 +14,79 @@ import {
     neutralOutlineRestBehavior,
 } from "../styles/index";
 
-export const TooltipStyles = css`
-    :host {
-        contain: layout;
-        overflow: visible;
-        height: 0;
-        width: 0;
-    }
+export const tooltipStyles = (context, definition) =>
+    css`
+        :host {
+            contain: layout;
+            overflow: visible;
+            height: 0;
+            width: 0;
+        }
 
-    .tooltip {
-        box-sizing: border-box;
-        border-radius: calc(var(--corner-radius) * 1px);
-        border: calc(var(--outline-width) * 1px) solid ${neutralFocusBehavior.var};
-        box-shadow: 0 0 0 1px ${neutralFocusBehavior.var} inset;
-        background: ${neutralFillRestBehavior.var};
-        color: ${neutralForegroundRestBehavior.var};
-        padding: 4px;
-        height: fit-content;
-        width: fit-content;
-        font-family: var(--body-font);
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
-        white-space: nowrap;
-        ${/* TODO: a mechanism to manage z-index across components
+        .tooltip {
+            box-sizing: border-box;
+            border-radius: calc(var(--corner-radius) * 1px);
+            border: calc(var(--outline-width) * 1px) solid ${neutralFocusBehavior.var};
+            box-shadow: 0 0 0 1px ${neutralFocusBehavior.var} inset;
+            background: ${neutralFillRestBehavior.var};
+            color: ${neutralForegroundRestBehavior.var};
+            padding: 4px;
+            height: fit-content;
+            width: fit-content;
+            font-family: var(--body-font);
+            font-size: var(--type-ramp-base-font-size);
+            line-height: var(--type-ramp-base-line-height);
+            white-space: nowrap;
+            ${/* TODO: a mechanism to manage z-index across components
             https://github.com/microsoft/fast/issues/3813 */ ""}
-        z-index: 10000;
-    }
+            z-index: 10000;
+        }
 
-    fast-anchored-region {
-        display: flex;
-        justify-content: center;
-        align-items: center;
-        overflow: visible;
-        flex-direction: row;
-    }
+        fast-anchored-region {
+            display: flex;
+            justify-content: center;
+            align-items: center;
+            overflow: visible;
+            flex-direction: row;
+        }
 
-    fast-anchored-region.right,
-    fast-anchored-region.left {
-        flex-direction: column;
-    }
+        fast-anchored-region.right,
+        fast-anchored-region.left {
+            flex-direction: column;
+        }
 
-    fast-anchored-region.top .tooltip {
-        margin-bottom: 4px;
-    }
+        fast-anchored-region.top .tooltip {
+            margin-bottom: 4px;
+        }
 
-    fast-anchored-region.bottom .tooltip {
-        margin-top: 4px;
-    }
+        fast-anchored-region.bottom .tooltip {
+            margin-top: 4px;
+        }
 
-    fast-anchored-region.left .tooltip {
-        margin-right: 4px;
-    }
+        fast-anchored-region.left .tooltip {
+            margin-right: 4px;
+        }
 
-    fast-anchored-region.right .tooltip {
-        margin-left: 4px;
-    }
-`.withBehaviors(
-    accentFillActiveBehavior,
-    accentFillHoverBehavior,
-    accentFillRestBehavior,
-    neutralFillHoverBehavior,
-    neutralFillInputActiveBehavior,
-    neutralFillInputHoverBehavior,
-    neutralFillInputRestBehavior,
-    neutralFillRestBehavior,
-    neutralFocusBehavior,
-    neutralForegroundRestBehavior,
-    neutralOutlineRestBehavior,
-    forcedColorsStylesheetBehavior(
-        css`
-            :host([disabled]) {
-                opacity: 1;
-            }
-        `
-    )
-);
+        fast-anchored-region.right .tooltip {
+            margin-left: 4px;
+        }
+    `.withBehaviors(
+        accentFillActiveBehavior,
+        accentFillHoverBehavior,
+        accentFillRestBehavior,
+        neutralFillHoverBehavior,
+        neutralFillInputActiveBehavior,
+        neutralFillInputHoverBehavior,
+        neutralFillInputRestBehavior,
+        neutralFillRestBehavior,
+        neutralFocusBehavior,
+        neutralForegroundRestBehavior,
+        neutralOutlineRestBehavior,
+        forcedColorsStylesheetBehavior(
+            css`
+                :host([disabled]) {
+                    opacity: 1;
+                }
+            `
+        )
+    );

--- a/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
@@ -1,6 +1,13 @@
 import { css } from "@microsoft/fast-element";
 import { forcedColorsStylesheetBehavior } from "@microsoft/fast-foundation";
 import {
+    bodyFont,
+    cornerRadius,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+import {
     accentFillActiveBehavior,
     accentFillHoverBehavior,
     accentFillRestBehavior,
@@ -25,17 +32,17 @@ export const tooltipStyles = (context, definition) =>
 
         .tooltip {
             box-sizing: border-box;
-            border-radius: calc(var(--corner-radius) * 1px);
-            border: calc(var(--outline-width) * 1px) solid ${neutralFocusBehavior.var};
+            border-radius: calc(${cornerRadius} * 1px);
+            border: calc(${outlineWidth} * 1px) solid ${neutralFocusBehavior.var};
             box-shadow: 0 0 0 1px ${neutralFocusBehavior.var} inset;
             background: ${neutralFillRestBehavior.var};
             color: ${neutralForegroundRestBehavior.var};
             padding: 4px;
             height: fit-content;
             width: fit-content;
-            font-family: var(--body-font);
-            font-size: var(--type-ramp-base-font-size);
-            line-height: var(--type-ramp-base-line-height);
+            font-family: ${bodyFont};
+            font-size: ${typeRampBaseFontSize};
+            line-height: ${typeRampBaseLineHeight};
             white-space: nowrap;
             ${/* TODO: a mechanism to manage z-index across components
             https://github.com/microsoft/fast/issues/3813 */ ""}

--- a/packages/web-components/fast-components/src/tree-item/index.ts
+++ b/packages/web-components/fast-components/src/tree-item/index.ts
@@ -21,4 +21,4 @@ export const fastTreeItem = TreeItem.compose({
  * Styles for TreeItem
  * @public
  */
-export const TreeItemStyles = styles;
+export const treeItemStyles = styles;

--- a/packages/web-components/fast-components/src/tree-item/index.ts
+++ b/packages/web-components/fast-components/src/tree-item/index.ts
@@ -1,10 +1,9 @@
-import { customElement } from "@microsoft/fast-element";
-import { TreeItemTemplate as template, TreeItem } from "@microsoft/fast-foundation";
-import { TreeItemStyles as styles } from "./tree-item.styles";
+import { treeItemTemplate as template, TreeItem } from "@microsoft/fast-foundation";
+import { treeItemStyles as styles } from "./tree-item.styles";
 
 /**
  * The FAST tree item Custom Element. Implements, {@link @microsoft/fast-foundation#TreeItem}
- * {@link @microsoft/fast-foundation#TreeItemTemplate}
+ * {@link @microsoft/fast-foundation#treeItemTemplate}
  *
  *
  * @public
@@ -12,12 +11,11 @@ import { TreeItemStyles as styles } from "./tree-item.styles";
  * HTML Element: \<fast-tree-item\>
  *
  */
-@customElement({
-    name: "fast-tree-item",
+export const fastTreeItem = TreeItem.compose({
+    baseName: "tree-item",
     template,
     styles,
-})
-export class FASTTreeItem extends TreeItem {}
+});
 
 /**
  * Styles for TreeItem

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -22,6 +22,16 @@ import {
 } from "../styles/index";
 import { neutralFillStealthHover, neutralFillStealthSelected } from "../color/index";
 import { FASTDesignSystemProvider } from "../design-system-provider/index";
+import {
+    bodyFont,
+    cornerRadius,
+    designUnit,
+    disabledOpacity,
+    focusOutlineWidth,
+    outlineWidth,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
 
 const ltr = css`
     .expand-collapse-glyph {
@@ -31,7 +41,7 @@ const ltr = css`
         left: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
     }
     :host([selected])::after {
-        left: calc(var(--focus-outline-width) * 1px);
+        left: calc(${focusOutlineWidth} * 1px);
     }
     :host([expanded]) > .positioning-region .expand-collapse-glyph {
         transform: rotate(45deg);
@@ -46,7 +56,7 @@ const rtl = css`
         right: var(--expand-collapse-button-nested-width, calc(${heightNumber} * -1px));
     }
     :host([selected])::after {
-        right: calc(var(--focus-outline-width) * 1px);
+        right: calc(${focusOutlineWidth} * 1px);
     }
     :host([expanded]) > .positioning-region .expand-collapse-glyph {
         transform: rotate(135deg);
@@ -54,7 +64,7 @@ const rtl = css`
 `;
 
 export const expandCollapseButtonSize =
-    "((var(--base-height-multiplier) / 2) * var(--design-unit)) + ((var(--design-unit) * var(--density)) / 2)";
+    "((var(--base-height-multiplier) / 2) * ${designUnit}) + ((${designUnit} * ${density}) / 2)";
 
 const expandCollapseHoverBehavior = cssCustomPropertyBehaviorFactory(
     "neutral-stealth-hover-over-hover",
@@ -77,7 +87,7 @@ export const treeItemStyles = (context, definition) =>
         color: ${neutralForegroundRestBehavior.var};
         background: ${neutralFillStealthRestBehavior.var};
         cursor: pointer;
-        font-family: var(--body-font);
+        font-family: ${bodyFont};
         --expand-collapse-button-size: calc(${heightNumber} * 1px);
         --tree-item-nested-width: 0;
     }
@@ -91,8 +101,8 @@ export const treeItemStyles = (context, definition) =>
     }
 
     :host(:${focusVisible}) .positioning-region {
-        border: ${neutralFocusBehavior.var} calc(var(--outline-width) * 1px) solid;
-        border-radius: calc(var(--corner-radius) * 1px);
+        border: ${neutralFocusBehavior.var} calc(${outlineWidth} * 1px) solid;
+        border-radius: calc(${cornerRadius} * 1px);
         color: ${neutralForegroundActiveBehavior.var};
     }
 
@@ -100,7 +110,7 @@ export const treeItemStyles = (context, definition) =>
         display: flex;
         position: relative;
         box-sizing: border-box;
-        border: transparent calc(var(--outline-width) * 1px) solid;
+        border: transparent calc(${outlineWidth} * 1px) solid;
         height: calc((${heightNumber} + 1) * 1px);
     }
 
@@ -125,9 +135,9 @@ export const treeItemStyles = (context, definition) =>
         white-space: nowrap;
         width: 100%;
         height: calc(${heightNumber} * 1px);
-        margin-inline-start: calc(var(--design-unit) * 2px + 8px);
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--type-ramp-base-line-height);
+        margin-inline-start: calc(${designUnit} * 2px + 8px);
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
         font-weight: 400;
     }
 
@@ -136,7 +146,7 @@ export const treeItemStyles = (context, definition) =>
         ${
             /* Font size should be based off calc(1em + (design-unit + glyph-size-number) * 1px) - 
             update when density story is figured out */ ""
-        } font-size: calc(1em + (var(--design-unit) + 16) * 1px);
+        } font-size: calc(1em + (${designUnit} + 16) * 1px);
     }
 
     .expand-collapse-button {
@@ -146,8 +156,8 @@ export const treeItemStyles = (context, definition) =>
         ${
             /* Width and Height should be based off calc(glyph-size-number + (design-unit * 4) * 1px) - 
             update when density story is figured out */ ""
-        } width: calc((${expandCollapseButtonSize} + (var(--design-unit) * 2)) * 1px);
-        height: calc((${expandCollapseButtonSize} + (var(--design-unit) * 2)) * 1px);
+        } width: calc((${expandCollapseButtonSize} + (${designUnit} * 2)) * 1px);
+        height: calc((${expandCollapseButtonSize} + (${designUnit} * 2)) * 1px);
         padding: 0;
         display: flex;
         justify-content: center;
@@ -186,13 +196,13 @@ export const treeItemStyles = (context, definition) =>
     .start {
         ${
             /* need to swap out once we understand how horizontalSpacing will work */ ""
-        } margin-inline-end: calc(var(--design-unit) * 2px + 2px);
+        } margin-inline-end: calc(${designUnit} * 2px + 2px);
     }
 
     .end {
         ${
             /* need to swap out once we understand how horizontalSpacing will work */ ""
-        } margin-inline-start: calc(var(--design-unit) * 2px + 2px);
+        } margin-inline-start: calc(${designUnit} * 2px + 2px);
     }
 
     :host([expanded]) > .items {
@@ -200,7 +210,7 @@ export const treeItemStyles = (context, definition) =>
     }
 
     :host([disabled]) .content-region {
-        opacity: var(--disabled-opacity);
+        opacity: ${disabledOpacity};
         cursor: ${disabledCursor};
     }
 
@@ -236,7 +246,7 @@ export const treeItemStyles = (context, definition) =>
             /* The french fry background needs to be calculated based on the selected background state for this control.
             We currently have no way of changing that, so setting to accent-foreground-rest for the time being */ ""
         } background: ${accentForegroundRestBehavior.var};
-        border-radius: calc(var(--corner-radius) * 1px);
+        border-radius: calc(${cornerRadius} * 1px);
     }
 
     ::slotted(fast-tree-item) {

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -68,7 +68,8 @@ const selectedExpandCollapseHoverBehavior = cssCustomPropertyBehaviorFactory(
     FASTDesignSystemProvider.findProvider
 );
 
-export const TreeItemStyles = css`
+export const treeItemStyles = (context, definition) =>
+    css`
     ${display("block")} :host {
         contain: content;
         position: relative;
@@ -243,20 +244,20 @@ export const TreeItemStyles = css`
         --expand-collapse-button-nested-width: calc(${heightNumber} * -1px);
     }
 `.withBehaviors(
-    accentForegroundRestBehavior,
-    neutralFillStealthSelectedBehavior,
-    neutralFillStealthActiveBehavior,
-    expandCollapseHoverBehavior,
-    neutralFillStealthHoverBehavior,
-    selectedExpandCollapseHoverBehavior,
-    neutralFillStealthRestBehavior,
-    neutralFocusBehavior,
-    neutralFocusInnerAccentBehavior,
-    neutralForegroundActiveBehavior,
-    neutralForegroundRestBehavior,
-    new DirectionalStyleSheetBehavior(ltr, rtl),
-    forcedColorsStylesheetBehavior(
-        css`
+        accentForegroundRestBehavior,
+        neutralFillStealthSelectedBehavior,
+        neutralFillStealthActiveBehavior,
+        expandCollapseHoverBehavior,
+        neutralFillStealthHoverBehavior,
+        selectedExpandCollapseHoverBehavior,
+        neutralFillStealthRestBehavior,
+        neutralFocusBehavior,
+        neutralFocusInnerAccentBehavior,
+        neutralForegroundActiveBehavior,
+        neutralForegroundRestBehavior,
+        new DirectionalStyleSheetBehavior(ltr, rtl),
+        forcedColorsStylesheetBehavior(
+            css`
         :host {
             forced-color-adjust: none;
             border-color: transparent;
@@ -318,5 +319,5 @@ export const TreeItemStyles = css`
             fill: ${SystemColors.FieldText};
         }
         `
-    )
-);
+        )
+    );

--- a/packages/web-components/fast-components/src/tree-view/index.ts
+++ b/packages/web-components/fast-components/src/tree-view/index.ts
@@ -1,10 +1,9 @@
-import { customElement } from "@microsoft/fast-element";
-import { TreeViewTemplate as template, TreeView } from "@microsoft/fast-foundation";
-import { TreeViewStyles as styles } from "./tree-view.styles";
+import { treeViewTemplate as template, TreeView } from "@microsoft/fast-foundation";
+import { treeViewStyles as styles } from "./tree-view.styles";
 
 /**
  * The FAST tree view Custom Element. Implements, {@link @microsoft/fast-foundation#TreeView}
- * {@link @microsoft/fast-foundation#TreeViewTemplate}
+ * {@link @microsoft/fast-foundation#treeViewTemplate}
  *
  *
  * @public
@@ -12,12 +11,11 @@ import { TreeViewStyles as styles } from "./tree-view.styles";
  * HTML Element: \<fast-tree-view\>
  *
  */
-@customElement({
-    name: "fast-tree-view",
+export const fastTreeView = TreeView.compose({
+    baseName: "tree-view",
     template,
     styles,
-})
-export class FASTTreeView extends TreeView {}
+});
 
 /**
  * Styles for TreeView

--- a/packages/web-components/fast-components/src/tree-view/index.ts
+++ b/packages/web-components/fast-components/src/tree-view/index.ts
@@ -21,4 +21,4 @@ export const fastTreeView = TreeView.compose({
  * Styles for TreeView
  * @public
  */
-export const TreeViewStyles = styles;
+export const treeViewStyles = styles;

--- a/packages/web-components/fast-components/src/tree-view/tree-view.styles.ts
+++ b/packages/web-components/fast-components/src/tree-view/tree-view.styles.ts
@@ -1,7 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { display } from "@microsoft/fast-foundation";
 
-export const TreeViewStyles = css`
+export const treeViewStyles = (context, definition) => css`
     :host([hidden]) {
         display: none;
     }

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -378,7 +378,8 @@ export interface ComponentPresentation {
 
 // @alpha
 export const ComponentPresentation: Readonly<{
-    keyFrom(tagName: string): InterfaceSymbol<ComponentPresentation>;
+    define(tagName: string, presentation: ComponentPresentation, container: Container): void;
+    forTag(tagName: string, element: HTMLElement): ComponentPresentation;
 }>;
 
 // @public
@@ -963,6 +964,8 @@ export interface ElementDefinitionContext {
     readonly container: Container;
     // (undocumented)
     defineElement(definition?: ContextualElementDefinition): void;
+    // (undocumented)
+    definePresentation(presentation: ComponentPresentation): void;
     // (undocumented)
     readonly name: string;
     // (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -752,16 +752,21 @@ export interface DelegatesARIATextbox extends ARIAGlobalStatesAndProperties {
 export type DerivedDesignTokenValue<T> = T extends Function ? never : (target: HTMLElement) => T;
 
 // @alpha (undocumented)
-export class DesignSystem {
+export interface DesignSystem {
     // (undocumented)
-    applyTo(element: HTMLElement): Container;
+    register(...params: any[]): DesignSystem;
     // (undocumented)
-    register(...params: any[]): this;
+    withElementDisambiguation(callback: ElementDisambiguationCallback): DesignSystem;
     // (undocumented)
-    withElementDisambiguation(callback: ElementDisambiguationCallback): this;
-    // (undocumented)
-    withPrefix(prefix: string): this;
+    withPrefix(prefix: string): DesignSystem;
 }
+
+// @alpha (undocumented)
+export const DesignSystem: Readonly<{
+    tagFor(type: Constructable): string;
+    responsibleFor(element: HTMLElement): DesignSystem;
+    getOrCreate(element?: HTMLElement): DesignSystem;
+}>;
 
 // @public
 export interface DesignSystemConsumer {

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -18,8 +18,10 @@ import { Orientation } from '@microsoft/fast-web-utilities';
 import { PartialFASTElementDefinition } from '@microsoft/fast-element';
 import { ViewTemplate } from '@microsoft/fast-element';
 
+// Warning: (ae-incompatible-release-tags) The symbol "Accordion" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Accordion extends FASTElement {
+export class Accordion extends FoundationElement {
     // @internal (undocumented)
     accordionItems: HTMLElement[];
     // @internal (undocumented)
@@ -34,10 +36,11 @@ export enum AccordionExpandMode {
 }
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-incompatible-release-tags) The symbol "AccordionItem" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "AccordionItem" because one of its declarations is marked as @internal
 //
 // @public
-export class AccordionItem extends FASTElement {
+export class AccordionItem extends FoundationElement {
     // @internal (undocumented)
     clickHandler: (e: MouseEvent) => void;
     // @internal (undocumented)
@@ -52,19 +55,20 @@ export interface AccordionItem extends StartEnd {
 }
 
 // @public
-export const AccordionItemTemplate: ViewTemplate<AccordionItem>;
+export const accordionItemTemplate: (context: any, definition: any) => ViewTemplate<AccordionItem>;
 
 // @public
-export const AccordionTemplate: ViewTemplate<Accordion>;
+export const accordionTemplate: (context: any, definition: any) => ViewTemplate<Accordion>;
 
 // @alpha (undocumented)
 export const all: (key: any, searchAncestors?: boolean | undefined) => ReturnType<typeof DI.inject>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-incompatible-release-tags) The symbol "Anchor" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Anchor" because one of its declarations is marked as @internal
 //
 // @public
-export class Anchor extends FASTElement {
+export class Anchor extends FoundationElement {
     control: HTMLAnchorElement;
     // @internal
     defaultSlottedContent: HTMLElement[];
@@ -82,8 +86,10 @@ export class Anchor extends FASTElement {
 export interface Anchor extends StartEnd, DelegatesARIALink {
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "AnchoredRegion" is marked as @beta, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @beta
-export class AnchoredRegion extends FASTElement {
+export class AnchoredRegion extends FoundationElement {
     // @internal (undocumented)
     adoptedCallback(): void;
     anchor: string;
@@ -118,10 +124,10 @@ export class AnchoredRegion extends FASTElement {
     }
 
 // @beta
-export const AnchoredRegionTemplate: ViewTemplate<AnchoredRegion>;
+export const anchoredRegionTemplate: (context: any, definition: any) => ViewTemplate<AnchoredRegion>;
 
 // @public
-export const AnchorTemplate: ViewTemplate<Anchor>;
+export const anchorTemplate: (context: any, definition: any) => ViewTemplate<Anchor>;
 
 // @public
 export function applyMixins(derivedCtor: any, ...baseCtors: any[]): void;
@@ -158,8 +164,10 @@ export type AxisPositioningMode = "uncontrolled" | "locktodefault" | "dynamic";
 // @beta
 export type AxisScalingMode = "anchor" | "fill" | "content";
 
+// Warning: (ae-incompatible-release-tags) The symbol "Badge" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Badge extends FASTElement {
+export class Badge extends FoundationElement {
     circular: boolean;
     color: string;
     fill: string;
@@ -168,18 +176,22 @@ export class Badge extends FASTElement {
 }
 
 // @public
-export const BadgeTemplate: ViewTemplate<Badge>;
+export const badgeTemplate: (context: any, definition: any) => ViewTemplate<Badge>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "BaseProgress" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class BaseProgress extends FASTElement {
+export class BaseProgress extends FoundationElement {
     max: number;
     min: number;
     paused: any;
     value: number | null;
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "Breadcrumb" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Breadcrumb extends FASTElement {
+export class Breadcrumb extends FoundationElement {
     // @internal (undocumented)
     slottedBreadcrumbItems: HTMLElement[];
     // (undocumented)
@@ -200,10 +212,10 @@ export interface BreadcrumbItem extends StartEnd, DelegatesARIALink {
 }
 
 // @public
-export const BreadcrumbItemTemplate: ViewTemplate<BreadcrumbItem>;
+export const breadcrumbItemTemplate: (context: any, definition: any) => ViewTemplate<BreadcrumbItem>;
 
 // @public
-export const BreadcrumbTemplate: ViewTemplate<Breadcrumb>;
+export const breadcrumbTemplate: (context: any, definition: any) => ViewTemplate<Breadcrumb>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedButton" needs to be exported by the entry point index.d.ts
@@ -233,7 +245,7 @@ export interface Button extends StartEnd, DelegatesARIAButton {
 }
 
 // @public
-export const ButtonTemplate: ViewTemplate<Button>;
+export const buttonTemplate: (context: any, definition: any) => ViewTemplate<Button>;
 
 // @public
 export class Card extends FASTElement {
@@ -267,7 +279,7 @@ export class Checkbox extends FormAssociatedCheckbox {
     }
 
 // @public
-export const CheckboxTemplate: ViewTemplate<Checkbox>;
+export const checkboxTemplate: (context: any, definition: any) => ViewTemplate<Checkbox>;
 
 // @public
 export interface ColumnDefinition {
@@ -356,7 +368,7 @@ export enum ComboboxAutocomplete {
 }
 
 // @public
-export const ComboboxTemplate: ViewTemplate<Combobox>;
+export const comboboxTemplate: (context: any, definition: any) => ViewTemplate<Combobox>;
 
 // @alpha
 export interface ComponentPresentation {
@@ -473,12 +485,6 @@ export function createDataGridRowTemplate(prefix: string): ViewTemplate;
 
 // @public
 export function createDataGridTemplate(prefix: string): ViewTemplate;
-
-// @public
-export function createMenuItemTemplate(prefix: string): ViewTemplate;
-
-// @public
-export function createTooltipTemplate(prefix: string): ViewTemplate;
 
 // @public
 export class CSSCustomPropertyBehavior implements Behavior, CSSCustomPropertyDefinition {
@@ -859,8 +865,10 @@ export const DI: Readonly<{
     singleton<T_1 extends Constructable<{}>>(target: T_1 & Partial<RegisterSelf<T_1>>, options?: SingletonOptions): T_1 & RegisterSelf<T_1>;
 }>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "Dialog" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Dialog extends FASTElement {
+export class Dialog extends FoundationElement {
     ariaDescribedby: string;
     ariaLabel: string;
     ariaLabelledby: string;
@@ -880,7 +888,7 @@ export class Dialog extends FASTElement {
     }
 
 // @public
-export const DialogTemplate: ViewTemplate<Dialog>;
+export const dialogTemplate: (context: any, definition: any) => ViewTemplate<Dialog>;
 
 // @public
 export class DirectionalStyleSheetBehavior implements Behavior {
@@ -894,8 +902,10 @@ export class DirectionalStyleSheetBehavior implements Behavior {
 // @public
 export const disabledCursor = "not-allowed";
 
+// Warning: (ae-incompatible-release-tags) The symbol "Disclosure" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Disclosure extends FASTElement {
+export class Disclosure extends FoundationElement {
     // @internal (undocumented)
     connectedCallback(): void;
     // @internal (undocumented)
@@ -912,13 +922,15 @@ export class Disclosure extends FASTElement {
 }
 
 // @public
-export const DisclosureTemplate: ViewTemplate<Disclosure>;
+export const disclosureTemplate: (context: any, definition: any) => ViewTemplate<Disclosure>;
 
 // @public
 export function display(displayValue: CSSDisplayPropertyValue): string;
 
+// Warning: (ae-incompatible-release-tags) The symbol "Divider" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Divider extends FASTElement {
+export class Divider extends FoundationElement {
     role: DividerRole;
 }
 
@@ -929,7 +941,7 @@ export enum DividerRole {
 }
 
 // @public
-export const DividerTemplate: ViewTemplate<Divider>;
+export const dividerTemplate: (context: any, definition: any) => ViewTemplate<Divider>;
 
 // @alpha (undocumented)
 export interface DOMParentLocatorEventDetail {
@@ -985,8 +997,10 @@ export class FactoryImpl<T extends Constructable = any> implements Factory<T> {
     Type: T;
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "Flipper" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Flipper extends FASTElement {
+export class Flipper extends FoundationElement {
     direction: FlipperDirection;
     disabled: boolean;
     hiddenFromAT: boolean;
@@ -1001,7 +1015,7 @@ export enum FlipperDirection {
 }
 
 // @public
-export const FlipperTemplate: ViewTemplate<Flipper>;
+export const flipperTemplate: (context: any, definition: any) => ViewTemplate<Flipper>;
 
 // @public
 export const focusVisible: string;
@@ -1082,7 +1096,7 @@ export interface FormAssociatedProxy {
 // @alpha
 export class FoundationElement extends FASTElement {
     protected get $presentation(): ComponentPresentation;
-    static compose<T extends FoundationElementDefinition = FoundationElementDefinition>(elementDefinition: T): (overrideDefinition?: OverrideFoundationElementDefinition<T>) => Registry;
+    static compose<T extends FoundationElementDefinition = FoundationElementDefinition, K extends Constructable<FoundationElement> = Constructable<FoundationElement>>(this: K, elementDefinition: T): (overrideDefinition?: OverrideFoundationElementDefinition<T>) => FoundationElementRegistry<T, K>;
     connectedCallback(): void;
     styles: ElementStyles | void | null;
     // (undocumented)
@@ -1101,6 +1115,17 @@ export interface FoundationElementDefinition {
     readonly styles?: EagerOrLazyFoundationOption<ComposableStyles | ComposableStyles[], this>;
     // Warning: (ae-forgotten-export) The symbol "EagerOrLazyFoundationOption" needs to be exported by the entry point index.d.ts
     readonly template?: EagerOrLazyFoundationOption<ElementViewTemplate, this>;
+}
+
+// @alpha
+export class FoundationElementRegistry<TDefinition extends FoundationElementDefinition, TType> implements Registry {
+    constructor(type: Constructable<FoundationElement>, elementDefinition: TDefinition, overrideDefinition: OverrideFoundationElementDefinition<TDefinition>);
+    // (undocumented)
+    readonly definition: OverrideFoundationElementDefinition<TDefinition>;
+    // (undocumented)
+    register(container: Container): void;
+    // (undocumented)
+    readonly type: Constructable<FoundationElement>;
 }
 
 // @public
@@ -1122,8 +1147,10 @@ export const hidden = ":host([hidden]){display:none}";
 // @beta
 export type HorizontalPosition = "start" | "end" | "left" | "right" | "unset";
 
+// Warning: (ae-incompatible-release-tags) The symbol "HorizontalScroll" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class HorizontalScroll extends FASTElement {
+export class HorizontalScroll extends FoundationElement {
     // (undocumented)
     connectedCallback(): void;
     // (undocumented)
@@ -1143,7 +1170,7 @@ export class HorizontalScroll extends FASTElement {
     }
 
 // @public (undocumented)
-export const HorizontalScrollTemplate: ViewTemplate<HorizontalScroll>;
+export const horizontalScrollTemplate: (context: any, definition: any) => ViewTemplate<HorizontalScroll>;
 
 // @public
 export type HorizontalScrollView = "default" | "mobile";
@@ -1195,10 +1222,11 @@ export const lazy: (key: any) => any;
 export const lightModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-incompatible-release-tags) The symbol "Listbox" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Listbox" because one of its declarations is marked as @internal
 //
 // @public
-export class Listbox extends FASTElement {
+export class Listbox extends FoundationElement {
     // @internal
     clickHandler(e: MouseEvent): boolean | void;
     disabled: boolean;
@@ -1256,10 +1284,11 @@ export interface Listbox extends DelegatesARIAListbox {
 }
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-incompatible-release-tags) The symbol "ListboxOption" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "ListboxOption" because one of its declarations is marked as @internal
 //
 // @public
-export class ListboxOption extends FASTElement {
+export class ListboxOption extends FoundationElement {
     constructor(text?: string, value?: string, defaultSelected?: boolean, selected?: boolean);
     defaultSelected: boolean;
     // (undocumented)
@@ -1295,7 +1324,7 @@ export interface ListboxOption extends StartEnd {
 }
 
 // @public
-export const ListboxOptionTemplate: ViewTemplate<ListboxOption>;
+export const listboxOptionTemplate: (context: any, definition: any) => ViewTemplate<ListboxOption>;
 
 // @public
 export enum ListboxRole {
@@ -1304,7 +1333,7 @@ export enum ListboxRole {
 }
 
 // @public
-export const ListboxTemplate: ViewTemplate<Listbox>;
+export const listboxTemplate: (context: any, definition: any) => ViewTemplate<Listbox>;
 
 // @public
 export abstract class MatchMediaBehavior implements Behavior {
@@ -1333,8 +1362,10 @@ export function matchMediaStylesheetBehaviorFactory(query: MediaQueryList): (sty
 // @public
 export type MediaQueryListListener = (this: MediaQueryList, ev?: MediaQueryListEvent) => void;
 
+// Warning: (ae-incompatible-release-tags) The symbol "Menu" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Menu extends FASTElement {
+export class Menu extends FoundationElement {
     collapseExpandedItem(): void;
     // @internal (undocumented)
     connectedCallback(): void;
@@ -1352,10 +1383,11 @@ export class Menu extends FASTElement {
     }
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-incompatible-release-tags) The symbol "MenuItem" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "MenuItem" because one of its declarations is marked as @internal
 //
 // @public
-export class MenuItem extends FASTElement {
+export class MenuItem extends FoundationElement {
     checked: boolean;
     // @internal (undocumented)
     connectedCallback(): void;
@@ -1395,11 +1427,11 @@ export enum MenuItemRole {
     menuitemradio = "menuitemradio"
 }
 
-// @public @deprecated
-export const MenuItemTemplate: ViewTemplate<MenuItem>;
+// @public
+export const menuItemTemplate: (context: any, definition: any) => ViewTemplate<MenuItem>;
 
 // @public
-export const MenuTemplate: ViewTemplate<Menu>;
+export const menuTemplate: (context: any, definition: any) => ViewTemplate<Menu>;
 
 // @alpha (undocumented)
 export const newInstanceForScope: (key: any) => any;
@@ -1449,7 +1481,7 @@ export interface NumberField extends StartEnd, DelegatesARIATextbox {
 }
 
 // @public
-export const NumberFieldTemplate: ViewTemplate<NumberField>;
+export const numberFieldTemplate: (context: any, definition: any) => ViewTemplate<NumberField>;
 
 // @alpha
 export const optional: (key: any) => any;
@@ -1463,10 +1495,10 @@ export type OverrideFoundationElementDefinition<T extends FoundationElementDefin
 export type ParentLocator = (owner: any) => Container | null;
 
 // @public
-export const ProgressRingTemplate: ViewTemplate<BaseProgress>;
+export const progressRingTemplate: (context: any, definition: any) => ViewTemplate<BaseProgress>;
 
 // @public
-export const ProgressTemplate: ViewTemplate<BaseProgress>;
+export const progressTemplate: (context: any, defintion: any) => ViewTemplate<BaseProgress>;
 
 // @public
 export class PropertyStyleSheetBehavior implements Behavior {
@@ -1508,8 +1540,10 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
 // @public
 export type RadioControl = Pick<HTMLInputElement, "checked" | "disabled" | "readOnly" | "focus" | "setAttribute" | "getAttribute">;
 
+// Warning: (ae-incompatible-release-tags) The symbol "RadioGroup" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class RadioGroup extends FASTElement {
+export class RadioGroup extends FoundationElement {
     // (undocumented)
     childItems: HTMLElement[];
     // @internal (undocumented)
@@ -1536,10 +1570,10 @@ export class RadioGroup extends FASTElement {
 }
 
 // @public
-export const RadioGroupTemplate: ViewTemplate<RadioGroup>;
+export const radioGroupTemplate: (context: any, definition: any) => ViewTemplate<RadioGroup>;
 
 // @public
-export const RadioTemplate: ViewTemplate<Radio>;
+export const radioTemplate: (context: any, definition: any) => ViewTemplate<Radio>;
 
 // @alpha (undocumented)
 export type RegisterSelf<T extends Constructable> = {
@@ -1696,7 +1730,7 @@ export enum SelectRole {
 }
 
 // @public
-export const SelectTemplate: ViewTemplate<Select>;
+export const selectTemplate: (context: any, definition: any) => ViewTemplate<Select>;
 
 // @alpha (undocumented)
 export interface ServiceLocator {
@@ -1730,8 +1764,10 @@ export function singleton<T extends Constructable>(options?: SingletonOptions): 
 // @alpha
 export function singleton<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "Skeleton" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Skeleton extends FASTElement {
+export class Skeleton extends FoundationElement {
     fill: string;
     pattern: string;
     shape: SkeletonShape;
@@ -1742,7 +1778,7 @@ export class Skeleton extends FASTElement {
 export type SkeletonShape = "rect" | "circle";
 
 // @public
-export const SkeletonTemplate: ViewTemplate<Skeleton>;
+export const skeletonTemplate: (context: any, definition: any) => ViewTemplate<Skeleton>;
 
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedSlider" needs to be exported by the entry point index.d.ts
 //
@@ -1803,8 +1839,10 @@ export interface SliderConfiguration {
     orientation?: Orientation;
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "SliderLabel" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class SliderLabel extends FASTElement {
+export class SliderLabel extends FoundationElement {
     // @internal (undocumented)
     connectedCallback(): void;
     disabled: boolean;
@@ -1831,7 +1869,7 @@ export class SliderLabel extends FASTElement {
 }
 
 // @public
-export const SliderLabelTemplate: ViewTemplate<SliderLabel>;
+export const sliderLabelTemplate: (context: any, definition: any) => ViewTemplate<SliderLabel>;
 
 // @public
 export enum SliderMode {
@@ -1840,7 +1878,7 @@ export enum SliderMode {
 }
 
 // @public
-export const SliderTemplate: ViewTemplate<Slider>;
+export const sliderTemplate: (context: any, definition: any) => ViewTemplate<Slider>;
 
 // @public
 export class StartEnd {
@@ -1902,25 +1940,30 @@ export class Switch extends FormAssociatedSwitch {
     }
 
 // @public
-export const SwitchTemplate: ViewTemplate<Switch>;
+export const switchTemplate: (context: any, definition: any) => ViewTemplate<Switch>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "Tab" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Tab extends FASTElement {
+export class Tab extends FoundationElement {
     disabled: boolean;
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "TabPanel" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class TabPanel extends FASTElement {
+export class TabPanel extends FoundationElement {
 }
 
 // @public
-export const TabPanelTemplate: ViewTemplate<TabPanel>;
+export const tabPanelTemplate: (context: any, definition: any) => ViewTemplate<TabPanel>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-incompatible-release-tags) The symbol "Tabs" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "Tabs" because one of its declarations is marked as @internal
 //
 // @public
-export class Tabs extends FASTElement {
+export class Tabs extends FoundationElement {
     activeid: string;
     // @internal (undocumented)
     activeidChanged(): void;
@@ -1957,10 +2000,10 @@ export enum TabsOrientation {
 }
 
 // @public
-export const TabsTemplate: ViewTemplate<Tabs>;
+export const tabsTemplate: (context: any, definition: any) => ViewTemplate<Tabs>;
 
 // @public
-export const TabTemplate: ViewTemplate<Tab>;
+export const tabTemplate: (context: any, definition: any) => ViewTemplate<Tab>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedTextArea" needs to be exported by the entry point index.d.ts
@@ -2003,7 +2046,7 @@ export enum TextAreaResize {
 }
 
 // @public
-export const TextAreaTemplate: ViewTemplate<TextArea>;
+export const textAreaTemplate: (context: any, definition: any) => ViewTemplate<TextArea>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedTextField" needs to be exported by the entry point index.d.ts
@@ -2038,7 +2081,7 @@ export interface TextField extends StartEnd, DelegatesARIATextbox {
 }
 
 // @public
-export const TextFieldTemplate: ViewTemplate<TextField>;
+export const textFieldTemplate: (context: any, definition: any) => ViewTemplate<TextField>;
 
 // @public
 export enum TextFieldType {
@@ -2049,8 +2092,10 @@ export enum TextFieldType {
     url = "url"
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "Tooltip" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class Tooltip extends FASTElement {
+export class Tooltip extends FoundationElement {
     anchor: string;
     anchorElement: HTMLElement | null;
     // (undocumented)
@@ -2098,6 +2143,9 @@ export enum TooltipPosition {
     top = "top"
 }
 
+// @public
+export const tooltipTemplate: (context: any, definition: any) => ViewTemplate;
+
 // @alpha (undocumented)
 type Transformer_2<K> = (instance: Resolved<K>) => Resolved<K>;
 
@@ -2112,10 +2160,11 @@ export function transient<T extends Constructable>(): typeof transientDecorator;
 export function transient<T extends Constructable>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T>;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-incompatible-release-tags) The symbol "TreeItem" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "TreeItem" because one of its declarations is marked as @internal
 //
 // @public
-export class TreeItem extends FASTElement {
+export class TreeItem extends FoundationElement {
     // (undocumented)
     childItemLength(): number;
     // (undocumented)
@@ -2158,10 +2207,12 @@ export interface TreeItem extends StartEnd {
 }
 
 // @public
-export const TreeItemTemplate: ViewTemplate<TreeItem>;
+export const treeItemTemplate: (context: any, definition: any) => ViewTemplate<TreeItem>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "TreeView" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
+//
 // @public
-export class TreeView extends FASTElement {
+export class TreeView extends FoundationElement {
     // (undocumented)
     connectedCallback(): void;
     // (undocumented)
@@ -2183,7 +2234,7 @@ export class TreeView extends FASTElement {
 }
 
 // @public
-export const TreeViewTemplate: ViewTemplate<TreeView>;
+export const treeViewTemplate: (context: any, definition: any) => ViewTemplate<TreeView>;
 
 // Warning: (ae-internal-missing-underscore) The name "validateKey" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.spec.ts
@@ -1,18 +1,15 @@
 import { expect } from "chai";
-import { AccordionItem, AccordionItemTemplate as template } from "./index";
+import { AccordionItem, accordionItemTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { customElement } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-accordion-item",
-    template,
+
+const FASTAccordionItem = AccordionItem.compose({
+    baseName: "accordion-item",
+    template
 })
-class FASTAccordionItem extends AccordionItem {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTAccordionItem>(
-        "fast-accordion-item"
-    );
+    const { element, connect, disconnect } = await fixture(FASTAccordionItem());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -7,7 +7,10 @@ import type { AccordionItem } from "./accordion-item";
  * The template for the {@link @microsoft/fast-foundation#(AccordionItem:class)} component.
  * @public
  */
-export const AccordionItemTemplate: ViewTemplate<AccordionItem> = html`
+export const accordionItemTemplate: (
+    context,
+    definition
+) => ViewTemplate<AccordionItem> = (context, definition) => html`
     <template
         class="${x => (x.expanded ? "expanded" : "")}"
         slot="item"

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
@@ -1,4 +1,5 @@
-import { attr, FASTElement, nullableNumberConverter } from "@microsoft/fast-element";
+import { attr, nullableNumberConverter } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
 import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 
@@ -6,7 +7,7 @@ import { applyMixins } from "../utilities/apply-mixins";
  * An individual item in an {@link @microsoft/fast-foundation#(Accordion:class) }.
  * @public
  */
-export class AccordionItem extends FASTElement {
+export class AccordionItem extends FoundationElement {
     /**
      * Configures the {@link https://www.w3.org/TR/wai-aria-1.1/#aria-level | level} of the
      * heading element.

--- a/packages/web-components/fast-foundation/src/accordion/accordion.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.spec.ts
@@ -1,26 +1,22 @@
 import { expect } from "chai";
-import { Accordion, AccordionTemplate as template } from "./index";
-import { AccordionItem, AccordionItemTemplate as itemTemplate } from "../accordion-item";
+import { Accordion, accordionTemplate as template } from "./index";
+import { AccordionItem, accordionItemTemplate as itemTemplate } from "../accordion-item";
 import { fixture } from "../fixture";
-import { customElement, DOM, elements } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { AccordionExpandMode } from "./accordion";
 
-@customElement({
-    name: "fast-accordion",
-    template,
+const FASTAccordion = Accordion.compose({
+    baseName: "accordion",
+    template
 })
-class FASTAccordion extends Accordion {}
 
-@customElement({
-    name: "fast-accordion-item",
+const FASTAccordionItem = AccordionItem.compose({
+    baseName: "accordion-item",
     template: itemTemplate,
 })
-class FASTAccordionItem extends AccordionItem {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTAccordion>(
-        "fast-accordion"
-    );
+    const { element, connect, disconnect } = await fixture([FASTAccordion(), FASTAccordionItem()]);
 
     const item1 = document.createElement("fast-accordion-item");
     const item2 = document.createElement("fast-accordion-item");
@@ -66,7 +62,7 @@ describe("Accordion", () => {
         await connect();
         await DOM.nextUpdate();
 
-        expect((element as FASTAccordion).expandmode).to.equal(AccordionExpandMode.multi);
+        expect((element as Accordion).expandmode).to.equal(AccordionExpandMode.multi);
         expect(element.getAttribute("expand-mode")).to.equal(AccordionExpandMode.multi);
 
         await disconnect();

--- a/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
@@ -6,7 +6,10 @@ import type { Accordion } from "./accordion";
  * The template for the {@link @microsoft/fast-foundation#Accordion} component.
  * @public
  */
-export const AccordionTemplate: ViewTemplate<Accordion> = html`
+export const accordionTemplate: (context, definition) => ViewTemplate<Accordion> = (
+    context,
+    definition
+) => html`
     <template>
         <slot name="item" part="item" ${slotted("accordionItems")}></slot>
     </template>

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -1,4 +1,4 @@
-import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import {
     keyCodeArrowDown,
     keyCodeArrowUp,
@@ -6,6 +6,7 @@ import {
     keyCodeHome,
     wrapInBounds,
 } from "@microsoft/fast-web-utilities";
+import { FoundationElement } from "../foundation-element";
 import { AccordionItem } from "../accordion-item";
 
 /**
@@ -30,9 +31,9 @@ export enum AccordionExpandMode {
  * @public
  *
  * @remarks
- * Designed to be used with {@link @microsoft/fast-foundation#AccordionTemplate} and {@link @microsoft/fast-foundation#(AccordionItem:class)}.
+ * Designed to be used with {@link @microsoft/fast-foundation#accordionTemplate} and {@link @microsoft/fast-foundation#(AccordionItem:class)}.
  */
-export class Accordion extends FASTElement {
+export class Accordion extends FoundationElement {
     /**
      * Controls the expand mode of the Accordion, either allowing
      * single or multiple item expansion.

--- a/packages/web-components/fast-foundation/src/anchor/anchor.spec.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.spec.ts
@@ -1,16 +1,14 @@
 import { expect } from "chai";
-import { Anchor, AnchorTemplate as template } from "./index";
+import { Anchor, anchorTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { customElement } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-anchor",
-    template,
-})
-class FASTAnchor extends Anchor {}
+const FASTAnchor = Anchor.compose({
+    baseName: "anchor",
+    template
+});
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTAnchor>("fast-anchor");
+    const { element, connect, disconnect } = await fixture(FASTAnchor());
 
     return { element, connect, disconnect };
 }
@@ -23,6 +21,7 @@ describe("Anchor", () => {
         element.download = download;
 
         await connect();
+
         expect(element.shadowRoot?.querySelector("a")?.getAttribute("download")).to.equal(
             download
         );

--- a/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
@@ -7,7 +7,10 @@ import type { Anchor } from "./anchor";
  * The template for the {@link @microsoft/fast-foundation#(Anchor:class)} component.
  * @public
  */
-export const AnchorTemplate: ViewTemplate<Anchor> = html`
+export const anchorTemplate: (context, definition) => ViewTemplate<Anchor> = (
+    context,
+    definition
+) => html`
     <a
         class="control"
         part="control"

--- a/packages/web-components/fast-foundation/src/anchor/anchor.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.ts
@@ -1,4 +1,5 @@
-import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
 
@@ -8,7 +9,7 @@ import { applyMixins } from "../utilities/apply-mixins";
  *
  * @public
  */
-export class Anchor extends FASTElement {
+export class Anchor extends FoundationElement {
     /**
      * Prompts the user to save the linked URL. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/a | <a> element } for more information.
      * @public

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.ts
@@ -1,68 +1,69 @@
 import { expect } from "chai";
-import { AnchoredRegion, AnchoredRegionTemplate as template } from "./index";
+import { AnchoredRegion, anchoredRegionTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement, html } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-anchored-region",
-    template,
+const FASTAnchoredRegion = AnchoredRegion.compose({
+    baseName: "anchored-region",
+    template
 })
-class FASTAnchoredRegion extends AnchoredRegion {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture(html<HTMLDivElement>`
-        <div id="viewport" style="width: 1000px; height: 1000px;">
-            <button id="anchor" style="width: 100px; height: 100px;">anchor</button>
-            <fast-anchored-region viewport="viewport" anchor="anchor" id="region">
-                <div id="contents" style="width: 100px; height: 100px;"></div>
-            </fast-anchored-region>
-        </div>
-    `);
-    return { element, connect, disconnect };
+    const { element, connect, disconnect, parent } = await fixture(FASTAnchoredRegion());
+
+    const button = document.createElement("button");
+    const content = document.createElement("div");
+
+    button.id = "anchor";
+    button.setAttribute("style", "width: 100px; height: 100px;");
+
+    content.id = "content";
+    content.setAttribute("style", "width: 100px; height: 100px;");
+
+    parent.id = "viewport";
+    parent.setAttribute("style", "width: 1000px; height: 1000px;");
+    parent.insertBefore(button, element);
+
+    element.appendChild(content);
+    element.setAttribute("viewport", "viewport");
+    element.setAttribute("anchor", "anchor");
+    element.id = "region";
+
+    return { element, connect, disconnect, content };
 }
 
 describe("Anchored Region", () => {
     it("should set positioning modes to 'uncontrolled' by default", async () => {
         const { element, connect, disconnect } = await setup();
-        const region: FASTAnchoredRegion = element.querySelector(
-            "fast-anchored-region"
-        ) as FASTAnchoredRegion;
 
         await connect();
 
-        expect(region.verticalPositioningMode).to.equal("uncontrolled");
-        expect(region.horizontalPositioningMode).to.equal("uncontrolled");
+        expect(element.verticalPositioningMode).to.equal("uncontrolled");
+        expect(element.horizontalPositioningMode).to.equal("uncontrolled");
 
         await disconnect();
     });
 
     it("should assign anchor and viewport elements by id", async () => {
         const { element, connect, disconnect } = await setup();
-        const region: FASTAnchoredRegion = element.querySelector(
-            "fast-anchored-region"
-        ) as FASTAnchoredRegion;
 
         await connect();
         await DOM.nextUpdate();
 
-        expect(region.anchorElement?.id).to.equal("anchor");
-        expect(region.viewportElement?.id).to.equal("viewport");
+        expect(element.anchorElement?.id).to.equal("anchor");
+        expect(element.viewportElement?.id).to.equal("viewport");
 
         await disconnect();
     });
 
     it("should be sized to match content by default", async () => {
-        const { element, connect, disconnect } = await setup();
-        const region: FASTAnchoredRegion = element.querySelector(
-            "fast-anchored-region"
-        ) as FASTAnchoredRegion;
-        const contents: HTMLElement = element.querySelector("#contents") as HTMLElement;
+        const { element, connect, disconnect, content } = await setup();
 
         await connect();
         await DOM.nextUpdate();
-
-        expect(region.clientHeight).to.equal(contents.clientHeight);
-        expect(region.clientWidth).to.equal(contents.clientWidth);
+        
+        expect(element.clientHeight).to.equal(content.clientHeight);
+        expect(element.clientWidth).to.equal(content.clientWidth);
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.template.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.template.ts
@@ -6,7 +6,10 @@ import type { AnchoredRegion } from "./anchored-region";
  * The template for the {@link @microsoft/fast-foundation#(AnchoredRegion:class)} component.
  * @beta
  */
-export const AnchoredRegionTemplate: ViewTemplate<AnchoredRegion> = html`
+export const anchoredRegionTemplate: (
+    context,
+    definition
+) => ViewTemplate<AnchoredRegion> = (context, definition) => html`
     <template class="${x => (x.initialLayoutComplete ? "loaded" : "")}">
         ${when(
             x => x.initialLayoutComplete,

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -1,12 +1,12 @@
-import { attr, DOM, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, DOM, observable } from "@microsoft/fast-element";
+import { Direction, eventResize, eventScroll } from "@microsoft/fast-web-utilities";
+import { FoundationElement } from "../foundation-element";
+import { getDirection } from "../utilities";
+import { IntersectionService } from "./intersection-service";
 import type {
     ConstructibleResizeObserver,
     ResizeObserverClassDefinition,
 } from "./resize-observer";
-import { Direction, eventResize, eventScroll } from "@microsoft/fast-web-utilities";
-
-import { getDirection } from "../utilities";
-import { IntersectionService } from "./intersection-service";
 import type { ResizeObserverEntry } from "./resize-observer-entry";
 
 // TODO: the Resize Observer related files are a temporary stopgap measure until
@@ -108,7 +108,7 @@ type Location = "top" | "left" | "right" | "bottom";
  *
  * @beta
  */
-export class AnchoredRegion extends FASTElement {
+export class AnchoredRegion extends FoundationElement {
     /**
      * The HTML ID of the anchor element this region is positioned relative to
      *
@@ -290,7 +290,7 @@ export class AnchoredRegion extends FASTElement {
     public fixedPlacement: boolean = false;
     private fixedPlacementChanged(): void {
         if (
-            (this as FASTElement).$fastController.isConnected &&
+            (this as FoundationElement).$fastController.isConnected &&
             this.initialLayoutComplete
         ) {
             this.initialize();
@@ -311,7 +311,7 @@ export class AnchoredRegion extends FASTElement {
         newMode: AutoUpdateMode
     ): void {
         if (
-            (this as FASTElement).$fastController.isConnected &&
+            (this as FoundationElement).$fastController.isConnected &&
             this.initialLayoutComplete
         ) {
             if (prevMode === "auto") {
@@ -344,7 +344,7 @@ export class AnchoredRegion extends FASTElement {
     public viewportElement: HTMLElement | null = null;
     private viewportElementChanged(): void {
         if (
-            (this as FASTElement).$fastController.isConnected &&
+            (this as FoundationElement).$fastController.isConnected &&
             this.initialLayoutComplete
         ) {
             this.initialize();
@@ -506,7 +506,7 @@ export class AnchoredRegion extends FASTElement {
      */
     private updateForAttributeChange(): void {
         if (
-            (this as FASTElement).$fastController.isConnected &&
+            (this as FoundationElement).$fastController.isConnected &&
             this.initialLayoutComplete
         ) {
             this.update();
@@ -539,7 +539,7 @@ export class AnchoredRegion extends FASTElement {
      */
     private requestReset(): void {
         if (
-            (this as FASTElement).$fastController.isConnected &&
+            (this as FoundationElement).$fastController.isConnected &&
             this.pendingReset === false
         ) {
             this.pendingLayoutUpdate = false;
@@ -702,13 +702,13 @@ export class AnchoredRegion extends FASTElement {
     private applyIntersectionEntries = (
         entries: IntersectionObserverEntry[]
     ): boolean => {
-        let regionEntry: IntersectionObserverEntry | undefined = entries.find(
+        const regionEntry: IntersectionObserverEntry | undefined = entries.find(
             x => x.target === this
         );
-        let anchorEntry: IntersectionObserverEntry | undefined = entries.find(
+        const anchorEntry: IntersectionObserverEntry | undefined = entries.find(
             x => x.target === this.anchorElement
         );
-        let viewportEntry: IntersectionObserverEntry | undefined = entries.find(
+        const viewportEntry: IntersectionObserverEntry | undefined = entries.find(
             x => x.target === this.viewportElement
         );
 

--- a/packages/web-components/fast-foundation/src/badge/badge.spec.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.spec.ts
@@ -1,16 +1,14 @@
 import { expect } from "chai";
-import { Badge, BadgeTemplate as template } from "./index";
+import { Badge, badgeTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-badge",
-    template,
+const FASTBadge = Badge.compose({
+    baseName: "badge",
+    template
 })
-class FASTBadge extends Badge {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTBadge>("fast-badge");
+    const { element, connect, disconnect } = await fixture(FASTBadge());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/badge/badge.template.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.template.ts
@@ -6,7 +6,10 @@ import type { Badge } from "./badge";
  * The template for the {@link @microsoft/fast-foundation#Badge} component.
  * @public
  */
-export const BadgeTemplate: ViewTemplate<Badge> = html`
+export const badgeTemplate: (context, definition) => ViewTemplate<Badge> = (
+    context,
+    definition
+) => html`
     <template class="${x => (x.circular ? "circular" : "")}">
         <div class="control" part="control" style="${x => x.generateBadgeStyle()}">
             <slot></slot>

--- a/packages/web-components/fast-foundation/src/badge/badge.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.ts
@@ -1,11 +1,12 @@
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { attr } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * A Badge Custom HTML Element.
  *
  * @public
  */
-export class Badge extends FASTElement {
+export class Badge extends FoundationElement {
     /**
      * Indicates the badge should have a filled style.
      * @public

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.spec.ts
@@ -1,18 +1,14 @@
 import { expect } from "chai";
-import { BreadcrumbItem, BreadcrumbItemTemplate as template } from "./index";
+import { BreadcrumbItem, breadcrumbItemTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { customElement, DOM } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-breadcrumb-item",
-    template,
+const FASTBreadcrumbItem = BreadcrumbItem.compose({
+    baseName: "breadcrumb-item",
+    template
 })
-class FASTBreadcrumbItem extends BreadcrumbItem {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTBreadcrumbItem>(
-        "fast-breadcrumb-item"
-    );
+    const { element, connect, disconnect } = await fixture(FASTBreadcrumbItem());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
@@ -1,6 +1,6 @@
 import { html, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { AnchorTemplate } from "../anchor";
+import { anchorTemplate } from "../anchor";
 import { endTemplate, startTemplate } from "../patterns/start-end";
 import type { BreadcrumbItem } from "./breadcrumb-item";
 
@@ -8,12 +8,15 @@ import type { BreadcrumbItem } from "./breadcrumb-item";
  * The template for the {@link @microsoft/fast-foundation#(BreadcrumbItem:class)} component.
  * @public
  */
-export const BreadcrumbItemTemplate: ViewTemplate<BreadcrumbItem> = html`
+export const breadcrumbItemTemplate: (
+    context,
+    definition
+) => ViewTemplate<BreadcrumbItem> = (context, definition) => html`
     <div role="listitem" class="listitem" part="listitem">
         ${when(
             x => x.href && x.href.length > 0,
             html<BreadcrumbItem>`
-                ${AnchorTemplate}
+                ${anchorTemplate(context, definition)}
             `
         )}
         ${when(

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.ts
@@ -1,5 +1,5 @@
 import { observable } from "@microsoft/fast-element";
-import { DelegatesARIALink, Anchor } from "../anchor";
+import { Anchor, DelegatesARIALink } from "../anchor";
 import { StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
 

--- a/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.spec.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.spec.ts
@@ -1,28 +1,35 @@
 import { expect } from "chai";
-import { Breadcrumb, BreadcrumbTemplate as template } from "./index";
+import { Breadcrumb, breadcrumbTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { customElement, html } from "@microsoft/fast-element";
-import type { BreadcrumbItem } from "../breadcrumb-item";
+import { BreadcrumbItem } from "../breadcrumb-item";
 
-@customElement({
-    name: "fast-breadcrumb",
-    template,
+const FASTBreadcrumb = Breadcrumb.compose({
+    baseName: "breadcrumb",
+    template
 })
-class FASTBreadcrumb extends Breadcrumb {}
+
+const FASTBreadcrumbItem = BreadcrumbItem.compose({
+    baseName: "breadcrumb-item",
+    template
+})
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTBreadcrumb>(
-        "fast-breadcrumb"
-    );
+    const { element, connect, disconnect } = await fixture([FASTBreadcrumb(), FASTBreadcrumbItem()]);
 
-    return { element, connect, disconnect };
+    const item1 = document.createElement("fast-breadcrumb-item");
+    const item2 = document.createElement("fast-breadcrumb-item");
+    const item3 = document.createElement("fast-breadcrumb-item");
+
+    element.appendChild(item1);
+    element.appendChild(item2);
+    element.appendChild(item3);
+
+    return { element, connect, disconnect, item1, item2, item3 };
 }
 
 describe("Breadcrumb", () => {
     it("should include a `role` of `navigation`", async () => {
-        const { element, connect, disconnect } = await fixture<Breadcrumb>(
-            "fast-breadcrumb"
-        );
+        const { element, connect, disconnect } = await setup();
 
         await connect();
 
@@ -36,19 +43,13 @@ describe("Breadcrumb", () => {
 
         await connect();
 
-        expect(element?.shadowRoot?.querySelector("[role='list']")).to.not.equal(null);
+        expect(element.shadowRoot?.querySelector("[role='list']")).to.not.equal(null);
 
         await disconnect();
     });
 
     it("should not render a separator on last item", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTBreadcrumb>`
-            <fast-breadcrumb>
-                <fast-breadcrumb-item>Item 1</fast-breadcrumb-item>
-                <fast-breadcrumb-item>Item 2</fast-breadcrumb-item>
-                <fast-breadcrumb-item>Item 3</fast-breadcrumb-item>
-            </fast-breadcrumb>
-        `);
+        const { element, connect, disconnect } = await setup();
 
         await connect();
 
@@ -62,19 +63,20 @@ describe("Breadcrumb", () => {
     });
 
     it("should set the `aria-current` on the internal, last node, anchor when `href` is passed", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTBreadcrumb>`
-            <fast-breadcrumb>
-                <fast-breadcrumb-item>
-                    <a href="#">Item1</a>
-                </fast-breadcrumb-item>
-                <fast-breadcrumb-item>
-                    <a href="#">Item2</a>
-                </fast-breadcrumb-item>
-                <fast-breadcrumb-item>
-                    <a href="#" aria-current="page">Item3</a>
-                </fast-breadcrumb-item>
-            </fast-breadcrumb>
-        `);
+        const { element, connect, disconnect, item1, item2, item3 } = await setup();
+
+        const anchor1 = document.createElement("a");
+        anchor1.href = "#";
+
+        const anchor2 = document.createElement("a");
+        anchor2.href = "#";
+
+        const anchor3 = document.createElement("a");
+        anchor3.href = "#";
+
+        item1.appendChild(anchor1);
+        item2.appendChild(anchor2);
+        item3.appendChild(anchor3);
 
         await connect();
 

--- a/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.template.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.template.ts
@@ -6,7 +6,10 @@ import type { Breadcrumb } from "./breadcrumb";
  * The template for the {@link @microsoft/fast-foundation#Breadcrumb} component.
  * @public
  */
-export const BreadcrumbTemplate: ViewTemplate<Breadcrumb> = html`
+export const breadcrumbTemplate: (context, definition) => ViewTemplate<Breadcrumb> = (
+    context,
+    definition
+) => html`
     <template role="navigation">
         <div role="list" class="list" part="list">
             <slot

--- a/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.ts
@@ -1,12 +1,13 @@
-import { FASTElement, observable } from "@microsoft/fast-element";
+import { observable } from "@microsoft/fast-element";
 import { BreadcrumbItem } from "../breadcrumb-item";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * A Breadcrumb Custom HTML Element.
  *
  * @public
  */
-export class Breadcrumb extends FASTElement {
+export class Breadcrumb extends FoundationElement {
     /**
      * @internal
      */

--- a/packages/web-components/fast-foundation/src/button/button.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/button/button.form-associated.ts
@@ -1,7 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
+import { FoundationElement } from "../foundation-element";
 
-class _Button extends FASTElement {}
+class _Button extends FoundationElement {}
 interface _Button extends FormAssociated {}
 
 /**

--- a/packages/web-components/fast-foundation/src/button/button.spec.ts
+++ b/packages/web-components/fast-foundation/src/button/button.spec.ts
@@ -1,18 +1,15 @@
 import { expect } from "chai";
-import { customElement, DOM } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { fixture } from "../fixture";
-import { Button, ButtonTemplate as template } from "./index";
+import { Button, buttonTemplate as template } from "./index";
 
-@customElement({
-    name: "fast-button",
-    template,
+const FASTButton = Button.compose({
+    baseName: "button",
+    template
 })
-class FASTButton extends Button {}
 
 async function setup() {
-    const { connect, disconnect, element, parent } = await fixture<FASTButton>(
-        "fast-button"
-    );
+    const { connect, disconnect, element, parent } = await fixture(FASTButton());
 
     return { connect, disconnect, element, parent };
 }

--- a/packages/web-components/fast-foundation/src/button/button.template.ts
+++ b/packages/web-components/fast-foundation/src/button/button.template.ts
@@ -7,7 +7,10 @@ import type { Button } from "./button";
  * The template for the {@link @microsoft/fast-foundation#(Button:class)} component.
  * @public
  */
-export const ButtonTemplate: ViewTemplate<Button> = html`
+export const buttonTemplate: (context, definition) => ViewTemplate<Button> = (
+    context,
+    definition
+) => html`
     <button
         class="control"
         part="control"

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.form-associated.ts
@@ -1,7 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
+import { FoundationElement } from "../foundation-element";
 
-class _Checkbox extends FASTElement {}
+class _Checkbox extends FoundationElement {}
 interface _Checkbox extends FormAssociated {}
 
 /**

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.spec.ts
@@ -1,19 +1,16 @@
 import { assert, expect } from "chai";
-import { Checkbox, CheckboxTemplate as template } from "./index";
+import { Checkbox, checkboxTemplate as template } from "./index";
 import { fixture } from "../fixture";
 import { DOM, customElement } from "@microsoft/fast-element";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-checkbox",
+const FASTCheckbox = Checkbox.compose({
+    baseName: "checkbox",
     template,
 })
-class FASTCheckbox extends Checkbox {}
 
 async function setup() {
-    const { connect, disconnect, element, parent } = await fixture<FASTCheckbox>(
-        "fast-checkbox"
-    );
+    const { connect, disconnect, element, parent } = await fixture(FASTCheckbox());
 
     return { connect, disconnect, element, parent };
 }

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
@@ -6,7 +6,10 @@ import type { Checkbox } from "./checkbox";
  * The template for the {@link @microsoft/fast-foundation#(Checkbox:class)} component.
  * @public
  */
-export const CheckboxTemplate: ViewTemplate<Checkbox> = html`
+export const checkboxTemplate: (context, definition) => ViewTemplate<Checkbox> = (
+    context,
+    definition
+) => html`
     <template
         role="checkbox"
         aria-checked="${x => x.checked}"

--- a/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
@@ -1,34 +1,32 @@
 import { assert, expect } from "chai";
-import { customElement, DOM } from "@microsoft/fast-element";
-import { ListboxOptionTemplate, ListboxOption } from "../listbox-option";
+import { DOM } from "@microsoft/fast-element";
+import { listboxOptionTemplate, ListboxOption } from "../listbox-option";
 import { fixture } from "../fixture";
-import { Combobox, ComboboxTemplate } from "./index";
+import { Combobox, comboboxTemplate as template } from "./index";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-combobox",
-    template: ComboboxTemplate,
+const FASTCombobox = Combobox.compose({
+    baseName: "combobox",
+    template
 })
-class FASTCombobox extends Combobox {}
 
-@customElement({
-    name: "fast-option",
-    template: ListboxOptionTemplate,
+const FASTOption = ListboxOption.compose({
+    baseName: "option",
+    template: listboxOptionTemplate
 })
-class FASTOption extends ListboxOption {}
 
 async function setup() {
-    const { element, connect, disconnect, parent } = await fixture<FASTCombobox>(
-        "fast-combobox"
+    const { element, connect, disconnect, parent } = await fixture(
+        [FASTCombobox(), FASTOption()]
     );
 
-    const option1 = document.createElement("fast-option") as FASTOption;
+    const option1 = document.createElement("fast-option") as ListboxOption;
     option1.textContent = "one";
 
-    const option2 = document.createElement("fast-option") as FASTOption;
+    const option2 = document.createElement("fast-option") as ListboxOption;
     option2.textContent = "two";
 
-    const option3 = document.createElement("fast-option") as FASTOption;
+    const option3 = document.createElement("fast-option") as ListboxOption;
     option3.textContent = "three";
 
     element.appendChild(option1);

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -8,7 +8,10 @@ import type { Combobox } from "./combobox";
  * The template for the {@link @microsoft/fast-foundation#(Combobox:class)} component.
  * @public
  */
-export const ComboboxTemplate: ViewTemplate<Combobox> = html`
+export const comboboxTemplate: (context, definition) => ViewTemplate<Combobox> = (
+    context,
+    definition
+) => html`
     <template
         autocomplete="${x => x.autocomplete}"
         class="${x => (x.disabled ? "disabled" : "")} ${x => x.position}"

--- a/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
@@ -1,53 +1,83 @@
 import type { Constructable } from "@microsoft/fast-element";
 import { expect } from "chai";
-import type { Container } from "../di";
+import { Container, DI } from "../di";
 import { uniqueElementName } from "../fixture";
 import { DesignSystem, DesignSystemRegistrationContext } from "./design-system";
 
 describe("DesignSystem", () => {
+    it("Should return the same instance for the same element", () => {
+        const host = document.createElement("div");
+        const ds1 = DesignSystem.getOrCreate(host);
+        const ds2 = DesignSystem.getOrCreate(host);
+
+        expect(ds1).to.equal(ds2);
+    });
+
+    it("Should find the responsible design system for an element in the hierarchy", () => {
+        const host = document.createElement("div");
+        const child = document.createElement("div");
+        host.appendChild(child);
+
+        const ds1 = DesignSystem.getOrCreate(host);
+        const ds2 = DesignSystem.responsibleFor(child);
+
+        expect(ds1).to.equal(ds2);
+    });
+
     it("Should initialize with a default prefix of 'fast'", () => {
         const host = document.createElement("div");
-        const container = new DesignSystem().applyTo(host);
+        let prefix = '';
 
-        expect(container.get(DesignSystemRegistrationContext).elementPrefix).to.equal(
-            "fast"
-        );
+        DesignSystem.getOrCreate(host)
+            .register({
+                register(container: Container) {
+                    prefix = container.get(DesignSystemRegistrationContext).elementPrefix;
+                }
+            });
+
+        expect(prefix).to.equal("fast");
     });
 
     it("Should initialize with a provided prefix", () => {
         const host = document.createElement("div");
-        const container = new DesignSystem().withPrefix("custom").applyTo(host);
+        let prefix = '';
 
-        expect(container.get(DesignSystemRegistrationContext).elementPrefix).to.equal(
-            "custom"
-        );
+        DesignSystem.getOrCreate(host)
+            .withPrefix("custom")
+            .register({
+                register(container: Container) {
+                    prefix = container.get(DesignSystemRegistrationContext).elementPrefix;
+                }
+            });
+
+        expect(prefix).to.equal("custom");
     });
 
-    it("Should apply registries to the container", () => {
+    it("Should apply registries to the container associated with the host", () => {
         let capturedContainer: Container | null = null;
         const host = document.createElement("div");
-        const container = new DesignSystem()
+
+        DesignSystem.getOrCreate(host)
             .register({
                 register(container: Container) {
                     capturedContainer = container;
                 },
-            })
-            .applyTo(host);
+            });
 
-        expect(capturedContainer).to.equal(container);
+        const container = DI.getOrCreateDOMContainer(host);
+        expect(container).equals(capturedContainer);
     });
 
     it("Should provide a way for registries to define elements", () => {
         let capturedDefine: any;
         const host = document.createElement("div");
-        new DesignSystem()
+        DesignSystem.getOrCreate(host)
             .register({
                 register(container: Container) {
                     capturedDefine = container.get(DesignSystemRegistrationContext)
                         .tryDefineElement;
                 },
-            })
-            .applyTo(host);
+            });
 
         expect(capturedDefine).to.not.be.null;
     });
@@ -55,35 +85,34 @@ describe("DesignSystem", () => {
     it("Should provide a way for registries to get the default prefix", () => {
         let capturePrefix: string | null = null;
         const host = document.createElement("div");
-        new DesignSystem()
+        DesignSystem.getOrCreate(host)
             .withPrefix("custom")
             .register({
                 register(container: Container) {
                     capturePrefix = container.get(DesignSystemRegistrationContext)
                         .elementPrefix;
                 },
-            })
-            .applyTo(host);
+            });
 
         expect(capturePrefix).to.equal("custom");
     });
 
-    it("Should register elements when applied", () => {
+    it("Should register elements", () => {
         const elementName = uniqueElementName();
         const customElement = class extends HTMLElement {};
         const host = document.createElement("div");
-        const system = new DesignSystem().register({
-            register(container: Container) {
-                const context = container.get(DesignSystemRegistrationContext);
-                context.tryDefineElement(elementName, customElement, x =>
-                    x.defineElement()
-                );
-            },
-        });
 
         expect(customElements.get(elementName)).to.be.undefined;
 
-        system.applyTo(host);
+        DesignSystem.getOrCreate(host)
+            .register({
+                register(container: Container) {
+                    const context = container.get(DesignSystemRegistrationContext);
+                    context.tryDefineElement(elementName, customElement, x =>
+                        x.defineElement()
+                    );
+                },
+            });
 
         expect(customElements.get(elementName)).to.equal(customElement);
     });
@@ -93,7 +122,7 @@ describe("DesignSystem", () => {
         const elementName2 = uniqueElementName();
         const host = document.createElement("div");
         let capturedType: Constructable | null = null;
-        const system = new DesignSystem()
+        DesignSystem.getOrCreate(host)
             .withElementDisambiguation((name, type, existingType) => {
                 capturedType = existingType;
                 return elementName2;
@@ -119,8 +148,7 @@ describe("DesignSystem", () => {
                         );
                     },
                 }
-            )
-            .applyTo(host);
+            );
 
         expect(capturedType).to.not.be.null;
         expect(customElements.get(elementName)).to.not.be.undefined;
@@ -131,28 +159,31 @@ describe("DesignSystem", () => {
         const elementName = uniqueElementName();
         const customElement = class extends HTMLElement {};
         const host = document.createElement("div");
-        const system = new DesignSystem().register(
-            {
-                register(container: Container) {
-                    const context = container.get(DesignSystemRegistrationContext);
-                    context.tryDefineElement(elementName, customElement, x =>
-                        x.defineElement()
-                    );
-                },
-            },
-            {
-                register(container: Container) {
-                    const context = container.get(DesignSystemRegistrationContext);
-                    context.tryDefineElement(
-                        elementName,
-                        class extends HTMLElement {},
-                        x => x.defineElement()
-                    );
-                },
-            }
-        );
+        const system = DesignSystem.getOrCreate(host);
 
-        expect(() => system.applyTo(host)).not.to.throw();
+        expect(() => {
+            system.register(
+                {
+                    register(container: Container) {
+                        const context = container.get(DesignSystemRegistrationContext);
+                        context.tryDefineElement(elementName, customElement, x =>
+                            x.defineElement()
+                        );
+                    },
+                },
+                {
+                    register(container: Container) {
+                        const context = container.get(DesignSystemRegistrationContext);
+                        context.tryDefineElement(
+                            elementName,
+                            class extends HTMLElement {},
+                            x => x.defineElement()
+                        );
+                    },
+                }
+            );
+        }).not.to.throw();
+
         expect(customElements.get(elementName)).to.equal(customElement);
     });
 });

--- a/packages/web-components/fast-foundation/src/design-system/design-system.ts
+++ b/packages/web-components/fast-foundation/src/design-system/design-system.ts
@@ -4,6 +4,7 @@ import {
     PartialFASTElementDefinition,
 } from "@microsoft/fast-element";
 import { Container, DI, InterfaceSymbol, Registration } from "../di/di";
+import { ComponentPresentation } from "./component-presentation";
 
 /**
  * Defines an element within the context of a design system.
@@ -21,6 +22,7 @@ export interface ElementDefinitionContext {
     readonly container: Container;
     readonly willDefine: boolean;
     defineElement(definition?: ContextualElementDefinition): void;
+    definePresentation(presentation: ComponentPresentation): void;
     tagFor(type: Constructable): string;
 }
 
@@ -223,6 +225,10 @@ class ElementDefinitionEntry implements ElementDefinitionContext {
         public readonly callback: ElementDefinitionCallback,
         public readonly willDefine: boolean
     ) {}
+
+    definePresentation(presentation: ComponentPresentation) {
+        ComponentPresentation.define(this.name, presentation, this.container);
+    }
 
     defineElement(definition: ContextualElementDefinition) {
         this.definition = new FASTElementDefinition(this.type, {

--- a/packages/web-components/fast-foundation/src/design-system/design-system.ts
+++ b/packages/web-components/fast-foundation/src/design-system/design-system.ts
@@ -68,31 +68,97 @@ const elementTagsByType = new Map<Constructable, string>();
 /**
  * @alpha
  */
-export class DesignSystem {
-    private registrations: any[] = [];
+export interface DesignSystem {
+    register(...params: any[]): DesignSystem;
+    withPrefix(prefix: string): DesignSystem;
+    withElementDisambiguation(callback: ElementDisambiguationCallback): DesignSystem;
+}
+
+const designSystemKey = DI.createInterface<DesignSystem>(x =>
+    x.cachedCallback(handler => {
+        const element = document.body as any;
+        const owned = element.$designSystem as DesignSystem;
+
+        if (owned) {
+            return owned;
+        }
+
+        return new DefaultDesignSystem(element, handler);
+    })
+);
+
+/**
+ * @alpha
+ */
+export const DesignSystem = Object.freeze({
+    tagFor(type: Constructable): string {
+        return elementTagsByType.get(type)!;
+    },
+
+    responsibleFor(element: HTMLElement): DesignSystem {
+        const owned = (element as any).$designSystem as DesignSystem;
+
+        if (owned) {
+            return owned;
+        }
+
+        const container = DI.findResponsibleContainer(element);
+        return container.get(designSystemKey);
+    },
+
+    getOrCreate(element: HTMLElement = document.body): DesignSystem {
+        const owned = (element as any).$designSystem as DesignSystem;
+
+        if (owned) {
+            return owned;
+        }
+
+        const container = DI.getOrCreateDOMContainer(element);
+
+        if (!container.has(designSystemKey, false)) {
+            container.register(
+                Registration.instance(
+                    designSystemKey,
+                    new DefaultDesignSystem(element, container)
+                )
+            );
+        }
+
+        return container.get(designSystemKey);
+    },
+});
+
+class DefaultDesignSystem implements DesignSystem {
     private prefix: string = "fast";
     private disambiguate: ElementDisambiguationCallback = () => null;
+    private context: DesignSystemRegistrationContext;
 
-    public withPrefix(prefix: string) {
+    constructor(private host: HTMLElement, private container: Container) {
+        (host as any).$designSystem = this;
+
+        container.register(
+            Registration.callback(DesignSystemRegistrationContext, () => this.context)
+        );
+    }
+
+    public withPrefix(prefix: string): DesignSystem {
         this.prefix = prefix;
         return this;
     }
 
-    public withElementDisambiguation(callback: ElementDisambiguationCallback) {
+    public withElementDisambiguation(
+        callback: ElementDisambiguationCallback
+    ): DesignSystem {
         this.disambiguate = callback;
         return this;
     }
 
-    public register(...params: any[]) {
-        this.registrations.push(...params);
-        return this;
-    }
-
-    public applyTo(element: HTMLElement) {
-        const container = DI.getOrCreateDOMContainer(element);
+    public register(...registrations: any[]): DesignSystem {
+        const container = this.container;
         const elementDefinitionEntries: ElementDefinitionEntry[] = [];
         const disambiguate = this.disambiguate;
-        const context: DesignSystemRegistrationContext = {
+
+        const context: DesignSystemRegistrationContext = (this.context = {
             elementPrefix: this.prefix,
             tryDefineElement(
                 name: string,
@@ -131,13 +197,9 @@ export class DesignSystem {
                     )
                 );
             },
-        };
+        });
 
-        container.register(
-            Registration.instance(DesignSystemRegistrationContext, context)
-        );
-
-        container.register(...this.registrations);
+        container.register(...registrations);
 
         for (const entry of elementDefinitionEntries) {
             entry.callback(entry);
@@ -147,7 +209,7 @@ export class DesignSystem {
             }
         }
 
-        return container;
+        return this;
     }
 }
 
@@ -170,6 +232,6 @@ class ElementDefinitionEntry implements ElementDefinitionContext {
     }
 
     tagFor(type: Constructable): string {
-        return elementTagsByType.get(type)!;
+        return DesignSystem.tagFor(type)!;
     }
 }

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -2,15 +2,22 @@
 import { css, DOM, FASTElement, Observable } from "@microsoft/fast-element";
 import { expect } from "chai";
 import { DesignSystem } from "../design-system";
+import { uniqueElementName } from "../fixture";
 import { FoundationElement } from "../foundation-element";
 import { DesignToken } from "./design-token";
 
-new DesignSystem().register(
-    FoundationElement.compose({ type: class extends FoundationElement { }, baseName: "custom-element" })()
-).applyTo(document.body)
+const elementName = uniqueElementName();
+
+DesignSystem.getOrCreate()
+    .register(
+        FoundationElement.compose({ 
+            type: class extends FoundationElement { }, 
+            baseName: elementName 
+        })()
+    );
 
 function addElement(parent = document.body): FASTElement & HTMLElement {
-    const el = document.createElement("fast-custom-element") as any;
+    const el = document.createElement(`fast-${elementName}`) as any;
     parent.appendChild(el);
     return el;
 }

--- a/packages/web-components/fast-foundation/src/dialog/dialog.spec.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.spec.ts
@@ -1,19 +1,16 @@
 import { expect } from "chai";
-import { Dialog, DialogTemplate as template } from "./index";
+import { Dialog, dialogTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-dialog",
-    template,
+const FASTDialog = Dialog.compose({
+    baseName: "dialog",
+    template,  
 })
-class FASTDialog extends Dialog {}
 
 async function setup() {
-    const { connect, disconnect, document, element } = await fixture<Dialog>(
-        "fast-dialog"
-    );
+    const { connect, disconnect, document, element } = await fixture(FASTDialog());
 
     return { connect, disconnect, document, element };
 }

--- a/packages/web-components/fast-foundation/src/dialog/dialog.template.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.template.ts
@@ -6,7 +6,10 @@ import type { Dialog } from "./dialog";
  * The template for the {@link @microsoft/fast-foundation#Dialog} component.
  * @public
  */
-export const DialogTemplate: ViewTemplate<Dialog> = html`
+export const dialogTemplate: (context, definition) => ViewTemplate<Dialog> = (
+    context,
+    definition
+) => html`
     <div class="positioning-region" part="positioning-region">
         ${when(
             x => x.modal,

--- a/packages/web-components/fast-foundation/src/dialog/dialog.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.ts
@@ -1,6 +1,7 @@
-import { attr, DOM, FASTElement } from "@microsoft/fast-element";
+import { attr, DOM } from "@microsoft/fast-element";
 import { keyCodeEscape, keyCodeTab } from "@microsoft/fast-web-utilities";
 import tabbable from "tabbable";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * A Switch Custom HTML Element.
@@ -8,7 +9,7 @@ import tabbable from "tabbable";
  *
  * @public
  */
-export class Dialog extends FASTElement {
+export class Dialog extends FoundationElement {
     /**
      * Indicates the element is modal. When modal, user interaction will be limited to the contents of the element.
      * @public

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.spec.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.spec.ts
@@ -1,18 +1,15 @@
 import { expect } from "chai";
 import { fixture } from "../fixture";
-import { customElement, DOM, html, ref } from "@microsoft/fast-element";
-import { Disclosure, DisclosureTemplate as template } from "./index";
+import { DOM } from "@microsoft/fast-element";
+import { Disclosure, disclosureTemplate as template } from "./index";
 
-@customElement({
-    name: "fast-disclosure",
-    template,
+const FastDisclosure = Disclosure.compose({
+    baseName: "disclosure",
+    template
 })
-class FastDisclosure extends Disclosure {}
 
 async function createDisclosure() {
-    const { element, connect, disconnect } = await fixture<FastDisclosure>(
-        "fast-disclosure"
-    );
+    const { element, connect, disconnect } = await fixture(FastDisclosure());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.template.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.template.ts
@@ -6,7 +6,10 @@ import type { Disclosure } from "./disclosure";
  * The template for the {@link @microsoft/fast-foundation#Disclosure} component.
  * @public
  */
-export const DisclosureTemplate: ViewTemplate<Disclosure> = html`
+export const disclosureTemplate: (context, definition) => ViewTemplate<Disclosure> = (
+    context,
+    definition
+) => html`
     <details class="disclosure" ${ref("details")}>
         <summary
             class="invoker"

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.ts
@@ -1,11 +1,12 @@
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { attr } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
 /**
  * A Disclosure Custom HTML Element.
  * Based largely on the {@link https://w3c.github.io/aria-practices/#disclosure | disclosure element }.
  *
  * @public
  */
-export class Disclosure extends FASTElement {
+export class Disclosure extends FoundationElement {
     /**
      * Determines if the element should show the extra content or not.
      *

--- a/packages/web-components/fast-foundation/src/divider/divider.spec.ts
+++ b/packages/web-components/fast-foundation/src/divider/divider.spec.ts
@@ -1,17 +1,16 @@
 import { expect } from "chai";
-import { customElement, DOM } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { fixture } from "../fixture";
 import { DividerRole } from "./divider.options";
-import { Divider, DividerTemplate as template } from "./index";
+import { Divider, dividerTemplate as template } from "./index";
 
-@customElement({
-    name: "fast-divider",
-    template,
+const FASTDivider = Divider.compose({
+    baseName: "divider",
+    template
 })
-class FASTDivider extends Divider {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<Divider>("fast-divider");
+    const { element, connect, disconnect } = await fixture(FASTDivider());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/divider/divider.template.ts
+++ b/packages/web-components/fast-foundation/src/divider/divider.template.ts
@@ -6,6 +6,9 @@ import type { Divider } from "./divider";
  * The template for the {@link @microsoft/fast-foundation#Divider} component.
  * @public
  */
-export const DividerTemplate: ViewTemplate<Divider> = html`
+export const dividerTemplate: (context, definition) => ViewTemplate<Divider> = (
+    context,
+    definition
+) => html`
     <template role="${x => x.role}"></template>
 `;

--- a/packages/web-components/fast-foundation/src/divider/divider.ts
+++ b/packages/web-components/fast-foundation/src/divider/divider.ts
@@ -1,4 +1,5 @@
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { attr } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
 import { DividerRole } from "./divider.options";
 
 export { DividerRole };
@@ -9,7 +10,7 @@ export { DividerRole };
  *
  * @public
  */
-export class Divider extends FASTElement {
+export class Divider extends FoundationElement {
     /**
      * The role of the element.
      *

--- a/packages/web-components/fast-foundation/src/fixture.ts
+++ b/packages/web-components/fast-foundation/src/fixture.ts
@@ -6,7 +6,7 @@ import {
     ViewTemplate,
 } from "@microsoft/fast-element";
 import { DesignSystem, DesignSystemRegistrationContext } from "./design-system";
-import type { Registry } from "./di";
+import { DI, Registry } from "./di";
 import type {
     FoundationElement,
     FoundationElementDefinition,
@@ -155,16 +155,14 @@ export async function fixture<TElement = HTMLElement>(
 
     if (Array.isArray(templateNameOrRegistry)) {
         const first = templateNameOrRegistry[0];
-        const container = (options.designSystem || new DesignSystem())
-            .register(templateNameOrRegistry)
-            .applyTo(parent);
-
+        (options.designSystem || DesignSystem.getOrCreate(parent)).register(
+            templateNameOrRegistry
+        );
+        const container = DI.getOrCreateDOMContainer(parent);
         const context = container.get(DesignSystemRegistrationContext);
         const elementName = `${context.elementPrefix}-${first.definition.baseName}`;
         const html = `<${elementName}></${elementName}>`;
         templateNameOrRegistry = new ViewTemplate(html, []);
-    } else if (options.designSystem) {
-        options.designSystem.applyTo(parent);
     }
 
     const view = templateNameOrRegistry.create();

--- a/packages/web-components/fast-foundation/src/fixture.ts
+++ b/packages/web-components/fast-foundation/src/fixture.ts
@@ -1,9 +1,18 @@
 import {
+    Constructable,
     defaultExecutionContext,
     ExecutionContext,
     HTMLView,
     ViewTemplate,
 } from "@microsoft/fast-element";
+import { DesignSystem, DesignSystemRegistrationContext } from "./design-system";
+import type { Registry } from "./di";
+import type {
+    FoundationElement,
+    FoundationElementDefinition,
+    FoundationElementRegistry,
+    OverrideFoundationElementDefinition,
+} from "./foundation-element/foundation-element";
 
 /**
  * Options used to customize the creation of the test fixture.
@@ -32,6 +41,11 @@ export interface FixtureOptions {
      * @defaultValue {@link @microsoft/fast-element#defaultExecutionContext}
      */
     context?: ExecutionContext;
+
+    /**
+     * A pre-configured design system instance used in setting up the fixture.
+     */
+    designSystem?: DesignSystem;
 }
 
 export interface Fixture<TElement = HTMLElement> {
@@ -99,28 +113,61 @@ export function uniqueElementName(): string {
     return `fast-unique-${Math.random().toString(36).substring(7)}`;
 }
 
+function isElementRegistry<T>(
+    obj: any
+): obj is FoundationElementRegistry<FoundationElementDefinition, any> {
+    return typeof obj.register === "function";
+}
+
 /**
  * Creates a test fixture suitable for testing custom elements, templates, and bindings.
- * @param templateOrElementName An HTML template or single element name to create the fixture for.
+ * @param templateNameOrRegistry An HTML template or single element name to create the fixture for.
  * @param options Enables customizing fixture creation behavior.
  * @remarks
  * Yields control to the caller one Microtask later, in order to
  * ensure that the DOM has settled.
  */
 export async function fixture<TElement = HTMLElement>(
-    templateOrElementName: ViewTemplate | string,
+    templateNameOrRegistry:
+        | ViewTemplate
+        | string
+        | FoundationElementRegistry<FoundationElementDefinition, Constructable<TElement>>
+        | [
+              FoundationElementRegistry<
+                  FoundationElementDefinition,
+                  Constructable<TElement>
+              >,
+              ...FoundationElementRegistry<FoundationElementDefinition, Constructable>[]
+          ],
     options: FixtureOptions = {}
 ): Promise<Fixture<TElement>> {
-    if (typeof templateOrElementName === "string") {
-        const html = `<${templateOrElementName}></${templateOrElementName}>`;
-        templateOrElementName = new ViewTemplate(html, []);
-    }
-
-    const view = templateOrElementName.create();
     const document = options.document || globalThis.document;
     const parent = options.parent || document.createElement("div");
     const source = options.source || {};
     const context = options.context || defaultExecutionContext;
+
+    if (typeof templateNameOrRegistry === "string") {
+        const html = `<${templateNameOrRegistry}></${templateNameOrRegistry}>`;
+        templateNameOrRegistry = new ViewTemplate(html, []);
+    } else if (isElementRegistry(templateNameOrRegistry)) {
+        templateNameOrRegistry = [templateNameOrRegistry];
+    }
+
+    if (Array.isArray(templateNameOrRegistry)) {
+        const first = templateNameOrRegistry[0];
+        const container = (options.designSystem || new DesignSystem())
+            .register(templateNameOrRegistry)
+            .applyTo(parent);
+
+        const context = container.get(DesignSystemRegistrationContext);
+        const elementName = `${context.elementPrefix}-${first.definition.baseName}`;
+        const html = `<${elementName}></${elementName}>`;
+        templateNameOrRegistry = new ViewTemplate(html, []);
+    } else if (options.designSystem) {
+        options.designSystem.applyTo(parent);
+    }
+
+    const view = templateNameOrRegistry.create();
     const element = findElement(view) as any;
     let isConnected = false;
 
@@ -155,7 +202,7 @@ export async function fixture<TElement = HTMLElement>(
 
     return {
         document,
-        template: templateOrElementName,
+        template: templateNameOrRegistry,
         view,
         parent,
         element,

--- a/packages/web-components/fast-foundation/src/flipper/flipper.spec.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.spec.ts
@@ -1,17 +1,16 @@
 import { expect } from "chai";
-import { customElement, DOM, html } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { fixture } from "../fixture";
 import { FlipperDirection } from "./flipper.options";
-import { Flipper, FlipperTemplate as template } from "./index";
+import { Flipper, flipperTemplate as template } from "./index";
 
-@customElement({
-    name: "fast-flipper",
-    template,
+const FASTFlipper = Flipper.compose({
+    baseName: "flipper",
+    template
 })
-class FASTFlipper extends Flipper {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<Flipper>("fast-flipper");
+    const { element, connect, disconnect } = await fixture(FASTFlipper());
 
     return { element, connect, disconnect };
 }
@@ -73,12 +72,10 @@ describe("Flipper", () => {
     });
 
     it("should set a tabindex of 0 when aria-hidden attribute is false", async () => {
-        const { element, connect, disconnect } = await fixture<Flipper>(
-            html`
-                <fast-flipper aria-hidden="false"></fast-flipper>
-            `
-        );
+        const { element, connect, disconnect } = await setup();
 
+        element.setAttribute("aria-hidden", "false");
+        
         await connect();
         await DOM.nextUpdate();
 

--- a/packages/web-components/fast-foundation/src/flipper/flipper.template.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.template.ts
@@ -7,7 +7,10 @@ import { FlipperDirection } from "./flipper.options";
  * The template for the {@link @microsoft/fast-foundation#Flipper} component.
  * @public
  */
-export const FlipperTemplate: ViewTemplate<Flipper> = html`
+export const flipperTemplate: (context, definition) => ViewTemplate<Flipper> = (
+    context,
+    definition
+) => html`
     <template
         role="button"
         aria-disabled="${x => (x.disabled ? true : void 0)}"

--- a/packages/web-components/fast-foundation/src/flipper/flipper.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.ts
@@ -1,4 +1,5 @@
-import { attr, booleanConverter, FASTElement } from "@microsoft/fast-element";
+import { attr, booleanConverter } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
 import { FlipperDirection } from "./flipper.options";
 
 export { FlipperDirection };
@@ -9,7 +10,7 @@ export { FlipperDirection };
  *
  * @public
  */
-export class Flipper extends FASTElement {
+export class Flipper extends FoundationElement {
     /**
      * The disabled state of the flipper.
      * @public

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
@@ -46,11 +46,10 @@ async function setup(tag: string) {
     `;
     const builtinStyles = css``;
 
-    container.register(
-        Registration.instance(
-            ComponentPresentation.keyFrom(tag),
-            new DefaultComponentPresentation(builtinTemplate, builtinStyles)
-        )
+    ComponentPresentation.define(
+        tag,
+        new DefaultComponentPresentation(builtinTemplate, builtinStyles),
+        container
     );
 
     return { element, connect, disconnect, builtinTemplate, builtinStyles };
@@ -133,12 +132,10 @@ describe("FoundationElement", () => {
 
             const host = document.createElement("div");
             DesignSystem.getOrCreate(host).register(myElement());
-            const container = DI.getOrCreateDOMContainer(host);
 
             const fullName = `fast-${baseName}`;
-            const presentation = container.get<DefaultComponentPresentation>(
-                ComponentPresentation.keyFrom(fullName)
-            );
+            const presentation = ComponentPresentation
+                .forTag(fullName, host) as DefaultComponentPresentation;
 
             expect(presentation.styles).to.equal(styles);
             expect(presentation.template).to.equal(template);
@@ -173,11 +170,9 @@ describe("FoundationElement", () => {
 
             const host = document.createElement("div");
             DesignSystem.getOrCreate(host).register(myElement());
-            const container = DI.getOrCreateDOMContainer(host);
 
-            const presentation = container.get<DefaultComponentPresentation>(
-                ComponentPresentation.keyFrom(fullName)
-            );
+            const presentation = ComponentPresentation
+                .forTag(fullName, host) as DefaultComponentPresentation;
 
             expect(presentation.styles).to.equal(styles);
             expect(presentation.template).to.equal(template);
@@ -204,19 +199,14 @@ describe("FoundationElement", () => {
             const host = document.createElement("div");
             DesignSystem.getOrCreate(host)
                 .register(myElement(overrides));
-            const container = DI.getOrCreateDOMContainer(host);
 
             const originalFullName = `fast-${originalName}`;
             const overrideFullName = `my-${overrideName}`;
 
-            expect(
-                container.has(ComponentPresentation.keyFrom(originalFullName), false)
-            ).to.equal(false);
             expect(customElements.get(originalFullName)).to.be.undefined;
 
-            const presentation = container.get<DefaultComponentPresentation>(
-                ComponentPresentation.keyFrom(overrideFullName)
-            );
+            const presentation = ComponentPresentation
+                .forTag(overrideFullName, host) as DefaultComponentPresentation;
 
             expect(presentation.styles).to.equal(overrides.styles);
             expect(presentation.template).to.equal(overrides.template);

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
@@ -132,7 +132,8 @@ describe("FoundationElement", () => {
             });
 
             const host = document.createElement("div");
-            const container = new DesignSystem().register(myElement()).applyTo(host);
+            DesignSystem.getOrCreate(host).register(myElement());
+            const container = DI.getOrCreateDOMContainer(host);
 
             const fullName = `fast-${baseName}`;
             const presentation = container.get<DefaultComponentPresentation>(
@@ -171,7 +172,8 @@ describe("FoundationElement", () => {
             });
 
             const host = document.createElement("div");
-            const container = new DesignSystem().register(myElement()).applyTo(host);
+            DesignSystem.getOrCreate(host).register(myElement());
+            const container = DI.getOrCreateDOMContainer(host);
 
             const presentation = container.get<DefaultComponentPresentation>(
                 ComponentPresentation.keyFrom(fullName)
@@ -200,9 +202,9 @@ describe("FoundationElement", () => {
             };
 
             const host = document.createElement("div");
-            const container = new DesignSystem()
-                .register(myElement(overrides))
-                .applyTo(host);
+            DesignSystem.getOrCreate(host)
+                .register(myElement(overrides));
+            const container = DI.getOrCreateDOMContainer(host);
 
             const originalFullName = `fast-${originalName}`;
             const overrideFullName = `my-${overrideName}`;

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
@@ -11,7 +11,7 @@ import {
     DesignSystemRegistrationContext,
     ElementDefinitionContext,
 } from "../design-system";
-import { Container, Registration, Registry } from "../di";
+import type { Container, Registry } from "../di";
 
 type LazyFoundationOption<T, K extends FoundationElementDefinition> = (
     context: ElementDefinitionContext,
@@ -85,8 +85,6 @@ export type OverrideFoundationElementDefinition<
  * @alpha
  */
 export class FoundationElement extends FASTElement {
-    @Container
-    private container: Container;
     private _presentation: ComponentPresentation | null = null;
 
     /**
@@ -95,9 +93,7 @@ export class FoundationElement extends FASTElement {
      */
     protected get $presentation(): ComponentPresentation {
         if (this._presentation === null) {
-            this._presentation = this.container.get(
-                ComponentPresentation.keyFrom(this.tagName)
-            );
+            this._presentation = ComponentPresentation.forTag(this.tagName, this);
         }
 
         return this._presentation;
@@ -211,9 +207,7 @@ export class FoundationElementRegistry<
                 resolveOption(definition.styles, x, definition)
             );
 
-            x.container.register(
-                Registration.instance(ComponentPresentation.keyFrom(x.name), presentation)
-            );
+            x.definePresentation(presentation);
 
             x.defineElement({
                 elementOptions: resolveOption(definition.elementOptions, x, definition),

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -1,7 +1,7 @@
-import { css, customElement, DOM, FASTElement, html } from "@microsoft/fast-element";
-import { expect, assert } from "chai";
+import { css, DOM, html } from "@microsoft/fast-element";
+import { expect } from "chai";
 import { fixture } from "../fixture";
-import { HorizontalScroll, HorizontalScrollTemplate as template } from "./index";
+import { HorizontalScroll, horizontalScrollTemplate as template } from "./index";
 
 const styles = css`
     :host {
@@ -23,12 +23,11 @@ const styles = css`
     }
 `;
 
-@customElement({
-    name: "fast-horizontal-scroll",
+const FASTHorizontalScroll = HorizontalScroll.compose({
+    baseName: "horizontal-scroll",
     template,
     styles
 })
-class FASTHorizontalScroll extends HorizontalScroll {}
 
 /**
  * Static widths for calculating expected returns
@@ -58,15 +57,21 @@ const cardTemplate: string = `<div class="card" style="width: ${cardWidth}px; he
  */
 const getCards = (cnt: number): string => new Array(cnt).fill(cardTemplate).reduce((s, c) => s += c, '');
 
-describe("HorinzontalScroll", () => {
+async function setup() {
+    const { element, connect, disconnect } = await fixture(FASTHorizontalScroll());
 
+
+    return { element, connect, disconnect };
+}
+
+describe("HorinzontalScroll", () => {
     describe("Flippers", () => {
         it("should enable the next flipper when content exceeds horizontal-scroll width", async () => {
-            const { element, connect, disconnect} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth}px">
-                    ${getCards(8)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
 
@@ -76,11 +81,11 @@ describe("HorinzontalScroll", () => {
         });
 
         it("should disable the next flipper if content is less than horizontal-scroll width", async () => {
-            const { element, connect, disconnect} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: 800px">
-                    ${cardTemplate}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.setAttribute("style", "width: 800px");
+            element.innerHTML = cardTemplate;
+
             await connect();
             await DOM.nextUpdate();
 
@@ -90,7 +95,10 @@ describe("HorinzontalScroll", () => {
         });
 
         it("should disable the previous flipper by default", async () => {
-            const { element, connect, disconnect} = await fixture(html<FASTHorizontalScroll>`<fast-horizontal-scroll>${getCards(8)}</fast-horizontal-scroll>`);
+            const { element, connect, disconnect} = await setup();
+
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
 
@@ -100,13 +108,15 @@ describe("HorinzontalScroll", () => {
         });
 
         it("should enable the previous flipper when content is scrolled", async () => {
-            const { element, connect, disconnect }: { element: FASTHorizontalScroll, connect: () => Promise<void>, disconnect: () => Promise<void>} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth}px" speed="-1">
-                    ${getCards(8)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.speed = -1;
+            element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
+
             element.scrollToNext();
 
             await setTimeout(async () => {
@@ -116,13 +126,15 @@ describe("HorinzontalScroll", () => {
         });
 
         it("should disable the previous flipper when scrolled back to the beginning", async () => {
-            const { element, connect, disconnect }: { element: FASTHorizontalScroll, connect: () => Promise<void>, disconnect: () => Promise<void>} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth}px" speed="-1">
-                    ${getCards(8)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.speed = -1;
+            element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
+
             element.scrollToNext();
             element.scrollToPrevious();
 
@@ -133,11 +145,12 @@ describe("HorinzontalScroll", () => {
         });
 
         it("should disable the next flipper when it reaches the end of the content", async () => {
-            const { element, connect, disconnect }: { element: FASTHorizontalScroll, connect: () => Promise<void>, disconnect: () => Promise<void>} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth}px" speed="-1">
-                    ${getCards(5)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.speed = -1;
+            element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+            element.innerHTML = getCards(5);
+
             await connect();
             await DOM.nextUpdate();
             element.scrollToNext();
@@ -152,11 +165,12 @@ describe("HorinzontalScroll", () => {
         });
 
         it("should re-enable the next flipper when its scrolled back from the end", async () => {
-            const { element, connect, disconnect }: { element: FASTHorizontalScroll, connect: () => Promise<void>, disconnect: () => Promise<void>} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth}px" speed="-1">
-                    ${getCards(8)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.speed = -1;
+            element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
             element.scrollToNext();
@@ -176,11 +190,11 @@ describe("HorinzontalScroll", () => {
 
     describe("Scrolling", () => {
         it("should start in the 0 position", async () => {
-            const { element, connect, disconnect} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth}px">
-                    ${getCards(8)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
 
@@ -190,11 +204,12 @@ describe("HorinzontalScroll", () => {
         });
 
         it("should scroll to the beginning of the last element in full view", async () => {
-            const { element, connect, disconnect }: { element: FASTHorizontalScroll, connect: () => Promise<void>, disconnect: () => Promise<void>} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth}px" speed="-1">
-                    ${getCards(8)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.speed = -1;
+            element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
             element.scrollToNext();
@@ -213,11 +228,11 @@ describe("HorinzontalScroll", () => {
         });
 
         it("should not scroll past the beginning", async () => {
-            const { element, connect, disconnect }: { element: FASTHorizontalScroll, connect: () => Promise<void>, disconnect: () => Promise<void>} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth}px">
-                    ${getCards(8)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
             element.scrollToPrevious();
@@ -232,11 +247,11 @@ describe("HorinzontalScroll", () => {
         });
 
         it("should not scroll past the last in view element", async () => {
-            const { element, connect, disconnect }: { element: FASTHorizontalScroll, connect: () => Promise<void>, disconnect: () => Promise<void>} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth}px">
-                    ${getCards(8)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
 
@@ -258,11 +273,12 @@ describe("HorinzontalScroll", () => {
         });
         
         it("should change scroll stop on resize", async () => {
-            const { element, connect, disconnect }: { element: FASTHorizontalScroll, connect: () => Promise<void>, disconnect: () => Promise<void>} = await fixture(html<FASTHorizontalScroll>`
-                <fast-horizontal-scroll style="width: ${horizontalScrollWidth * 2}px" speed="-1">
-                    ${getCards(8)}
-                </fast-horizontal-scroll>
-            `);
+            const { element, connect, disconnect } = await setup();
+
+            element.speed = -1;
+            element.setAttribute("style", `width: ${horizontalScrollWidth * 2}px}`);
+            element.innerHTML = getCards(8);
+
             await connect();
             await DOM.nextUpdate();
             const scrollContent: any = element.shadowRoot?.querySelector(".content-container");

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
@@ -6,7 +6,10 @@ import type { HorizontalScroll } from "./horizontal-scroll";
 /**
  * @public
  */
-export const HorizontalScrollTemplate: ViewTemplate<HorizontalScroll> = html`
+export const horizontalScrollTemplate: (
+    context,
+    definition
+) => ViewTemplate<HorizontalScroll> = (context, definition) => html`
     <template class="horizontal-scroll">
         ${startTemplate}
         <div class="scroll-area">

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -1,4 +1,4 @@
-import { attr, DOM, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, DOM, observable } from "@microsoft/fast-element";
 // TODO: the Resize Observer related files are a temporary stopgap measure until
 // Resize Observer types are pulled into TypeScript, which seems imminent
 // At that point these files should be deleted.
@@ -8,6 +8,7 @@ import type {
     ResizeObserverClassDefinition,
 } from "../anchored-region/resize-observer";
 import type { ResizeObserverEntry } from "../anchored-region/resize-observer-entry";
+import { FoundationElement } from "../foundation-element";
 
 declare global {
     interface WindowWithResizeObserver extends Window {
@@ -31,7 +32,7 @@ export type ScrollEasing = "linear" | "ease-in" | "ease-out" | "ease-in-out";
  * A HorizontalScroll Custom HTML Element
  * @public
  */
-export class HorizontalScroll extends FASTElement {
+export class HorizontalScroll extends FoundationElement {
     /**
      * Reference to DOM element that scrolls the content
      * @public

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
@@ -1,18 +1,17 @@
 import { expect } from "chai";
 import { fixture } from "../fixture";
-import { customElement, DOM } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { ListboxOption } from "./listbox-option";
-import { ListboxOptionTemplate } from "../listbox-option/listbox-option.template";
+import { listboxOptionTemplate } from "../listbox-option/listbox-option.template";
 
-@customElement({
-    name: "fast-option",
-    template: ListboxOptionTemplate,
+const FASTOption = ListboxOption.compose({
+    baseName: "option",
+    template: listboxOptionTemplate,
 })
-class FASTOption extends ListboxOption {}
 
 describe("ListboxOption", () => {
     async function setup() {
-        const { element, connect, disconnect } = await fixture<FASTOption>("fast-option");
+        const { element, connect, disconnect } = await fixture(FASTOption());
 
         return { element, connect, disconnect };
     }

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
@@ -7,7 +7,10 @@ import type { ListboxOption } from "./listbox-option";
  * The template for the {@link @microsoft/fast-foundation#(ListboxOption:class)} component.
  * @public
  */
-export const ListboxOptionTemplate: ViewTemplate<ListboxOption> = html`
+export const listboxOptionTemplate: (
+    context,
+    definition
+) => ViewTemplate<ListboxOption> = (context, definition) => html`
     <template
         aria-selected="${x => x.selected}"
         class="${x => (x.selected ? "selected" : "")} ${x =>

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
@@ -1,7 +1,8 @@
-import { attr, FASTElement, observable, Observable } from "@microsoft/fast-element";
+import { attr, observable, Observable } from "@microsoft/fast-element";
 import { isHTMLElement } from "@microsoft/fast-web-utilities";
 import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * Determines if the element is a {@link (ListboxOption:class)}
@@ -19,11 +20,11 @@ export function isListboxOption(el: Element): el is ListboxOption {
 
 /**
  * An Option Custom HTML Element.
- * Implements {@link https://www.w3.org/TR/wai-aria-1.1/#option | ARIA menuitem }.
+ * Implements {@link https://www.w3.org/TR/wai-aria-1.1/#option | ARIA option }.
  *
  * @public
  */
-export class ListboxOption extends FASTElement {
+export class ListboxOption extends FoundationElement {
     /**
      * @internal
      */

--- a/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
@@ -1,37 +1,33 @@
-import { customElement, DOM } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { assert, expect } from "chai";
 import { fixture } from "../fixture";
 import { ListboxOption } from "../listbox-option/listbox-option";
-import { ListboxOptionTemplate as itemTemplate } from "../listbox-option/listbox-option.template";
-import { Listbox, ListboxTemplate as template } from "./index";
+import { listboxOptionTemplate as itemTemplate } from "../listbox-option/listbox-option.template";
+import { Listbox, listboxTemplate as template } from "./index";
 
-@customElement({
-    name: "fast-listbox",
-    template,
+const FASTListbox = Listbox.compose({
+    baseName: "listbox",
+    template
 })
-class FASTListbox extends Listbox {}
 
 // TODO: Need to add tests for keyboard handling & focus management
 describe("Listbox", () => {
-    @customElement({
-        name: "fast-option",
-        template: itemTemplate,
+    const FASTOption = ListboxOption.compose({
+        baseName: "option",
+        template: itemTemplate
     })
-    class FASTOption extends ListboxOption {}
 
     async function setup() {
-        const { element, connect, disconnect } = await fixture<FASTListbox>(
-            "fast-listbox"
-        );
+        const { element, connect, disconnect } = await fixture([FASTListbox(), FASTOption()]);
 
         const option1 = document.createElement("fast-option");
-        (option1 as FASTOption).textContent = "option 1";
+        (option1 as ListboxOption).textContent = "option 1";
 
         const option2 = document.createElement("fast-option");
-        (option2 as FASTOption).textContent = "option 2";
+        (option2 as ListboxOption).textContent = "option 2";
 
         const option3 = document.createElement("fast-option");
-        (option3 as FASTOption).textContent = "option 3";
+        (option3 as ListboxOption).textContent = "option 3";
 
         element.appendChild(option1);
         element.appendChild(option2);

--- a/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
@@ -6,7 +6,10 @@ import { Listbox } from "./listbox";
  * The template for the {@link @microsoft/fast-foundation#(Listbox:class)} component.
  * @public
  */
-export const ListboxTemplate: ViewTemplate<Listbox> = html`
+export const listboxTemplate: (context, definition) => ViewTemplate<Listbox> = (
+    context,
+    definition
+) => html`
     <template
         aria-activedescendant="${x => x.ariaActiveDescendant}"
         class="listbox"

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -1,5 +1,6 @@
-import { attr, FASTElement, observable, Observable } from "@microsoft/fast-element";
+import { attr, observable, Observable } from "@microsoft/fast-element";
 import uniqueId from "lodash-es/uniqueId";
+import { FoundationElement } from "../foundation-element";
 import { isListboxOption, ListboxOption } from "../listbox-option/listbox-option";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
 import { applyMixins } from "../utilities/apply-mixins";
@@ -11,7 +12,7 @@ import { ListboxRole } from "./listbox.options";
  *
  * @public
  */
-export class Listbox extends FASTElement {
+export class Listbox extends FoundationElement {
     /**
      * The index of the selected option
      *

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
@@ -1,20 +1,23 @@
 import { expect } from "chai";
-import { MenuItem, MenuItemTemplate as template } from "./index";
+import { MenuItem, menuItemTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { MenuItemRole } from "./menu-item";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
+import { AnchoredRegion, anchoredRegionTemplate } from "../anchored-region";
 
-@customElement({
-    name: "fast-menu-item",
-    template,
+const FASTMenuItem = MenuItem.compose({
+    baseName: "menu-item",
+    template
 })
-class FASTMenuItem extends MenuItem {}
+
+const FASTAnchoredRegion = AnchoredRegion.compose({
+    baseName: "anchored-region",
+    template: anchoredRegionTemplate
+})
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTMenuItem>(
-        "fast-menu-item"
-    );
+    const { element, connect, disconnect } = await fixture([FASTMenuItem(), FASTAnchoredRegion()]);
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -1,14 +1,9 @@
 import { html, ref, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
+import { AnchoredRegion } from "../anchored-region";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import { MenuItem, MenuItemRole } from "./menu-item";
-
-/**
- * The template for the {@link @microsoft/fast-foundation#(MenuItem:class)} component.
- * @deprecated  use {@link @microsoft/fast-foundation#(createMenuItemTemplate:function)|createMenuItemTemplate} instead.
- * @public
- */
-export const MenuItemTemplate: ViewTemplate<MenuItem> = createMenuItemTemplate("fast");
+import { MenuItemRole } from "./menu-item";
+import type { MenuItem } from "./menu-item";
 
 /**
  * Generates a template for the {@link @microsoft/fast-foundation#(MenuItem:class)} component using
@@ -16,8 +11,10 @@ export const MenuItemTemplate: ViewTemplate<MenuItem> = createMenuItemTemplate("
  *
  * @public
  */
-export function createMenuItemTemplate(prefix: string): ViewTemplate {
-    return html<MenuItem>`
+export const menuItemTemplate: (context, definition) => ViewTemplate<MenuItem> = (
+    context,
+    definition
+) => html<MenuItem>`
     <template
         role="${x => x.role}"
         aria-haspopup="${x => (x.hasSubmenu ? "menu" : void 0)}"
@@ -29,7 +26,7 @@ export function createMenuItemTemplate(prefix: string): ViewTemplate {
         @mouseover="${(x, c) => x.handleMouseOver(c.event as MouseEvent)}"
         @mouseout="${(x, c) => x.handleMouseOut(c.event as MouseEvent)}"
         class="${x => (x.disabled ? "disabled" : "")} ${x =>
-        x.expanded ? "expanded" : ""}"
+    x.expanded ? "expanded" : ""}"
     >
 
             ${when(
@@ -104,7 +101,7 @@ export function createMenuItemTemplate(prefix: string): ViewTemplate {
         ${when(
             x => x.expanded,
             html<MenuItem>`
-                <${prefix}-anchored-region
+                <${context.tagFor(AnchoredRegion)}
                     :anchorElement="${x => x}"
                     vertical-positioning-mode="dynamic"
                     vertical-default-position="bottom"
@@ -118,9 +115,8 @@ export function createMenuItemTemplate(prefix: string): ViewTemplate {
                     part="submenu-region"
                 >
                     <slot name="submenu"></slot>
-                </${prefix}-anchored-region>
+                </${context.tagFor(AnchoredRegion)}>
             `
         )}
     </template>
 `;
-}

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -7,6 +7,7 @@ import {
     keyCodeSpace,
 } from "@microsoft/fast-web-utilities";
 import type { AnchoredRegion } from "../anchored-region";
+import { FoundationElement } from "../foundation-element";
 import type { Menu } from "../menu/menu";
 import { StartEnd } from "../patterns/start-end";
 import { getDirection } from "../utilities/";
@@ -21,7 +22,7 @@ export { MenuItemRole };
  *
  * @public
  */
-export class MenuItem extends FASTElement {
+export class MenuItem extends FoundationElement {
     /**
      * The disabled state of the element.
      *

--- a/packages/web-components/fast-foundation/src/menu/menu.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.spec.ts
@@ -1,21 +1,19 @@
 import { expect } from "chai";
-import { Menu, MenuTemplate as template } from "./index";
-import { MenuItem, MenuItemTemplate as itemTemplate } from "../menu-item";
+import { Menu, menuTemplate as template } from "./index";
+import { MenuItem, menuItemTemplate as itemTemplate, MenuItemRole } from "../menu-item";
 import { fixture } from "../fixture";
-import { DOM, customElement, html } from "@microsoft/fast-element";
+import { DOM, html } from "@microsoft/fast-element";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-menu",
+const FASTMenu = Menu.compose({
+    baseName: "menu",
     template,
 })
-class FASTMenu extends Menu {}
 
-@customElement({
-    name: "fast-menu-item",
+const FASTMenuItem = MenuItem.compose({
+    baseName: "menu-item",
     template: itemTemplate,
 })
-class FASTMenuItem extends MenuItem {}
 
 const arrowUpEvent = new KeyboardEvent("keydown", {
     key: "ArrowUp",
@@ -29,9 +27,36 @@ const arrowDownEvent = new KeyboardEvent("keydown", {
     bubbles: true,
 } as KeyboardEventInit);
 
+async function setup() {
+    const { element, connect, disconnect } = await fixture([FASTMenu(), FASTMenuItem()]);
+
+    const menuItem1 = document.createElement("fast-menu-item");
+    (menuItem1 as MenuItem).textContent = "Foo";
+    (menuItem1 as MenuItem).id = "id1";
+
+    const menuItem2 = document.createElement("fast-menu-item");
+    (menuItem2 as MenuItem).textContent = "Bar";
+    (menuItem2 as MenuItem).id = "id2";
+
+    const menuItem3 = document.createElement("fast-menu-item");
+    (menuItem3 as MenuItem).textContent = "Baz";
+    (menuItem3 as MenuItem).id = "id3";
+
+    const menuItem4 = document.createElement("fast-menu-item");
+    (menuItem4 as MenuItem).textContent = "Bat";
+    (menuItem4 as MenuItem).id = "id4";
+
+    element.appendChild(menuItem1);
+    element.appendChild(menuItem2);
+    element.appendChild(menuItem3);
+    element.appendChild(menuItem4);
+
+    return { element, connect, disconnect, menuItem1, menuItem2, menuItem3, menuItem4 };
+}
+
 describe("Menu", () => {
     it("should include a role of menu", async () => {
-        const { element, connect, disconnect } = await fixture<Menu>("fast-menu");
+        const { element, connect, disconnect } = await fixture([FASTMenu(), FASTMenuItem()]);
 
         await connect();
 
@@ -41,12 +66,7 @@ describe("Menu", () => {
     });
 
     it("should focus on first menu item when focus is called", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu id="menu">
-                <fast-menu-item id="id1">Foo</fast-menu-item>
-                <fast-menu-item id="id2">Bar</fast-menu-item>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect } = await setup();
 
         await connect();
         await DOM.nextUpdate();
@@ -58,10 +78,7 @@ describe("Menu", () => {
     });
 
     it("should not throw when focus is called with no items", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu id="menu">
-            </fast-menu>
-        `);
+        const { element, connect, disconnect } = await fixture(FASTMenu());
 
         await connect();
         await DOM.nextUpdate();
@@ -73,12 +90,7 @@ describe("Menu", () => {
     });
 
     it("should not throw when focus is called before initialization is complete", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu id="menu">
-                <fast-menu-item id="id1">Foo</fast-menu-item>
-                <fast-menu-item id="id2">Bar</fast-menu-item>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect } = await setup();
 
         //don't wait for connect...
 
@@ -90,14 +102,7 @@ describe("Menu", () => {
 
 
     it("should set tabindex of the first focusable menu item to 0", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <div>I put a div in my menu</div>
-                <fast-menu-item id="id1">Foo</fast-menu-item>
-                <fast-menu-item id="id2">Bar</fast-menu-item>
-                <fast-menu-item>Baz</fast-menu-item>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect } = await setup();
 
         await connect();
 
@@ -107,14 +112,12 @@ describe("Menu", () => {
     });
 
     it("should not set any tabindex on non menu items elements", async () => {
-        const { connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <div id="not-an-item">I put a div in my menu</div>
-                <fast-menu-item id="id1">Foo</fast-menu-item>
-                <fast-menu-item id="id2">Bar</fast-menu-item>
-                <fast-menu-item>Baz</fast-menu-item>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect, menuItem1 } = await setup();
+
+        const notMenuItem = document.createElement("div");
+        notMenuItem.id = "not-an-item";
+
+        element.insertBefore(notMenuItem, menuItem1);
 
         await connect();
 
@@ -124,14 +127,9 @@ describe("Menu", () => {
     });
 
     it("should focus disabled items", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <div>I put a div in my menu</div>
-                <fast-menu-item disabled id="id1">Foo</fast-menu-item>
-                <fast-menu-item id="id2">Bar</fast-menu-item>
-                <fast-menu-item>Baz</fast-menu-item>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect, menuItem1 } = await setup();
+
+        (menuItem1 as MenuItem).disabled = true;
 
         await connect();
 
@@ -141,13 +139,24 @@ describe("Menu", () => {
     });
 
     it("should accept elements with role of `menuitem` as focusable child", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <div role="menuitem" id="id1">Foo</div>
-                <div role="menuitem">Bar</div>
-                <div role="menuitem">Baz</div>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect } = await setup();
+
+        const menuItem1 = document.createElement("div");
+        const menuItem2 = document.createElement("div");
+        const menuItem3 = document.createElement("div");
+
+        menuItem1.textContent = "Foo";
+        (menuItem1 as any).role = "menuitem";
+    
+        menuItem2.textContent = "Bar";
+        (menuItem2 as any).role = "menuitem";
+    
+        menuItem3.textContent = "Baz";
+        (menuItem3 as any).role = "menuitem";
+    
+        element.appendChild(menuItem1);
+        element.appendChild(menuItem2);
+        element.appendChild(menuItem3);
 
         await connect();
 
@@ -159,15 +168,26 @@ describe("Menu", () => {
     });
 
     it("should accept elements with role of `menuitemcheckbox` as focusable child", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <div role="menuitemcheckbox" id="id1">Foo</div>
-                <div role="menuitemcheckbox">Bar</div>
-                <div role="menuitemcheckbox">Baz</div>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect } = await fixture(FASTMenu());
+
+        const menuItem1 = document.createElement("div");
+        const menuItem2 = document.createElement("div");
+        const menuItem3 = document.createElement("div");
+
+        menuItem1.textContent = "Foo";
+        menuItem2.textContent = "Bar";
+        menuItem3.textContent = "Baz";
+    
+        element.appendChild(menuItem1);
+        element.appendChild(menuItem2);
+        element.appendChild(menuItem3);
+
+        menuItem1.setAttribute("role", "menuitemcheckbox");
+        menuItem2.setAttribute("role", "menuitemcheckbox");
+        menuItem3.setAttribute("role", "menuitemcheckbox");
 
         await connect();
+        await DOM.nextUpdate();
 
         expect(
             element.querySelector("[role='menuitemcheckbox']")?.getAttribute("tabindex")
@@ -177,15 +197,26 @@ describe("Menu", () => {
     });
 
     it("should accept elements with role of `menuitemradio` as focusable child", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <div role="menuitemradio" id="id1">Foo</div>
-                <div role="menuitemradio">Bar</div>
-                <div role="menuitemradio">Baz</div>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect } = await fixture(FASTMenu());
+
+        const menuItem1 = document.createElement("div");
+        const menuItem2 = document.createElement("div");
+        const menuItem3 = document.createElement("div");
+
+        menuItem1.textContent = "Foo";
+        menuItem2.textContent = "Bar";
+        menuItem3.textContent = "Baz";
+    
+        element.appendChild(menuItem1);
+        element.appendChild(menuItem2);
+        element.appendChild(menuItem3);
+
+        menuItem1.setAttribute("role", "menuitemradio");
+        menuItem2.setAttribute("role", "menuitemradio");
+        menuItem3.setAttribute("role", "menuitemradio");
 
         await connect();
+        await DOM.nextUpdate();
 
         expect(
             element.querySelector("[role='menuitemradio']")?.getAttribute("tabindex")
@@ -195,16 +226,16 @@ describe("Menu", () => {
     });
 
     it("should navigate the menu on arrow up/down keys", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <fast-menu-item id="id1">One</fast-menu-item>
-                <fast-menu-item role="menuitem" id="id2">Two</fast-menu-item>
-                <div>I put a div in my menu</div>
-                <fast-menu-item role="menuitemradio" id="id3">Three</fast-menu-item>
-                <div>I put a div in my menu</div>
-                <fast-menu-item role="menuitemcheckbox" id="id4">Four</fast-menu-item>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect, menuItem1, menuItem2, menuItem3, menuItem4 } = await setup();
+
+        const notMenuItem1 = document.createElement("div");
+        const notMenuItem2 = document.createElement("div");
+
+        (menuItem3 as MenuItem).role = MenuItemRole.menuitemradio;
+        (menuItem4 as MenuItem).role = MenuItemRole.menuitemcheckbox;
+
+        element.insertBefore(notMenuItem1, menuItem3);
+        element.insertBefore(notMenuItem2, menuItem4);
 
         await connect();
         await DOM.nextUpdate();
@@ -241,13 +272,11 @@ describe("Menu", () => {
     });
 
     it("should treat all checkbox menu items as individually selectable items", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <fast-menu-item role="menuitemcheckbox" id="id1">One</fast-menu-item>
-                <fast-menu-item role="menuitemcheckbox" id="id2">Two</fast-menu-item>
-                <fast-menu-item role="menuitemcheckbox" id="id3">Three</fast-menu-item>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect, menuItem1, menuItem2, menuItem3 } = await setup();
+
+        (menuItem1 as MenuItem).role = MenuItemRole.menuitemcheckbox;
+        (menuItem2 as MenuItem).role = MenuItemRole.menuitemcheckbox;
+        (menuItem3 as MenuItem).role = MenuItemRole.menuitemcheckbox;
 
         await connect();
         await DOM.nextUpdate();
@@ -288,13 +317,13 @@ describe("Menu", () => {
     });
 
     it("should treat all radio menu items as a 'radio group' and limit selection to one item within the group by default", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <fast-menu-item role="menuitemradio" id="id1">One</fast-menu-item>
-                <fast-menu-item role="menuitemradio" id="id2">Two</fast-menu-item>
-                <fast-menu-item role="menuitemradio" id="id3">Three</fast-menu-item>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect, menuItem1, menuItem2, menuItem3, menuItem4 } = await setup();
+
+        element.removeChild(menuItem4);
+        
+        (menuItem1 as MenuItem).role = MenuItemRole.menuitemradio;
+        (menuItem2 as MenuItem).role = MenuItemRole.menuitemradio;
+        (menuItem3 as MenuItem).role = MenuItemRole.menuitemradio;
 
         await connect();
         await DOM.nextUpdate();
@@ -329,15 +358,18 @@ describe("Menu", () => {
     });
 
     it("should use elements with role='separator' to divide radio menu items into different radio groups ", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTMenu>`
-            <fast-menu>
-                <fast-menu-item role="menuitemradio" id="id1">One</fast-menu-item>
-                <fast-menu-item role="menuitemradio" id="id2">Two</fast-menu-item>
-                <div role="separator"></div>
-                <fast-menu-item role="menuitemradio" id="id3">Three</fast-menu-item>
-                <fast-menu-item role="menuitemradio" id="id4">Four</fast-menu-item>
-            </fast-menu>
-        `);
+        const { element, connect, disconnect, menuItem1, menuItem2, menuItem3, menuItem4 } = await setup();
+        
+        (menuItem1 as MenuItem).role = MenuItemRole.menuitemradio;
+        (menuItem2 as MenuItem).role = MenuItemRole.menuitemradio;
+        (menuItem3 as MenuItem).role = MenuItemRole.menuitemradio;
+        (menuItem4 as MenuItem).role = MenuItemRole.menuitemradio;
+
+        const separator = document.createElement("div");
+
+        element.insertBefore(separator, menuItem3);
+
+        separator.setAttribute("role", "separator");
 
         await connect();
         await DOM.nextUpdate();

--- a/packages/web-components/fast-foundation/src/menu/menu.template.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.template.ts
@@ -6,7 +6,10 @@ import type { Menu } from "./menu";
  * The template for the {@link @microsoft/fast-foundation#Menu} component.
  * @public
  */
-export const MenuTemplate: ViewTemplate<Menu> = html`
+export const menuTemplate: (context, definition) => ViewTemplate<Menu> = (
+    context,
+    definition
+) => html`
     <template
         slot="${x => (x.isNestedMenu() ? "submenu" : void 0)}"
         role="menu"

--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -1,4 +1,4 @@
-import { FASTElement, observable } from "@microsoft/fast-element";
+import { observable } from "@microsoft/fast-element";
 import { inRange, invert } from "lodash-es";
 import {
     isHTMLElement,
@@ -8,6 +8,7 @@ import {
     keyCodeHome,
 } from "@microsoft/fast-web-utilities";
 import { MenuItem, MenuItemRole } from "../menu-item/index";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * A Menu Custom HTML Element.
@@ -15,7 +16,7 @@ import { MenuItem, MenuItemRole } from "../menu-item/index";
  *
  * @public
  */
-export class Menu extends FASTElement {
+export class Menu extends FoundationElement {
     /**
      * @internal
      */

--- a/packages/web-components/fast-foundation/src/number-field/number-field.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.form-associated.ts
@@ -1,7 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
+import { FoundationElement } from "../foundation-element";
 
-class _NumberField extends FASTElement {}
+class _NumberField extends FoundationElement {}
 interface _NumberField extends FormAssociated {}
 
 /**

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -1,18 +1,15 @@
-import { customElement, DOM } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { expect, assert } from "chai";
 import { fixture } from "../fixture";
-import { NumberField, NumberFieldTemplate as template } from "./index";
+import { NumberField, numberFieldTemplate as template } from "./index";
 
-@customElement({
-    name: "fast-number-field",
+const FASTNumberField = NumberField.compose({
+    baseName: "number-field",
     template,
 })
-class FASTNumberField extends NumberField {}
 
 async function setup() {
-    const { element, connect, disconnect, parent } = await fixture<FASTNumberField>(
-        "fast-number-field"
-    );
+    const { element, connect, disconnect, parent } = await fixture(FASTNumberField());
 
     return { element, connect, disconnect, parent };
 }

--- a/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
@@ -7,7 +7,10 @@ import type { NumberField } from "./number-field";
  * The template for the {@link @microsoft/fast-foundation#(NumberField:class)} component.
  * @public
  */
-export const NumberFieldTemplate: ViewTemplate<NumberField> = html`
+export const numberFieldTemplate: (context, definition) => ViewTemplate<NumberField> = (
+    context,
+    definition
+) => html`
     <template class="${x => (x.readOnly ? "readonly" : "")}">
         <label
             part="label"

--- a/packages/web-components/fast-foundation/src/progress-ring/progress-ring.spec.ts
+++ b/packages/web-components/fast-foundation/src/progress-ring/progress-ring.spec.ts
@@ -1,19 +1,15 @@
 import { expect } from "chai";
 import { BaseProgress as Progress } from "../progress";
-import { ProgressRingTemplate as template } from "./index";
+import { progressRingTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-progress-ring",
-    template,
+const FASTProgressRing = Progress.compose({
+    baseName: "progress-ring",
+    template
 })
-class FASTProgressRing extends Progress {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTProgressRing>(
-        "fast-progress-ring"
-    );
+    const { element, connect, disconnect } = await fixture(FASTProgressRing());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/progress-ring/progress-ring.template.ts
+++ b/packages/web-components/fast-foundation/src/progress-ring/progress-ring.template.ts
@@ -6,7 +6,10 @@ import type { BaseProgress } from "../progress/base-progress";
  * The template for the {@link @microsoft/fast-foundation#BaseProgress} component.
  * @public
  */
-export const ProgressRingTemplate: ViewTemplate<BaseProgress> = html`
+export const progressRingTemplate: (context, definition) => ViewTemplate<BaseProgress> = (
+    context,
+    definition
+) => html`
     <template
         role="progressbar"
         aria-valuenow="${x => x.value}"

--- a/packages/web-components/fast-foundation/src/progress/base-progress.ts
+++ b/packages/web-components/fast-foundation/src/progress/base-progress.ts
@@ -1,11 +1,13 @@
-import { attr, FASTElement, nullableNumberConverter } from "@microsoft/fast-element";
+import { attr, nullableNumberConverter } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
+
 /**
  * An Progress HTML Element.
  * Implements the {@link https://www.w3.org/TR/wai-aria-1.1/#progressbar | ARIA progressbar }.
  *
  * @public
  */
-export class BaseProgress extends FASTElement {
+export class BaseProgress extends FoundationElement {
     /**
      * The value of the progress
      * @public

--- a/packages/web-components/fast-foundation/src/progress/progress.spec.ts
+++ b/packages/web-components/fast-foundation/src/progress/progress.spec.ts
@@ -1,16 +1,15 @@
 import { expect } from "chai";
-import { BaseProgress as Progress, ProgressTemplate as template } from "./index";
+import { BaseProgress as Progress, progressTemplate as template } from "./index";
 import { fixture } from "../fixture";
 import { customElement } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-progress",
-    template,
+const FASTProgress = Progress.compose({
+    baseName: "progress",
+    template
 })
-class FASTProgress extends Progress {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTProgress>("fast-progress");
+    const { element, connect, disconnect } = await fixture(FASTProgress());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/progress/progress.template.ts
+++ b/packages/web-components/fast-foundation/src/progress/progress.template.ts
@@ -6,7 +6,10 @@ import type { BaseProgress } from "./base-progress";
  * The template for the {@link @microsoft/fast-foundation#BaseProgress} component.
  * @public
  */
-export const ProgressTemplate: ViewTemplate<BaseProgress> = html`
+export const progressTemplate: (context, defintion) => ViewTemplate<BaseProgress> = (
+    context,
+    defintion
+) => html`
     <template
         role="progressbar"
         aria-valuenow="${x => x.value}"

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
@@ -1,32 +1,33 @@
 import { assert, expect } from "chai";
-import { RadioGroup, RadioGroupTemplate as template } from "./index";
-import { Radio, RadioTemplate as itemTemplate } from "../radio";
+import { RadioGroup, radioGroupTemplate as template } from "./index";
+import { Radio, radioTemplate as itemTemplate } from "../radio";
 import { fixture } from "../fixture";
-import { DOM, customElement, html } from "@microsoft/fast-element";
-import { KeyCodes, Orientation } from "@microsoft/fast-web-utilities";
+import { DOM, html } from "@microsoft/fast-element";
+import { Orientation } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-radio-group",
+const FASTRadioGroup = RadioGroup.compose({
+    baseName: "radio-group",
     template,
 })
-class FASTRadioGroup extends RadioGroup {}
+
+const FASTRadio = Radio.compose({
+    baseName: "radio",
+    template,
+})
 
 // TODO: Need to add tests for keyboard handling & focus management
 describe("Radio Group", () => {
-    @customElement({
-        name: "fast-radio",
-        template: itemTemplate,
+    const FASTRadio = Radio.compose({
+        baseName: "radio",
+        template: itemTemplate
     })
-    class FASTRadio extends Radio {}
 
     async function setup() {
-        const { element, connect, disconnect, parent } = await fixture<FASTRadioGroup>(
-            "fast-radio-group"
-        );
+        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
 
-        const radio1 = document.createElement("fast-radio") as FASTRadio;
-        const radio2 = document.createElement("fast-radio") as FASTRadio;
-        const radio3 = document.createElement("fast-radio") as FASTRadio;
+        const radio1 = document.createElement("fast-radio") as Radio;
+        const radio2 = document.createElement("fast-radio") as Radio;
+        const radio3 = document.createElement("fast-radio") as Radio;
 
         radio1.className = "one";
         radio2.className = "two";
@@ -130,9 +131,9 @@ describe("Radio Group", () => {
         await connect();
         await DOM.nextUpdate();
 
-        expect((element.querySelector(".one") as FASTRadio).disabled).to.equal(true);
-        expect((element.querySelector(".two") as FASTRadio).disabled).to.equal(true);
-        expect((element.querySelector(".three") as FASTRadio).disabled).to.equal(true);
+        expect((element.querySelector(".one") as Radio).disabled).to.equal(true);
+        expect((element.querySelector(".two") as Radio).disabled).to.equal(true);
+        expect((element.querySelector(".three") as Radio).disabled).to.equal(true);
 
         expect(element.querySelector(".one")?.getAttribute("aria-disabled")).to.equal(
             "true"
@@ -148,9 +149,7 @@ describe("Radio Group", () => {
     });
 
     it("should set the `aria-readonly` attribute equal to the `readonly` value", async () => {
-        const { element, connect, disconnect } = await fixture<FASTRadioGroup>(
-            "fast-radio-group"
-        );
+        const { element, connect, disconnect } = await fixture(FASTRadioGroup());
 
         element.readOnly = true;
 
@@ -168,9 +167,7 @@ describe("Radio Group", () => {
     });
 
     it("should NOT set a default `aria-readonly` value when `readonly` is not defined", async () => {
-        const { element, connect, disconnect } = await fixture<FASTRadioGroup>(
-            "fast-radio-group"
-        );
+        const { element, connect, disconnect } = await fixture(FASTRadioGroup());
 
         await connect();
 
@@ -186,9 +183,9 @@ describe("Radio Group", () => {
         await connect();
         await DOM.nextUpdate();
 
-        expect((element.querySelector(".one") as FASTRadio).readOnly).to.equal(true);
-        expect((element.querySelector(".two") as FASTRadio).readOnly).to.equal(true);
-        expect((element.querySelector(".three") as FASTRadio).readOnly).to.equal(true);
+        expect((element.querySelector(".one") as Radio).readOnly).to.equal(true);
+        expect((element.querySelector(".two") as Radio).readOnly).to.equal(true);
+        expect((element.querySelector(".three") as Radio).readOnly).to.equal(true);
 
         expect(element.querySelector(".one")?.getAttribute("aria-readonly")).to.equal(
             "true"
@@ -204,15 +201,27 @@ describe("Radio Group", () => {
     });
 
     it("should set tabindex of 0 to a child radio with a matching `value`", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTRadioGroup>`
-            <fast-radio-group value="baz">
-                <fast-radio value="foo">Foo</fast-radio>
-                <fast-radio value="bar">Bar</fast-radio>
-                <fast-radio value="baz">Baz</fast-radio>
-            </fast-radio-group>
-        `);
+        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
 
-        await connect();
+        element.value = "baz";
+
+        const radio1 = document.createElement("fast-radio") as Radio;
+        const radio2 = document.createElement("fast-radio") as Radio;
+        const radio3 = document.createElement("fast-radio") as Radio;
+
+        radio1.className = "one";
+        radio2.className = "two";
+        radio3.className = "three";
+
+        radio1.value = "foo";
+        radio2.value = "bar";
+        radio3.value = "baz";
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        await connect()
         await DOM.nextUpdate();
 
         expect(
@@ -223,13 +232,25 @@ describe("Radio Group", () => {
     });
 
     it("should NOT set tabindex of 0 to a child radio if its value does not match the radiogroup `value`", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTRadioGroup>`
-            <fast-radio-group value="baz">
-                <fast-radio value="foo">Foo</fast-radio>
-                <fast-radio value="bar">Bar</fast-radio>
-                <fast-radio value="baz">Baz</fast-radio>
-            </fast-radio-group>
-        `);
+        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        element.value = "baz";
+
+        const radio1 = document.createElement("fast-radio") as Radio;
+        const radio2 = document.createElement("fast-radio") as Radio;
+        const radio3 = document.createElement("fast-radio") as Radio;
+
+        radio1.className = "one";
+        radio2.className = "two";
+        radio3.className = "three";
+
+        radio1.value = "foo";
+        radio2.value = "bar";
+        radio3.value = "baz";
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
 
         await connect();
         await DOM.nextUpdate();
@@ -245,18 +266,30 @@ describe("Radio Group", () => {
     });
 
     it("should set a child radio with a matching `value` to `checked`", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTRadioGroup>`
-            <fast-radio-group value="baz">
-                <fast-radio value="foo">Foo</fast-radio>
-                <fast-radio value="bar">Bar</fast-radio>
-                <fast-radio value="baz">Baz</fast-radio>
-            </fast-radio-group>
-        `);
+        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        element.value = "baz";
+
+        const radio1 = document.createElement("fast-radio") as Radio;
+        const radio2 = document.createElement("fast-radio") as Radio;
+        const radio3 = document.createElement("fast-radio") as Radio;
+
+        radio1.className = "one";
+        radio2.className = "two";
+        radio3.className = "three";
+
+        radio1.value = "foo";
+        radio2.value = "bar";
+        radio3.value = "baz";
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
 
         await connect();
         await DOM.nextUpdate();
 
-        expect((element.querySelectorAll("fast-radio")[2] as FASTRadio).checked).to.equal(
+        expect((element.querySelectorAll("fast-radio")[2] as Radio).checked).to.equal(
             true
         );
         expect(
@@ -267,14 +300,27 @@ describe("Radio Group", () => {
     });
 
     it("should mark the last radio defaulted to checked as checked, the rest should not be checked", async () => {
-        const { element, connect, disconnect } = await fixture(html`
-            <fast-radio-group>
-                <fast-radio value="foo">Foo</fast-radio>
-                <fast-radio value="bar" checked>Bar</fast-radio>
-                <fast-radio value="baz" checked>Baz</fast-radio>
-            </fast-radio-group>
-        `);
+        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
 
+        const radio1 = document.createElement("fast-radio") as Radio;
+        const radio2 = document.createElement("fast-radio") as Radio;
+        const radio3 = document.createElement("fast-radio") as Radio;
+
+        radio1.className = "one";
+        radio2.className = "two";
+        radio3.className = "three";
+
+        radio1.value = "foo";
+        radio2.value = "bar";
+        radio3.value = "baz";
+
+        radio2.setAttribute("checked","");
+        radio3.setAttribute("checked","");
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+        
         await connect();
         await DOM.nextUpdate();
 
@@ -286,14 +332,29 @@ describe("Radio Group", () => {
     });
 
     it("should mark radio matching value on radio-group over any checked attributes", async () => {
-        const { element, connect, disconnect } = await fixture(html`
-            <fast-radio-group value="bar">
-                <fast-radio value="foo">Foo</fast-radio>
-                <fast-radio value="bar" checked>Bar</fast-radio>
-                <fast-radio value="baz" checked>Baz</fast-radio>
-            </fast-radio-group>
-        `);
+        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
 
+        element.value = "bar";
+
+        const radio1 = document.createElement("fast-radio") as Radio;
+        const radio2 = document.createElement("fast-radio") as Radio;
+        const radio3 = document.createElement("fast-radio") as Radio;
+
+        radio1.className = "one";
+        radio2.className = "two";
+        radio3.className = "three";
+
+        radio1.value = "foo";
+        radio2.value = "bar";
+        radio3.value = "baz";
+
+        radio2.setAttribute("checked","");
+        radio3.setAttribute("checked","");
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+        
         await connect();
         await DOM.nextUpdate();
 
@@ -309,25 +370,37 @@ describe("Radio Group", () => {
     });
 
     it("should NOT set a child radio to `checked` if its value does not match the radiogroup `value`", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTRadioGroup>`
-            <fast-radio-group value="baz">
-                <fast-radio value="foo">Foo</fast-radio>
-                <fast-radio value="bar">Bar</fast-radio>
-                <fast-radio value="baz">Baz</fast-radio>
-            </fast-radio-group>
-        `);
+        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
 
+        element.value = "baz";
+
+        const radio1 = document.createElement("fast-radio") as Radio;
+        const radio2 = document.createElement("fast-radio") as Radio;
+        const radio3 = document.createElement("fast-radio") as Radio;
+
+        radio1.className = "one";
+        radio2.className = "two";
+        radio3.className = "three";
+
+        radio1.value = "foo";
+        radio2.value = "bar";
+        radio3.value = "baz";
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+        
         await connect();
         await DOM.nextUpdate();
 
-        expect((element.querySelectorAll("fast-radio")[0] as FASTRadio).checked).to.equal(
+        expect((element.querySelectorAll("fast-radio")[0] as Radio).checked).to.equal(
             false
         );
         expect(
             element.querySelectorAll("fast-radio")[0].getAttribute("aria-checked")
         ).to.equal("false");
 
-        expect((element.querySelectorAll("fast-radio")[1] as FASTRadio).checked).to.equal(
+        expect((element.querySelectorAll("fast-radio")[1] as Radio).checked).to.equal(
             false
         );
         expect(

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
@@ -7,7 +7,10 @@ import type { RadioGroup } from "./radio-group";
  * The template for the {@link @microsoft/fast-foundation#RadioGroup} component.
  * @public
  */
-export const RadioGroupTemplate: ViewTemplate<RadioGroup> = html`
+export const radioGroupTemplate: (context, definition) => ViewTemplate<RadioGroup> = (
+    context,
+    definition
+) => html`
     <template
         role="radiogroup"
         aria-disabled="${x => x.disabled}"

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -1,4 +1,4 @@
-import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import {
     Direction,
     keyCodeArrowDown,
@@ -11,6 +11,7 @@ import {
     Orientation,
 } from "@microsoft/fast-web-utilities";
 import { getDirection } from "../utilities";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * An Radio Group Custom HTML Element.
@@ -18,7 +19,7 @@ import { getDirection } from "../utilities";
  *
  * @public
  */
-export class RadioGroup extends FASTElement {
+export class RadioGroup extends FoundationElement {
     /**
      * When true, the child radios will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
      * @public
@@ -175,7 +176,7 @@ export class RadioGroup extends FASTElement {
                 radio.readOnly = true;
             }
 
-            if (this.value && this.value === radio.getAttribute("value")) {
+            if (this.value && this.value === radio.value) {
                 this.selectedRadio = radio;
                 this.focusedRadio = radio;
                 radio.checked = true;

--- a/packages/web-components/fast-foundation/src/radio/radio.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.form-associated.ts
@@ -1,7 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
+import { FoundationElement } from "../foundation-element";
 
-class _Radio extends FASTElement {}
+class _Radio extends FoundationElement {}
 interface _Radio extends FormAssociated {}
 
 /**

--- a/packages/web-components/fast-foundation/src/radio/radio.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.spec.ts
@@ -1,19 +1,16 @@
 import { expect, assert } from "chai";
-import { Radio, RadioTemplate as template } from "./index";
+import { Radio, radioTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-radio",
+const FASTRadio = Radio.compose({
+    baseName: "radio",
     template,
 })
-class FASTRadio extends Radio {}
 
 async function setup() {
-    const { connect, disconnect, element, parent } = await fixture<FASTRadio>(
-        "fast-radio"
-    );
+    const { connect, disconnect, element, parent } = await fixture(FASTRadio());
 
     return { element, connect, disconnect, parent };
 }

--- a/packages/web-components/fast-foundation/src/radio/radio.template.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.template.ts
@@ -6,7 +6,10 @@ import type { Radio } from "./radio";
  * The template for the {@link @microsoft/fast-foundation#(Radio:class)} component.
  * @public
  */
-export const RadioTemplate: ViewTemplate<Radio> = html`
+export const radioTemplate: (context, definition) => ViewTemplate<Radio> = (
+    context,
+    definition
+) => html`
     <template
         role="radio"
         class="${x => (x.checked ? "checked" : "")} ${x =>

--- a/packages/web-components/fast-foundation/src/select/select.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.spec.ts
@@ -1,34 +1,30 @@
 import { assert, expect } from "chai";
-import { customElement, DOM } from "@microsoft/fast-element";
-import { ListboxOptionTemplate, ListboxOption } from "../listbox-option";
+import { DOM } from "@microsoft/fast-element";
+import { listboxOptionTemplate, ListboxOption } from "../listbox-option";
 import { fixture } from "../fixture";
-import { Select, SelectTemplate } from "./index";
+import { Select, selectTemplate as template } from "./index";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-select",
-    template: SelectTemplate,
+const FASTSelect = Select.compose({
+    baseName: "fast",
+    template
 })
-class FASTSelect extends Select {}
 
-@customElement({
-    name: "fast-option",
-    template: ListboxOptionTemplate,
+const FASTOption = ListboxOption.compose({
+    baseName: "option",
+    template: listboxOptionTemplate,
 })
-class FASTOption extends ListboxOption {}
 
 async function setup() {
-    const { element, connect, disconnect, parent } = await fixture<FASTSelect>(
-        "fast-select"
-    );
+    const { element, connect, disconnect, parent } = await fixture([FASTSelect(), FASTOption()]);
 
-    const option1 = document.createElement("fast-option") as FASTOption;
+    const option1 = document.createElement("fast-option") as ListboxOption;
     option1.value = "one";
 
-    const option2 = document.createElement("fast-option") as FASTOption;
+    const option2 = document.createElement("fast-option") as ListboxOption;
     option2.value = "two";
 
-    const option3 = document.createElement("fast-option") as FASTOption;
+    const option3 = document.createElement("fast-option") as ListboxOption;
     option3.value = "three";
 
     element.appendChild(option1);

--- a/packages/web-components/fast-foundation/src/select/select.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.spec.ts
@@ -6,7 +6,7 @@ import { Select, selectTemplate as template } from "./index";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 
 const FASTSelect = Select.compose({
-    baseName: "fast",
+    baseName: "select",
     template
 })
 

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -8,7 +8,10 @@ import type { Select } from "./select";
  * The template for the {@link @microsoft/fast-foundation#(Select:class)} component.
  * @public
  */
-export const SelectTemplate: ViewTemplate<Select> = html`
+export const selectTemplate: (context, definition) => ViewTemplate<Select> = (
+    context,
+    definition
+) => html`
     <template
         class="${x => (x.open ? "open" : "")} ${x =>
             x.disabled ? "disabled" : ""} ${x => x.position}"

--- a/packages/web-components/fast-foundation/src/skeleton/skeleton.template.ts
+++ b/packages/web-components/fast-foundation/src/skeleton/skeleton.template.ts
@@ -6,7 +6,10 @@ import type { Skeleton } from "./skeleton";
  * The template for the fast-skeleton component
  * @public
  */
-export const SkeletonTemplate: ViewTemplate<Skeleton> = html`
+export const skeletonTemplate: (context, definition) => ViewTemplate<Skeleton> = (
+    context,
+    definition
+) => html`
     <template
         class="${x => (x.shape === "circle" ? "circle" : "rect")}"
         pattern="${x => x.pattern}"

--- a/packages/web-components/fast-foundation/src/skeleton/skeleton.ts
+++ b/packages/web-components/fast-foundation/src/skeleton/skeleton.ts
@@ -1,4 +1,5 @@
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { attr } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * A structure representing skeleton shapes
@@ -11,7 +12,7 @@ export type SkeletonShape = "rect" | "circle";
  *
  * @public
  */
-export class Skeleton extends FASTElement {
+export class Skeleton extends FoundationElement {
     /**
      * Indicates the Skeleton should have a filled style.
      *

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.spec.ts
@@ -1,32 +1,22 @@
 import { expect } from "chai";
-import { Slider, SliderTemplate } from "../slider";
-import { SliderLabel, SliderLabelTemplate as template } from "../index";
+import { SliderLabel, sliderLabelTemplate as template } from "../index";
 import { fixture } from "../fixture";
-import { DOM, customElement, html } from "@microsoft/fast-element";
-import { KeyCodes, Orientation } from "@microsoft/fast-web-utilities";
+import { DOM } from "@microsoft/fast-element";
+import { Orientation } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-slider",
-    template: SliderTemplate,
+const FASTSliderLabel = SliderLabel.compose({
+    baseName: "slider-label",
+    template
 })
-class FASTSlider extends Slider {}
-
-@customElement({
-    name: "fast-slider-label",
-    template,
-})
-class FASTSliderLabel extends SliderLabel {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTSliderLabel>(
-        "fast-slider-label"
-    );
+    const { element, connect, disconnect } = await fixture(FASTSliderLabel())
 
     return { element, connect, disconnect };
 }
 
 // TODO: Need to add tests for positioning and slider configuration
-describe("Slider", () => {
+describe("Slider label", () => {
     it("should set the `aria-disabled` attribute when `disabled` value is true", async () => {
         const { element, connect, disconnect } = await setup();
 
@@ -52,13 +42,13 @@ describe("Slider", () => {
     it("should add a class equal to the `sliderOrientation` value", async () => {
         const { element, connect, disconnect } = await setup();
 
-        (element as FASTSliderLabel).sliderOrientation = Orientation.horizontal;
+        (element as SliderLabel).sliderOrientation = Orientation.horizontal;
 
         await connect();
 
         expect(element.classList.contains(`${Orientation.horizontal}`)).to.equal(true);
 
-        (element as FASTSliderLabel).sliderOrientation = Orientation.vertical;
+        (element as SliderLabel).sliderOrientation = Orientation.vertical;
 
         await DOM.nextUpdate();
 

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
@@ -7,7 +7,10 @@ import type { SliderLabel } from "./slider-label";
  * The template for the {@link @microsoft/fast-foundation#(SliderLabel:class)} component.
  * @public
  */
-export const SliderLabelTemplate: ViewTemplate<SliderLabel> = html`
+export const sliderLabelTemplate: (context, definition) => ViewTemplate<SliderLabel> = (
+    context,
+    definition
+) => html`
     <template
         aria-disabled="${x => x.disabled}"
         class="${x => x.sliderOrientation || Orientation.horizontal}

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.ts
@@ -1,13 +1,8 @@
-import {
-    attr,
-    FASTElement,
-    Notifier,
-    Observable,
-    observable,
-} from "@microsoft/fast-element";
+import { attr, Notifier, Observable, observable } from "@microsoft/fast-element";
 import { Direction, Orientation } from "@microsoft/fast-web-utilities";
 import type { SliderConfiguration } from "../slider/index";
 import { convertPixelToPercent } from "../slider/slider-utilities";
+import { FoundationElement } from "../foundation-element";
 
 const defaultConfig: SliderConfiguration = {
     min: 0,
@@ -22,7 +17,7 @@ const defaultConfig: SliderConfiguration = {
  *
  * @public
  */
-export class SliderLabel extends FASTElement {
+export class SliderLabel extends FoundationElement {
     /**
      * @internal
      */

--- a/packages/web-components/fast-foundation/src/slider/slider.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.form-associated.ts
@@ -1,7 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
+import { FoundationElement } from "../foundation-element";
 
-class _Slider extends FASTElement {}
+class _Slider extends FoundationElement {}
 interface _Slider extends FormAssociated {}
 
 /**

--- a/packages/web-components/fast-foundation/src/slider/slider.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.spec.ts
@@ -1,26 +1,16 @@
 import { expect, assert } from "chai";
-import { Slider, SliderTemplate as template } from "./index";
-import { SliderLabel, SliderLabelTemplate as itemTemplate } from "../slider-label";
+import { Slider, sliderTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { Orientation, Direction } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-slider",
-    template,
+const FASTSlider = Slider.compose({
+    baseName: "slider",
+    template
 })
-class FASTSlider extends Slider {}
-
-@customElement({
-    name: "fast-slider-label",
-    template: itemTemplate,
-})
-class FASTSliderLabel extends SliderLabel {}
 
 async function setup() {
-    const { element, connect, disconnect, parent } = await fixture<FASTSlider>(
-        "fast-slider"
-    );
+    const { element, connect, disconnect, parent } = await fixture(FASTSlider());
 
     return { element, connect, disconnect, parent };
 }

--- a/packages/web-components/fast-foundation/src/slider/slider.template.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.template.ts
@@ -7,7 +7,10 @@ import type { Slider } from "./slider";
  * The template for the {@link @microsoft/fast-foundation#(Slider:class)} component.
  * @public
  */
-export const SliderTemplate: ViewTemplate<Slider> = html`
+export const sliderTemplate: (context, definition) => ViewTemplate<Slider> = (
+    context,
+    definition
+) => html`
     <template
         role="slider"
         class="${x => (x.readOnly ? "readonly" : "")}

--- a/packages/web-components/fast-foundation/src/switch/switch.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.form-associated.ts
@@ -1,7 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
+import { FoundationElement } from "../foundation-element";
 
-class _Switch extends FASTElement {}
+class _Switch extends FoundationElement {}
 interface _Switch extends FormAssociated {}
 
 /**

--- a/packages/web-components/fast-foundation/src/switch/switch.spec.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.spec.ts
@@ -1,19 +1,16 @@
 import { expect, assert } from "chai";
-import { Switch, SwitchTemplate as template } from "./index";
+import { Switch, switchTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement, html } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { KeyCodes } from "@microsoft/fast-web-utilities";
 
-@customElement({
-    name: "fast-switch",
-    template,
+const FASTSwitch = Switch.compose({
+    baseName: "switch",
+    template
 })
-class FASTSwitch extends Switch {}
 
 async function setup() {
-    const { element, connect, disconnect, parent } = await fixture<FASTSwitch>(
-        "fast-switch"
-    );
+    const { element, connect, disconnect, parent } = await fixture(FASTSwitch());
 
     return { element, connect, disconnect, parent };
 }
@@ -225,9 +222,7 @@ describe("Switch", () => {
 
     describe("events", () => {
         it("should fire an event on click", async () => {
-            const { element, connect, disconnect } = await fixture<FASTSwitch>(
-                "fast-switch"
-            );
+            const { element, connect, disconnect } = await setup();
             let wasClicked: boolean = false;
 
             await connect();
@@ -248,9 +243,7 @@ describe("Switch", () => {
         });
 
         it("should fire an event when spacebar is invoked", async () => {
-            const { element, connect, disconnect } = await fixture<FASTSwitch>(
-                "fast-switch"
-            );
+            const { element, connect, disconnect } = await setup();
             let wasInvoked: boolean = false;
             const event = new KeyboardEvent("keydown", {
                 key: "space",

--- a/packages/web-components/fast-foundation/src/switch/switch.template.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.template.ts
@@ -6,7 +6,10 @@ import type { Switch } from "./switch";
  * The template for the {@link @microsoft/fast-foundation#(Switch:class)} component.
  * @public
  */
-export const SwitchTemplate: ViewTemplate<Switch> = html`
+export const switchTemplate: (context, definition) => ViewTemplate<Switch> = (
+    context,
+    definition
+) => html`
     <template
         role="switch"
         aria-checked="${x => x.checked}"

--- a/packages/web-components/fast-foundation/src/tab-panel/tab-panel.spec.ts
+++ b/packages/web-components/fast-foundation/src/tab-panel/tab-panel.spec.ts
@@ -1,18 +1,14 @@
 import { expect } from "chai";
-import { TabPanel, TabPanelTemplate as template } from "./index";
+import { TabPanel, tabPanelTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { customElement } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-tab-panel",
+const FASTTabPanel = TabPanel.compose({
+    baseName: "tab-panel",
     template,
 })
-class FASTTabPanel extends TabPanel {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTTabPanel>(
-        "fast-tab-panel"
-    );
+    const { element, connect, disconnect } = await fixture(FASTTabPanel());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/tab-panel/tab-panel.template.ts
+++ b/packages/web-components/fast-foundation/src/tab-panel/tab-panel.template.ts
@@ -5,7 +5,10 @@ import type { TabPanel } from "./tab-panel";
  * The template for the {@link @microsoft/fast-foundation#TabPanel} component.
  * @public
  */
-export const TabPanelTemplate: ViewTemplate<TabPanel> = html`
+export const tabPanelTemplate: (context, definition) => ViewTemplate<TabPanel> = (
+    context,
+    definition
+) => html`
     <template slot="tabpanel" role="tabpanel">
         <slot></slot>
     </template>

--- a/packages/web-components/fast-foundation/src/tab-panel/tab-panel.ts
+++ b/packages/web-components/fast-foundation/src/tab-panel/tab-panel.ts
@@ -1,7 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * A TabPanel Component to be used with {@link @microsoft/fast-foundation#(Tabs:class)}
  * @public
  */
-export class TabPanel extends FASTElement {}
+export class TabPanel extends FoundationElement {}

--- a/packages/web-components/fast-foundation/src/tab/tab.spec.ts
+++ b/packages/web-components/fast-foundation/src/tab/tab.spec.ts
@@ -1,16 +1,14 @@
 import { expect } from "chai";
-import { Tab, TabTemplate as template } from "./index";
+import { Tab, tabTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { customElement } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-tab",
-    template,
+const FASTTab = Tab.compose({
+    baseName: "tab",
+    template
 })
-class FASTTab extends Tab {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTTab>("fast-tab");
+    const { element, connect, disconnect } = await fixture(FASTTab());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/tab/tab.template.ts
+++ b/packages/web-components/fast-foundation/src/tab/tab.template.ts
@@ -6,7 +6,10 @@ import type { Tab } from "./tab";
  * The template for the {@link @microsoft/fast-foundation#Tab} component.
  * @public
  */
-export const TabTemplate: ViewTemplate<Tab> = html`
+export const tabTemplate: (context, definition) => ViewTemplate<Tab> = (
+    context,
+    definition
+) => html`
     <template slot="tab" role="tab" aria-disabled="${x => x.disabled}">
         <slot></slot>
     </template>

--- a/packages/web-components/fast-foundation/src/tab/tab.ts
+++ b/packages/web-components/fast-foundation/src/tab/tab.ts
@@ -1,10 +1,11 @@
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { attr } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * A Tab Component to be used with {@link @microsoft/fast-foundation#(Tabs:class)}
  * @public
  */
-export class Tab extends FASTElement {
+export class Tab extends FoundationElement {
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled | disabled HTML attribute} for more information.
      * @public

--- a/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
@@ -1,24 +1,23 @@
 import { assert, expect } from "chai";
 import { css, DOM, customElement, html } from "@microsoft/fast-element";
 import { fixture } from "../fixture";
-import { Tab, TabTemplate } from "../tab";
-import { TabPanel, TabPanelTemplate } from "../tab-panel";
-import { TabsOrientation, Tabs, TabsTemplate as template } from "./index";
+import { Tab, tabTemplate } from "../tab";
+import { TabPanel, tabPanelTemplate } from "../tab-panel";
+import { TabsOrientation, Tabs, tabsTemplate as template } from "./index";
 
-@customElement({
-    name: "fast-tab",
-    template: TabTemplate,
+const FASTTab = Tab.compose({
+    baseName: "tab",
+    template: tabTemplate,
 })
-class FASTTab extends Tab {}
 
-@customElement({
-    name: "fast-tab-panel",
-    template: TabPanelTemplate,
+const FASTTabPanel = TabPanel.compose({
+    baseName: "tab-panel",
+    template: tabPanelTemplate,
 })
-class FASTTabPanel extends TabPanel {}
 
-@customElement({
-    name: "fast-tabs",
+
+const FASTTabs = Tabs.compose({
+    baseName: "tabs",
     template,
     styles: css`
         .activeIndicatorTransition {
@@ -26,16 +25,15 @@ class FASTTabPanel extends TabPanel {}
         }
     `,
 })
-class FASTTabs extends Tabs {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTTabs>("fast-tabs");
+    const { element, connect, disconnect } = await fixture([FASTTabs(), FASTTabPanel(), FASTTab()])
 
     for (let i = 1; i < 4; i++) {
-        const tab = document.createElement("fast-tab") as FASTTab;
+        const tab = document.createElement("fast-tab") as Tab;
         tab.id = `tab${i}`;
 
-        const panel = document.createElement("fast-tab-panel") as FASTTabPanel;
+        const panel = document.createElement("fast-tab-panel") as TabPanel;
         panel.id = `panel${i}`;
         element.appendChild(panel);
         element.insertBefore(tab, element.querySelector("fast-tab-panel"));
@@ -118,22 +116,11 @@ describe("Tabs", () => {
     });
 
     it("should set an `id` attribute on the active tab when an `id` is provided", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-            <fast-tabs>
-                <fast-tab id="01">Tab one</fast-tab>
-                <fast-tab id="02">Tab two</fast-tab>
-                <fast-tab id="03">Tab three</fast-tab>
-                <fast-tab-panel>
-                    Tab one content. This is for testing.
-                </fast-tab-panel>
-                <fast-tab-panel>
-                    Tab two content. This is for testing.
-                </fast-tab-panel>
-                <fast-tab-panel>
-                    Tab three content. This is for testing.
-                </fast-tab-panel>
-            </fast-tabs>
-        `);
+        const { element, connect, disconnect, tab1, tab2, tab3 } = await setup();
+
+        tab1.id = "01";
+        tab2.id = "02";
+        tab3.id = "03";
 
         await connect();
 
@@ -146,22 +133,15 @@ describe("Tabs", () => {
     });
 
     it("should set an `id` attribute tab items relative to the index if an `id is NOT provided", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-            <fast-tabs>
-                <fast-tab>Tab one</fast-tab>
-                <fast-tab>Tab two</fast-tab>
-                <fast-tab>Tab three</fast-tab>
-                <fast-tab-panel>
-                    Tab one content. This is for testing.
-                </fast-tab-panel>
-                <fast-tab-panel>
-                    Tab two content. This is for testing.
-                </fast-tab-panel>
-                <fast-tab-panel>
-                    Tab three content. This is for testing.
-                </fast-tab-panel>
-            </fast-tabs>
-        `);
+        const { element, connect, disconnect } = await fixture([FASTTabs(), FASTTabPanel(), FASTTab()])
+
+        for (let i = 1; i < 4; i++) {
+            const tab = document.createElement("fast-tab") as Tab;    
+            const panel = document.createElement("fast-tab-panel") as TabPanel;
+
+            element.appendChild(panel);
+            element.insertBefore(tab, element.querySelector("fast-tab-panel"));
+        }
 
         await connect();
 
@@ -174,52 +154,30 @@ describe("Tabs", () => {
     });
 
     it("should set an `id` attribute on the tabpanel when an `id is provided", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-            <fast-tabs>
-                <fast-tab id="01">Tab one</fast-tab>
-                <fast-tab id="02">Tab two</fast-tab>
-                <fast-tab id="03">Tab three</fast-tab>
-                <fast-tab-panel id="panel01">
-                    Tab one content. This is for testing.
-                </fast-tab-panel>
-                <fast-tab-panel id="panel02">
-                    Tab two content. This is for testing.
-                </fast-tab-panel>
-                <fast-tab-panel id="panel03">
-                    Tab three content. This is for testing.
-                </fast-tab-panel>
-            </fast-tabs>
-        `);
+        const { element, connect, disconnect } = await setup();
 
         await connect();
 
         expect(element.querySelector("fast-tab-panel")?.getAttribute("id")).to.equal(
-            "panel01"
+            "panel1"
         );
         expect(
             element.querySelectorAll("fast-tab-panel")[1]?.getAttribute("id")
-        ).to.equal("panel02");
+        ).to.equal("panel2");
 
         await disconnect();
     });
 
     it("should set an `id` attribute on tabpanel items relative to the index if an `id is NOT provided", async () => {
-        const { element, connect, disconnect } = await fixture(html<FASTTabs>`
-            <fast-tabs>
-                <fast-tab>Tab one</fast-tab>
-                <fast-tab>Tab two</fast-tab>
-                <fast-tab>Tab three</fast-tab>
-                <fast-tab-panel>
-                    Tab one content. This is for testing.
-                </fast-tab-panel>
-                <fast-tab-panel>
-                    Tab two content. This is for testing.
-                </fast-tab-panel>
-                <fast-tab-panel>
-                    Tab three content. This is for testing.
-                </fast-tab-panel>
-            </fast-tabs>
-        `);
+        const { element, connect, disconnect } = await fixture([FASTTabs(), FASTTabPanel(), FASTTab()])
+
+        for (let i = 1; i < 4; i++) {
+            const tab = document.createElement("fast-tab") as Tab;    
+            const panel = document.createElement("fast-tab-panel") as TabPanel;
+
+            element.appendChild(panel);
+            element.insertBefore(tab, element.querySelector("fast-tab-panel"));
+        }
 
         await connect();
 
@@ -357,25 +315,18 @@ describe("Tabs", () => {
 
     describe("disabled tab", () => {
         it("should not display an active indicator if all tabs are disabled", async () => {
-            const { element, connect, disconnect } = await fixture<FASTTabs>(html<
-                FASTTabs
-            >`
-                <fast-tabs>
-                    <fast-tab disabled>Tab one</fast-tab>
-                    <fast-tab disabled>Tab two</fast-tab>
-                    <fast-tab disabled>Tab three</fast-tab>
-                    <fast-tab-panel>
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+            const { element, connect, disconnect } = await fixture([FASTTabs(), FASTTabPanel(), FASTTab()]);
 
+            for (let i = 1; i < 4; i++) {
+                const tab = document.createElement("fast-tab") as Tab;
+                tab.disabled = true;
+        
+                const panel = document.createElement("fast-tab-panel") as TabPanel;
+                panel.id = `panel${i}`;
+                element.appendChild(panel);
+                element.insertBefore(tab, element.querySelector("fast-tab-panel"));
+            }
+            
             await connect();
 
             expect(element.showActiveIndicator).to.be.false;
@@ -384,27 +335,24 @@ describe("Tabs", () => {
         });
 
         it("should display an active indicator if the last tab is disabled", async () => {
-            const { element, connect, disconnect } = await fixture<FASTTabs>(html<
-                FASTTabs
-            >`
-                <fast-tabs>
-                    <fast-tab>Tab one</fast-tab>
-                    <fast-tab>Tab two</fast-tab>
-                    <fast-tab disabled>Tab three</fast-tab>
-                    <fast-tab-panel>
-                        Tab one content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab two content. This is for testing.
-                    </fast-tab-panel>
-                    <fast-tab-panel>
-                        Tab three content. This is for testing.
-                    </fast-tab-panel>
-                </fast-tabs>
-            `);
+            const { element, connect, disconnect } = await fixture([FASTTabs(), FASTTabPanel(), FASTTab()]);
+
+            for (let i = 1; i < 4; i++) {
+                const tab = document.createElement("fast-tab") as Tab;
+                tab.id = `tab${i}`;
+
+                if (i === 3) {
+                    tab.disabled = true;
+                }
+        
+                const panel = document.createElement("fast-tab-panel") as TabPanel;
+                panel.id = `panel${i}`;
+                element.appendChild(panel);
+                element.insertBefore(tab, element.querySelector("fast-tab-panel"));
+            }
 
             await connect();
-
+            
             expect(element.showActiveIndicator).to.be.true;
 
             await disconnect();

--- a/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
@@ -7,7 +7,10 @@ import type { Tabs } from "./tabs";
  * The template for the {@link @microsoft/fast-foundation#(Tabs:class)} component.
  * @public
  */
-export const TabsTemplate: ViewTemplate<Tabs> = html`
+export const tabsTemplate: (context, definition) => ViewTemplate<Tabs> = (
+    context,
+    definition
+) => html`
     <template class="${x => x.orientation}">
         ${startTemplate}
         <div class="tablist" part="tablist" role="tablist">

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -1,4 +1,4 @@
-import { attr, FASTElement, observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import {
     keyCodeArrowDown,
     keyCodeArrowLeft,
@@ -10,6 +10,7 @@ import {
 } from "@microsoft/fast-web-utilities";
 import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * The orientation of the {@link @microsoft/fast-foundation#(Tabs:class)} component
@@ -26,7 +27,7 @@ export enum TabsOrientation {
  *
  * @public
  */
-export class Tabs extends FASTElement {
+export class Tabs extends FoundationElement {
     /**
      * The orientation
      * @public

--- a/packages/web-components/fast-foundation/src/text-area/text-area.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.form-associated.ts
@@ -1,7 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
+import { FoundationElement } from "../foundation-element";
 
-class _TextArea extends FASTElement {}
+class _TextArea extends FoundationElement {}
 interface _TextArea extends FormAssociated {}
 
 /**

--- a/packages/web-components/fast-foundation/src/text-area/text-area.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.spec.ts
@@ -1,18 +1,14 @@
 import { expect, assert } from "chai";
-import { TextArea, TextAreaTemplate as template } from "./index";
+import { TextArea, textAreaTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { customElement } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-text-area",
+const FASTTextArea = TextArea.compose({
+    baseName: "text-area",
     template,
 })
-class FASTTextArea extends TextArea {}
 
 async function setup() {
-    const { element, connect, disconnect, parent } = await fixture<FASTTextArea>(
-        "fast-text-area"
-    );
+    const { element, connect, disconnect, parent } = await fixture(FASTTextArea());
 
     return { element, connect, disconnect, parent };
 }

--- a/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
@@ -7,7 +7,10 @@ import type { TextArea } from "./text-area";
  * The template for the {@link @microsoft/fast-foundation#(TextArea:class)} component.
  * @public
  */
-export const TextAreaTemplate: ViewTemplate<TextArea> = html`
+export const textAreaTemplate: (context, definition) => ViewTemplate<TextArea> = (
+    context,
+    definition
+) => html`
     <template
         class="
             ${x => (x.readOnly ? "readonly" : "")}

--- a/packages/web-components/fast-foundation/src/text-field/text-field.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.form-associated.ts
@@ -1,7 +1,7 @@
-import { FASTElement } from "@microsoft/fast-element";
 import { FormAssociated } from "../form-associated/form-associated";
+import { FoundationElement } from "../foundation-element";
 
-class _TextField extends FASTElement {}
+class _TextField extends FoundationElement {}
 interface _TextField extends FormAssociated {}
 
 /**

--- a/packages/web-components/fast-foundation/src/text-field/text-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.spec.ts
@@ -1,19 +1,15 @@
-import { customElement } from "@microsoft/fast-element";
 import { expect, assert } from "chai";
 import { fixture } from "../fixture";
-import { TextField, TextFieldTemplate as template, TextFieldTemplate } from "./index";
+import { TextField, textFieldTemplate as template } from "./index";
 import { TextFieldType } from "./text-field";
 
-@customElement({
-    name: "fast-text-field",
+const FASTTextField = TextField.compose({
+    baseName: "text-field",
     template,
 })
-class FASTTextField extends TextField {}
 
 async function setup() {
-    const { element, connect, disconnect, parent } = await fixture<FASTTextField>(
-        "fast-text-field"
-    );
+    const { element, connect, disconnect, parent } = await fixture(FASTTextField());
 
     return { element, connect, disconnect, parent };
 }

--- a/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
@@ -8,7 +8,10 @@ import type { TextField } from "./text-field";
  * The template for the {@link @microsoft/fast-foundation#(TextField:class)} component.
  * @public
  */
-export const TextFieldTemplate: ViewTemplate<TextField> = html`
+export const textFieldTemplate: (context, definition) => ViewTemplate<TextField> = (
+    context,
+    definition
+) => html`
     <template
         class="
             ${x => (x.readOnly ? "readonly" : "")}

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
@@ -1,31 +1,38 @@
 import { expect } from "chai";
-import { customElement, DOM, html } from "@microsoft/fast-element";
+import { DOM } from "@microsoft/fast-element";
 import { fixture } from "../fixture";
-import { createTooltipTemplate, Tooltip } from "./index";
+import { tooltipTemplate as template, Tooltip } from "./index";
 import { TooltipPosition } from "./tooltip";
+import { AnchoredRegion, anchoredRegionTemplate } from '../anchored-region';
 
-@customElement({
-    name: "fast-tooltip",
-    template: createTooltipTemplate("fast"),
+const FASTTooltip = Tooltip.compose({
+    baseName: "tooltip",
+    template
 })
-class FASTTooltip extends Tooltip {}
+
+const FASTAnchoredRegion = AnchoredRegion.compose({
+    baseName: "anchored-region",
+    template: anchoredRegionTemplate
+})
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture(html<HTMLDivElement>`
-        <div>
-            <button id="anchor">anchor</button>
-            <fast-tooltip anchor="anchor" id="tooltip">
-                helpful text
-            </fast-tooltip>
-        </div>
-    `);
+    const { element, connect, disconnect, parent } = await fixture([FASTTooltip(), FASTAnchoredRegion()]);
+    
+    const button = document.createElement("button");
+    button.id = "anchor";
+
+    parent.insertBefore(button, element);
+
+    element.setAttribute("anchor", "anchor");
+    element.id = "tooltip";
+
     return { element, connect, disconnect };
 }
 
 describe("Tooltip", () => {
-    it("should not render the toolip by default", async () => {
+    it("should not render the tooltip by default", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
         tooltip.delay = 0;
 
         await connect();
@@ -37,9 +44,9 @@ describe("Tooltip", () => {
         await disconnect();
     });
 
-    it("should render the toolip when visible is true", async () => {
+    it("should render the tooltip when visible is true", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.visible = true;
         tooltip.delay = 0;
@@ -55,9 +62,9 @@ describe("Tooltip", () => {
         await disconnect();
     });
 
-    it("should not render the toolip when visible is false", async () => {
+    it("should not render the tooltip when visible is false", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.visible = false;
         tooltip.delay = 0;
@@ -73,7 +80,7 @@ describe("Tooltip", () => {
 
     it("should set positioning mode to dynamic by default", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         await connect();
 
@@ -85,7 +92,7 @@ describe("Tooltip", () => {
 
     it("should not set a default position by default", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         await connect();
 
@@ -97,7 +104,7 @@ describe("Tooltip", () => {
 
     it("should set horizontal scaling to match anchor and vertical scaling to match content by default", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         await connect();
 
@@ -111,7 +118,7 @@ describe("Tooltip", () => {
 
     it("should set vertical positioning mode to locked and horizontal to dynamic when position is set to top", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.top;
 
@@ -125,7 +132,7 @@ describe("Tooltip", () => {
 
     it("should set default vertical position to top when position is set to top", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.top;
 
@@ -139,7 +146,7 @@ describe("Tooltip", () => {
 
     it("should set horizontal scaling to match anchor and vertical scaling to match content when position is set to top", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.top;
 
@@ -155,7 +162,7 @@ describe("Tooltip", () => {
 
     it("should set vertical positioning mode to locked and horizontal to dynamic when position is set to bottom", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.bottom;
 
@@ -169,7 +176,7 @@ describe("Tooltip", () => {
 
     it("should set default vertical position to top when position is set to top", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.bottom;
 
@@ -183,7 +190,7 @@ describe("Tooltip", () => {
 
     it("should set horizontal scaling to match anchor and vertical scaling to match content when position is set to bottom", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.bottom;
 
@@ -199,7 +206,7 @@ describe("Tooltip", () => {
 
     it("should set horizontal positioning mode to locked and vertical to dynamic when position is set to left", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.left;
 
@@ -213,7 +220,7 @@ describe("Tooltip", () => {
 
     it("should set default horizontal position to left when position is set to left", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.left;
 
@@ -227,7 +234,7 @@ describe("Tooltip", () => {
 
     it("should set vertical scaling to match anchor and horizontal scaling to match content when position is set to bottom", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.left;
 
@@ -243,7 +250,7 @@ describe("Tooltip", () => {
 
     it("should set horizontal positioning mode to locked and vertical to dynamic when position is set to right", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.right;
 
@@ -257,7 +264,7 @@ describe("Tooltip", () => {
 
     it("should set default horizontal position to right when position is set to right", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.right;
 
@@ -271,7 +278,7 @@ describe("Tooltip", () => {
 
     it("should set vertical scaling to match anchor and horizontal scaling to match content when position is set to rig", async () => {
         const { element, connect, disconnect } = await setup();
-        const tooltip: FASTTooltip = element.querySelector("fast-tooltip") as FASTTooltip;
+        const tooltip: Tooltip = element;
 
         tooltip.position = TooltipPosition.right;
 

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
@@ -1,17 +1,21 @@
 import { html, ref, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
+import { AnchoredRegion } from "../anchored-region";
 import type { Tooltip } from "./tooltip";
 
 /**
  * Creates a template for the {@link @microsoft/fast-foundation#(Tooltip:class)} component using the provided prefix.
  * @public
  */
-export function createTooltipTemplate(prefix: string): ViewTemplate {
+export const tooltipTemplate: (context, definition) => ViewTemplate = (
+    context,
+    definition
+) => {
     return html<Tooltip>`
         ${when(
             x => x.tooltipVisible,
             html<Tooltip>`
-            <${prefix}-anchored-region
+            <${context.tagFor(AnchoredRegion)}
                 fixed-placement="true"
                 vertical-positioning-mode="${x => x.verticalPositioningMode}"
                 vertical-default-position="${x => x.verticalDefaultPosition}"
@@ -27,8 +31,8 @@ export function createTooltipTemplate(prefix: string): ViewTemplate {
                 <div class="tooltip" part="tooltip" role="tooltip">
                     <slot></slot>
                 </div>
-            </${prefix}-anchored-region>
+            </${context.tagFor(AnchoredRegion)}>
         `
         )}
     `;
-}
+};

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -6,6 +6,7 @@ import type {
     AxisScalingMode,
 } from "../anchored-region";
 import { getDirection } from "../utilities/";
+import { FoundationElement } from "../foundation-element";
 import { TooltipPosition } from "./tooltip.options";
 
 export { TooltipPosition };
@@ -15,7 +16,7 @@ export { TooltipPosition };
  *
  * @public
  */
-export class Tooltip extends FASTElement {
+export class Tooltip extends FoundationElement {
     private static DirectionAttributeName: string = "dir";
 
     /**

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.spec.ts
@@ -1,19 +1,15 @@
 import { expect } from "chai";
-import { TreeItem, TreeItemTemplate as template } from "./index";
+import { TreeItem, treeItemTemplate as template } from "./index";
 import { fixture } from "../fixture";
-import { DOM, customElement } from "@microsoft/fast-element";
-import { Button } from "../button";
+import { DOM } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-tree-item",
-    template,
+const FASTTreeItem = TreeItem.compose({
+    baseName: "tree-item",
+    template
 })
-class FASTTreeItem extends TreeItem {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTTreeItem>(
-        "fast-tree-item"
-    );
+    const { element, connect, disconnect } = await fixture(FASTTreeItem());
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -7,7 +7,10 @@ import type { TreeItem } from "./tree-item";
  * The template for the {@link @microsoft/fast-foundation#(TreeItem:class)} component.
  * @public
  */
-export const TreeItemTemplate: ViewTemplate<TreeItem> = html`
+export const treeItemTemplate: (context, definition) => ViewTemplate<TreeItem> = (
+    context,
+    definition
+) => html`
     <template
         role="treeitem"
         slot="${x => (x.isNestedItem() ? "item" : void 0)}"

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -1,10 +1,4 @@
-import {
-    attr,
-    FASTElement,
-    Notifier,
-    observable,
-    Observable,
-} from "@microsoft/fast-element";
+import { attr, Notifier, observable, Observable } from "@microsoft/fast-element";
 import {
     getDisplayedNodes,
     isHTMLElement,
@@ -17,6 +11,7 @@ import {
 import { StartEnd } from "../patterns/start-end";
 import type { TreeView } from "../tree-view";
 import { applyMixins } from "../utilities/apply-mixins";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * check if the item is a tree item
@@ -33,7 +28,7 @@ export function isTreeItemElement(el: Element): el is HTMLElement {
  *
  * @public
  */
-export class TreeItem extends FASTElement {
+export class TreeItem extends FoundationElement {
     /**
      * When true, the control will be appear expanded by user interaction.
      * @public

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.spec.ts
@@ -1,25 +1,21 @@
 import { expect } from "chai";
-import { TreeView, TreeViewTemplate as template } from "./index";
-import { TreeItem, TreeItemTemplate as itemTemplate } from "../tree-item";
+import { TreeView, treeViewTemplate as template } from "./index";
+import { TreeItem, treeItemTemplate as itemTemplate } from "../tree-item";
 import { fixture } from "../fixture";
 import { DOM, customElement } from "@microsoft/fast-element";
 
-@customElement({
-    name: "fast-tree-view",
-    template,
+const FASTTreeView = TreeView.compose({
+    baseName: "tree-view",
+    template
 })
-class FASTTreeView extends TreeView {}
 
-@customElement({
-    name: "fast-tree-item",
-    template: itemTemplate,
+const FASTTreeItem = TreeItem.compose({
+    baseName: "tree-item",
+    template: itemTemplate
 })
-class FASTTreeItem extends TreeItem {}
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture<FASTTreeView>(
-        "fast-tree-view"
-    );
+    const { element, connect, disconnect } = await fixture([FASTTreeView(), FASTTreeItem()]);
 
     return { element, connect, disconnect };
 }

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
@@ -6,7 +6,10 @@ import type { TreeView } from "./tree-view";
  * The template for the {@link @microsoft/fast-foundation#TreeView} component.
  * @public
  */
-export const TreeViewTemplate: ViewTemplate<TreeView> = html`
+export const treeViewTemplate: (context, definition) => ViewTemplate<TreeView> = (
+    context,
+    definition
+) => html`
     <template
         role="tree"
         ${ref("treeView")}

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -1,6 +1,7 @@
-import { attr, DOM, FASTElement, observable } from "@microsoft/fast-element";
-import { isHTMLElement, keyCodeEnd, keyCodeHome } from "@microsoft/fast-web-utilities";
+import { attr, DOM, observable } from "@microsoft/fast-element";
+import { keyCodeEnd, keyCodeHome } from "@microsoft/fast-web-utilities";
 import { isTreeItemElement, TreeItem } from "../tree-item";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * A Tree view Custom HTML Element.
@@ -8,7 +9,7 @@ import { isTreeItemElement, TreeItem } from "../tree-item";
  *
  * @public
  */
-export class TreeView extends FASTElement {
+export class TreeView extends FoundationElement {
     public treeView: HTMLElement;
 
     @attr({ attribute: "render-collapsed-nodes" })

--- a/packages/web-components/fast-foundation/src/utilities/apply-mixins.ts
+++ b/packages/web-components/fast-foundation/src/utilities/apply-mixins.ts
@@ -6,11 +6,13 @@
 export function applyMixins(derivedCtor: any, ...baseCtors: any[]) {
     baseCtors.forEach(baseCtor => {
         Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {
-            Object.defineProperty(
-                derivedCtor.prototype,
-                name,
-                Object.getOwnPropertyDescriptor(baseCtor.prototype, name)!
-            );
+            if (name !== "constructor") {
+                Object.defineProperty(
+                    derivedCtor.prototype,
+                    name,
+                    Object.getOwnPropertyDescriptor(baseCtor.prototype, name)!
+                );
+            }
         });
 
         if (baseCtor.attributes) {

--- a/sites/fast-color-explorer/app/site-footer.tsx
+++ b/sites/fast-color-explorer/app/site-footer.tsx
@@ -5,7 +5,7 @@ import "@microsoft/fast-website/src/app/css/root.css";
 import "@microsoft/fast-website/src/app/css/site-wrapper.css";
 import React from "react";
 
-export { FASTAnchor, SiteNavigation } from "@microsoft/fast-website";
+export { fastAnchor, SiteNavigation } from "@microsoft/fast-website";
 
 export class Footer extends React.Component<{}, {}> {
     render(): React.ReactNode {

--- a/sites/fast-component-explorer/app/site-footer.tsx
+++ b/sites/fast-component-explorer/app/site-footer.tsx
@@ -5,7 +5,7 @@ import "@microsoft/fast-website/src/app/css/root.css";
 import "@microsoft/fast-website/src/app/css/site-wrapper.css";
 import React from "react";
 
-export { FASTAnchor, SiteNavigation } from "@microsoft/fast-website";
+export { fastAnchor, SiteNavigation } from "@microsoft/fast-website";
 
 export class Footer extends React.Component<{}, {}> {
     render(): React.ReactNode {

--- a/sites/fast-component-explorer/app/web-components/index.tsx
+++ b/sites/fast-component-explorer/app/web-components/index.tsx
@@ -2,29 +2,30 @@
 
 import React from "react";
 import {
-    FASTButton,
+    fastButton,
     FASTDesignSystemProvider,
-    FASTOption,
-    FASTSelect,
-    FASTTab,
-    FASTTabPanel,
-    FASTTabs,
+    fastOption,
+    fastSelect,
+    fastTab,
+    fastTabPanel,
+    fastTabs,
 } from "@microsoft/fast-components";
 import { downChevron, upChevron } from "@microsoft/site-utilities";
 import h from "@microsoft/site-utilities/dist/web-components/pragma";
 import { ListboxOption } from "@microsoft/fast-foundation";
+import { Select } from "@microsoft/fast-foundation";
 import { Scenario } from "../fast-components/configs/data.props";
 
 /**
  * Ensure tree-shaking doesn't remove these components from the bundle
  */
-FASTButton;
+fastButton;
 FASTDesignSystemProvider;
-FASTOption;
-FASTSelect;
-FASTTab;
-FASTTabPanel;
-FASTTabs;
+fastOption;
+fastSelect;
+fastTab;
+fastTabPanel;
+fastTabs;
 
 interface RenderDevToolsTabsConfig {
     codeRenderCallback: (e: HTMLElement) => void;
@@ -77,8 +78,8 @@ export function renderScenarioSelect(
             events={{
                 change: (e: React.ChangeEvent): void => {
                     onChangeCallback(
-                        (e.target as FASTSelect).value,
-                        (e.target as FASTSelect).selectedOptions
+                        (e.target as Select).value,
+                        (e.target as Select).selectedOptions
                     );
                 },
             }}

--- a/sites/fast-creator/app/components/project-file-transfer/index.tsx
+++ b/sites/fast-creator/app/components/project-file-transfer/index.tsx
@@ -1,12 +1,12 @@
 /** @jsx h */ /* Note: Set the JSX pragma to the wrapped version of createElement */
 
 import React from "react";
-import { FASTButton } from "@microsoft/fast-components";
+import { fastButton } from "@microsoft/fast-components";
 import { downChevron, upChevron } from "@microsoft/site-utilities";
 import h from "@microsoft/site-utilities/dist/web-components/pragma";
 import { ProjectFileTransferProps } from "./project-file-transfer.props";
 
-FASTButton;
+fastButton;
 
 export const ProjectFileTransfer: React.FC<ProjectFileTransferProps> = ({
     projectFile,

--- a/sites/fast-creator/app/site-footer.tsx
+++ b/sites/fast-creator/app/site-footer.tsx
@@ -5,7 +5,7 @@ import "@microsoft/fast-website/src/app/css/root.css";
 import "@microsoft/fast-website/src/app/css/site-wrapper.css";
 import React from "react";
 
-export { FASTAnchor, SiteNavigation } from "@microsoft/fast-website";
+export { fastAnchor, SiteNavigation } from "@microsoft/fast-website";
 
 export class Footer extends React.Component<{}, {}> {
     render(): React.ReactNode {

--- a/sites/fast-creator/app/web-components/index.tsx
+++ b/sites/fast-creator/app/web-components/index.tsx
@@ -1,16 +1,16 @@
 /** @jsx h */ /* Note: Set the JSX pragma to the wrapped version of createElement */
-
-import React from "react";
-import {
-    FASTButton,
-    FASTSelect,
-    FASTSlider,
-    FASTSliderLabel,
-    FASTTab,
-    FASTTabPanel,
-    FASTTabs,
-} from "@microsoft/fast-components";
+import h from "@microsoft/site-utilities/dist/web-components/pragma";
 import { FASTColorPicker } from "@microsoft/fast-tooling/dist/esm/web-components";
+import {
+    fastButton,
+    fastSelect,
+    fastSlider,
+    fastSliderLabel,
+    fastTab,
+    fastTabPanel,
+    fastTabs,
+} from "@microsoft/fast-components";
+import { Select } from "@microsoft/fast-foundation";
 import { componentCategories, downChevron, upChevron } from "@microsoft/site-utilities";
 import { MessageSystem } from "@microsoft/fast-tooling";
 import {
@@ -19,7 +19,6 @@ import {
     StandardControlPlugin,
 } from "@microsoft/fast-tooling-react";
 
-import h from "@microsoft/site-utilities/dist/web-components/pragma";
 import CSSControl from "@microsoft/fast-tooling-react/dist/form/custom-controls/control.css";
 import { CSSPropertiesDictionary } from "@microsoft/fast-tooling/dist/esm/data-utilities/mapping.mdn-data";
 import { ControlContext } from "@microsoft/fast-tooling-react/dist/form/templates/types";
@@ -31,13 +30,14 @@ import { defaultDevices, Device } from "./devices";
 /**
  * Ensure tree-shaking doesn't remove these components from the bundle
  */
-FASTButton;
 FASTColorPicker;
-FASTSlider;
-FASTSliderLabel;
-FASTTab;
-FASTTabs;
-FASTTabPanel;
+fastSlider;
+fastSliderLabel;
+fastButton;
+fastSelect;
+fastTab;
+fastTabPanel;
+fastTabs;
 
 export function renderDevToolToggle(selected: boolean, onToggleCallback: () => void) {
     return (
@@ -78,7 +78,7 @@ export function renderDeviceSelect(
             selectedIndex={selectedDeviceId}
             events={{
                 change: (e: React.ChangeEvent): void => {
-                    onChangeCallback((e.target as FASTSelect).value);
+                    onChangeCallback((e.target as Select).value);
                 },
             }}
             disabled={disable ? true : null}

--- a/sites/fast-tooling-examples/app/index.ts
+++ b/sites/fast-tooling-examples/app/index.ts
@@ -1,11 +1,11 @@
 import {
-    FASTAnchor,
-    FASTBadge,
+    fastAnchor,
+    fastBadge,
     FASTDesignSystemProvider,
-    FASTDivider,
-    FASTTab,
-    FASTTabPanel,
-    FASTTabs,
+    fastDivider,
+    fastTab,
+    fastTabPanel,
+    fastTabs,
     neutralLayerL1,
     StandardLuminance,
 } from "@microsoft/fast-components";
@@ -18,13 +18,13 @@ import toolingReactGuidance from "./.tmp/tooling-react-guidance";
 const FASTInlineLogo = require("@microsoft/site-utilities/statics/assets/fast-inline-logo.svg");
 
 // prevent tree shaking
-FASTAnchor;
-FASTBadge;
-FASTDivider;
+fastAnchor;
+fastBadge;
+fastDivider;
 FASTDesignSystemProvider;
-FASTTabs;
-FASTTab;
-FASTTabPanel;
+fastTabs;
+fastTab;
+fastTabPanel;
 FASTInlineLogo;
 
 /**

--- a/sites/fast-website/src/app/components/color-swatch/color-swatch.ts
+++ b/sites/fast-website/src/app/components/color-swatch/color-swatch.ts
@@ -1,7 +1,7 @@
-import { attr, observable, FASTElement } from "@microsoft/fast-element";
-import { FASTRadio } from "@microsoft/fast-components";
+import { attr, observable } from "@microsoft/fast-element";
+import { Radio } from "@microsoft/fast-foundation";
 
-export class ColorSwatch extends FASTRadio {
+export class ColorSwatch extends Radio {
     @attr({ attribute: "background-color" })
     public backgroundColor: string = "#F33378";
 

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.ts
@@ -1,13 +1,12 @@
 import { FASTElement, attr, observable } from "@microsoft/fast-element";
 import {
     createColorPalette,
-    FASTSlider,
     FASTDesignSystem,
     fastDesignSystemDefaults,
     StandardLuminance,
     neutralLayerCardContainer,
-    FASTRadioGroup,
 } from "@microsoft/fast-components";
+import { RadioGroup, Slider } from "@microsoft/fast-foundation";
 import {
     ColorHSL,
     ColorRGBA64,
@@ -83,7 +82,7 @@ export class FastFrame extends FASTElement {
     public isMobile: boolean = this.mql.matches;
 
     public accentChangeHandler = (e: CustomEvent): void => {
-        if (e.target instanceof FASTRadioGroup) {
+        if (e.target instanceof RadioGroup) {
             this.accentColor = e.target.value;
             const accentColorHSL = rgbToHSL(parseColorHexRGB(this.accentColor)!);
             this.hue = accentColorHSL.h;
@@ -95,7 +94,7 @@ export class FastFrame extends FASTElement {
     };
 
     public neutralChangeHandler = (e: CustomEvent): void => {
-        if (e.target instanceof FASTRadioGroup) {
+        if (e.target instanceof RadioGroup) {
             const parsedColor = parseColorHexRGB(e.target.value);
             this.neutralPalette = createColorPalette(parsedColor as ColorRGBA64);
             this.updateBackgroundColor();
@@ -103,32 +102,32 @@ export class FastFrame extends FASTElement {
     };
 
     public densityChangeHandler = (e: CustomEvent): void => {
-        if (e.target instanceof FASTSlider) {
+        if (e.target instanceof Slider) {
             this.density = parseInt(e.target.value);
         }
     };
 
     public borderRadiusChangeHandler = (e: CustomEvent): void => {
-        if (e.target instanceof FASTSlider) {
+        if (e.target instanceof Slider) {
             this.borderRadius = parseInt(e.target.value);
         }
     };
 
     public outlineWidthChangeHandler = (e: CustomEvent): void => {
-        if (e.target instanceof FASTSlider) {
+        if (e.target instanceof Slider) {
             this.outlineWidth = parseInt(e.target.value);
         }
     };
 
     public saturationChangeHandler = (e: CustomEvent): void => {
-        if (e.target instanceof FASTSlider) {
+        if (e.target instanceof Slider) {
             this.saturation = parseFloat(e.target.value);
         }
         this.updateAccentColor();
     };
 
     public hueChangeHandler = (e: CustomEvent): void => {
-        if (e.target instanceof FASTSlider) {
+        if (e.target instanceof Slider) {
             this.hue = parseFloat(e.target.value);
         }
         this.updateAccentColor();

--- a/sites/fast-website/src/app/components/navigation-item/navigation-item.template.ts
+++ b/sites/fast-website/src/app/components/navigation-item/navigation-item.template.ts
@@ -1,6 +1,5 @@
 import { html, when } from "@microsoft/fast-element";
 import { NavigationItem } from "./navigation-item";
-export { FASTAnchor } from "@microsoft/fast-components";
 
 export const NavigationItemTemplate = html<NavigationItem>`
     <li>

--- a/sites/site-utilities/src/components/dimension/index.tsx
+++ b/sites/site-utilities/src/components/dimension/index.tsx
@@ -1,13 +1,13 @@
 /** @jsx h */ /* Note: Set the JSX pragma to the wrapped version of createElement */
 
 import React from "react";
-import { FASTButton, FASTNumberField } from "@microsoft/fast-components";
+import { fastButton, fastNumberField } from "@microsoft/fast-components";
 import { RotateGlyph } from "../../icons/rotate";
 import h from "../../web-components/pragma";
 import { DimensionProps } from "./dimension.props";
 
-FASTButton;
-FASTNumberField;
+fastButton;
+fastNumberField;
 
 export const Dimension: React.FC<DimensionProps> = ({
     width,

--- a/sites/site-utilities/src/components/logo/index.tsx
+++ b/sites/site-utilities/src/components/logo/index.tsx
@@ -1,14 +1,14 @@
 /** @jsx h */ /* Note: Set the JSX pragma to the wrapped version of createElement */
 
 import React from "react";
-import { FASTBadge } from "@microsoft/fast-components";
+import { fastBadge } from "@microsoft/fast-components";
 import h from "../../web-components/pragma";
 import { LogoProps } from "./logo.props";
 
 /**
  * Ensure tree-shaking doesn't remove these components from the bundle
  */
-FASTBadge;
+fastBadge;
 
 const backgroundStyle = {
     display: "flex",


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR changes the APIs related to ComponentPresentation so that internally we can fast-path the scenario where only one presentation configuration exists for a given tag name.

## 👩‍💻 Reviewer Notes

Noteworthy changes were made in `component-presentation.ts`. The rest was fix-up to use the new APIs.

## 📑 Test Plan

Existing tests should continue to function after the optimization.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

In the future we could look to expand the `ComponentPresentation` such that it could also add/remove behaviors, in addition to templates and styles. We could also look at enabling the presentation object to store a WeakSet of components that use it so that all components with a presentation could be dynamically updated at once. These are just a few ideas for enhancements we could make. Currently, there aren't particular needs for this functionality.