### PR TITLE
Revert "update to exclude tooling from beachball publishing"

### DIFF
--- a/build/releasing/index.ts
+++ b/build/releasing/index.ts
@@ -11,7 +11,6 @@ export const config: BeachballConfig = {
                 "packages/utilities/*",
                 "packages/web-components/*",
             ],
-            exclude: ["packages/tooling/fast-tooling"],
             disallowedChangeTypes: ["major"],
         },
     ],


### PR DESCRIPTION
Reverts microsoft/fast#4722