### PR TITLE
split playwright steps in PR actions

### DIFF
--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -42,14 +42,31 @@ jobs:
     - name: Testing unit tests
       run: yarn lerna run test --stream
 
-    - name: Test Playwright
+    - name: Build Playwright tests
       run: |
-        cd packages/web-components/fast-components
-        npm install playwright
-        yarn test-chromium:pw 
-        yarn test-firefox:pw 
-        yarn test-webkit:pw
-      
+        yarn workspace @microsoft/fast-components build:pw
+
+    - name: Test Playwright (chromium)
+      env:
+        PLAYWRIGHT_BROWSER: chromium
+      run: |
+        yarn playwright install chromium
+        yarn workspace @microsoft/fast-components test-pw
+
+    - name: Test Playwright (firefox)
+      env:
+        PLAYWRIGHT_BROWSER: firefox
+      run: |
+        yarn playwright install firefox
+        yarn workspace @microsoft/fast-components test-pw
+
+    - name: Test Playwright (webkit)
+      env:
+        PLAYWRIGHT_BROWSER: webkit
+      run: |
+        yarn playwright install webkit
+        yarn workspace @microsoft/fast-components test-pw
+
     - name: Initialize CodeQL
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
       uses: github/codeql-action/init@v1
@@ -99,14 +116,31 @@ jobs:
 
     - name: Testing unit tests
       run: yarn lerna run test --stream
-     
-    - name: Test Playwright
+
+    - name: Build Playwright tests
       run: |
-        cd packages/web-components/fast-components
-        npm install playwright
-        yarn test-chromium:pw 
-        yarn test-firefox:pw 
-        yarn test-webkit:pw
+        yarn workspace @microsoft/fast-components build:pw
+
+    - name: Test Playwright (chromium)
+      env:
+        PLAYWRIGHT_BROWSER: chromium
+      run: |
+        yarn playwright install chromium
+        yarn workspace @microsoft/fast-components test-pw
+
+    - name: Test Playwright (firefox)
+      env:
+        PLAYWRIGHT_BROWSER: firefox
+      run: |
+        yarn playwright install firefox
+        yarn workspace @microsoft/fast-components test-pw
+
+    - name: Test Playwright (webkit)
+      env:
+        PLAYWRIGHT_BROWSER: webkit
+      run: |
+        yarn playwright install webkit
+        yarn workspace @microsoft/fast-components test-pw
 
   macos_cross-platform_cross-browser:
     runs-on: [macos-latest]
@@ -139,10 +173,27 @@ jobs:
     - name: Testing unit tests
       run: yarn lerna run test --stream
 
-    - name: Test Playwright
+    - name: Build Playwright tests
       run: |
-        cd packages/web-components/fast-components
-        npm install playwright
-        yarn test-chromium:pw 
-        yarn test-firefox:pw 
-        yarn test-webkit:pw
+        yarn workspace @microsoft/fast-components build:pw
+
+    - name: Test Playwright (chromium)
+      env:
+        PLAYWRIGHT_BROWSER: chromium
+      run: |
+        yarn playwright install chromium
+        yarn workspace @microsoft/fast-components test-pw
+
+    - name: Test Playwright (firefox)
+      env:
+        PLAYWRIGHT_BROWSER: firefox
+      run: |
+        yarn playwright install firefox
+        yarn workspace @microsoft/fast-components test-pw
+
+    - name: Test Playwright (webkit)
+      env:
+        PLAYWRIGHT_BROWSER: webkit
+      run: |
+        yarn playwright install webkit
+        yarn workspace @microsoft/fast-components test-pw

--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -56,19 +56,25 @@ jobs:
       run: yarn workspace @microsoft/fast-components build:pw
 
     - name: Test Playwright (chromium)
+      run: yarn workspace @microsoft/fast-components test-pw
+      continue-on-error: true
+      timeout-minutes: 2
       env:
         PLAYWRIGHT_BROWSER: chromium
-      run: yarn workspace @microsoft/fast-components test-pw
 
     - name: Test Playwright (firefox)
+      run: yarn workspace @microsoft/fast-components test-pw
+      continue-on-error: true
+      timeout-minutes: 2
       env:
         PLAYWRIGHT_BROWSER: firefox
-      run: yarn workspace @microsoft/fast-components test-pw
 
     - name: Test Playwright (webkit)
