### PR TITLE
docs(integrations): fix adpater typo

### DIFF
--- a/packages/web-components/fast-foundation/docs/integrations/aurelia.md
+++ b/packages/web-components/fast-foundation/docs/integrations/aurelia.md
@@ -101,7 +101,7 @@ fast-card > fast-button {
 
 ### Enabling two-way bindings
 
-Aurelia knows by default how to listen for changes in native elements. Now we need to teach it how to listen for changes in FAST elements. You can do so by [extending its templating syntax](https://docs.aurelia.io/examples/integration/ms-fast). We suggest to create an adpater file and then register it in your `main.ts`. Here is how:
+Aurelia knows by default how to listen for changes in native elements. Now we need to teach it how to listen for changes in FAST elements. You can do so by [extending its templating syntax](https://docs.aurelia.io/examples/integration/ms-fast). We suggest to create an adapter file and then register it in your `main.ts`. Here is how:
 
 First create a `src/aurelia-fast-adapter.ts` file and copy the following code:
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

While browsing the docs I noticed a small typo, which this PR fixes.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

n/a

## 📑 Test Plan

n/a

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

n/a