### PR TITLE
feat(design-system): enable overriding the shadow root mode

### DIFF
--- a/change/@microsoft-fast-foundation-84313fab-6646-4094-bf23-c2ce86be930c.json
+++ b/change/@microsoft-fast-foundation-84313fab-6646-4094-bf23-c2ce86be930c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(design-system): enable overriding the shadow root mode",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -818,6 +818,8 @@ export interface DesignSystem {
     withElementDisambiguation(callback: ElementDisambiguationCallback): DesignSystem;
     // (undocumented)
     withPrefix(prefix: string): DesignSystem;
+    // (undocumented)
+    withShadowRootMode(mode: ShadowRootMode): DesignSystem;
 }
 
 // @alpha (undocumented)
@@ -1031,6 +1033,8 @@ export interface ElementDefinitionContext {
     definePresentation(presentation: ComponentPresentation): void;
     // (undocumented)
     readonly name: string;
+    // (undocumented)
+    readonly shadowRootMode: ShadowRootMode | undefined;
     // (undocumented)
     tagFor(type: Constructable): string;
     // (undocumented)

--- a/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
@@ -186,4 +186,66 @@ describe("DesignSystem", () => {
 
         expect(customElements.get(elementName)).to.equal(customElement);
     });
+
+    it("Should have an undefined shadow mode by default", () => {
+        const elementName = uniqueElementName();
+        const customElement = class extends HTMLElement {};
+        const host = document.createElement("div");
+        let mode: ShadowRootMode | undefined | null = null;
+
+        DesignSystem.getOrCreate(host)
+            .register({
+                register(container: Container) {
+                    const context = container.get(DesignSystemRegistrationContext);
+                    context.tryDefineElement(elementName, customElement, x => {
+                        mode = x.shadowRootMode;
+                        x.defineElement();
+                    });
+                },
+            });
+
+        expect(mode).to.equal(undefined);
+    });
+
+    it("Should pass through open shadow mode overrides", () => {
+        const elementName = uniqueElementName();
+        const customElement = class extends HTMLElement {};
+        const host = document.createElement("div");
+        let mode: ShadowRootMode | undefined | null = null;
+
+        DesignSystem.getOrCreate(host)
+            .withShadowRootMode('open')
+            .register({
+                register(container: Container) {
+                    const context = container.get(DesignSystemRegistrationContext);
+                    context.tryDefineElement(elementName, customElement, x => {
+                        mode = x.shadowRootMode;
+                        x.defineElement();
+                    });
+                },
+            });
+
+        expect(mode).to.equal('open');
+    });
+
+    it("Should pass through closed shadow mode overrides", () => {
+        const elementName = uniqueElementName();
+        const customElement = class extends HTMLElement {};
+        const host = document.createElement("div");
+        let mode: ShadowRootMode | undefined | null = null;
+
+        DesignSystem.getOrCreate(host)
+            .withShadowRootMode('closed')
+            .register({
+                register(container: Container) {
+                    const context = container.get(DesignSystemRegistrationContext);
+                    context.tryDefineElement(elementName, customElement, x => {
+                        mode = x.shadowRootMode;
+                        x.defineElement();
+                    });
+                },
+            });
+
+        expect(mode).to.equal('closed');
+    });
 });

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
@@ -213,4 +213,88 @@ describe("FoundationElement", () => {
             expect(customElements.get(overrideFullName)).to.equal(MyElement);
         });
     });
+
+    describe("shadow mode", () => {
+        it("should be open by default", () => {
+            class MyElement extends FoundationElement {}
+            const baseName = uniqueElementName();
+            const fullName = `fast-${baseName}`;
+            const myElement = MyElement.compose({
+                styles: css``,
+                template: html`test`,
+                baseName
+            });
+
+            const host = document.createElement("div");
+            DesignSystem.getOrCreate(host)
+                .register(myElement());
+
+            const element = document.createElement(fullName);
+            expect(element.shadowRoot).to.be.instanceof(ShadowRoot);
+        });
+
+        it("can be overridden to closed by the design system", () => {
+            class MyElement extends FoundationElement {}
+            const baseName = uniqueElementName();
+            const fullName = `fast-${baseName}`;
+            const myElement = MyElement.compose({
+                styles: css``,
+                template: html`test`,
+                baseName,
+                shadowOptions: {
+                    mode: 'open'
+                }
+            });
+
+            const host = document.createElement("div");
+            DesignSystem.getOrCreate(host)
+                .withShadowRootMode('closed')
+                .register(myElement());
+
+            const element = document.createElement(fullName);
+            expect(element.shadowRoot).to.be.null;
+        });
+
+        it("can be be override to open by the design system", () => {
+            class MyElement extends FoundationElement {}
+            const baseName = uniqueElementName();
+            const fullName = `fast-${baseName}`;
+            const myElement = MyElement.compose({
+                styles: css``,
+                template: html`test`,
+                baseName,
+                shadowOptions: {
+                    mode: 'closed'
+                }
+            });
+
+            const host = document.createElement("div");
+            DesignSystem.getOrCreate(host)
+                .withShadowRootMode('open')
+                .register(myElement());
+
+            const element = document.createElement(fullName);
+            expect(element.shadowRoot).to.be.instanceof(ShadowRoot);
+        });
+
+        it("is not overridden when the component targets light DOM", () => {
+            class MyElement extends FoundationElement {}
+            const baseName = uniqueElementName();
+            const fullName = `fast-${baseName}`;
+            const myElement = MyElement.compose({
+                styles: css``,
+                template: html`test`,
+                baseName,
+                shadowOptions: null
+            });
+
+            const host = document.createElement("div");
+            DesignSystem.getOrCreate(host)
+                .withShadowRootMode('open')
+                .register(myElement());
+
+            const element = document.createElement(fullName);
+            expect(element.shadowRoot).to.be.null;
+        });
+    });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

Enables the consumer of the components to override the component's configured shadow root mode across the design system. Individual component overrides still take precedence.

## 👩‍💻 Reviewer Notes

The first change was made in the `DesignSystem` API, adding a method to provide the configuration and piping that through. The second change was made in `FoundationElement#compose` internals, which now takes advantage of this configuration information when defining the component.

## 📑 Test Plan

Tests were added both for `DesignSystem` and for `FoundationElement` covering the basic use cases as well as the special light DOM exception.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Future PRs will likely be focused around adding code documentation around `DesignSytem`, `FoundationElement`, and `DI`. We'll also move the various APIs out of alpha as we add the docs.