+      run: yarn workspace @microsoft/fast-components test-pw
+      continue-on-error: true
+      timeout-minutes: 2
       env:
         PLAYWRIGHT_BROWSER: webkit
-      run: yarn workspace @microsoft/fast-components test-pw
 
     - name: Initialize CodeQL
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -135,16 +141,22 @@ jobs:
 
     - name: Test Playwright (chromium)
       run: yarn workspace @microsoft/fast-components test-pw
+      continue-on-error: true
+      timeout-minutes: 2
       env:
         PLAYWRIGHT_BROWSER: chromium
 
     - name: Test Playwright (firefox)
       run: yarn workspace @microsoft/fast-components test-pw
+      continue-on-error: true
+      timeout-minutes: 2
       env:
         PLAYWRIGHT_BROWSER: firefox
 
     - name: Test Playwright (webkit)
       run: yarn workspace @microsoft/fast-components test-pw
+      continue-on-error: true
+      timeout-minutes: 2
       env:
         PLAYWRIGHT_BROWSER: webkit
 
@@ -194,15 +206,21 @@ jobs:
 
     - name: Test Playwright (chromium)
       run: yarn workspace @microsoft/fast-components test-pw
+      continue-on-error: true
+      timeout-minutes: 2
       env:
         PLAYWRIGHT_BROWSER: chromium
 
     - name: Test Playwright (firefox)
       run: yarn workspace @microsoft/fast-components test-pw
+      continue-on-error: true
+      timeout-minutes: 2
       env:
         PLAYWRIGHT_BROWSER: firefox
 
     - name: Test Playwright (webkit)
       run: yarn workspace @microsoft/fast-components test-pw
+      continue-on-error: true
+      timeout-minutes: 2
       env:
         PLAYWRIGHT_BROWSER: webkit

--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -13,6 +13,8 @@ on:
 jobs:
   linux_cross-platform_cross-browser:
     runs-on: [ubuntu-latest]
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: 0
 
     steps:
     - uses: actions/checkout@v2
@@ -82,6 +84,8 @@ jobs:
 
   windows_cross-platform_cross-browser:
     runs-on: [windows-latest]
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: 0
 
     steps:
     - name: Set git to use LF
@@ -150,6 +154,8 @@ jobs:
 
   macos_cross-platform_cross-browser:
     runs-on: [macos-latest]
+    env:
+      PLAYWRIGHT_BROWSERS_PATH: 0
 
     steps:
     - uses: actions/checkout@v2

--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -47,30 +47,28 @@ jobs:
     - name: Testing unit tests
       run: yarn lerna run test --stream
 
-    - name: Build Playwright tests
+    - name: Install playwright dependencies and browsers
       run: |
-        yarn workspace @microsoft/fast-components build:pw
+        yarn playwright install-deps
+        yarn playwright install
+
+    - name: Build Playwright tests
+      run: yarn workspace @microsoft/fast-components build:pw
 
     - name: Test Playwright (chromium)
       env:
         PLAYWRIGHT_BROWSER: chromium
-      run: |
-        yarn playwright install chromium
-        yarn workspace @microsoft/fast-components test-pw
+      run: yarn workspace @microsoft/fast-components test-pw
 
     - name: Test Playwright (firefox)
       env:
         PLAYWRIGHT_BROWSER: firefox
-      run: |
-        yarn playwright install firefox
-        yarn workspace @microsoft/fast-components test-pw
+      run: yarn workspace @microsoft/fast-components test-pw
 
     - name: Test Playwright (webkit)
       env:
         PLAYWRIGHT_BROWSER: webkit
-      run: |
-        yarn playwright install webkit
-        yarn workspace @microsoft/fast-components test-pw
+      run: yarn workspace @microsoft/fast-components test-pw
 
     - name: Initialize CodeQL
       if: ${{ github.event_name == 'push' && github.ref == 'refs/heads/master' }}
@@ -127,30 +125,28 @@ jobs:
     - name: Testing unit tests
       run: yarn lerna run test --stream
 
-    - name: Build Playwright tests
+    - name: Install playwright dependencies and browsers
       run: |
-        yarn workspace @microsoft/fast-components build:pw
+        yarn playwright install-deps
+        yarn playwright install
+
+    - name: Build Playwright tests
+      run: yarn workspace @microsoft/fast-components build:pw
 
     - name: Test Playwright (chromium)
+      run: yarn workspace @microsoft/fast-components test-pw
       env:
         PLAYWRIGHT_BROWSER: chromium
