### PR TITLE
feat: improve design token performance

### DIFF
--- a/change/@microsoft-fast-foundation-dfc8ac08-2fb7-4ea0-a824-6db5b72ce23c.json
+++ b/change/@microsoft-fast-foundation-dfc8ac08-2fb7-4ea0-a824-6db5b72ce23c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Addresses significant performance issues with DesignToken implmentation. This change removes several alpha APIs on DesignToken.",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2196,7 +2196,7 @@ export function whitespaceFilter(value: Node, index: number, array: Node[]): boo
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/design-token/design-token.d.ts:54:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
+// dist/dts/design-token/design-token.d.ts:46:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
 // dist/dts/di/di.d.ts:204:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -828,9 +828,6 @@ export interface DesignToken<T extends {
     // (undocumented)
     readonly name: string;
     setValueFor(element: HTMLElement, value: DesignTokenValue<T> | DesignToken<T>): void;
-    // Warning: (ae-forgotten-export) The symbol "DesignTokenSubscriber" needs to be exported by the entry point index.d.ts
-    subscribe(subscriber: DesignTokenSubscriber): void;
-    unsubscribe(subscriber: DesignTokenSubscriber): void;
     withDefault(value: DesignTokenValue<T> | DesignToken<T>): this;
 }
 
@@ -2199,7 +2196,7 @@ export function whitespaceFilter(value: Node, index: number, array: Node[]): boo
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/design-token/design-token.d.ts:59:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
+// dist/dts/design-token/design-token.d.ts:49:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
 // dist/dts/di/di.d.ts:204:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2196,7 +2196,7 @@ export function whitespaceFilter(value: Node, index: number, array: Node[]): boo
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/design-token/design-token.d.ts:49:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
+// dist/dts/design-token/design-token.d.ts:46:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
 // dist/dts/di/di.d.ts:204:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -822,14 +822,11 @@ export const DesignSystemRegistrationContext: InterfaceSymbol<DesignSystemRegist
 export interface DesignToken<T extends {
     createCSS?(): string;
 }> extends CSSDirective {
-    addCustomPropertyFor(element: HTMLElement & FASTElement): this;
     readonly cssCustomProperty: string;
     deleteValueFor(element: HTMLElement): this;
     getValueFor(element: HTMLElement): StaticDesignTokenValue<T>;
     // (undocumented)
     readonly name: string;
-    // (undocumented)
-    removeCustomPropertyFor(element: HTMLElement & FASTElement): this;
     setValueFor(element: HTMLElement, value: DesignTokenValue<T> | DesignToken<T>): void;
     withDefault(value: DesignTokenValue<T> | DesignToken<T>): this;
 }
@@ -2199,7 +2196,7 @@ export function whitespaceFilter(value: Node, index: number, array: Node[]): boo
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/design-token/design-token.d.ts:56:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
+// dist/dts/design-token/design-token.d.ts:54:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
 // dist/dts/di/di.d.ts:204:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -828,6 +828,9 @@ export interface DesignToken<T extends {
     // (undocumented)
     readonly name: string;
     setValueFor(element: HTMLElement, value: DesignTokenValue<T> | DesignToken<T>): void;
+    // Warning: (ae-forgotten-export) The symbol "DesignTokenSubscriber" needs to be exported by the entry point index.d.ts
+    subscribe(subscriber: DesignTokenSubscriber): void;
+    unsubscribe(subscriber: DesignTokenSubscriber): void;
     withDefault(value: DesignTokenValue<T> | DesignToken<T>): this;
 }
 
@@ -2196,7 +2199,7 @@ export function whitespaceFilter(value: Node, index: number, array: Node[]): boo
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/design-token/design-token.d.ts:46:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
+// dist/dts/design-token/design-token.d.ts:59:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
 // dist/dts/di/di.d.ts:204:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-foundation/src/design-token/README.md
+++ b/packages/web-components/fast-foundation/src/design-token/README.md
@@ -4,7 +4,7 @@
 The FAST Design Token implementation is designed to provide first-class support for Design Tokens and make setting, getting, and using Design Tokens simple.
 
 ## What is a Design Token
