### PR TITLE
update the html render tests to reliably await message system messages before proceeding

### DIFF
--- a/change/@microsoft-fast-tooling-160defd8-c1aa-443b-8365-6a4d23883291.json
+++ b/change/@microsoft-fast-tooling-160defd8-c1aa-443b-8365-6a4d23883291.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update the html render tests to reliably await message system messages before proceeding",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This resolves an issue with async tests would be skipped because they did not await the message system messages and would then cause coverage errors intermittently.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
It's difficult to test this as it fails intermittently but it would appear that this solution works after running it several times.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
This affects the html render tests in the `@microsoft/fast-tooling` package.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.