### PR TITLE
update the html render tests to reliably await message system messages before proceeding

### DIFF
--- a/change/@microsoft-fast-tooling-160defd8-c1aa-443b-8365-6a4d23883291.json
+++ b/change/@microsoft-fast-tooling-160defd8-c1aa-443b-8365-6a4d23883291.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update the html render tests to reliably await message system messages before proceeding",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.spec.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.spec.ts
@@ -1,7 +1,7 @@
 import { DOM } from "@microsoft/fast-element";
 import { fixture } from "@microsoft/fast-foundation/dist/esm/fixture";
 import { expect } from "chai";
-import { MessageSystem } from "../../message-system";
+import { MessageSystem, MessageSystemType } from "../../message-system";
 import dataDictionaryConfig from "../../__test__/html-render/data-dictionary-config";
 import schemaDictionary from "../../__test__/html-render/schema-dictionary";
 import { ActivityType } from "../html-render-layer/html-render-layer";
@@ -20,33 +20,79 @@ async function setup() {
     >("fast-tooling-html-render-layer-navigation");
     const message = new MessageSystem({
         webWorker: fastMessageSystemWorker,
-        dataDictionary: dataDictionaryConfig as any,
-        schemaDictionary,
     });
+
+    let hasBeenCalled = false;
+    let intervalInstance;
+
+    async function messageSystemHasBeenCalled() {
+        return new Promise(resolve => {
+            // Continue checking to see if a message has been set
+            intervalInstance = window.setInterval(() => {
+                if (hasBeenCalled) {
+                    resolve(true);
+                    hasBeenCalled = false;
+                    window.clearInterval(intervalInstance);
+                }
+            }, 5);
+        });
+    }
+
+    const messageSystemCallback = {
+        onMessage: e => {
+            // This function is used for monitoring to ensure
+            // the initialization (or other message) is called
+            // and provided in the return to await any further messages
+            hasBeenCalled = true;
+        },
+    };
+
+    message.add(messageSystemCallback);
+
+    /**
+     * Give this a set timeout so initialize can always happen after
+     * component connect has been checked
+     */
+    window.setTimeout(() => {
+        message.postMessage({
+            type: MessageSystemType.initialize,
+            dataDictionary: dataDictionaryConfig as any,
+            schemaDictionary,
+        });
+    }, 20);
+
     element.messageSystem = message;
-    return { element, connect, disconnect, parent };
+    return { element, connect, disconnect, messageSystemHasBeenCalled, parent };
 }
 
 describe("HTMLRenderLayerNavgation", () => {
     it("should handle click / clear", async () => {
-        const { element, connect, disconnect, parent } = await setup();
+        const {
+            element,
+            connect,
+            messageSystemHasBeenCalled,
+            disconnect,
+            parent,
+        } = await setup();
 
         await connect();
+        await messageSystemHasBeenCalled();
+        await DOM.nextUpdate();
 
         const div = document.createElement("div");
         parent.appendChild(div);
 
-        element.elementActivity(ActivityType.click, "Foo", div);
+        element.elementActivity(ActivityType.click, "root", div);
         await DOM.nextUpdate();
 
         const select = element.shadowRoot?.querySelector(".click-layer");
         expect(select.classList.contains("active")).to.equal(true);
 
         let pill = element.shadowRoot?.querySelector(".click-layer .pill");
-        expect(pill.innerHTML).to.equal("Untitled");
+        expect(pill.innerHTML).to.equal(schemaDictionary["div"].title);
 
         element.dataDictionary = null;
-        element.elementActivity(ActivityType.click, "Foo", div);
+        element.elementActivity(ActivityType.click, "root", div);
         await DOM.nextUpdate();
 
         pill = element.shadowRoot?.querySelector(".click-layer .pill");
@@ -65,24 +111,32 @@ describe("HTMLRenderLayerNavgation", () => {
     });
 
     it("should handle hover / blur", async () => {
-        const { element, connect, disconnect, parent } = await setup();
+        const {
+            element,
+            connect,
+            messageSystemHasBeenCalled,
+            disconnect,
+            parent,
+        } = await setup();
 
         await connect();
+        await messageSystemHasBeenCalled();
+        await DOM.nextUpdate();
 
         const div = document.createElement("div");
         parent.appendChild(div);
 
-        element.elementActivity(ActivityType.hover, "Foo", div);
+        element.elementActivity(ActivityType.hover, "root", div);
         await DOM.nextUpdate();
 
         const hover = element.shadowRoot?.querySelector(".hover-layer");
         expect(hover.classList.contains("active")).to.equal(true);
 
         let pill = element.shadowRoot?.querySelector(".hover-layer .pill");
-        expect(pill.innerHTML).to.equal("Untitled");
+        expect(pill.innerHTML).to.equal(schemaDictionary["div"].title);
 
         element.dataDictionary = null;
-        element.elementActivity(ActivityType.hover, "Foo", div);
+        element.elementActivity(ActivityType.hover, "root", div);
         await DOM.nextUpdate();
 
         pill = element.shadowRoot?.querySelector(".hover-layer .pill");

--- a/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
@@ -46,10 +46,10 @@ export class HTMLRenderLayerNavgation extends HTMLRenderLayer {
         return new OverylayPosition(pos[0].top, pos[0].left, pos[0].width, pos[0].height);
     }
 
-    private handleSelect(datadictionaryId: string, elementRef: HTMLElement) {
+    private handleSelect(dataDictionaryId: string, elementRef: HTMLElement) {
         const title =
             this.schemaDictionary && this.dataDictionary
-                ? this.schemaDictionary[this.dataDictionary[0][datadictionaryId].schemaId]
+                ? this.schemaDictionary[this.dataDictionary[0][dataDictionaryId].schemaId]
                       .title
                 : null;
         this.clickPosition = this.GetPositionFromElement(elementRef);
@@ -58,10 +58,10 @@ export class HTMLRenderLayerNavgation extends HTMLRenderLayer {
         this.hoverLayerActive = false;
     }
 
-    private handleHighlight(datadictionaryId: string, elementRef: HTMLElement) {
+    private handleHighlight(dataDictionaryId: string, elementRef: HTMLElement) {
         const title =
             this.schemaDictionary && this.dataDictionary
-                ? this.schemaDictionary[this.dataDictionary[0][datadictionaryId].schemaId]
+                ? this.schemaDictionary[this.dataDictionary[0][dataDictionaryId].schemaId]
                       .title
                 : null;
         this.hoverPosition = this.GetPositionFromElement(elementRef);
@@ -80,18 +80,18 @@ export class HTMLRenderLayerNavgation extends HTMLRenderLayer {
 
     public elementActivity(
         activityType: ActivityType,
-        datadictionaryId: string,
+        dataDictionaryId: string,
         elementRef: HTMLElement
     ) {
         switch (activityType) {
             case ActivityType.hover:
-                this.handleHighlight(datadictionaryId, elementRef);
+                this.handleHighlight(dataDictionaryId, elementRef);
                 break;
             case ActivityType.blur:
                 this.handleUnHighlight();
                 break;
             case ActivityType.click:
-                this.handleSelect(datadictionaryId, elementRef);
+                this.handleSelect(dataDictionaryId, elementRef);
                 break;
             case ActivityType.clear:
                 this.handleClear();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This resolves an issue with async tests would be skipped because they did not await the message system messages and would then cause coverage errors intermittently.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
It's difficult to test this as it fails intermittently but it would appear that this solution works after running it several times.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
This affects the html render tests in the `@microsoft/fast-tooling` package.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.