-      run: |
-        yarn playwright install chromium
-        yarn workspace @microsoft/fast-components test-pw
 
     - name: Test Playwright (firefox)
+      run: yarn workspace @microsoft/fast-components test-pw
       env:
         PLAYWRIGHT_BROWSER: firefox
-      run: |
-        yarn playwright install firefox
-        yarn workspace @microsoft/fast-components test-pw
 
     - name: Test Playwright (webkit)
+      run: yarn workspace @microsoft/fast-components test-pw
       env:
         PLAYWRIGHT_BROWSER: webkit
-      run: |
-        yarn playwright install webkit
-        yarn workspace @microsoft/fast-components test-pw
 
   macos_cross-platform_cross-browser:
     runs-on: [macos-latest]
@@ -188,27 +184,25 @@ jobs:
     - name: Testing unit tests
       run: yarn lerna run test --stream
 
-    - name: Build Playwright tests
+    - name: Install playwright dependencies and browsers
       run: |
-        yarn workspace @microsoft/fast-components build:pw
+        yarn playwright install-deps
+        yarn playwright install
+
+    - name: Build Playwright tests
+      run: yarn workspace @microsoft/fast-components build:pw
 
     - name: Test Playwright (chromium)
+      run: yarn workspace @microsoft/fast-components test-pw
       env:
         PLAYWRIGHT_BROWSER: chromium
-      run: |
-        yarn playwright install chromium
-        yarn workspace @microsoft/fast-components test-pw
 
     - name: Test Playwright (firefox)
+      run: yarn workspace @microsoft/fast-components test-pw
       env:
         PLAYWRIGHT_BROWSER: firefox
-      run: |
-        yarn playwright install firefox
-        yarn workspace @microsoft/fast-components test-pw
 
     - name: Test Playwright (webkit)
+      run: yarn workspace @microsoft/fast-components test-pw
       env:
         PLAYWRIGHT_BROWSER: webkit
-      run: |
-        yarn playwright install webkit
-        yarn workspace @microsoft/fast-components test-pw

--- a/.github/workflows/ci-weekly.yml
+++ b/.github/workflows/ci-weekly.yml
@@ -1,7 +1,7 @@
 name: CI - FAST Validation
 
 on:
-  push: 
+  push:
     branches:
     - master
   pull_request:
@@ -9,11 +9,11 @@ on:
     - master
   schedule:
     - cron: 0 7 * * 3
-  
+
 jobs:
   linux_cross-platform_cross-browser:
     runs-on: [ubuntu-latest]
-    
+
     steps:
     - uses: actions/checkout@v2
 
@@ -22,10 +22,13 @@ jobs:
       run: echo '::set-output name=dir::$(yarn cache dir)'
 
     - name: Set up node_modules cache
-      uses: actions/cache@v1.1.2
+      uses: actions/cache@v2
       id: yarn-cache
       with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        path: |
+          ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          node_modules
+          */*/node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
@@ -97,20 +100,23 @@ jobs:
       run: echo '::set-output name=dir::$(yarn cache dir)'
 
     - name: Set up node_modules cache
-      uses: actions/cache@v1.1.2
+      uses: actions/cache@v2
       id: yarn-cache
       with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        path: |
+          ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          node_modules
+          */*/node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
 
     - name: Install package dependencies
       run: yarn install --frozen-lockfile --ignore-scripts
-    
+
     - name: Testing Prettier format
       run: yarn format:check
-      
+
     - name: Prepare workspaces
       run: yarn prepare
 
@@ -153,17 +159,20 @@ jobs:
       run: echo '::set-output name=dir::$(yarn cache dir)'
 
     - name: Set up node_modules cache
-      uses: actions/cache@v1.1.2
+      uses: actions/cache@v2
       id: yarn-cache
       with:
-        path: ${{ steps.yarn-cache-dir-path.outputs.dir }}
+        path: |
+          ${{ steps.yarn-cache-dir-path.outputs.dir }}
+          node_modules
+          */*/node_modules
         key: ${{ runner.os }}-yarn-${{ hashFiles('**/yarn.lock') }}
         restore-keys: |
           ${{ runner.os }}-yarn-
 
     - name: Install package dependencies
       run: yarn install --network-timeout=36000 --frozen-lockfile --ignore-scripts
-    
+
     - name: Testing Prettier format
       run: yarn format:check
 

