### PR TITLE
add API support for setting default slotted content as part of component composition

### DIFF
--- a/change/@microsoft-fast-components-ce7be667-0b03-4a67-8c20-bead419ac671.json
+++ b/change/@microsoft-fast-components-ce7be667-0b03-4a67-8c20-bead419ac671.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add support for default slotted content for components with visual indicators",
+  "packageName": "@microsoft/fast-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-b7335824-d180-4904-abbb-63fad5c468af.json
+++ b/change/@microsoft-fast-foundation-b7335824-d180-4904-abbb-63fad5c468af.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "add API support for setting default slotted content as part of component composition",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -9,8 +9,11 @@ import { AccordionItemOptions } from '@microsoft/fast-foundation';
 import { Anchor as Anchor_2 } from '@microsoft/fast-foundation';
 import { AnchoredRegion } from '@microsoft/fast-foundation';
 import { Badge } from '@microsoft/fast-foundation';
+<<<<<<< HEAD
 import { BaseProgress } from '@microsoft/fast-foundation';
 import { Behavior } from '@microsoft/fast-element';
+=======
+>>>>>>> update progress
 import { Breadcrumb } from '@microsoft/fast-foundation';
 import { BreadcrumbItemOptions } from '@microsoft/fast-foundation';
 import { Button as Button_2 } from '@microsoft/fast-foundation';
@@ -35,6 +38,8 @@ import { Menu } from '@microsoft/fast-foundation';
 import { MenuItemOptions } from '@microsoft/fast-foundation';
 import { NumberField as NumberField_2 } from '@microsoft/fast-foundation';
 import { NumberFieldOptions } from '@microsoft/fast-foundation';
+import { ProgressOptions } from '@microsoft/fast-foundation';
+import { ProgressRingOptions } from '@microsoft/fast-foundation';
 import { Radio } from '@microsoft/fast-foundation';
 import { RadioGroup } from '@microsoft/fast-foundation';
 import { Select } from '@microsoft/fast-foundation';
