### PR TITLE
feat: encapsulate and optimize ComponentPresentation resolution

### DIFF
--- a/change/@microsoft-fast-foundation-deafb619-c242-42d8-a45d-7b2cbca0327e.json
+++ b/change/@microsoft-fast-foundation-deafb619-c242-42d8-a45d-7b2cbca0327e.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat: encapsulate and optimize ComponentPresentation resolution",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -378,7 +378,8 @@ export interface ComponentPresentation {
 
 // @alpha
 export const ComponentPresentation: Readonly<{
-    keyFrom(tagName: string): InterfaceSymbol<ComponentPresentation>;
+    define(tagName: string, presentation: ComponentPresentation, container: Container): void;
+    forTag(tagName: string, element: HTMLElement): ComponentPresentation;
 }>;
 
 // @public
@@ -963,6 +964,8 @@ export interface ElementDefinitionContext {
     readonly container: Container;
     // (undocumented)
     defineElement(definition?: ContextualElementDefinition): void;
+    // (undocumented)
+    definePresentation(presentation: ComponentPresentation): void;
     // (undocumented)
     readonly name: string;
     // (undocumented)

--- a/packages/web-components/fast-foundation/src/design-system/design-system.ts
+++ b/packages/web-components/fast-foundation/src/design-system/design-system.ts
@@ -4,6 +4,7 @@ import {
     PartialFASTElementDefinition,
 } from "@microsoft/fast-element";
 import { Container, DI, InterfaceSymbol, Registration } from "../di/di";
+import { ComponentPresentation } from "./component-presentation";
 
 /**
  * Defines an element within the context of a design system.
@@ -21,6 +22,7 @@ export interface ElementDefinitionContext {
     readonly container: Container;
     readonly willDefine: boolean;
     defineElement(definition?: ContextualElementDefinition): void;
+    definePresentation(presentation: ComponentPresentation): void;
     tagFor(type: Constructable): string;
 }
 
@@ -223,6 +225,10 @@ class ElementDefinitionEntry implements ElementDefinitionContext {
         public readonly callback: ElementDefinitionCallback,
         public readonly willDefine: boolean
     ) {}
+
+    definePresentation(presentation: ComponentPresentation) {
+        ComponentPresentation.define(this.name, presentation, this.container);
+    }
 
     defineElement(definition: ContextualElementDefinition) {
         this.definition = new FASTElementDefinition(this.type, {

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
@@ -46,11 +46,10 @@ async function setup(tag: string) {
     `;
     const builtinStyles = css``;
 
-    container.register(
-        Registration.instance(
-            ComponentPresentation.keyFrom(tag),
-            new DefaultComponentPresentation(builtinTemplate, builtinStyles)
-        )
+    ComponentPresentation.define(
+        tag,
+        new DefaultComponentPresentation(builtinTemplate, builtinStyles),
+        container
     );
 
     return { element, connect, disconnect, builtinTemplate, builtinStyles };
@@ -133,12 +132,10 @@ describe("FoundationElement", () => {
 
             const host = document.createElement("div");
             DesignSystem.getOrCreate(host).register(myElement());
-            const container = DI.getOrCreateDOMContainer(host);
 
             const fullName = `fast-${baseName}`;
-            const presentation = container.get<DefaultComponentPresentation>(
-                ComponentPresentation.keyFrom(fullName)
-            );
+            const presentation = ComponentPresentation
+                .forTag(fullName, host) as DefaultComponentPresentation;
 
             expect(presentation.styles).to.equal(styles);
             expect(presentation.template).to.equal(template);
@@ -173,11 +170,9 @@ describe("FoundationElement", () => {
 
             const host = document.createElement("div");
             DesignSystem.getOrCreate(host).register(myElement());
-            const container = DI.getOrCreateDOMContainer(host);
 
-            const presentation = container.get<DefaultComponentPresentation>(
-                ComponentPresentation.keyFrom(fullName)
-            );
+            const presentation = ComponentPresentation
+                .forTag(fullName, host) as DefaultComponentPresentation;
 
             expect(presentation.styles).to.equal(styles);
             expect(presentation.template).to.equal(template);
@@ -204,19 +199,14 @@ describe("FoundationElement", () => {
             const host = document.createElement("div");
             DesignSystem.getOrCreate(host)
                 .register(myElement(overrides));
-            const container = DI.getOrCreateDOMContainer(host);
 
             const originalFullName = `fast-${originalName}`;
             const overrideFullName = `my-${overrideName}`;
 
-            expect(
-                container.has(ComponentPresentation.keyFrom(originalFullName), false)
-            ).to.equal(false);
             expect(customElements.get(originalFullName)).to.be.undefined;
 
-            const presentation = container.get<DefaultComponentPresentation>(
-                ComponentPresentation.keyFrom(overrideFullName)
-            );
+            const presentation = ComponentPresentation
+                .forTag(overrideFullName, host) as DefaultComponentPresentation;
 
             expect(presentation.styles).to.equal(overrides.styles);
             expect(presentation.template).to.equal(overrides.template);

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
@@ -11,7 +11,7 @@ import {
     DesignSystemRegistrationContext,
     ElementDefinitionContext,
 } from "../design-system";
-import { Container, Registration, Registry } from "../di";
+import type { Container, Registry } from "../di";
 
 type LazyFoundationOption<T, K extends FoundationElementDefinition> = (
     context: ElementDefinitionContext,
@@ -85,8 +85,6 @@ export type OverrideFoundationElementDefinition<
  * @alpha
  */
 export class FoundationElement extends FASTElement {
-    @Container
-    private container: Container;
     private _presentation: ComponentPresentation | null = null;
 
     /**
@@ -95,9 +93,7 @@ export class FoundationElement extends FASTElement {
      */
     protected get $presentation(): ComponentPresentation {
         if (this._presentation === null) {
-            this._presentation = this.container.get(
-                ComponentPresentation.keyFrom(this.tagName)
-            );
+            this._presentation = ComponentPresentation.forTag(this.tagName, this);
         }
 
         return this._presentation;
@@ -211,9 +207,7 @@ export class FoundationElementRegistry<
                 resolveOption(definition.styles, x, definition)
             );
 
-            x.container.register(
-                Registration.instance(ComponentPresentation.keyFrom(x.name), presentation)
-            );
+            x.definePresentation(presentation);
 
             x.defineElement({
                 elementOptions: resolveOption(definition.elementOptions, x, definition),


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR changes the APIs related to ComponentPresentation so that internally we can fast-path the scenario where only one presentation configuration exists for a given tag name.

## 👩‍💻 Reviewer Notes

Noteworthy changes were made in `component-presentation.ts`. The rest was fix-up to use the new APIs.

## 📑 Test Plan

Existing tests should continue to function after the optimization.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

In the future we could look to expand the `ComponentPresentation` such that it could also add/remove behaviors, in addition to templates and styles. We could also look at enabling the presentation object to store a WeakSet of components that use it so that all components with a presentation could be dynamically updated at once. These are just a few ideas for enhancements we could make. Currently, there aren't particular needs for this functionality.