--- a/change/@microsoft-fast-components-7ed967b6-eff5-4071-ab45-ea6f05c428da.json
+++ b/change/@microsoft-fast-components-7ed967b6-eff5-4071-ab45-ea6f05c428da.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix mismatched environment variable",
+  "packageName": "@microsoft/fast-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-components/__test__/harness.js
+++ b/packages/web-components/fast-components/__test__/harness.js
@@ -1,7 +1,7 @@
 /* eslint-env node */
 import { chromium, firefox, webkit } from "playwright";
 
-const selectedBrowser = process.env.PW_BROWSER || "chromium";
+const selectedBrowser = process.env.PLAYWRIGHT_BROWSER || "chromium";
 const FixtureURL = process.env.FIXTURE_URL;
 const fixture = process.env.FIXTURE || "index.html";
 const expressPort = process.env.PW_PORT || 7001;

--- a/packages/web-components/fast-components/package.json
+++ b/packages/web-components/fast-components/package.json
@@ -93,7 +93,7 @@
     "karma-webpack": "^4.0.2",
     "lodash-es": "4.17.15",
     "mocha": "^8.2.1",
-    "playwright": "^1.9.1",
+    "playwright": "^1.11.0",
     "prettier": "2.0.2",
     "rollup": "^2.7.6",
     "rollup-plugin-commonjs": "^10.1.0",

--- a/yarn.lock
+++ b/yarn.lock
@@ -17018,10 +17018,10 @@ platform@^1.3.3:
   resolved "https://registry.yarnpkg.com/platform/-/platform-1.3.6.tgz#48b4ce983164b209c2d45a107adb31f473a6e7a7"
   integrity sha512-fnWVljUchTro6RiCFvCXBbNhJc2NijN7oIQxbwsyL0buWJPG85v81ehlHI9fXrJsMNgTofEoWIQeClKpgxFLrg==
 
-playwright@^1.9.1:
-  version "1.9.1"
-  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.9.1.tgz#b4db35f69076b2dc91e347e58d81f2f391d1ed49"
-  integrity sha512-bZXnks4UGJZoqja6TqVEUG0IQ2liqYFcO1R4lT43aO4oDVTQtawEJjS+EqLYsAuniRFWVE87Cemus4fRQbyXMg==
+playwright@^1.11.0:
+  version "1.11.0"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.11.0.tgz#0796cf08f4756e8187e01c705315d8e1fb48e25f"
+  integrity sha512-s3FQBRpu/pW/vZ/lFYhG/Q3WBUbT2rvMgrgy1PHDA7QtPN910C2rj9Ovd6A/m8yxuLnltd/OKqvlAGevWISHKw==
   dependencies:
     commander "^6.1.0"
     debug "^4.1.1"
@@ -17036,6 +17036,7 @@ playwright@^1.9.1:
     rimraf "^3.0.2"
     stack-utils "^2.0.3"
     ws "^7.3.1"
+    yazl "^2.5.1"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"
@@ -23629,6 +23630,13 @@ yauzl@^2.10.0:
   dependencies:
     buffer-crc32 "~0.2.3"
     fd-slicer "~1.1.0"
+
+yazl@^2.5.1:
+  version "2.5.1"
+  resolved "https://registry.yarnpkg.com/yazl/-/yazl-2.5.1.tgz#a3d65d3dd659a5b0937850e8609f22fffa2b5c35"
+  integrity sha512-phENi2PLiHnHb6QBVot+dJnaAZ0xosj7p3fWl+znIjBDlnMI2PsZCJZ306BPTFOaHf5qdDEI8x5qFrSOBN5vrw==
+  dependencies:
+    buffer-crc32 "~0.2.3"
 
 yeast@0.1.2:
   version "0.1.2"


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

- Fix a mismatched environment variable (`PLAYWRIGHT_BROWSER`)
- Update CI actions to use `actions/cache@v2`
- Add a CI environment variable to store Playwright binaries in `node_modules`
- Split CI playwright browser runs into separate tasks

### 🎫 Issues

## 👩‍💻 Reviewer Notes

These changes are intended to make it easier to catch actions that are hanging on the playwright step.

## 📑 Test Plan

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

It may be a good idea to store the Playwright binaries as artifacts and load them separately. The [Installation page](https://playwright.dev/docs/installation/#managing-browser-binaries) has some extra environment variables that we may want to explore in the future.