-A Design Token is a semantic, named variable used to describe a Design System. They often describe design concepts like typography, color, sizes, UI spacing, etc. FAST encourages checking out [https://github.com/design-tokens/community-group#design-tokens](the Design Tokens Community Group) for more information on Design Tokens themselves.
+A Design Token is a semantic, named variable used to describe a Design System. They often describe design concepts like typography, color, sizes, UI spacing, etc. FAST encourages checking out [the Design Tokens Community Group](https://github.com/design-tokens/community-group#design-tokens) for more information on Design Tokens themselves.
 
 ## Using Design Tokens in FAST
 This usage guide walks through creating and using a Design Token *background-color*, which is represented in code as a hexadecimal color string.
@@ -54,23 +54,7 @@ A default value can be set for a token, so that the default value is returned fr
 fillColor.withDefault("#FFFFFF");
 ```
 ### 6. Emit a token to a CSS Custom Property
-A Design Token can be made available in CSS through CSS custom properties. The custom property value will be set to the token's value for the supplied target element.
-
-```ts
-fillColor.addCustomPropertyFor(descendent); // --fill-color: #FFFFFF;
-```
-
-If the value of the token *changes* for the target element, the CSS custom property will be updated to the new value:
-
-```ts
-fillColor.setValueFor(descendent, "#F7F7F7"); // --fill-color: #F7F7F7;
-```
-
-The CSS custom property can also be removed through a parallel method:
-
-```ts
-fillColor.removeCustomPropertyFor(descendent);
-```
+DesignToken emits a token to CSS automatically whenever the value is set for an element. In the case when a DesignToken is assigned a (derived value)[#derived-design-token-values], the CSS custom property will also be emitted when any dependent tokens change.
 
 #### Values with a 'createCSS' method
 It is sometimes useful to be able to set a token to a complex object but still use that value in CSS. If a DesignToken is assigned a value with a `createCSS` method on it, the product of that method will be used when emitting to a CSS custom property instead of the Design Token value itself:
@@ -92,7 +76,6 @@ const value = {
     }
 }
 fancyFillColor.setValueFor(descendent, value)
-fancyFillColor.addCustomPropertyFor(descendent); // --fancy-fill-color: rgb(255, 0, 0);
 ```
 
 ## Using Design Tokens in CSS

--- a/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
+++ b/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
@@ -46,13 +46,13 @@ class CustomPropertyManagerImpl {
         token: { cssCustomProperty: string },
         value: any
     ): void {
-        if (isFastElement(element)) {
-            element.$fastController.addStyles(this.getElementStyles(token, value));
-        } else {
-            DOM.queueUpdate(() =>
-                element.style.setProperty(token.cssCustomProperty, value)
-            );
-        }
+        // if (isFastElement(element)) {
+        //     element.$fastController.addStyles(this.getElementStyles(token, value));
+        // } else {
+        //DOM.queueUpdate(() =>
+        element.style.setProperty(token.cssCustomProperty, value);
+        // );
+        //}
     }
 
     public removeFrom(
@@ -60,11 +60,13 @@ class CustomPropertyManagerImpl {
         token: { cssCustomProperty: string },
         value: any
     ): void {
-        if (isFastElement(element)) {
-            element.$fastController.removeStyles(this.getElementStyles(token, value));
-        } else if (element.style.getPropertyValue(token.cssCustomProperty) === value) {
-            DOM.queueUpdate(() => element.style.removeProperty(token.cssCustomProperty));
-        }
+        // if (isFastElement(element)) {
+        //     element.$fastController.removeStyles(this.getElementStyles(token, value));
+        // } else if (element.style.getPropertyValue(token.cssCustomProperty) === value) {
+        // DOM.queueUpdate(() =>
+        element.style.removeProperty(token.cssCustomProperty);
+        // );
+        // }
     }
 }
 

--- a/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
+++ b/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
@@ -46,23 +46,25 @@ class CustomPropertyManagerImpl {
         token: { cssCustomProperty: string },
         value: any
     ): void {
-        // if (isFastElement(element)) {
-        //     element.$fastController.addStyles(this.getElementStyles(token, value));
-        // } else {
-        //DOM.queueUpdate(() =>
-        element.style.setProperty(token.cssCustomProperty, value);
-        // );
-        //}
+        if (isFastElement(element)) {
+            element.$fastController.addStyles(this.getElementStyles(token, value));
+        } else {
+            DOM.queueUpdate(() =>
+                element.style.setProperty(token.cssCustomProperty, value)
+            );
+        }
     }
 
-    public removeFrom(element: HTMLElement, token: { cssCustomProperty: string }): void {
-        // if (isFastElement(element)) {
-        //     element.$fastController.removeStyles(this.getElementStyles(token, value));
-        // } else if (element.style.getPropertyValue(token.cssCustomProperty) === value) {
-        // DOM.queueUpdate(() =>
-        element.style.removeProperty(token.cssCustomProperty);
-        // );
-        // }
+    public removeFrom(
+        element: HTMLElement,
+        token: { cssCustomProperty: string },
+        value: any
+    ): void {
+        if (isFastElement(element)) {
+            element.$fastController.removeStyles(this.getElementStyles(token, value));
+        } else if (element.style.getPropertyValue(token.cssCustomProperty) === value) {
+            DOM.queueUpdate(() => element.style.removeProperty(token.cssCustomProperty));
+        }
     }
 }
 

--- a/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
+++ b/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
@@ -55,11 +55,7 @@ class CustomPropertyManagerImpl {
         //}
     }
 
-    public removeFrom(
-        element: HTMLElement,
-        token: { cssCustomProperty: string },
-        value: any
-    ): void {
+    public removeFrom(element: HTMLElement, token: { cssCustomProperty: string }): void {
         // if (isFastElement(element)) {
         //     element.$fastController.removeStyles(this.getElementStyles(token, value));
         // } else if (element.style.getPropertyValue(token.cssCustomProperty) === value) {

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -344,10 +344,7 @@ describe("A DesignToken", () => {
 
             expect(token.getValueFor(target)).to.equal(12)
             
-            // TODO: should it throw here? It throws because writing the CSS custom property
-            // requires inspecting the value, which can't resolve (see expect below). Seems a bit
-            // odd that just deleting a value would throw though.
-            expect(() => token.deleteValueFor(target)).to.throw();
+            token.deleteValueFor(target);
  
             expect(() => token.getValueFor(target)).to.throw();
             removeElement(target)
@@ -377,10 +374,7 @@ describe("A DesignToken", () => {
 
             expect(token.getValueFor(target)).to.equal(12)
 
-            // TODO: should it throw here? It throws because writing the CSS custom property
-            // requires inspecting the value, which can't resolve (see expect below). Seems a bit
-            // odd that just deleting a value would throw though.
-            expect(() => token.deleteValueFor(target)).to.throw();
+            token.deleteValueFor(target);
 
             expect(() => token.getValueFor(target)).to.throw();
             removeElement(target)

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -281,7 +281,6 @@ describe("A DesignToken", () => {
             tokenA.setValueFor(target, 7);
             tokenB.setValueFor(parent, (target: HTMLElement & FASTElement) => tokenA.getValueFor(target) * 2);
 
-            DOM.nextUpdate();
 
             expect(window.getComputedStyle(parent).getPropertyValue(tokenB.cssCustomProperty)).to.equal('12');
             expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal('14');

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -336,7 +336,7 @@ describe("A DesignToken", () => {
         });
     })
     describe("deleting simple values", () => {
-        xit("should throw when deleted and no parent token value is set", () => {
+        it("should throw when deleted and no parent token value is set", () => {
             const target = addElement();
             const token = DesignToken.create<number>("test");
 
@@ -344,7 +344,10 @@ describe("A DesignToken", () => {
 
             expect(token.getValueFor(target)).to.equal(12)
             
-            token.deleteValueFor(target);
+            // TODO: should it throw here? It throws because writing the CSS custom property
+            // requires inspecting the value, which can't resolve (see expect below). Seems a bit
+            // odd that just deleting a value would throw though.
+            expect(() => token.deleteValueFor(target)).to.throw();
  
             expect(() => token.getValueFor(target)).to.throw();
             removeElement(target)

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -421,16 +421,6 @@ describe("A DesignToken", () => {
     });
 
     describe("when used as a CSSDirective", () => {
-        it("should throw if no value has been set for the token", () => {
-            const target = addElement();
-            const token = DesignToken.create<number>("test");
-            const styles = css`:host{width: calc(${token} * 1px);}`
-
-
-            expect(() => target.$fastController.addStyles(styles)).to.throw()
-
-            removeElement(target)
-        })
         it("should set a CSS custom property for the element when the token is set for the element", () => {
             const target = addElement();
             const token = DesignToken.create<number>("test");

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -245,9 +245,24 @@ describe("A DesignToken", () => {
             const tokenB = DesignToken.create<number>("B");
 
             tokenA.setValueFor(parent, 6);
+            tokenB.setValueFor(parent, (target: HTMLElement & FASTElement) => tokenA.getValueFor(target) * 2);
+            tokenA.setValueFor(target, 7);
+            
+
+            expect(window.getComputedStyle(parent).getPropertyValue(tokenB.cssCustomProperty)).to.equal('12');
+            expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal('14');
+            removeElement(target);
+        });
+
+        it("should set a CSS custom property equal to the resolved value for an both elements for which a dependent token is set when setting a derived token value", () => {
+            const parent = addElement();
+            const target = addElement(parent);
+            const tokenA = DesignToken.create<number>("A");
+            const tokenB = DesignToken.create<number>("B");
+
+            tokenA.setValueFor(parent, 6);
             tokenA.setValueFor(target, 7);
             tokenB.setValueFor(parent, (target: HTMLElement & FASTElement) => tokenA.getValueFor(target) * 2);
-            
 
             expect(window.getComputedStyle(parent).getPropertyValue(tokenB.cssCustomProperty)).to.equal('12');
             expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal('14');

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -1,12 +1,12 @@
 
-import { css, DOM, FASTElement, Observable } from "@microsoft/fast-element";
+import { css, DOM, FASTElement, html, Observable } from "@microsoft/fast-element";
 import { expect } from "chai";
 import { DesignSystem } from "../design-system";
 import { FoundationElement } from "../foundation-element";
 import { DesignToken } from "./design-token";
 
 new DesignSystem().register(
-    FoundationElement.compose({ type: class extends FoundationElement { }, baseName: "custom-element" })()
+    FoundationElement.compose({ type: class extends FoundationElement { }, template: html`<slot></slot>`, baseName: "custom-element" })()
 ).applyTo(document.body)
 
 function addElement(parent = document.body): FASTElement & HTMLElement {
@@ -90,6 +90,8 @@ describe("A DesignToken", () => {
             parentB.appendChild(target);
 
             expect(token.getValueFor(target)).to.equal(14);
+
+            removeElement(parentA, parentB);
         });
 
         it("should support getting and setting falsey values", () => {
@@ -104,8 +106,17 @@ describe("A DesignToken", () => {
                 } else {
                     expect(token.getValueFor(target)).to.equal(value);
                 }
-            })
-        })
+            });
+
+            removeElement(target);
+        });
+
+        it("should set the CSS custom property for the element", () => {
+            const target = addElement();
+            const token = DesignToken.create<number>("test");
+            token.setValueFor(target, 12);
+            expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal('12');
+        });
     });
     describe("getting and setting derived values", () => {
         it("should get the return value of a derived value", () => {
@@ -234,7 +245,7 @@ describe("A DesignToken", () => {
             const tokenA = DesignToken.create<number>("token-a");
             const tokenB = DesignToken.create<number>("token-b");
             const target = addElement();
-            
+
             tokenA.setValueFor(target, 12);
             tokenB.setValueFor(target, tokenA);
 
@@ -255,9 +266,9 @@ describe("A DesignToken", () => {
             token.setValueFor(target, 12);
 
             expect(token.getValueFor(target)).to.equal(12)
-
+            
             token.deleteValueFor(target);
-
+ 
             expect(() => token.getValueFor(target)).to.throw();
             removeElement(target)
         });
@@ -327,299 +338,8 @@ describe("A DesignToken", () => {
         })
     });
 
-    describe("setting CSS Custom Properties", () => {
-        describe("to static token values", () => {
-            it("should emit the value set for an element when emitted to the same element", () => {
-                const target = addElement();
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(target, 12)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-                removeElement(target);
-            });
-
-            it("should emit the value set for an element ancestor", () => {
-                const ancestor = addElement()
-                const target = addElement(ancestor);
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(ancestor, 12)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-                removeElement(ancestor);
-            });
-
-            it("should emit the value set for an nearest element ancestor", () => {
-                const grandparent = addElement();
-                const parent = addElement(grandparent);
-                const target = addElement(parent);
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(grandparent, 12)
-                token.setValueFor(parent, 14)
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("14");
-                removeElement(grandparent);
-            });
-
-            it("should emit the value set for the element when a value is set for both the element and an ancestor", () => {
-                const ancestor = addElement()
-                const target = addElement(ancestor);
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(ancestor, 12)
-                token.setValueFor(target, 14)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("14");
-                removeElement(ancestor);
-            });
-
-            it("should update the CSS custom property value for an element when the value changes for that element", async () => {
-                const target = addElement();
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(target, 12)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-
-                token.setValueFor(target, 14);
-                await DOM.nextUpdate()
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("14");
-                removeElement(target);
-            });
-
-            it("should update the CSS custom property value for an element when the value changes for an ancestor node", () => {
-                const parent = addElement()
-                const target = addElement(parent);
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(parent, 12)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-
-                token.setValueFor(parent, 14);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("14");
-                removeElement(parent);
-            });
-
-        })
-
-        describe("to dynamic token values", () => {
-            it("should emit the value set for an element when emitted to the same element", () => {
-                const target = addElement();
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(target, () => 12)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-                removeElement(target);
-            });
-
-            it("should emit the value set for an element ancestor", () => {
-                const ancestor = addElement()
-                const target = addElement(ancestor);
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(ancestor, () => 12)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-                removeElement(ancestor);
-            });
-
-            it("should emit the value set for an nearest element ancestor", () => {
-                const grandparent = addElement();
-                const parent = addElement(grandparent);
-                const target = addElement(parent);
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(grandparent, () => 12)
-                token.setValueFor(parent, () => 14)
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("14");
-                removeElement(grandparent);
-            });
-
-            it("should emit the value set for the element when a value is set for both the element and an ancestor", () => {
-                const ancestor = addElement()
-                const target = addElement(ancestor);
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(ancestor, () => 12)
-                token.setValueFor(target, () => 14)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("14");
-                removeElement(ancestor);
-            });
-
-            it("should update the CSS custom property value for an element when the value changes for that element", async () => {
-                const target = addElement();
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(target, () => 12)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-
-                token.setValueFor(target, () => 14);
-                await DOM.nextUpdate()
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("14");
-                removeElement(target);
-            });
-
-            it("should update the CSS custom property value for an element when the value changes for an ancestor node", () => {
-                const parent = addElement()
-                const target = addElement(parent);
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(parent, () => 12)
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-
-                token.setValueFor(parent, () => 14);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("14");
-                removeElement(parent);
-            });
-
-            it("should update the CSS custom property when a value's dependent design token", async () => {
-                const target = addElement();
-                const dep = DesignToken.create<number>("dependency");
-                const token = DesignToken.create<number>("test");
-                dep.setValueFor(target, 6)
-                token.setValueFor(target, (element) => dep.getValueFor(element) * 2);
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-
-                dep.setValueFor(target, 7);
-
-                await DOM.nextUpdate();
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("14");
-            });
-        });
-
-        describe("to DesignToken values", () => {
-            it("should emit the CSS custom property with a value of the token's value", () => {
-                const tokenA = DesignToken.create<number>("token-a");
-                const tokenB = DesignToken.create<number>("token-b");
-                const target = addElement()
-
-                tokenA.setValueFor(target, 12);
-                tokenB.setValueFor(target, tokenA);
-
-                tokenB.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal("12");
-                removeElement(target);
-            });
-            it("should update the CSS custom property when the value of the token changes", async () => {
-                const tokenA = DesignToken.create<number>("token-a");
-                const tokenB = DesignToken.create<number>("token-b");
-                const target = addElement()
-
-                tokenA.setValueFor(target, 12);
-                tokenB.setValueFor(target, tokenA);
-
-                tokenB.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal("12");
-
-                tokenA.setValueFor(target, 14);
-                await DOM.nextUpdate()
-
-                expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal("14");
-
-                removeElement(target);
-            });
-
-            it("should update the CSS custom property of a downstream element when the token changes", async () => {
-                const tokenA = DesignToken.create<number>("token-a");
-                const tokenB = DesignToken.create<number>("token-b");
-                const parent = addElement()
-                const target = addElement(parent);
-
-                tokenA.setValueFor(parent, 12);
-                tokenB.setValueFor(parent, tokenA);
-
-                tokenB.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal("12");
-
-                tokenA.setValueFor(parent, 14);
-
-                await DOM.nextUpdate();
-                expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal("14");
-
-                removeElement(parent);
-            })
-        });
-
-        describe("to values with a 'createCSS' method", () => {
-            it("should emit the product of 'createCSS' to CSS", () => {
-                const target = addElement();
-                const token = DesignToken.create<{ createCSS: () => string}>("test");
-                token.setValueFor(target, { createCSS: () => "12"})
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-                removeElement(target);
-            })
-        })
-    });
-
-    describe("removing CSS Custom Properties", () => {
-        it("should remove the custom property from the element", async () => {
-                const target = addElement();
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(target, 12);
-
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-
-                token.removeCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("");
-
-                removeElement(target);
-        });
-
-        it("should remove the custom property from the element on the first invocation if the property has been added multiple times", () => {
-                const target = addElement();
-                const token = DesignToken.create<number>("test");
-                token.setValueFor(target, 12);
-
-                token.addCustomPropertyFor(target);
-                token.addCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("12");
-
-                token.removeCustomPropertyFor(target);
-
-                expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal("");
-
-                removeElement(target);
-        });
-    });
-
     describe("when used as a CSSDirective", () => {
-        it("should throw if now value has been set for the token", () => {
+        it("should throw if no value has been set for the token", () => {
             const target = addElement();
             const token = DesignToken.create<number>("test");
             const styles = css`:host{width: calc(${token} * 1px);}`

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -238,6 +238,22 @@ describe("A DesignToken", () => {
             removeElement(target);
         });
 
+        it("should update a CSS custom property to the resolved value of a derived token value with a dependent token when the dependent token changes", async () => {
+            const target = addElement();
+            const tokenA = DesignToken.create<number>("A");
+            const tokenB = DesignToken.create<number>("B");
+
+            tokenA.setValueFor(target, 6);
+            tokenB.setValueFor(target, (target: HTMLElement & FASTElement) => tokenA.getValueFor(target) * 2);
+            expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal('12');
+
+            tokenA.setValueFor(target, 7);
+            await DOM.nextUpdate();
+            expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal('14');
+
+            removeElement(target);
+        });
+
         it("should set a CSS custom property equal to the resolved value for an element of a derived token value with a dependent token", () => {
             const parent = addElement();
             const target = addElement(parent);

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -213,6 +213,47 @@ describe("A DesignToken", () => {
             expect(tokenB.getValueFor(target)).to.equal(14);
             removeElement(ancestor);
         });
+
+        it("should set a CSS custom property equal to the resolved value of a derived token value", () => {
+            const target = addElement();
+            const token = DesignToken.create<number>("test");
+
+            token.setValueFor(target, (target: HTMLElement & FASTElement) => 12);
+
+            expect(window.getComputedStyle(target).getPropertyValue(token.cssCustomProperty)).to.equal('12');
+
+            removeElement(target);
+
+        });
+        it("should set a CSS custom property equal to the resolved value of a derived token value with a dependent token", () => {
+            const target = addElement();
+            const tokenA = DesignToken.create<number>("A");
+            const tokenB = DesignToken.create<number>("B");
+
+            tokenA.setValueFor(target, 6);
+            tokenB.setValueFor(target, (target: HTMLElement & FASTElement) => tokenA.getValueFor(target) * 2);
+
+
+            expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal('12');
+            removeElement(target);
+        });
+
+        it("should set a CSS custom property equal to the resolved value for an element of a derived token value with a dependent token", () => {
+            const parent = addElement();
+            const target = addElement(parent);
+            const tokenA = DesignToken.create<number>("A");
+            const tokenB = DesignToken.create<number>("B");
+
+            tokenA.setValueFor(parent, 6);
+            tokenA.setValueFor(target, 7);
+            tokenB.setValueFor(parent, (target: HTMLElement & FASTElement) => tokenA.getValueFor(target) * 2);
+            
+
+            expect(window.getComputedStyle(parent).getPropertyValue(tokenB.cssCustomProperty)).to.equal('12');
+            expect(window.getComputedStyle(target).getPropertyValue(tokenB.cssCustomProperty)).to.equal('14');
+            removeElement(target);
+        });
+
         it("should support getting and setting falsey values", () => {
             const target = addElement();
             [false, null, 0, "", NaN].forEach(value => {
@@ -226,7 +267,8 @@ describe("A DesignToken", () => {
                     expect(token.getValueFor(target)).to.equal(value);
                 }
             })
-        })
+        });
+
     });
     describe("getting and setting a token value", () => {
         it("should retrieve the value of the token it was set to", () => {

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -352,15 +352,14 @@ class DesignTokenNode<T> {
 
         if (this.target !== document.body && this.target.parentNode) {
             const container = DI.getOrCreateDOMContainer(this.target.parentElement!);
+
             // TODO: use Container.tryGet() when added by https://github.com/microsoft/fast/issues/4582
-            try {
+            if (container.has(DesignTokenNode.channel(this.token), true)) {
                 return container.get(DesignTokenNode.channel(this.token));
-            } catch (e) {
-                return DesignTokenNode.for(this.token, defaultElement);
             }
-        } else {
-            return DesignTokenNode.for(this.token, defaultElement);
         }
+
+        return DesignTokenNode.for(this.token, defaultElement);
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -55,6 +55,14 @@ export interface DesignToken<T extends { createCSS?(): string }> extends CSSDire
     withDefault(value: DesignTokenValue<T> | DesignToken<T>): this;
 }
 
+interface DesignTokenSubscriber {
+    handleChange(
+        token: DesignToken<any>,
+        element: HTMLElement,
+        operation: "set" | "delete"
+    ): void;
+}
+
 /**
  * Implementation of {@link (DesignToken:interface)}
  */

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -413,9 +413,9 @@ class DesignTokenNode<T extends { createCSS?(): string }> {
         this.bindCSSCustomProperty();
 
         if (this.bindingObserver) {
-            const dependencies = this.bindingObserver.dependencies();
+            const records = this.bindingObserver.records();
 
-            for (const dep of dependencies) {
+            for (const dep of records) {
                 if (
                     dep.propertySource instanceof DesignTokenNode &&
                     dep.propertySource.token instanceof DesignTokenImpl

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -1,5 +1,4 @@
 import {
-    Behavior,
     BindingObserver,
     CSSDirective,
     defaultExecutionContext,
@@ -7,7 +6,6 @@ import {
     observable,
     Observable,
 } from "@microsoft/fast-element";
-import { result } from "lodash";
 import { DI, InterfaceSymbol, Registration } from "../di/di";
 import { CustomPropertyManager } from "./custom-property-manager";
 import type {
@@ -56,18 +54,6 @@ export interface DesignToken<T extends { createCSS?(): string }> extends CSSDire
      */
     withDefault(value: DesignTokenValue<T> | DesignToken<T>): this;
 }
-
-interface Disposable {
-    dispose(): void;
-}
-
-export type DesignTokenSubscriber = {
-    handleChange: (
-        token: DesignToken<any>,
-        element: HTMLElement,
-        operation: "set" | "delete"
-    ) => void;
-};
 
 /**
  * Implementation of {@link (DesignToken:interface)}

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -254,6 +254,7 @@ class DesignTokenNode<T extends { createCSS?(): string }> {
 
         const handler = {
             handleChange: (source: Binding<HTMLElement>) => {
+                this.setCSSCustomProperty();
                 Observable.getNotifier(this).notify("value");
             },
         };
@@ -266,6 +267,14 @@ class DesignTokenNode<T extends { createCSS?(): string }> {
             this.bindingObserver.disconnect();
             this.bindingObserver = undefined;
         }
+    }
+
+    private setCSSCustomProperty() {
+        CustomPropertyManager.addTo(
+            this.target,
+            this.token,
+            this.resolveCSSValue(this.value)
+        );
     }
 
     public static for<T>(token: DesignToken<T>, target: HTMLElement) {
@@ -369,11 +378,7 @@ class DesignTokenNode<T extends { createCSS?(): string }> {
 
         this._rawValue = value;
 
-        CustomPropertyManager.addTo(
-            this.target,
-            this.token,
-            this.resolveCSSValue(this.value)
-        );
+        this.setCSSCustomProperty();
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -142,6 +142,7 @@ class DesignTokenBehavior<T> implements Behavior {
         }
     }
 
+    /* eslint-disable-next-line */
     unbind(target: HTMLElement & FASTElement) {}
 }
 
@@ -202,7 +203,12 @@ class DesignTokenNode<T extends { createCSS?(): string }> {
             if (current.rawValue !== undefined) {
                 const { rawValue } = current;
                 if (DesignTokenNode.isDerivedTokenValue(rawValue)) {
-                    this.setupBindingObserver(rawValue);
+                    if (
+                        !this.bindingObserver ||
+                        this.bindingObserver.source !== rawValue
+                    ) {
+                        this.setupBindingObserver(rawValue);
+                    }
 
                     return this.bindingObserver!.observe(
                         this.target,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR addresses significant performance issues uncovered with the initial implementation of `DesignTokens`, specifically removing the behavior that using a `DesignToken` as a `CSSDirective` causes value resolution for *each token instance in the stylesheet*. It removes the `addCustomPropertyFor()` and `removeCustomPropertyFor()` methods from `DesignToken`.

Instead, CSS custom properties are written for an element in two cases:
1. A value is *set* for an element via `DesignToken.setValueFor()`
2. A token that some other `DesignToken` *depends* on is set via `DesignToken.setValueFor()`

Setting CSS custom properties in these two cases ensures that all a DesignToken can always be used as a CSS directive, and using the CSSDirective simply interpolates the CSS variable string (no value resolution).

A few things notable:
1. Because using a `DesignToken` is an inert action, we don't really know *where* tokens are being used in CSS. To guarantee any usage anywhere is accurate, we must write *all* CSS custom properties that depend on another token value whenever that value is set. For instance, all neutral recipes depend on the `neutralPalette` `DesignToken`. If `neutralPalette` is set for some arbitrary node, *all neutral recipes are emitted to CSS custom properties for that node*. This is an area we can do some performance work on; it could be more performant to do a *little* work when a `DesignToken` is used in a stylesheet and only write out the token when we know that the CSS custom property is actually being used.
2. The decision-tree to fully reconcile when and where CSS custom properties should exist is complex and not fully implemented. Tokens are set for arbitrary elements and dependency graphs for derived token values can and do change throughout the tree. Token values can have *many* dependencies, making it hard to track exactly which dependent token is causing a dependee to write out it's CSS custom property (and thus when to *remove* the CSS custom property). This implementation largely avoids tearing down CSS custom properties for elements after they've been required at some point in time, instead relying on the value resolution mechanism to ensure the *value* of the CSS custom property is always correct (even if it is no longer necessary). All this really means is that we can get into a case where a CSS custom property is set to the same value for a parent/child element pair when the CSS custom property only existing on the parent would suffice. In practice I don't think this will happen that often (It can happen if a dependent token is set and then deleted for a node).

**Todo:** 
- [ ] Implement mechanism to sync the defaultElement with the DesignSystem's element context.
- [ ] Add ability for a token to opt out of CSS custom property creation (neutralPalette, accentPalette)
- [x] Set up inspection for `rawValue` so that we can determine if the node for which a dependent token is set is still the same as the token value that has the dependency.
- [x] Ensure we only explicitly write the CSS custom property once for a node, and otherwise rely on `value` change handlers to update the property.
- [ ] Catch when a token being set is using the same token to derive the value. When that happens, use the parent element.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->