### PR TITLE
chore: fix/add to data grid component explorer examples

### DIFF
--- a/change/@microsoft-fast-components-2370cffd-4603-4a31-be75-333aaaa0c377.json
+++ b/change/@microsoft-fast-components-2370cffd-4603-4a31-be75-333aaaa0c377.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix/add to data grid component explorer sample",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-components/src/data-grid/data-grid.vscode.definition.json
+++ b/packages/web-components/fast-components/src/data-grid/data-grid.vscode.definition.json
@@ -10,8 +10,12 @@
                     "name": "generate-header",
                     "title": "Generate header",
                     "description": "Whether the grid should auto generate a header row",
-                    "type": "boolean",
-                    "default": true,
+                    "type": "string",
+                    "values": [
+                        { "name": "none" },
+                        { "name": "default" },
+                        { "name": "sticky" }
+                    ],
                     "required": false
                 },
                 {
@@ -20,11 +24,6 @@
                     "description":
                         "Value that gets applied to the the css gridTemplateColumns attribute of child rows",
                     "type": "string",
-                    "values": [
-                        { "name": "none" },
-                        { "name": "default" },
-                        { "name": "sticky" }
-                    ],
                     "required": false
                 }
             ],

--- a/packages/web-components/fast-components/src/data-grid/scenarios/index.html
+++ b/packages/web-components/fast-components/src/data-grid/scenarios/index.html
@@ -252,10 +252,6 @@
             </fast-button>
         </p>
 
-        <p>
-            <fast-data-grid id="samplegrid"></fast-data-grid>
-        </p>
-
         <p></p>
         <h1>Column widths</h1>
         <h2>Each row of a data grid is rendered using css grid layout</h2>
@@ -282,4 +278,36 @@
         </h2>
     </div>
 </template>
-a
+<template title="Manual grid">
+    <div>
+        <fast-data-grid
+            id="samplegrid"
+            grid-template-columns="1fr 1fr"
+            generate-header="none"
+        >
+            <fast-data-grid-row row-type="header">
+                <fast-data-grid-cell grid-column="1" cell-type="columnheader">
+                    Column 1
+                </fast-data-grid-cell>
+                <fast-data-grid-cell grid-column="2" cell-type="columnheader">
+                    Column 2
+                </fast-data-grid-cell>
+            </fast-data-grid-row>
+            <fast-data-grid-row>
+                <fast-data-grid-cell grid-column="1">1.1</fast-data-grid-cell>
+                <fast-data-grid-cell grid-column="2">1.2</fast-data-grid-cell>
+            </fast-data-grid-row>
+            <fast-data-grid-row>
+                <fast-data-grid-cell grid-column="1">2.1</fast-data-grid-cell>
+                <fast-data-grid-cell grid-column="2">2.2</fast-data-grid-cell>
+            </fast-data-grid-row>
+        </fast-data-grid>
+        <p></p>
+        <h1>Manual grid</h1>
+        <h2>Grids can also be defined with html</h2>
+        <h2>
+            Authors will need to define the 'grid-template-columns' of manual grids as
+            well as assign each cell to a 'grid-column'.
+        </h2>
+    </div>
+</template>

--- a/sites/site-utilities/statics/assets/components/fast-data-grid.schema.json
+++ b/sites/site-utilities/statics/assets/components/fast-data-grid.schema.json
@@ -9,18 +9,17 @@
   "mapsToTagName": "fast-data-grid",
   "properties": {
     "generate-header": {
-      "default": true,
-      "title": "Generate header",
-      "description": "Whether the grid should auto generate a header row",
-      "mapsToAttribute": "generate-header",
-      "type": "boolean"
-    },
-    "grid-template-columns": {
       "enum": [
         "none",
         "default",
         "sticky"
       ],
+      "title": "Generate header",
+      "description": "Whether the grid should auto generate a header row",
+      "mapsToAttribute": "generate-header",
+      "type": "string"
+    },
+    "grid-template-columns": {
       "title": "Grid template columns",
       "description": "Value that gets applied to the the css gridTemplateColumns attribute of child rows",
       "mapsToAttribute": "grid-template-columns",


### PR DESCRIPTION
## 📖 Description
Added a "manual" (defined in html) data grid example to component explorer scenarios, fixed issue with definition file.

### 🎫 Issues
https://github.com/microsoft/fast/issues/4677

## ✅ Checklist

### General
- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [ ] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