@@ -753,26 +758,10 @@ export const fastOption: (overrideDefinition?: import("@microsoft/fast-foundatio
 }, typeof ListboxOption>;
 
 // @public
-export const fastProgress: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, defintion: any) => import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, defintion: any) => import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof BaseProgress>;
+export const fastProgress: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<ProgressOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<ProgressOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
-export const fastProgressRing: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
-    styles: (context: any, defintion: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BaseProgress, any>;
-    styles: (context: any, defintion: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof BaseProgress>;
+export const fastProgressRing: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<ProgressRingOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<ProgressRingOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
 export const fastRadio: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -32,7 +32,7 @@ import { HorizontalScroll as HorizontalScroll_2 } from '@microsoft/fast-foundati
 import { Listbox } from '@microsoft/fast-foundation';
 import { ListboxOption } from '@microsoft/fast-foundation';
 import { Menu } from '@microsoft/fast-foundation';
-import { MenuItem } from '@microsoft/fast-foundation';
+import { MenuItemOptions } from '@microsoft/fast-foundation';
 import { NumberField as NumberField_2 } from '@microsoft/fast-foundation';
 import { Radio } from '@microsoft/fast-foundation';
 import { RadioGroup } from '@microsoft/fast-foundation';
@@ -697,15 +697,7 @@ export const fastDivider: (overrideDefinition?: import("@microsoft/fast-foundati
 }, typeof Divider>;
 
 // @public
-export const fastFlipper: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Flipper, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Flipper, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof Flipper>;
+export const fastFlipper: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<FlipperOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<FlipperOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "fastHorizontalScroll" is marked as @public, but its signature references "HorizontalScroll" which is marked as @internal
 //
@@ -743,15 +735,7 @@ export const fastMenu: (overrideDefinition?: import("@microsoft/fast-foundation"
 }, typeof Menu>;
 
 // @public
-export const fastMenuItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<MenuItem, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<MenuItem, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof MenuItem>;
+export const fastMenuItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<MenuItemOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<MenuItemOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "fastNumberField" is marked as @public, but its signature references "NumberField" which is marked as @internal
 //

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -9,11 +9,7 @@ import { AccordionItemOptions } from '@microsoft/fast-foundation';
 import { Anchor as Anchor_2 } from '@microsoft/fast-foundation';
 import { AnchoredRegion } from '@microsoft/fast-foundation';
 import { Badge } from '@microsoft/fast-foundation';
-<<<<<<< HEAD
-import { BaseProgress } from '@microsoft/fast-foundation';
 import { Behavior } from '@microsoft/fast-element';
-=======
->>>>>>> update progress
 import { Breadcrumb } from '@microsoft/fast-foundation';
 import { BreadcrumbItemOptions } from '@microsoft/fast-foundation';
 import { Button as Button_2 } from '@microsoft/fast-foundation';
@@ -30,7 +26,7 @@ import { Disclosure as Disclosure_2 } from '@microsoft/fast-foundation';
 import { Divider } from '@microsoft/fast-foundation';
 import { ElementStyles } from '@microsoft/fast-element';
 import { FASTElement } from '@microsoft/fast-element';
-import { Flipper } from '@microsoft/fast-foundation';
+import { FlipperOptions } from '@microsoft/fast-foundation';
 import { HorizontalScroll as HorizontalScroll_2 } from '@microsoft/fast-foundation';
 import { Listbox } from '@microsoft/fast-foundation';
 import { ListboxOption } from '@microsoft/fast-foundation';

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -333,10 +333,14 @@ export const fastAccordionItem: (overrideDefinition?: import("@microsoft/fast-fo
     baseName: string;
     template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<AccordionItem, any>;
     styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    collapsedIcon: import("@microsoft/fast-element").ViewTemplate<any, any>;
+    expandedIcon: import("@microsoft/fast-element").ViewTemplate<any, any>;
 }> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
     baseName: string;
     template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<AccordionItem, any>;
     styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    collapsedIcon: import("@microsoft/fast-element").ViewTemplate<any, any>;
+    expandedIcon: import("@microsoft/fast-element").ViewTemplate<any, any>;
 }, typeof AccordionItem>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "fastAnchor" is marked as @public, but its signature references "Anchor" which is marked as @internal
@@ -396,6 +400,7 @@ export const fastBreadcrumbItem: (overrideDefinition?: import("@microsoft/fast-f
     baseName: string;
     template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BreadcrumbItem, any>;
     styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    separator: string;
     shadowOptions: {
         delegatesFocus: true;
     };
@@ -403,6 +408,7 @@ export const fastBreadcrumbItem: (overrideDefinition?: import("@microsoft/fast-f
     baseName: string;
     template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BreadcrumbItem, any>;
     styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
+    separator: string;
     shadowOptions: {
         delegatesFocus: true;
     };

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -53,7 +53,7 @@ import { Tabs } from '@microsoft/fast-foundation';
 import { TextArea as TextArea_2 } from '@microsoft/fast-foundation';
 import { TextField as TextField_2 } from '@microsoft/fast-foundation';
 import { Tooltip } from '@microsoft/fast-foundation';
-import { TreeItem } from '@microsoft/fast-foundation';
+import { TreeItemOptions } from '@microsoft/fast-foundation';
 import { TreeView } from '@microsoft/fast-foundation';
 
 // Warning: (ae-forgotten-export) The symbol "SwatchFamilyResolver" needs to be exported by the entry point index.d.ts
@@ -893,15 +893,7 @@ export const fastTooltip: (overrideDefinition?: import("@microsoft/fast-foundati
 }, typeof Tooltip>;
 
 // @public
-export const fastTreeItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TreeItem, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<TreeItem, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof TreeItem>;
+export const fastTreeItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<TreeItemOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<TreeItemOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
 export const fastTreeView: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -40,13 +40,13 @@ import { NumberField as NumberField_2 } from '@microsoft/fast-foundation';
 import { NumberFieldOptions } from '@microsoft/fast-foundation';
 import { ProgressOptions } from '@microsoft/fast-foundation';
 import { ProgressRingOptions } from '@microsoft/fast-foundation';
-import { Radio } from '@microsoft/fast-foundation';
 import { RadioGroup } from '@microsoft/fast-foundation';
-import { Select } from '@microsoft/fast-foundation';
+import { RadioOptions } from '@microsoft/fast-foundation';
+import { SelectOptions } from '@microsoft/fast-foundation';
 import { Skeleton } from '@microsoft/fast-foundation';
-import { Slider } from '@microsoft/fast-foundation';
 import { SliderLabel as SliderLabel_2 } from '@microsoft/fast-foundation';
-import { Switch } from '@microsoft/fast-foundation';
+import { SliderOptions } from '@microsoft/fast-foundation';
+import { SwitchOptions } from '@microsoft/fast-foundation';
 import { Tab } from '@microsoft/fast-foundation';
 import { TabPanel } from '@microsoft/fast-foundation';
 import { Tabs } from '@microsoft/fast-foundation';
@@ -764,15 +764,7 @@ export const fastProgress: (overrideDefinition?: import("@microsoft/fast-foundat
 export const fastProgressRing: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<ProgressRingOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<ProgressRingOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
-export const fastRadio: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Radio, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Radio, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof Radio>;
+export const fastRadio: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<RadioOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<RadioOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
 export const fastRadioGroup: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
@@ -786,15 +778,7 @@ export const fastRadioGroup: (overrideDefinition?: import("@microsoft/fast-found
 }, typeof RadioGroup>;
 
 // @public
-export const fastSelect: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Select, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Select, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof Select>;
+export const fastSelect: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<SelectOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<SelectOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
 export const fastSkeleton: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
@@ -808,15 +792,7 @@ export const fastSkeleton: (overrideDefinition?: import("@microsoft/fast-foundat
 }, typeof Skeleton>;
 
 // @public
-export const fastSlider: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Slider, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Slider, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof Slider>;
+export const fastSlider: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<SliderOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<SliderOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "fastSliderLabel" is marked as @public, but its signature references "SliderLabel" which is marked as @internal
 //
@@ -832,15 +808,7 @@ export const fastSliderLabel: (overrideDefinition?: import("@microsoft/fast-foun
 }, typeof SliderLabel>;
 
 // @public
-export const fastSwitch: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Switch, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Switch, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof Switch>;
+export const fastSwitch: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<SwitchOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<SwitchOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
 export const fastTab: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -34,6 +34,7 @@ import { ListboxOption } from '@microsoft/fast-foundation';
 import { Menu } from '@microsoft/fast-foundation';
 import { MenuItemOptions } from '@microsoft/fast-foundation';
 import { NumberField as NumberField_2 } from '@microsoft/fast-foundation';
+import { NumberFieldOptions } from '@microsoft/fast-foundation';
 import { Radio } from '@microsoft/fast-foundation';
 import { RadioGroup } from '@microsoft/fast-foundation';
 import { Select } from '@microsoft/fast-foundation';
@@ -737,24 +738,8 @@ export const fastMenu: (overrideDefinition?: import("@microsoft/fast-foundation"
 // @public
 export const fastMenuItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<MenuItemOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<MenuItemOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "fastNumberField" is marked as @public, but its signature references "NumberField" which is marked as @internal
-//
 // @public
-export const fastNumberField: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<NumberField_2, any>;
-    shadowOptions: {
-        delegatesFocus: true;
-    };
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<NumberField_2, any>;
-    shadowOptions: {
-        delegatesFocus: true;
-    };
-}, typeof NumberField>;
+export const fastNumberField: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<NumberFieldOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<NumberFieldOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
 export const fastOption: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -5,16 +5,16 @@
 ```ts
 
 import { Accordion } from '@microsoft/fast-foundation';
-import { AccordionItem } from '@microsoft/fast-foundation';
+import { AccordionItemOptions } from '@microsoft/fast-foundation';
 import { Anchor as Anchor_2 } from '@microsoft/fast-foundation';
 import { AnchoredRegion } from '@microsoft/fast-foundation';
 import { Badge } from '@microsoft/fast-foundation';
 import { BaseProgress } from '@microsoft/fast-foundation';
 import { Behavior } from '@microsoft/fast-element';
 import { Breadcrumb } from '@microsoft/fast-foundation';
-import { BreadcrumbItem } from '@microsoft/fast-foundation';
+import { BreadcrumbItemOptions } from '@microsoft/fast-foundation';
 import { Button as Button_2 } from '@microsoft/fast-foundation';
-import { Checkbox } from '@microsoft/fast-foundation';
+import { CheckboxOptions } from '@microsoft/fast-foundation';
 import { ColorRGBA64 } from '@microsoft/fast-colors';
 import { Combobox } from '@microsoft/fast-foundation';
 import { DataGrid } from '@microsoft/fast-foundation';
@@ -329,19 +329,7 @@ export const fastAccordion: (overrideDefinition?: import("@microsoft/fast-founda
 }, typeof Accordion>;
 
 // @public
-export const fastAccordionItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<AccordionItem, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-    collapsedIcon: import("@microsoft/fast-element").ViewTemplate<any, any>;
-    expandedIcon: import("@microsoft/fast-element").ViewTemplate<any, any>;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<AccordionItem, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-    collapsedIcon: import("@microsoft/fast-element").ViewTemplate<any, any>;
-    expandedIcon: import("@microsoft/fast-element").ViewTemplate<any, any>;
-}, typeof AccordionItem>;
+export const fastAccordionItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<AccordionItemOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<AccordionItemOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "fastAnchor" is marked as @public, but its signature references "Anchor" which is marked as @internal
 //
@@ -396,23 +384,7 @@ export const fastBreadcrumb: (overrideDefinition?: import("@microsoft/fast-found
 }, typeof Breadcrumb>;
 
 // @public
-export const fastBreadcrumbItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BreadcrumbItem, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-    separator: string;
-    shadowOptions: {
-        delegatesFocus: true;
-    };
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<BreadcrumbItem, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-    separator: string;
-    shadowOptions: {
-        delegatesFocus: true;
-    };
-}, typeof BreadcrumbItem>;
+export const fastBreadcrumbItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<BreadcrumbItemOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<BreadcrumbItemOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "fastButton" is marked as @public, but its signature references "Button" which is marked as @internal
 //
@@ -447,15 +419,7 @@ export class FASTCard extends DesignSystemProvider implements Pick<FASTDesignSys
 }
 
 // @public
-export const fastCheckbox: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Checkbox, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Checkbox, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof Checkbox>;
+export const fastCheckbox: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<CheckboxOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<CheckboxOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
 export const fastCombobox: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -16,7 +16,7 @@ import { BreadcrumbItemOptions } from '@microsoft/fast-foundation';
 import { Button as Button_2 } from '@microsoft/fast-foundation';
 import { CheckboxOptions } from '@microsoft/fast-foundation';
 import { ColorRGBA64 } from '@microsoft/fast-colors';
-import { Combobox } from '@microsoft/fast-foundation';
+import { ComboboxOptions } from '@microsoft/fast-foundation';
 import { DataGrid } from '@microsoft/fast-foundation';
 import { DataGridCell } from '@microsoft/fast-foundation';
 import { DataGridRow } from '@microsoft/fast-foundation';
@@ -422,15 +422,7 @@ export class FASTCard extends DesignSystemProvider implements Pick<FASTDesignSys
 export const fastCheckbox: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<CheckboxOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<CheckboxOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
-export const fastCombobox: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Combobox, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
-    baseName: string;
-    template: (context: any, definition: any) => import("@microsoft/fast-element").ViewTemplate<Combobox, any>;
-    styles: (context: any, definition: any) => import("@microsoft/fast-element").ElementStyles;
-}, typeof Combobox>;
+export const fastCombobox: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<ComboboxOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<ComboboxOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
 export const fastDataGrid: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{

--- a/packages/web-components/fast-components/src/accordion-item/index.ts
+++ b/packages/web-components/fast-components/src/accordion-item/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     AccordionItem,
     AccordionItemOptions,
@@ -19,7 +18,7 @@ export const fastAccordionItem = AccordionItem.compose<AccordionItemOptions>({
     baseName: "accordion-item",
     template,
     styles,
-    collapsedIcon: html`
+    collapsedIcon: `
         <svg
             width="20"
             height="20"
@@ -33,7 +32,7 @@ export const fastAccordionItem = AccordionItem.compose<AccordionItemOptions>({
             />
         </svg>
     `,
-    expandedIcon: html`
+    expandedIcon: `
         <svg
             width="20"
             height="20"

--- a/packages/web-components/fast-components/src/accordion-item/index.ts
+++ b/packages/web-components/fast-components/src/accordion-item/index.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import {
     AccordionItem,
     accordionItemTemplate as template,
@@ -17,6 +18,34 @@ export const fastAccordionItem = AccordionItem.compose({
     baseName: "accordion-item",
     template,
     styles,
+    collapsedIcon: html`
+        <svg
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M16.22 3H3.78a.78.78 0 00-.78.78v12.44c0 .43.35.78.78.78h12.44c.43 0 .78-.35.78-.78V3.78a.78.78 0 00-.78-.78zM3.78 2h12.44C17.2 2 18 2.8 18 3.78v12.44c0 .98-.8 1.78-1.78 1.78H3.78C2.8 18 2 17.2 2 16.22V3.78C2 2.8 2.8 2 3.78 2zM11 9h3v2h-3v3H9v-3H6V9h3V6h2v3z"
+            />
+        </svg>
+    `,
+    expandedIcon: html`
+        <svg
+            width="20"
+            height="20"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M3.78 3h12.44c.43 0 .78.35.78.78v12.44c0 .43-.35.78-.78.78H3.78a.78.78 0 01-.78-.78V3.78c0-.43.35-.78.78-.78zm12.44-1H3.78C2.8 2 2 2.8 2 3.78v12.44C2 17.2 2.8 18 3.78 18h12.44c.98 0 1.78-.8 1.78-1.78V3.78C18 2.8 17.2 2 16.22 2zM14 9H6v2h8V9z"
+            />
+        </svg>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/accordion-item/index.ts
+++ b/packages/web-components/fast-components/src/accordion-item/index.ts
@@ -1,6 +1,7 @@
 import { html } from "@microsoft/fast-element";
 import {
     AccordionItem,
+    AccordionItemOptions,
     accordionItemTemplate as template,
 } from "@microsoft/fast-foundation";
 import { accordionItemStyles as styles } from "./accordion-item.styles";
@@ -14,7 +15,7 @@ import { accordionItemStyles as styles } from "./accordion-item.styles";
  * @remarks
  * HTML Element: \<fast-accordion-item\>
  */
-export const fastAccordionItem = AccordionItem.compose({
+export const fastAccordionItem = AccordionItem.compose<AccordionItemOptions>({
     baseName: "accordion-item",
     template,
     styles,

--- a/packages/web-components/fast-components/src/breadcrumb-item/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/index.ts
@@ -1,5 +1,6 @@
 import {
     BreadcrumbItem,
+    BreadcrumbItemOptions,
     breadcrumbItemTemplate as template,
 } from "@microsoft/fast-foundation";
 import { breadcrumbItemStyles as styles } from "./breadcrumb-item.styles";
@@ -13,7 +14,7 @@ import { breadcrumbItemStyles as styles } from "./breadcrumb-item.styles";
  * @remarks
  * HTML Element: \<fast-breadcrumb-item\>
  */
-export const fastBreadcrumbItem = BreadcrumbItem.compose({
+export const fastBreadcrumbItem = BreadcrumbItem.compose<BreadcrumbItemOptions>({
     baseName: "breadcrumb-item",
     template,
     styles,

--- a/packages/web-components/fast-components/src/breadcrumb-item/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/index.ts
@@ -17,6 +17,7 @@ export const fastBreadcrumbItem = BreadcrumbItem.compose({
     baseName: "breadcrumb-item",
     template,
     styles,
+    separator: "/",
     shadowOptions: {
         delegatesFocus: true,
     },

--- a/packages/web-components/fast-components/src/checkbox/index.ts
+++ b/packages/web-components/fast-components/src/checkbox/index.ts
@@ -1,4 +1,9 @@
-import { Checkbox, checkboxTemplate as template } from "@microsoft/fast-foundation";
+import { html } from "@microsoft/fast-element";
+import {
+    Checkbox,
+    CheckboxOptions,
+    checkboxTemplate as template,
+} from "@microsoft/fast-foundation";
 import { checkboxStyles as styles } from "./checkbox.styles";
 
 /**
@@ -10,10 +15,28 @@ import { checkboxStyles as styles } from "./checkbox.styles";
  * @remarks
  * HTML Element: \<fast-checkbox\>
  */
-export const fastCheckbox = Checkbox.compose({
+export const fastCheckbox = Checkbox.compose<CheckboxOptions>({
     baseName: "checkbox",
     template,
     styles,
+    checkedIndicator: html`
+        <svg
+            aria-hidden="true"
+            part="checked-indicator"
+            class="checked-indicator"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M8.143 12.6697L15.235 4.5L16.8 5.90363L8.23812 15.7667L3.80005 11.2556L5.27591 9.7555L8.143 12.6697Z"
+            />
+        </svg>
+    `,
+    indeterminateIndicator: html`
+        <div part="indeterminate-indicator" class="indeterminate-indicator"></div>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/checkbox/index.ts
+++ b/packages/web-components/fast-components/src/checkbox/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     Checkbox,
     CheckboxOptions,
@@ -19,7 +18,7 @@ export const fastCheckbox = Checkbox.compose<CheckboxOptions>({
     baseName: "checkbox",
     template,
     styles,
-    checkedIndicator: html`
+    checkedIndicator: `
         <svg
             aria-hidden="true"
             part="checked-indicator"
@@ -34,7 +33,7 @@ export const fastCheckbox = Checkbox.compose<CheckboxOptions>({
             />
         </svg>
     `,
-    indeterminateIndicator: html`
+    indeterminateIndicator: `
         <div part="indeterminate-indicator" class="indeterminate-indicator"></div>
     `,
 });

--- a/packages/web-components/fast-components/src/combobox/index.ts
+++ b/packages/web-components/fast-components/src/combobox/index.ts
@@ -1,4 +1,9 @@
-import { Combobox, comboboxTemplate as template } from "@microsoft/fast-foundation";
+import { html } from "@microsoft/fast-element";
+import {
+    Combobox,
+    ComboboxOptions,
+    comboboxTemplate as template,
+} from "@microsoft/fast-foundation";
 import { comboboxStyles as styles } from "./combobox.styles";
 
 /**
@@ -10,10 +15,22 @@ import { comboboxStyles as styles } from "./combobox.styles";
  * HTML Element: \<fast-combobox\>
  *
  */
-export const fastCombobox = Combobox.compose({
+export const fastCombobox = Combobox.compose<ComboboxOptions>({
     baseName: "combobox",
     template,
     styles,
+    indicator: html`
+        <svg
+            class="select-indicator"
+            part="select-indicator"
+            viewBox="0 0 12 7"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                d="M11.85.65c.2.2.2.5 0 .7L6.4 6.84a.55.55 0 01-.78 0L.14 1.35a.5.5 0 11.71-.7L6 5.8 11.15.65c.2-.2.5-.2.7 0z"
+            />
+        </svg>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/combobox/index.ts
+++ b/packages/web-components/fast-components/src/combobox/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     Combobox,
     ComboboxOptions,
@@ -19,7 +18,7 @@ export const fastCombobox = Combobox.compose<ComboboxOptions>({
     baseName: "combobox",
     template,
     styles,
-    indicator: html`
+    indicator: `
         <svg
             class="select-indicator"
             part="select-indicator"

--- a/packages/web-components/fast-components/src/flipper/index.ts
+++ b/packages/web-components/fast-components/src/flipper/index.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { Flipper, flipperTemplate as template } from "@microsoft/fast-foundation";
 import { flipperStyles as styles } from "./flipper.styles";
 
@@ -10,10 +11,24 @@ import { flipperStyles as styles } from "./flipper.styles";
  * @remarks
  * HTML Element: \<fast-flipper\>
  */
-export const fastFlipper = Flipper.compose({
+export const fastFlipper = Flipper.compose<FlipperOptions>({
     baseName: "flipper",
     template,
     styles,
+    next: html`
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M4.023 15.273L11.29 8 4.023.727l.704-.704L12.71 8l-7.984 7.977-.704-.704z"
+            />
+        </svg>
+    `,
+    prevoius: html`
+        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
+            <path
+                d="M11.273 15.977L3.29 8 11.273.023l.704.704L4.71 8l7.266 7.273-.704.704z"
+            />
+        </svg>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/flipper/index.ts
+++ b/packages/web-components/fast-components/src/flipper/index.ts
@@ -1,5 +1,9 @@
 import { html } from "@microsoft/fast-element";
-import { Flipper, flipperTemplate as template } from "@microsoft/fast-foundation";
+import {
+    Flipper,
+    FlipperOptions,
+    flipperTemplate as template,
+} from "@microsoft/fast-foundation";
 import { flipperStyles as styles } from "./flipper.styles";
 
 /**
@@ -22,7 +26,7 @@ export const fastFlipper = Flipper.compose<FlipperOptions>({
             />
         </svg>
     `,
-    prevoius: html`
+    previous: html`
         <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <path
                 d="M11.273 15.977L3.29 8 11.273.023l.704.704L4.71 8l7.266 7.273-.704.704z"

--- a/packages/web-components/fast-components/src/flipper/index.ts
+++ b/packages/web-components/fast-components/src/flipper/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     Flipper,
     FlipperOptions,
@@ -19,14 +18,14 @@ export const fastFlipper = Flipper.compose<FlipperOptions>({
     baseName: "flipper",
     template,
     styles,
-    next: html`
+    next: `
         <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <path
                 d="M4.023 15.273L11.29 8 4.023.727l.704-.704L12.71 8l-7.984 7.977-.704-.704z"
             />
         </svg>
     `,
-    previous: html`
+    previous: `
         <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
             <path
                 d="M11.273 15.977L3.29 8 11.273.023l.704.704L4.71 8l7.266 7.273-.704.704z"

--- a/packages/web-components/fast-components/src/menu-item/index.ts
+++ b/packages/web-components/fast-components/src/menu-item/index.ts
@@ -1,5 +1,9 @@
 import { html } from "@microsoft/fast-element";
-import { MenuItem, menuItemTemplate as template } from "@microsoft/fast-foundation";
+import {
+    MenuItem,
+    MenuItemOptions,
+    menuItemTemplate as template,
+} from "@microsoft/fast-foundation";
 import { menuItemStyles as styles } from "./menu-item.styles";
 
 /**

--- a/packages/web-components/fast-components/src/menu-item/index.ts
+++ b/packages/web-components/fast-components/src/menu-item/index.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { MenuItem, menuItemTemplate as template } from "@microsoft/fast-foundation";
 import { menuItemStyles as styles } from "./menu-item.styles";
 
@@ -10,10 +11,40 @@ import { menuItemStyles as styles } from "./menu-item.styles";
  * @remarks
  * HTML Element: \<fast-menu-item\>
  */
-export const fastMenuItem = MenuItem.compose({
+export const fastMenuItem = MenuItem.compose<MenuItemOptions>({
     baseName: "menu-item",
     template,
     styles,
+    checkboxIndicator: html`
+        <svg
+            aria-hidden="true"
+            part="checkbox-indicator"
+            class="checkbox-indicator"
+            viewBox="0 0 20 20"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                fill-rule="evenodd"
+                clip-rule="evenodd"
+                d="M8.143 12.6697L15.235 4.5L16.8 5.90363L8.23812 15.7667L3.80005 11.2556L5.27591 9.7555L8.143 12.6697Z"
+            />
+        </svg>
+    `,
+    expandCollapseGlyph: html`
+        <svg
+            viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg"
+            class="expand-collapse-glyph"
+            part="expand-collapse-glyph"
+        >
+            <path
+                d="M5.00001 12.3263C5.00124 12.5147 5.05566 12.699 5.15699 12.8578C5.25831 13.0167 5.40243 13.1437 5.57273 13.2242C5.74304 13.3047 5.9326 13.3354 6.11959 13.3128C6.30659 13.2902 6.4834 13.2152 6.62967 13.0965L10.8988 8.83532C11.0739 8.69473 11.2153 8.51658 11.3124 8.31402C11.4096 8.11146 11.46 7.88966 11.46 7.66499C11.46 7.44033 11.4096 7.21853 11.3124 7.01597C11.2153 6.81341 11.0739 6.63526 10.8988 6.49467L6.62967 2.22347C6.48274 2.10422 6.30501 2.02912 6.11712 2.00691C5.92923 1.9847 5.73889 2.01628 5.56823 2.09799C5.39757 2.17969 5.25358 2.30817 5.153 2.46849C5.05241 2.62882 4.99936 2.8144 5.00001 3.00369V12.3263Z"
+            />
+        </svg>
+    `,
+    radioIndicator: html`
+        <span part="radio-indicator" class="radio-indicator"></span>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/menu-item/index.ts
+++ b/packages/web-components/fast-components/src/menu-item/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     MenuItem,
     MenuItemOptions,
@@ -19,7 +18,7 @@ export const fastMenuItem = MenuItem.compose<MenuItemOptions>({
     baseName: "menu-item",
     template,
     styles,
-    checkboxIndicator: html`
+    checkboxIndicator: `
         <svg
             aria-hidden="true"
             part="checkbox-indicator"
@@ -34,7 +33,7 @@ export const fastMenuItem = MenuItem.compose<MenuItemOptions>({
             />
         </svg>
     `,
-    expandCollapseGlyph: html`
+    expandCollapseGlyph: `
         <svg
             viewBox="0 0 16 16"
             xmlns="http://www.w3.org/2000/svg"
@@ -46,7 +45,7 @@ export const fastMenuItem = MenuItem.compose<MenuItemOptions>({
             />
         </svg>
     `,
-    radioIndicator: html`
+    radioIndicator: `
         <span part="radio-indicator" class="radio-indicator"></span>
     `,
 });

--- a/packages/web-components/fast-components/src/number-field/index.ts
+++ b/packages/web-components/fast-components/src/number-field/index.ts
@@ -1,6 +1,7 @@
-import { attr } from "@microsoft/fast-element";
+import { attr, html } from "@microsoft/fast-element";
 import {
     NumberField as FoundationNumberField,
+    NumberFieldOptions,
     numberFieldTemplate as template,
 } from "@microsoft/fast-foundation";
 import { numberFieldStyles as styles } from "./number-field.styles";
@@ -54,11 +55,17 @@ export const numberFieldStyles = styles;
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */
-export const fastNumberField = NumberField.compose({
+export const fastNumberField = NumberField.compose<NumberFieldOptions>({
     baseName: "number-field",
     styles,
     template,
     shadowOptions: {
         delegatesFocus: true,
     },
+    stepDownGlyph: html`
+        <span class="step-down-glyph" part="step-down-glyph"></span>
+    `,
+    stepUpGlyph: html`
+        <span class="step-up-glyph" part="step-up-glyph"></span>
+    `,
 });

--- a/packages/web-components/fast-components/src/number-field/index.ts
+++ b/packages/web-components/fast-components/src/number-field/index.ts
@@ -1,4 +1,4 @@
-import { attr, html } from "@microsoft/fast-element";
+import { attr } from "@microsoft/fast-element";
 import {
     NumberField as FoundationNumberField,
     NumberFieldOptions,
@@ -62,10 +62,10 @@ export const fastNumberField = NumberField.compose<NumberFieldOptions>({
     shadowOptions: {
         delegatesFocus: true,
     },
-    stepDownGlyph: html`
+    stepDownGlyph: `
         <span class="step-down-glyph" part="step-down-glyph"></span>
     `,
-    stepUpGlyph: html`
+    stepUpGlyph: `
         <span class="step-up-glyph" part="step-up-glyph"></span>
     `,
 });

--- a/packages/web-components/fast-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/fast-components/src/number-field/number-field.styles.ts
@@ -94,24 +94,25 @@ export const numberFieldStyles = (context, definition) =>
         fill: currentcolor;
     }
 
-    .step-up,
-    .step-down {
+    .step-up-glyph,
+    .step-down-glyph {
+        display: block;
         padding: 4px 10px;
         cursor: pointer;
     }
 
-    .step-up:before,
-    .step-down:before {
+    .step-up-glyph:before,
+    .step-down-glyph:before {
         content: '';
         display: block;
         border: solid transparent 6px;
     }
 
-    .step-up:before {
+    .step-up-glyph:before {
         border-bottom-color: ${neutralForegroundRest};
     }
 
-    .step-down:before {
+    .step-down-glyph:before {
         border-top-color: ${neutralForegroundRest};
     }
 

--- a/packages/web-components/fast-components/src/progress-ring/index.ts
+++ b/packages/web-components/fast-components/src/progress-ring/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     BaseProgress as Progress,
     ProgressRingOptions,
@@ -19,7 +18,7 @@ export const fastProgressRing = Progress.compose<ProgressRingOptions>({
     baseName: "progress-ring",
     template,
     styles,
-    indeterminateIndicator: html`
+    indeterminateIndicator: `
         <svg class="progress" part="progress" viewBox="0 0 16 16">
             <circle
                 class="background"

--- a/packages/web-components/fast-components/src/progress-ring/index.ts
+++ b/packages/web-components/fast-components/src/progress-ring/index.ts
@@ -1,5 +1,7 @@
+import { html } from "@microsoft/fast-element";
 import {
     BaseProgress as Progress,
+    ProgressRingOptions,
     progressRingTemplate as template,
 } from "@microsoft/fast-foundation";
 import { progressRingStyles as styles } from "./progress-ring.styles";
@@ -13,10 +15,28 @@ import { progressRingStyles as styles } from "./progress-ring.styles";
  * @remarks
  * HTML Element: \<fast-progress-ring\>
  */
-export const fastProgressRing = Progress.compose({
+export const fastProgressRing = Progress.compose<ProgressRingOptions>({
     baseName: "progress-ring",
     template,
     styles,
+    indeterminateIndicator: html`
+        <svg class="progress" part="progress" viewBox="0 0 16 16">
+            <circle
+                class="background"
+                part="background"
+                cx="8px"
+                cy="8px"
+                r="7px"
+            ></circle>
+            <circle
+                class="indeterminate-indicator-1"
+                part="indeterminate-indicator-1"
+                cx="8px"
+                cy="8px"
+                r="7px"
+            ></circle>
+        </svg>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/progress/index.ts
+++ b/packages/web-components/fast-components/src/progress/index.ts
@@ -1,5 +1,7 @@
+import { html } from "@microsoft/fast-element";
 import {
     BaseProgress as Progress,
+    ProgressOptions,
     progressTemplate as template,
 } from "@microsoft/fast-foundation";
 import { progressStyles as styles } from "./progress.styles";
@@ -13,10 +15,16 @@ import { progressStyles as styles } from "./progress.styles";
  * @remarks
  * HTML Element: \<fast-progress\>
  */
-export const fastProgress = Progress.compose({
+export const fastProgress = Progress.compose<ProgressOptions>({
     baseName: "progress",
     template,
     styles,
+    indeterminateIndicator1: html`
+        <span class="indeterminate-indicator-1" part="indeterminate-indicator-1"></span>
+    `,
+    indeterminateIndicator2: html`
+        <span class="indeterminate-indicator-1" part="indeterminate-indicator-1"></span>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/progress/index.ts
+++ b/packages/web-components/fast-components/src/progress/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     BaseProgress as Progress,
     ProgressOptions,
@@ -19,10 +18,10 @@ export const fastProgress = Progress.compose<ProgressOptions>({
     baseName: "progress",
     template,
     styles,
-    indeterminateIndicator1: html`
+    indeterminateIndicator1: `
         <span class="indeterminate-indicator-1" part="indeterminate-indicator-1"></span>
     `,
-    indeterminateIndicator2: html`
+    indeterminateIndicator2: `
         <span class="indeterminate-indicator-1" part="indeterminate-indicator-1"></span>
     `,
 });

--- a/packages/web-components/fast-components/src/radio/index.ts
+++ b/packages/web-components/fast-components/src/radio/index.ts
@@ -1,4 +1,9 @@
-import { Radio, radioTemplate as template } from "@microsoft/fast-foundation";
+import { html } from "@microsoft/fast-element";
+import {
+    Radio,
+    RadioOptions,
+    radioTemplate as template,
+} from "@microsoft/fast-foundation";
 import { radioStyles as styles } from "./radio.styles";
 
 /**
@@ -10,10 +15,13 @@ import { radioStyles as styles } from "./radio.styles";
  * @remarks
  * HTML Element: \<fast-radio\>
  */
-export const fastRadio = Radio.compose({
+export const fastRadio = Radio.compose<RadioOptions>({
     baseName: "radio",
     template,
     styles,
+    checkedIndicator: html`
+        <div part="checked-indicator" class="checked-indicator"></div>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/radio/index.ts
+++ b/packages/web-components/fast-components/src/radio/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     Radio,
     RadioOptions,
@@ -19,7 +18,7 @@ export const fastRadio = Radio.compose<RadioOptions>({
     baseName: "radio",
     template,
     styles,
-    checkedIndicator: html`
+    checkedIndicator: `
         <div part="checked-indicator" class="checked-indicator"></div>
     `,
 });

--- a/packages/web-components/fast-components/src/select/index.ts
+++ b/packages/web-components/fast-components/src/select/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     Select,
     SelectOptions,
@@ -20,7 +19,7 @@ export const fastSelect = Select.compose<SelectOptions>({
     baseName: "select",
     template,
     styles,
-    indicator: html`
+    indicator: `
         <svg
             class="select-indicator"
             part="select-indicator"

--- a/packages/web-components/fast-components/src/select/index.ts
+++ b/packages/web-components/fast-components/src/select/index.ts
@@ -1,4 +1,9 @@
-import { Select, selectTemplate as template } from "@microsoft/fast-foundation";
+import { html } from "@microsoft/fast-element";
+import {
+    Select,
+    SelectOptions,
+    selectTemplate as template,
+} from "@microsoft/fast-foundation";
 import { selectStyles as styles } from "./select.styles";
 
 /**
@@ -11,10 +16,22 @@ import { selectStyles as styles } from "./select.styles";
  * HTML Element: \<fast-select\>
  *
  */
-export const fastSelect = Select.compose({
+export const fastSelect = Select.compose<SelectOptions>({
     baseName: "select",
     template,
     styles,
+    indicator: html`
+        <svg
+            class="select-indicator"
+            part="select-indicator"
+            viewBox="0 0 12 7"
+            xmlns="http://www.w3.org/2000/svg"
+        >
+            <path
+                d="M11.85.65c.2.2.2.5 0 .7L6.4 6.84a.55.55 0 01-.78 0L.14 1.35a.5.5 0 11.71-.7L6 5.8 11.15.65c.2-.2.5-.2.7 0z"
+            />
+        </svg>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/slider/index.ts
+++ b/packages/web-components/fast-components/src/slider/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     Slider,
     SliderOptions,
@@ -19,7 +18,7 @@ export const fastSlider = Slider.compose<SliderOptions>({
     baseName: "slider",
     template,
     styles,
-    thumb: html`
+    thumb: `
         <div class="thumb-cursor"></div>
     `,
 });

--- a/packages/web-components/fast-components/src/slider/index.ts
+++ b/packages/web-components/fast-components/src/slider/index.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { Slider, sliderTemplate as template } from "@microsoft/fast-foundation";
 import { sliderStyles as styles } from "./slider.styles";
 
@@ -10,10 +11,13 @@ import { sliderStyles as styles } from "./slider.styles";
  * @remarks
  * HTML Element: \<fast-slider\>
  */
-export const fastSlider = Slider.compose({
+export const fastSlider = Slider.compose<SliderOptions>({
     baseName: "slider",
     template,
     styles,
+    thumb: html`
+        <div class="thumb-cursor"></div>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/slider/index.ts
+++ b/packages/web-components/fast-components/src/slider/index.ts
@@ -1,5 +1,9 @@
 import { html } from "@microsoft/fast-element";
-import { Slider, sliderTemplate as template } from "@microsoft/fast-foundation";
+import {
+    Slider,
+    SliderOptions,
+    sliderTemplate as template,
+} from "@microsoft/fast-foundation";
 import { sliderStyles as styles } from "./slider.styles";
 
 /**

--- a/packages/web-components/fast-components/src/switch/index.ts
+++ b/packages/web-components/fast-components/src/switch/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     Switch,
     SwitchOptions,
@@ -19,7 +18,7 @@ export const fastSwitch = Switch.compose<SwitchOptions>({
     baseName: "switch",
     template,
     styles,
-    switch: html`
+    switch: `
         <span class="checked-indicator" part="checked-indicator"></span>
     `,
 });

--- a/packages/web-components/fast-components/src/switch/index.ts
+++ b/packages/web-components/fast-components/src/switch/index.ts
@@ -1,4 +1,9 @@
-import { Switch, switchTemplate as template } from "@microsoft/fast-foundation";
+import { html } from "@microsoft/fast-element";
+import {
+    Switch,
+    SwitchOptions,
+    switchTemplate as template,
+} from "@microsoft/fast-foundation";
 import { switchStyles as styles } from "./switch.styles";
 
 /**
@@ -10,10 +15,13 @@ import { switchStyles as styles } from "./switch.styles";
  * @remarks
  * HTML Element: \<fast-switch\>
  */
-export const fastSwitch = Switch.compose({
+export const fastSwitch = Switch.compose<SwitchOptions>({
     baseName: "switch",
     template,
     styles,
+    switch: html`
+        <span class="checked-indicator" part="checked-indicator"></span>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-components/src/tree-item/index.ts
+++ b/packages/web-components/fast-components/src/tree-item/index.ts
@@ -1,4 +1,3 @@
-import { html } from "@microsoft/fast-element";
 import {
     treeItemTemplate as template,
     TreeItem,
@@ -20,7 +19,7 @@ export const fastTreeItem = TreeItem.compose<TreeItemOptions>({
     baseName: "tree-item",
     template,
     styles,
-    expandCollapseGlyph: html`
+    expandCollapseGlyph: `
         <svg
             viewBox="0 0 16 16"
             xmlns="http://www.w3.org/2000/svg"

--- a/packages/web-components/fast-components/src/tree-item/index.ts
+++ b/packages/web-components/fast-components/src/tree-item/index.ts
@@ -1,4 +1,9 @@
-import { treeItemTemplate as template, TreeItem } from "@microsoft/fast-foundation";
+import { html } from "@microsoft/fast-element";
+import {
+    treeItemTemplate as template,
+    TreeItem,
+    TreeItemOptions,
+} from "@microsoft/fast-foundation";
 import { treeItemStyles as styles } from "./tree-item.styles";
 
 /**
@@ -11,10 +16,21 @@ import { treeItemStyles as styles } from "./tree-item.styles";
  * HTML Element: \<fast-tree-item\>
  *
  */
-export const fastTreeItem = TreeItem.compose({
+export const fastTreeItem = TreeItem.compose<TreeItemOptions>({
     baseName: "tree-item",
     template,
     styles,
+    expandCollapseGlyph: html`
+        <svg
+            viewBox="0 0 16 16"
+            xmlns="http://www.w3.org/2000/svg"
+            class="expand-collapse-glyph"
+        >
+            <path
+                d="M5.00001 12.3263C5.00124 12.5147 5.05566 12.699 5.15699 12.8578C5.25831 13.0167 5.40243 13.1437 5.57273 13.2242C5.74304 13.3047 5.9326 13.3354 6.11959 13.3128C6.30659 13.2902 6.4834 13.2152 6.62967 13.0965L10.8988 8.83532C11.0739 8.69473 11.2153 8.51658 11.3124 8.31402C11.4096 8.11146 11.46 7.88966 11.46 7.66499C11.46 7.44033 11.4096 7.21853 11.3124 7.01597C11.2153 6.81341 11.0739 6.63526 10.8988 6.49467L6.62967 2.22347C6.48274 2.10422 6.30501 2.02912 6.11712 2.00691C5.92923 1.9847 5.73889 2.01628 5.56823 2.09799C5.39757 2.17969 5.25358 2.30817 5.153 2.46849C5.05241 2.62882 4.99936 2.8144 5.00001 3.00369V12.3263Z"
+            />
+        </svg>
+    `,
 });
 
 /**

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -16,6 +16,7 @@ import { ElementViewTemplate } from '@microsoft/fast-element';
 import { FASTElement } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import { PartialFASTElementDefinition } from '@microsoft/fast-element';
+import { SyntheticViewTemplate } from '@microsoft/fast-element';
 import { ViewTemplate } from '@microsoft/fast-element';
 
 // Warning: (ae-incompatible-release-tags) The symbol "Accordion" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
@@ -53,6 +54,14 @@ export class AccordionItem extends FoundationElement {
 // @internal
 export interface AccordionItem extends StartEnd {
 }
+
+// Warning: (ae-incompatible-release-tags) The symbol "AccordionItemOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
+// @public (undocumented)
+export type AccordionItemOptions = FoundationElementDefinition & {
+    expandedIcon?: string | SyntheticViewTemplate;
+    collapsedIcon?: string | SyntheticViewTemplate;
+};
 
 // @public
 export const accordionItemTemplate: (context: any, definition: any) => ViewTemplate<AccordionItem>;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -393,8 +393,15 @@ export enum ComboboxAutocomplete {
     none = "none"
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "ComboboxOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
 // @public
-export const comboboxTemplate: (context: any, definition: any) => ViewTemplate<Combobox>;
+export type ComboboxOptions = FoundationElementDefinition & {
+    indicator?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const comboboxTemplate: (context: any, definition: ComboboxOptions) => ViewTemplate<Combobox>;
 
 // @alpha
 export interface ComponentPresentation {

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -57,7 +57,7 @@ export interface AccordionItem extends StartEnd {
 
 // Warning: (ae-incompatible-release-tags) The symbol "AccordionItemOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
 //
-// @public (undocumented)
+// @public
 export type AccordionItemOptions = FoundationElementDefinition & {
     expandedIcon?: string | SyntheticViewTemplate;
     collapsedIcon?: string | SyntheticViewTemplate;
@@ -219,6 +219,13 @@ export class BreadcrumbItem extends Anchor {
 // @internal
 export interface BreadcrumbItem extends StartEnd, DelegatesARIALink {
 }
+
+// Warning: (ae-incompatible-release-tags) The symbol "BreadcrumbItemOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
+// @public
+export type BreadcrumbItemOptions = FoundationElementDefinition & {
+    separator?: string | SyntheticViewTemplate;
+};
 
 // @public
 export const breadcrumbItemTemplate: (context: any, definition: any) => ViewTemplate<BreadcrumbItem>;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1072,8 +1072,16 @@ export enum FlipperDirection {
     previous = "previous"
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "FlipperOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
 // @public
-export const flipperTemplate: (context: any, definition: any) => ViewTemplate<Flipper>;
+export type FlipperOptions = FoundationElementDefinition & {
+    next?: string | SyntheticViewTemplate;
+    previous?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const flipperTemplate: (context: any, definition: FlipperOptions) => ViewTemplate<Flipper>;
 
 // @public
 export const focusVisible: string;
@@ -1486,6 +1494,15 @@ export interface MenuItem extends StartEnd {
 // @public
 export type MenuItemColumnCount = 0 | 1 | 2;
 
+// Warning: (ae-incompatible-release-tags) The symbol "MenuItemOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
+// @public
+export type MenuItemOptions = FoundationElementDefinition & {
+    checkboxIndicator?: string | SyntheticViewTemplate;
+    expandCollapseGlyph?: string | SyntheticViewTemplate;
+    radioIndicator?: string | SyntheticViewTemplate;
+};
+
 // @public
 export enum MenuItemRole {
     menuitem = "menuitem",
@@ -1494,7 +1511,7 @@ export enum MenuItemRole {
 }
 
 // @public
-export const menuItemTemplate: (context: any, definition: any) => ViewTemplate<MenuItem>;
+export const menuItemTemplate: (context: any, definition: MenuItemOptions) => ViewTemplate<MenuItem>;
 
 // @public
 export const menuTemplate: (context: any, definition: any) => ViewTemplate<Menu>;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2340,8 +2340,15 @@ export class TreeItem extends FoundationElement {
 export interface TreeItem extends StartEnd {
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "TreeItemOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
 // @public
-export const treeItemTemplate: (context: any, definition: any) => ViewTemplate<TreeItem>;
+export type TreeItemOptions = FoundationElementDefinition & {
+    expandCollapseGlyph?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const treeItemTemplate: (context: any, definition: TreeItemOptions) => ViewTemplate<TreeItem>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "TreeView" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
 //

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -64,7 +64,7 @@ export type AccordionItemOptions = FoundationElementDefinition & {
 };
 
 // @public
-export const accordionItemTemplate: (context: any, definition: any) => ViewTemplate<AccordionItem>;
+export const accordionItemTemplate: (context: any, definition: AccordionItemOptions) => ViewTemplate<AccordionItem>;
 
 // @public
 export const accordionTemplate: (context: any, definition: any) => ViewTemplate<Accordion>;
@@ -228,7 +228,7 @@ export type BreadcrumbItemOptions = FoundationElementDefinition & {
 };
 
 // @public
-export const breadcrumbItemTemplate: (context: any, definition: any) => ViewTemplate<BreadcrumbItem>;
+export const breadcrumbItemTemplate: (context: any, definition: BreadcrumbItemOptions) => ViewTemplate<BreadcrumbItem>;
 
 // @public
 export const breadcrumbTemplate: (context: any, definition: any) => ViewTemplate<Breadcrumb>;
@@ -296,8 +296,16 @@ export class Checkbox extends FormAssociatedCheckbox {
     readOnly: boolean;
     }
 
+// Warning: (ae-incompatible-release-tags) The symbol "CheckboxOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
 // @public
-export const checkboxTemplate: (context: any, definition: any) => ViewTemplate<Checkbox>;
+export type CheckboxOptions = FoundationElementDefinition & {
+    checkedIndicator?: string | SyntheticViewTemplate;
+    indeterminateIndicator?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const checkboxTemplate: (context: any, definition: CheckboxOptions) => ViewTemplate<Checkbox>;
 
 // @public
 export interface ColumnDefinition {

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1678,8 +1678,15 @@ export class RadioGroup extends FoundationElement {
 // @public
 export const radioGroupTemplate: (context: any, definition: any) => ViewTemplate<RadioGroup>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "RadioOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
 // @public
-export const radioTemplate: (context: any, definition: any) => ViewTemplate<Radio>;
+export type RadioOptions = FoundationElementDefinition & {
+    checkedIndicator?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const radioTemplate: (context: any, definition: RadioOptions) => ViewTemplate<Radio>;
 
 // @alpha (undocumented)
 export type RegisterSelf<T extends Constructable> = {
@@ -1821,6 +1828,13 @@ export class Select extends FormAssociatedSelect {
 export interface Select extends StartEnd, DelegatesARIASelect {
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "SelectOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
+// @public
+export type SelectOptions = FoundationElementDefinition & {
+    indicator?: string | SyntheticViewTemplate;
+};
+
 // @public
 export enum SelectPosition {
     // (undocumented)
@@ -1836,7 +1850,7 @@ export enum SelectRole {
 }
 
 // @public
-export const selectTemplate: (context: any, definition: any) => ViewTemplate<Select>;
+export const selectTemplate: (context: any, definition: SelectOptions) => ViewTemplate<Select>;
 
 // @alpha (undocumented)
 export interface ServiceLocator {
@@ -1983,8 +1997,15 @@ export enum SliderMode {
     singleValue = "single-value"
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "SliderOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
 // @public
-export const sliderTemplate: (context: any, definition: any) => ViewTemplate<Slider>;
+export type SliderOptions = FoundationElementDefinition & {
+    thumb?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const sliderTemplate: (context: any, definition: SliderOptions) => ViewTemplate<Slider>;
 
 // @public
 export class StartEnd {
@@ -2045,8 +2066,15 @@ export class Switch extends FormAssociatedSwitch {
     readOnly: boolean;
     }
 
+// Warning: (ae-incompatible-release-tags) The symbol "SwitchOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
 // @public
-export const switchTemplate: (context: any, definition: any) => ViewTemplate<Switch>;
+export type SwitchOptions = FoundationElementDefinition & {
+    switch?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const switchTemplate: (context: any, definition: SwitchOptions) => ViewTemplate<Switch>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "Tab" is marked as @public, but its signature references "FoundationElement" which is marked as @alpha
 //

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1585,11 +1585,26 @@ export type OverrideFoundationElementDefinition<T extends FoundationElementDefin
 // @alpha (undocumented)
 export type ParentLocator = (owner: any) => Container | null;
 
+// Warning: (ae-incompatible-release-tags) The symbol "ProgressOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
+// @public
+export type ProgressOptions = FoundationElementDefinition & {
+    indeterminateIndicator1?: string | SyntheticViewTemplate;
+    indeterminateIndicator2?: string | SyntheticViewTemplate;
+};
+
+// Warning: (ae-incompatible-release-tags) The symbol "ProgressRingOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
+// @public
+export type ProgressRingOptions = FoundationElementDefinition & {
+    indeterminateIndicator?: string | SyntheticViewTemplate;
+};
+
 // @public
 export const progressRingTemplate: (context: any, definition: any) => ViewTemplate<BaseProgress>;
 
 // @public
-export const progressTemplate: (context: any, defintion: any) => ViewTemplate<BaseProgress>;
+export const progressTemplate: (context: any, defintion: ProgressOptions) => ViewTemplate<BaseProgress>;
 
 // @public
 export class PropertyStyleSheetBehavior implements Behavior {

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1563,8 +1563,16 @@ export class NumberField extends FormAssociatedNumberField {
 export interface NumberField extends StartEnd, DelegatesARIATextbox {
 }
 
+// Warning: (ae-incompatible-release-tags) The symbol "NumberFieldOptions" is marked as @public, but its signature references "FoundationElementDefinition" which is marked as @alpha
+//
 // @public
-export const numberFieldTemplate: (context: any, definition: any) => ViewTemplate<NumberField>;
+export type NumberFieldOptions = FoundationElementDefinition & {
+    stepDownGlyph?: string | SyntheticViewTemplate;
+    stepUpGlyph?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const numberFieldTemplate: (context: any, definition: NumberFieldOptions) => ViewTemplate<NumberField>;
 
 // @alpha
 export const optional: (key: any) => any;

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -1,7 +1,7 @@
 import { html, ref } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import type { AccordionItem } from "./accordion-item";
+import type { AccordionItem, AccordionItemOptions } from "./accordion-item";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(AccordionItem:class)} component.
@@ -10,7 +10,7 @@ import type { AccordionItem } from "./accordion-item";
 export const accordionItemTemplate: (
     context,
     definition
-) => ViewTemplate<AccordionItem> = (context, definition) => html`
+) => ViewTemplate<AccordionItem> = (context, definition: AccordionItemOptions) => html`
     <template
         class="${x => (x.expanded ? "expanded" : "")}"
         slot="item"
@@ -38,22 +38,10 @@ export const accordionItemTemplate: (
             ${endTemplate}
             <span class="icon" part="icon" aria-hidden="true">
                 <slot name="expanded-icon" part="expanded-icon">
-                    <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                        <path
-                            fill-rule="evenodd"
-                            clip-rule="evenodd"
-                            d="M3.78 3h12.44c.43 0 .78.35.78.78v12.44c0 .43-.35.78-.78.78H3.78a.78.78 0 01-.78-.78V3.78c0-.43.35-.78.78-.78zm12.44-1H3.78C2.8 2 2 2.8 2 3.78v12.44C2 17.2 2.8 18 3.78 18h12.44c.98 0 1.78-.8 1.78-1.78V3.78C18 2.8 17.2 2 16.22 2zM14 9H6v2h8V9z"
-                        />
-                    </svg>
+                    ${definition.expandedIcon || ""}
                 </slot>
                 <slot name="collapsed-icon" part="collapsed-icon">
-                    <svg width="20" height="20" viewBox="0 0 20 20" xmlns="http://www.w3.org/2000/svg">
-                        <path
-                            fill-rule="evenodd"
-                            clip-rule="evenodd"
-                            d="M16.22 3H3.78a.78.78 0 00-.78.78v12.44c0 .43.35.78.78.78h12.44c.43 0 .78-.35.78-.78V3.78a.78.78 0 00-.78-.78zM3.78 2h12.44C17.2 2 18 2.8 18 3.78v12.44c0 .98-.8 1.78-1.78 1.78H3.78C2.8 18 2 17.2 2 16.22V3.78C2 2.8 2.8 2 3.78 2zM11 9h3v2h-3v3H9v-3H6V9h3V6h2v3z"
-                        />
-                    </svg>
+                    ${definition.collapsedIcon || ""}
                 </slot>
             <span>
         </div>

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -9,7 +9,7 @@ import type { AccordionItem, AccordionItemOptions } from "./accordion-item";
  */
 export const accordionItemTemplate: (
     context,
-    definition
+    definition: AccordionItemOptions
 ) => ViewTemplate<AccordionItem> = (context, definition: AccordionItemOptions) => html`
     <template
         class="${x => (x.expanded ? "expanded" : "")}"

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
@@ -1,7 +1,16 @@
-import { attr, nullableNumberConverter } from "@microsoft/fast-element";
-import { FoundationElement } from "../foundation-element";
+import {
+    attr,
+    nullableNumberConverter,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
+import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
 import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
+
+export type AccordionItemOptions = FoundationElementDefinition & {
+    expandedIcon?: string | SyntheticViewTemplate;
+    collapsedIcon?: string | SyntheticViewTemplate;
+};
 
 /**
  * An individual item in an {@link @microsoft/fast-foundation#(Accordion:class) }.

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
@@ -7,6 +7,10 @@ import { FoundationElement, FoundationElementDefinition } from "../foundation-el
 import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 
+/**
+ * Accordion Item configuration options
+ * @public
+ */
 export type AccordionItemOptions = FoundationElementDefinition & {
     expandedIcon?: string | SyntheticViewTemplate;
     collapsedIcon?: string | SyntheticViewTemplate;

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
@@ -10,7 +10,7 @@ import type { BreadcrumbItem, BreadcrumbItemOptions } from "./breadcrumb-item";
  */
 export const breadcrumbItemTemplate: (
     context,
-    definition
+    definition: BreadcrumbItemOptions
 ) => ViewTemplate<BreadcrumbItem> = (context, definition: BreadcrumbItemOptions) => html`
     <div role="listitem" class="listitem" part="listitem">
         ${when(

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
@@ -2,7 +2,7 @@ import { html, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { anchorTemplate } from "../anchor";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import type { BreadcrumbItem } from "./breadcrumb-item";
+import type { BreadcrumbItem, BreadcrumbItemOptions } from "./breadcrumb-item";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(BreadcrumbItem:class)} component.
@@ -11,7 +11,7 @@ import type { BreadcrumbItem } from "./breadcrumb-item";
 export const breadcrumbItemTemplate: (
     context,
     definition
-) => ViewTemplate<BreadcrumbItem> = (context, definition) => html`
+) => ViewTemplate<BreadcrumbItem> = (context, definition: BreadcrumbItemOptions) => html`
     <div role="listitem" class="listitem" part="listitem">
         ${when(
             x => x.href && x.href.length > 0,
@@ -31,7 +31,7 @@ export const breadcrumbItemTemplate: (
             x => x.separator,
             html<BreadcrumbItem>`
                 <span class="separator" part="separator" aria-hidden="true">
-                    <slot name="separator">/</slot>
+                    <slot name="separator">${definition.separator || ""}</slot>
                 </span>
             `
         )}

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.ts
@@ -1,7 +1,16 @@
-import { observable } from "@microsoft/fast-element";
+import { observable, SyntheticViewTemplate } from "@microsoft/fast-element";
+import type { FoundationElementDefinition } from "../foundation-element";
 import { Anchor, DelegatesARIALink } from "../anchor";
 import { StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
+
+/**
+ * Breadcrumb Item configuration options
+ * @public
+ */
+export type BreadcrumbItemOptions = FoundationElementDefinition & {
+    separator?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Breadcrumb Item Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
@@ -1,15 +1,15 @@
 import { html, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import type { Checkbox } from "./checkbox";
+import type { Checkbox, CheckboxOptions } from "./checkbox";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Checkbox:class)} component.
  * @public
  */
-export const checkboxTemplate: (context, definition) => ViewTemplate<Checkbox> = (
+export const checkboxTemplate: (
     context,
-    definition
-) => html`
+    definition: CheckboxOptions
+) => ViewTemplate<Checkbox> = (context, definition: CheckboxOptions) => html`
     <template
         role="checkbox"
         aria-checked="${x => x.checked}"
@@ -24,22 +24,10 @@ export const checkboxTemplate: (context, definition) => ViewTemplate<Checkbox> =
     >
         <div part="control" class="control">
             <slot name="checked-indicator">
-                <svg
-                    aria-hidden="true"
-                    part="checked-indicator"
-                    class="checked-indicator"
-                    viewBox="0 0 20 20"
-                    xmlns="http://www.w3.org/2000/svg"
-                >
-                    <path
-                        fill-rule="evenodd"
-                        clip-rule="evenodd"
-                        d="M8.143 12.6697L15.235 4.5L16.8 5.90363L8.23812 15.7667L3.80005 11.2556L5.27591 9.7555L8.143 12.6697Z"
-                    />
-                </svg>
+                ${definition.checkedIndicator || ""}
             </slot>
             <slot name="indeterminate-indicator">
-                <div part="indeterminate-indicator" class="indeterminate-indicator"></div>
+                ${definition.indeterminateIndicator || ""}
             </slot>
         </div>
         <label

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -1,6 +1,16 @@
-import { attr, observable } from "@microsoft/fast-element";
+import { attr, observable, SyntheticViewTemplate } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
+import type { FoundationElementDefinition } from "../foundation-element";
 import { FormAssociatedCheckbox } from "./checkbox.form-associated";
+
+/**
+ * Checkbox configuration options
+ * @public
+ */
+export type CheckboxOptions = FoundationElementDefinition & {
+    checkedIndicator?: string | SyntheticViewTemplate;
+    indeterminateIndicator?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Checkbox Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -2,16 +2,16 @@ import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { Listbox } from "../listbox/listbox";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import type { Combobox } from "./combobox";
+import type { Combobox, ComboboxOptions } from "./combobox";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Combobox:class)} component.
  * @public
  */
-export const comboboxTemplate: (context, definition) => ViewTemplate<Combobox> = (
+export const comboboxTemplate: (
     context,
-    definition
-) => html`
+    definition: ComboboxOptions
+) => ViewTemplate<Combobox> = (context, definition: ComboboxOptions) => html`
     <template
         autocomplete="${x => x.autocomplete}"
         class="${x => (x.disabled ? "disabled" : "")} ${x => x.position}"
@@ -44,16 +44,7 @@ export const comboboxTemplate: (context, definition) => ViewTemplate<Combobox> =
                 />
                 <div class="indicator" part="indicator" aria-hidden="true">
                     <slot name="indicator">
-                        <svg
-                            class="select-indicator"
-                            part="select-indicator"
-                            viewBox="0 0 12 7"
-                            xmlns="http://www.w3.org/2000/svg"
-                        >
-                            <path
-                                d="M11.85.65c.2.2.2.5 0 .7L6.4 6.84a.55.55 0 01-.78 0L.14 1.35a.5.5 0 11.71-.7L6 5.8 11.15.65c.2-.2.5-.2.7 0z"
-                            />
-                        </svg>
+                        ${definition.indicator || ""}
                     </slot>
                 </div>
             </slot>

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -1,4 +1,9 @@
-import { attr, Observable, observable } from "@microsoft/fast-element";
+import {
+    attr,
+    Observable,
+    observable,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 import { limit } from "@microsoft/fast-web-utilities";
 import uniqueId from "lodash-es/uniqueId";
 import type { ListboxOption } from "../listbox-option/listbox-option";
@@ -6,8 +11,17 @@ import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
 import { StartEnd } from "../patterns/start-end";
 import { SelectPosition, SelectRole } from "../select/select.options";
 import { applyMixins } from "../utilities/apply-mixins";
+import type { FoundationElementDefinition } from "../foundation-element";
 import { FormAssociatedCombobox } from "./combobox.form-associated";
 import { ComboboxAutocomplete } from "./combobox.options";
+
+/**
+ * Combobox configuration options
+ * @public
+ */
+export type ComboboxOptions = FoundationElementDefinition & {
+    indicator?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Combobox Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/flipper/flipper.template.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.template.ts
@@ -1,16 +1,16 @@
 import { html, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import type { Flipper } from "./flipper";
+import type { Flipper, FlipperOptions } from "./flipper";
 import { FlipperDirection } from "./flipper.options";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#Flipper} component.
  * @public
  */
-export const flipperTemplate: (context, definition) => ViewTemplate<Flipper> = (
+export const flipperTemplate: (
     context,
-    definition
-) => html`
+    definition: FlipperOptions
+) => ViewTemplate<Flipper> = (context, definition: FlipperOptions) => html`
     <template
         role="button"
         aria-disabled="${x => (x.disabled ? true : void 0)}"
@@ -22,11 +22,7 @@ export const flipperTemplate: (context, definition) => ViewTemplate<Flipper> = (
             html`
                 <span part="next" class="next">
                     <slot name="next">
-                        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-                            <path
-                                d="M4.023 15.273L11.29 8 4.023.727l.704-.704L12.71 8l-7.984 7.977-.704-.704z"
-                            />
-                        </svg>
+                        ${definition.next || ""}
                     </slot>
                 </span>
             `
@@ -36,11 +32,7 @@ export const flipperTemplate: (context, definition) => ViewTemplate<Flipper> = (
             html`
                 <span part="previous" class="previous">
                     <slot name="previous">
-                        <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
-                            <path
-                                d="M11.273 15.977L3.29 8 11.273.023l.704.704L4.71 8l7.266 7.273-.704.704z"
-                            />
-                        </svg>
+                        ${definition.previous || ""}
                     </slot>
                 </span>
             `

--- a/packages/web-components/fast-foundation/src/flipper/flipper.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.ts
@@ -1,8 +1,17 @@
-import { attr, booleanConverter } from "@microsoft/fast-element";
-import { FoundationElement } from "../foundation-element";
+import { attr, booleanConverter, SyntheticViewTemplate } from "@microsoft/fast-element";
+import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
 import { FlipperDirection } from "./flipper.options";
 
 export { FlipperDirection };
+
+/**
+ * Flipper configuration options
+ * @public
+ */
+export type FlipperOptions = FoundationElementDefinition & {
+    next?: string | SyntheticViewTemplate;
+    previous?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Flipper Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -2,7 +2,7 @@ import { html, ref, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { AnchoredRegion } from "../anchored-region";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import { MenuItemRole } from "./menu-item";
+import { MenuItemRole, MenuItemOptions } from "./menu-item";
 import type { MenuItem } from "./menu-item";
 
 /**
@@ -11,10 +11,10 @@ import type { MenuItem } from "./menu-item";
  *
  * @public
  */
-export const menuItemTemplate: (context, definition) => ViewTemplate<MenuItem> = (
+export const menuItemTemplate: (
     context,
-    definition
-) => html<MenuItem>`
+    definition: MenuItemOptions
+) => ViewTemplate<MenuItem> = (context, definition: MenuItemOptions) => html<MenuItem>`
     <template
         role="${x => x.role}"
         aria-haspopup="${x => (x.hasSubmenu ? "menu" : void 0)}"
@@ -34,19 +34,7 @@ export const menuItemTemplate: (context, definition) => ViewTemplate<MenuItem> =
                     <div part="input-container" class="input-container">
                         <span part="checkbox" class="checkbox">
                             <slot name="checkbox-indicator">
-                                <svg
-                                    aria-hidden="true"
-                                    part="checkbox-indicator"
-                                    class="checkbox-indicator"
-                                    viewBox="0 0 20 20"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                >
-                                    <path
-                                        fill-rule="evenodd"
-                                        clip-rule="evenodd"
-                                        d="M8.143 12.6697L15.235 4.5L16.8 5.90363L8.23812 15.7667L3.80005 11.2556L5.27591 9.7555L8.143 12.6697Z"
-                                    />
-                                </svg>
+                                ${definition.checkboxIndicator || ""}
                             </slot>
                         </span>
                     </div>
@@ -58,10 +46,7 @@ export const menuItemTemplate: (context, definition) => ViewTemplate<MenuItem> =
                     <div part="input-container" class="input-container">
                         <span part="radio" class="radio">
                             <slot name="radio-indicator">
-                                <span
-                                    part="radio-indicator"
-                                    class="radio-indicator"
-                                ></span>
+                                ${definition.radioIndicator || ""}
                             </slot>
                         </span>
                     </div>
@@ -82,16 +67,7 @@ export const menuItemTemplate: (context, definition) => ViewTemplate<MenuItem> =
                 >
                     <span part="expand-collapse" class="expand-collapse">
                         <slot name="expand-collapse-indicator">
-                            <svg
-                                viewBox="0 0 16 16"
-                                xmlns="http://www.w3.org/2000/svg"
-                                class="expand-collapse-glyph"
-                                part="expand-collapse-glyph"
-                            >
-                                <path
-                                    d="M5.00001 12.3263C5.00124 12.5147 5.05566 12.699 5.15699 12.8578C5.25831 13.0167 5.40243 13.1437 5.57273 13.2242C5.74304 13.3047 5.9326 13.3354 6.11959 13.3128C6.30659 13.2902 6.4834 13.2152 6.62967 13.0965L10.8988 8.83532C11.0739 8.69473 11.2153 8.51658 11.3124 8.31402C11.4096 8.11146 11.46 7.88966 11.46 7.66499C11.46 7.44033 11.4096 7.21853 11.3124 7.01597C11.2153 6.81341 11.0739 6.63526 10.8988 6.49467L6.62967 2.22347C6.48274 2.10422 6.30501 2.02912 6.11712 2.00691C5.92923 1.9847 5.73889 2.01628 5.56823 2.09799C5.39757 2.17969 5.25358 2.30817 5.153 2.46849C5.05241 2.62882 4.99936 2.8144 5.00001 3.00369V12.3263Z"
-                                />
-                            </svg>
+                            ${definition.expandCollapseGlyph || ""}
                         </slot>
                     </span>
                 </div>

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -2,8 +2,8 @@ import { html, ref, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { AnchoredRegion } from "../anchored-region";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import { MenuItemRole, MenuItemOptions } from "./menu-item";
-import type { MenuItem } from "./menu-item";
+import { MenuItemRole } from "./menu-item";
+import type { MenuItem, MenuItemOptions } from "./menu-item";
 
 /**
  * Generates a template for the {@link @microsoft/fast-foundation#(MenuItem:class)} component using

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -1,4 +1,4 @@
-import { attr, DOM, observable } from "@microsoft/fast-element";
+import { attr, DOM, observable, SyntheticViewTemplate } from "@microsoft/fast-element";
 import {
     Direction,
     keyCodeArrowLeft,
@@ -7,7 +7,7 @@ import {
     keyCodeSpace,
 } from "@microsoft/fast-web-utilities";
 import type { AnchoredRegion } from "../anchored-region";
-import { FoundationElement } from "../foundation-element";
+import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
 import type { Menu } from "../menu/menu";
 import { StartEnd } from "../patterns/start-end";
 import { getDirection } from "../utilities/";
@@ -21,6 +21,16 @@ export { MenuItemRole };
  * @public
  */
 export type MenuItemColumnCount = 0 | 1 | 2;
+
+/**
+ * Menu Item configuration options
+ * @public
+ */
+export type MenuItemOptions = FoundationElementDefinition & {
+    checkboxIndicator?: string | SyntheticViewTemplate;
+    expandCollapseGlyph?: string | SyntheticViewTemplate;
+    radioIndicator?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Switch Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
@@ -1,16 +1,16 @@
 import { html, ref, slotted, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns";
-import type { NumberField } from "./number-field";
+import type { NumberField, NumberFieldOptions } from "./number-field";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(NumberField:class)} component.
  * @public
  */
-export const numberFieldTemplate: (context, definition) => ViewTemplate<NumberField> = (
+export const numberFieldTemplate: (
     context,
-    definition
-) => html`
+    definition: NumberFieldOptions
+) => ViewTemplate<NumberField> = (context, definition: NumberFieldOptions) => html`
     <template class="${x => (x.readOnly ? "readonly" : "")}">
         <label
             part="label"
@@ -70,16 +70,20 @@ export const numberFieldTemplate: (context, definition) => ViewTemplate<NumberFi
                 x => !x.hideStep,
                 html`
                     <div class="controls" part="controls">
-                        <div
-                            class="step-up"
-                            part="step-up"
-                            @click="${x => x.stepUp()}"
-                        ></div>
+                        <div class="step-up" part="step-up" @click="${x => x.stepUp()}">
+                            <slot name="step-up-glyph">
+                                ${definition.stepUpGlyph || ""}
+                            </slot>
+                        </div>
                         <div
                             class="step-down"
                             part="step-down"
                             @click="${x => x.stepDown()}"
-                        ></div>
+                        >
+                            <slot name="step-down-glyph">
+                                ${definition.stepDownGlyph || ""}
+                            </slot>
+                        </div>
                     </div>
                 `
             )}

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -1,8 +1,24 @@
-import { attr, DOM, nullableNumberConverter, observable } from "@microsoft/fast-element";
+import {
+    attr,
+    DOM,
+    nullableNumberConverter,
+    observable,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 import { StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/index";
+import type { FoundationElementDefinition } from "../foundation-element";
 import { DelegatesARIATextbox } from "../text-field/index";
 import { FormAssociatedNumberField } from "./number-field.form-associated";
+
+/**
+ * Number Field configuration options
+ * @public
+ */
+export type NumberFieldOptions = FoundationElementDefinition & {
+    stepDownGlyph?: string | SyntheticViewTemplate;
+    stepUpGlyph?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Number Field Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/progress-ring/progress-ring.template.ts
+++ b/packages/web-components/fast-foundation/src/progress-ring/progress-ring.template.ts
@@ -48,22 +48,7 @@ export const progressRingTemplate: (context, definition) => ViewTemplate<BasePro
             x => typeof x.value !== "number",
             html<BaseProgress>`
                 <slot name="indeterminate" slot="indeterminate">
-                    <svg class="progress" part="progress" viewBox="0 0 16 16">
-                        <circle
-                            class="background"
-                            part="background"
-                            cx="8px"
-                            cy="8px"
-                            r="7px"
-                        ></circle>
-                        <circle
-                            class="indeterminate-indicator-1"
-                            part="indeterminate-indicator-1"
-                            cx="8px"
-                            cy="8px"
-                            r="7px"
-                        ></circle>
-                    </svg>
+                    ${definition.indeterminateIndicator}
                 </slot>
             `
         )}

--- a/packages/web-components/fast-foundation/src/progress/base-progress.ts
+++ b/packages/web-components/fast-foundation/src/progress/base-progress.ts
@@ -1,6 +1,26 @@
-import { attr, nullableNumberConverter } from "@microsoft/fast-element";
-import { FoundationElement } from "../foundation-element";
+import {
+    attr,
+    nullableNumberConverter,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
+import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
 
+/**
+ * Progress configuration options
+ * @public
+ */
+export type ProgressOptions = FoundationElementDefinition & {
+    indeterminateIndicator1?: string | SyntheticViewTemplate;
+    indeterminateIndicator2?: string | SyntheticViewTemplate;
+};
+
+/**
+ * ProgressRing configuration options
+ * @public
+ */
+export type ProgressRingOptions = FoundationElementDefinition & {
+    indeterminateIndicator?: string | SyntheticViewTemplate;
+};
 /**
  * An Progress HTML Element.
  * Implements the {@link https://www.w3.org/TR/wai-aria-1.1/#progressbar | ARIA progressbar }.

--- a/packages/web-components/fast-foundation/src/progress/progress.template.ts
+++ b/packages/web-components/fast-foundation/src/progress/progress.template.ts
@@ -1,15 +1,15 @@
 import { html, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import type { BaseProgress } from "./base-progress";
+import type { BaseProgress, ProgressOptions } from "./base-progress";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#BaseProgress} component.
  * @public
  */
-export const progressTemplate: (context, defintion) => ViewTemplate<BaseProgress> = (
+export const progressTemplate: (
     context,
-    defintion
-) => html`
+    defintion: ProgressOptions
+) => ViewTemplate<BaseProgress> = (context, defintion: ProgressOptions) => html`
     <template
         role="progressbar"
         aria-valuenow="${x => x.value}"
@@ -34,14 +34,8 @@ export const progressTemplate: (context, defintion) => ViewTemplate<BaseProgress
             html<BaseProgress>`
                 <div class="progress" part="progress" slot="indeterminate">
                     <slot class="indeterminate" name="indeterminate">
-                        <span
-                            class="indeterminate-indicator-1"
-                            part="indeterminate-indicator-1"
-                        ></span>
-                        <span
-                            class="indeterminate-indicator-2"
-                            part="indeterminate-indicator-2"
-                        ></span>
+                        ${defintion.indeterminateIndicator1 || ""}
+                        ${defintion.indeterminateIndicator2 || ""}
                     </slot>
                 </div>
             `

--- a/packages/web-components/fast-foundation/src/radio/radio.template.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.template.ts
@@ -1,14 +1,14 @@
 import { html, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import type { Radio } from "./radio";
+import type { Radio, RadioOptions } from "./radio";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Radio:class)} component.
  * @public
  */
-export const radioTemplate: (context, definition) => ViewTemplate<Radio> = (
+export const radioTemplate: (context, definition: RadioOptions) => ViewTemplate<Radio> = (
     context,
-    definition
+    definition: RadioOptions
 ) => html`
     <template
         role="radio"
@@ -23,7 +23,7 @@ export const radioTemplate: (context, definition) => ViewTemplate<Radio> = (
     >
         <div part="control" class="control">
             <slot name="checked-indicator">
-                <div part="checked-indicator" class="checked-indicator"></div>
+                ${definition.checkedIndicator || ""}
             </slot>
         </div>
         <label

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -1,5 +1,6 @@
-import { attr, observable } from "@microsoft/fast-element";
+import { attr, observable, SyntheticViewTemplate } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
+import type { FoundationElementDefinition } from "../foundation-element";
 import { FormAssociatedRadio } from "./radio.form-associated";
 
 /**
@@ -10,6 +11,14 @@ export type RadioControl = Pick<
     HTMLInputElement,
     "checked" | "disabled" | "readOnly" | "focus" | "setAttribute" | "getAttribute"
 >;
+
+/**
+ * Radio configuration options
+ * @public
+ */
+export type RadioOptions = FoundationElementDefinition & {
+    checkedIndicator?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Radio Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -2,16 +2,16 @@ import { html, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { Listbox } from "../listbox/listbox";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import type { Select } from "./select";
+import type { Select, SelectOptions } from "./select";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Select:class)} component.
  * @public
  */
-export const selectTemplate: (context, definition) => ViewTemplate<Select> = (
+export const selectTemplate: (
     context,
-    definition
-) => html`
+    definition: SelectOptions
+) => ViewTemplate<Select> = (context, definition: SelectOptions) => html`
     <template
         class="${x => (x.open ? "open" : "")} ${x =>
             x.disabled ? "disabled" : ""} ${x => x.position}"
@@ -40,7 +40,7 @@ export const selectTemplate: (context, definition) => ViewTemplate<Select> = (
                 </div>
                 <div class="indicator" part="indicator" aria-hidden="true">
                     <slot name="indicator">
-                        ${definition.inidicator || ""}
+                        ${definition.indicator || ""}
                     </slot>
                 </div>
             </slot>

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -40,16 +40,7 @@ export const selectTemplate: (context, definition) => ViewTemplate<Select> = (
                 </div>
                 <div class="indicator" part="indicator" aria-hidden="true">
                     <slot name="indicator">
-                        <svg
-                            class="select-indicator"
-                            part="select-indicator"
-                            viewBox="0 0 12 7"
-                            xmlns="http://www.w3.org/2000/svg"
-                        >
-                            <path
-                                d="M11.85.65c.2.2.2.5 0 .7L6.4 6.84a.55.55 0 01-.78 0L.14 1.35a.5.5 0 11.71-.7L6 5.8 11.15.65c.2-.2.5-.2.7 0z"
-                            />
-                        </svg>
+                        ${definition.inidicator || ""}
                     </slot>
                 </div>
             </slot>

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -1,10 +1,24 @@
-import { attr, Observable, observable } from "@microsoft/fast-element";
+import {
+    attr,
+    Observable,
+    observable,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
+import type { FoundationElementDefinition } from "../foundation-element";
 import type { ListboxOption } from "../listbox-option/listbox-option";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
 import { StartEnd } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 import { FormAssociatedSelect } from "./select.form-associated";
 import { SelectPosition, SelectRole } from "./select.options";
+
+/**
+ * Select configuration options
+ * @public
+ */
+export type SelectOptions = FoundationElementDefinition & {
+    indicator?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Select Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/slider/slider.template.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.template.ts
@@ -1,16 +1,16 @@
 import { html, ref } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { Orientation } from "@microsoft/fast-web-utilities";
-import type { Slider } from "./slider";
+import type { Slider, SliderOptions } from "./slider";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Slider:class)} component.
  * @public
  */
-export const sliderTemplate: (context, definition) => ViewTemplate<Slider> = (
+export const sliderTemplate: (
     context,
-    definition
-) => html`
+    definition: SliderOptions
+) => ViewTemplate<Slider> = (context, definition: SliderOptions) => html`
     <template
         role="slider"
         class="${x => (x.readOnly ? "readonly" : "")}
@@ -36,7 +36,7 @@ export const sliderTemplate: (context, definition) => ViewTemplate<Slider> = (
                 class="thumb-container"
                 style=${x => x.position}
             >
-                <slot name="thumb"><div class="thumb-cursor"></div></slot>
+                <slot name="thumb">${definition.thumb || ""}</slot>
             </div>
         </div>
     </template>

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -1,4 +1,9 @@
-import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
+import {
+    attr,
+    nullableNumberConverter,
+    observable,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 import {
     Direction,
     keyCodeArrowDown,
@@ -10,6 +15,7 @@ import {
     keyCodeTab,
     Orientation,
 } from "@microsoft/fast-web-utilities";
+import type { FoundationElementDefinition } from "../foundation-element";
 import { getDirection } from "../utilities/direction";
 import { convertPixelToPercent } from "./slider-utilities";
 import { FormAssociatedSlider } from "./slider.form-associated";
@@ -33,6 +39,14 @@ export interface SliderConfiguration {
     direction?: Direction;
     disabled?: boolean;
 }
+
+/**
+ * Slider configuration options
+ * @public
+ */
+export type SliderOptions = FoundationElementDefinition & {
+    thumb?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Slider Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/switch/switch.template.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.template.ts
@@ -1,15 +1,15 @@
 import { html, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import type { Switch } from "./switch";
+import type { Switch, SwitchOptions } from "./switch";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Switch:class)} component.
  * @public
  */
-export const switchTemplate: (context, definition) => ViewTemplate<Switch> = (
+export const switchTemplate: (
     context,
-    definition
-) => html`
+    definition: SwitchOptions
+) => ViewTemplate<Switch> = (context, definition: SwitchOptions) => html`
     <template
         role="switch"
         aria-checked="${x => x.checked}"
@@ -30,7 +30,7 @@ export const switchTemplate: (context, definition) => ViewTemplate<Switch> = (
             <slot ${slotted("defaultSlottedNodes")}></slot>
         </label>
         <div part="switch" class="switch">
-            <span class="checked-indicator" part="checked-indicator"></span>
+            <slot name="switch">${definition.switch || ""}</slot>
         </div>
         <span class="status-message" part="status-message">
             <span class="checked-message" part="checked-message">

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -1,6 +1,15 @@
-import { attr, observable } from "@microsoft/fast-element";
+import { attr, observable, SyntheticViewTemplate } from "@microsoft/fast-element";
 import { keyCodeSpace } from "@microsoft/fast-web-utilities";
+import type { FoundationElementDefinition } from "../foundation-element";
 import { FormAssociatedSwitch } from "./switch.form-associated";
+
+/**
+ * Switch configuration options
+ * @public
+ */
+export type SwitchOptions = FoundationElementDefinition & {
+    switch?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Switch Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -1,16 +1,16 @@
 import { children, elements, html, ref, slotted, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import type { TreeItem } from "./tree-item";
+import type { TreeItem, TreeItemOptions } from "./tree-item";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(TreeItem:class)} component.
  * @public
  */
-export const treeItemTemplate: (context, definition) => ViewTemplate<TreeItem> = (
+export const treeItemTemplate: (
     context,
-    definition
-) => html`
+    definition: TreeItemOptions
+) => ViewTemplate<TreeItem> = (context, definition: TreeItemOptions) => html`
     <template
         role="treeitem"
         slot="${x => (x.isNestedItem() ? "item" : void 0)}"
@@ -43,15 +43,7 @@ export const treeItemTemplate: (context, definition) => ViewTemplate<TreeItem> =
                             ${ref("expandCollapseButton")}
                         >
                             <slot name="expand-collapse-glyph">
-                                <svg
-                                    viewBox="0 0 16 16"
-                                    xmlns="http://www.w3.org/2000/svg"
-                                    class="expand-collapse-glyph"
-                                >
-                                    <path
-                                        d="M5.00001 12.3263C5.00124 12.5147 5.05566 12.699 5.15699 12.8578C5.25831 13.0167 5.40243 13.1437 5.57273 13.2242C5.74304 13.3047 5.9326 13.3354 6.11959 13.3128C6.30659 13.2902 6.4834 13.2152 6.62967 13.0965L10.8988 8.83532C11.0739 8.69473 11.2153 8.51658 11.3124 8.31402C11.4096 8.11146 11.46 7.88966 11.46 7.66499C11.46 7.44033 11.4096 7.21853 11.3124 7.01597C11.2153 6.81341 11.0739 6.63526 10.8988 6.49467L6.62967 2.22347C6.48274 2.10422 6.30501 2.02912 6.11712 2.00691C5.92923 1.9847 5.73889 2.01628 5.56823 2.09799C5.39757 2.17969 5.25358 2.30817 5.153 2.46849C5.05241 2.62882 4.99936 2.8144 5.00001 3.00369V12.3263Z"
-                                    />
-                                </svg>
+                                ${definition.expandCollapseGlyph || ""}
                             </slot>
                         </div>
                     `

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -1,4 +1,10 @@
-import { attr, Notifier, observable, Observable } from "@microsoft/fast-element";
+import {
+    attr,
+    Notifier,
+    observable,
+    Observable,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 import {
     getDisplayedNodes,
     isHTMLElement,
@@ -11,7 +17,7 @@ import {
 import { StartEnd } from "../patterns/start-end";
 import type { TreeView } from "../tree-view";
 import { applyMixins } from "../utilities/apply-mixins";
-import { FoundationElement } from "../foundation-element";
+import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
 
 /**
  * check if the item is a tree item
@@ -22,6 +28,14 @@ import { FoundationElement } from "../foundation-element";
 export function isTreeItemElement(el: Element): el is HTMLElement {
     return isHTMLElement(el) && (el.getAttribute("role") as string) === "treeitem";
 }
+
+/**
+ * Tree Item configuration options
+ * @public
+ */
+export type TreeItemOptions = FoundationElementDefinition & {
+    expandCollapseGlyph?: string | SyntheticViewTemplate;
+};
 
 /**
  * A Tree item Custom HTML Element.


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR adds support for default slotted content for certain components (primarily those with visual state or behavior indicators). During this I took the opportunity to close #4724.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->