### PR TITLE
fix DesignToken typing to work with declared types

### DIFF
--- a/change/@microsoft-fast-foundation-5acf04f9-e080-4f74-bc81-8db1c89758c9.json
+++ b/change/@microsoft-fast-foundation-5acf04f9-e080-4f74-bc81-8db1c89758c9.json
@@ -1,0 +1,6 @@
+{
+  "type": "patch",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -819,7 +819,7 @@ export interface DesignSystemRegistrationContext {
 export const DesignSystemRegistrationContext: InterfaceSymbol<DesignSystemRegistrationContext>;
 
 // @alpha
-export interface DesignToken<T extends {
+export interface DesignToken<T extends string | number | boolean | BigInteger | null | Array<any> | symbol | {
     createCSS?(): string;
 }> extends CSSDirective {
     readonly cssCustomProperty: string;

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -22,6 +22,16 @@ function removeElement(...els: HTMLElement[]) {
 }
 
 describe("A DesignToken", () => {
+    it("should support declared types", () => {
+        const number: DesignToken<number> = DesignToken.create<number>('number');
+        const nil: DesignToken<null> = DesignToken.create<null>('number');
+        const bool: DesignToken<boolean> = DesignToken.create<boolean>("bool");
+        const arr: DesignToken<number[]> = DesignToken.create<number[]>("arr");
+        const obj: DesignToken<{}> = DesignToken.create<{}>("obj");
+        class Foo {}
+        const _class: DesignToken<Foo> = DesignToken.create<Foo>("class");
+        const sym: DesignToken<symbol> = DesignToken.create<symbol>("symbol")
+    })
     it("should have a createCSS() method that returns a string with the name property formatted as a CSS variable", () => {
         expect(DesignToken.create<number>("implicit").createCSS()).to.equal("var(--implicit)");
     });

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -20,7 +20,17 @@ const defaultElement = document.body;
  * Describes a DesignToken instance.
  * @alpha
  */
-export interface DesignToken<T extends { createCSS?(): string }> extends CSSDirective {
+export interface DesignToken<
+    T extends
+        | string
+        | number
+        | boolean
+        | BigInteger
+        | null
+        | Array<any>
+        | symbol
+        | { createCSS?(): string }
+> extends CSSDirective {
     readonly name: string;
 
     /**


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
For some reason the generic type signature for `DesignToken` worked fine with implicit types, but did not work for declared types or types emitted to .d.ts files.

Example:
```ts
// Compiles fine
const a = DesignToken.create<number>("a"); // a is a DesignToken<number>

// Does not compile
const b: DesignToken<number> = DesignToken.create<number>("b"); 
```

This PR adds a long-hand type signature to include all acceptable types in the generic type parameter. It also adds some typing tests to guard against regression.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->