### PR TITLE
fix an incorrect definition name which for default slots should be an empty string

### DIFF
--- a/change/@microsoft-fast-tooling-8262e4bb-e41d-4cda-8269-09137e23b3e4.json
+++ b/change/@microsoft-fast-tooling-8262e4bb-e41d-4cda-8269-09137e23b3e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix an incorrect definition name which for default slots should be an empty string",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling/src/definitions/native/svg.definition.ts
+++ b/packages/tooling/fast-tooling/src/definitions/native/svg.definition.ts
@@ -52,7 +52,7 @@ export const svgDefinition: WebComponentDefinition = {
             ],
             slots: [
                 {
-                    name: "Default slot",
+                    name: "",
                     description: "The default slot",
                     title: "Default slot",
                 },


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
A `name` slot in the description corresponds to the name of the slot. As such a default slot has an empty string, this has been corrected for a definition being used in the Component Explorer site.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

Run `yarn start` in the component explorer site after building the project to check for runtime errors.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->