### PR TITLE
feat: nested grid

### DIFF
--- a/change/@microsoft-fast-components-39bb9635-0498-4578-9bdc-e067511340bc.json
+++ b/change/@microsoft-fast-components-39bb9635-0498-4578-9bdc-e067511340bc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "enable no tabbing",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-4f66052e-e470-4bb4-b664-b587959b300b.json
+++ b/change/@microsoft-fast-foundation-4f66052e-e470-4bb4-b664-b587959b300b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "enable no tabbing",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/data-grid/data-grid.stories.ts
+++ b/packages/web-components/fast-components/src/data-grid/data-grid.stories.ts
@@ -13,6 +13,7 @@ import DataGridTemplate from "./fixtures/base.html";
 import "./index";
 
 let defaultGridElement: DataGrid | null = null;
+
 const defaultRowData: object = newDataRow("default");
 
 const columnWidths: string[] = ["1fr", "1fr", "1fr", "1fr"];
@@ -56,6 +57,11 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
     if (name.toLowerCase().startsWith("data-grid")) {
         defaultGridElement = document.getElementById("defaultGrid") as DataGrid;
         reset();
+
+        const nestedCell1 = document.getElementById("nestedCell1") as DataGridCell;
+        nestedCell1.columnDefinition = nestedColumn;
+        const nestedCell2 = document.getElementById("nestedCell2") as DataGridCell;
+        nestedCell2.columnDefinition = nestedColumn;
 
         const defaultGridRow = document.getElementById("defaultGridRow") as DataGridRow;
         if (defaultGridRow) {
@@ -431,6 +437,12 @@ const baseColumns: ColumnDefinition[] = [
     { columnDataKey: "item3" },
 ];
 
+const nestedColumn: ColumnDefinition = {
+    columnDataKey: "item2",
+    cellInternalFocusQueue: true,
+    cellFocusTargetCallback: getFocusTarget,
+};
+
 const templateColumns: ColumnDefinition[] = [
     {
         title: "RowID",
@@ -468,7 +480,7 @@ const templateColumns: ColumnDefinition[] = [
 ];
 
 function getFocusTarget(cell: DataGridCell): HTMLElement {
-    return cell.querySelector("fast-button") as HTMLElement;
+    return cell.children[0] as HTMLElement;
 }
 
 export default {

--- a/packages/web-components/fast-components/src/data-grid/data-grid.vscode.definition.json
+++ b/packages/web-components/fast-components/src/data-grid/data-grid.vscode.definition.json
@@ -25,6 +25,14 @@
                         "Value that gets applied to the the css gridTemplateColumns attribute of child rows",
                     "type": "string",
                     "required": false
+                },
+                {
+                    "name": "no-tabbing",
+                    "title": "Disable tabbing",
+                    "description":
+                        "When true the component will not add itself or its children to the tab queue",
+                    "type": "boolean",
+                    "required": false
                 }
             ],
             "slots": [

--- a/packages/web-components/fast-components/src/data-grid/fixtures/base.html
+++ b/packages/web-components/fast-components/src/data-grid/fixtures/base.html
@@ -82,3 +82,47 @@
         <fast-data-grid-cell grid-column="2">2.2</fast-data-grid-cell>
     </fast-data-grid-row>
 </fast-data-grid>
+
+<h2>nested grid</h2>
+<fast-data-grid id="nestedGrid" grid-template-columns="1fr 1fr" generate-header="none">
+    <fast-data-grid-row>
+        <fast-data-grid-cell grid-column="1">1.1</fast-data-grid-cell>
+        <fast-data-grid-cell grid-column="2" id="nestedCell1">
+            <fast-data-grid
+                grid-template-columns="1fr 1fr"
+                generate-header="none"
+                no-tabbing="true"
+                style="background-color: darkolivegreen;"
+            >
+                <fast-data-grid-row>
+                    <fast-data-grid-cell grid-column="1">1.2.1.1</fast-data-grid-cell>
+                    <fast-data-grid-cell grid-column="2">1.2.1.2</fast-data-grid-cell>
+                </fast-data-grid-row>
+                <fast-data-grid-row>
+                    <fast-data-grid-cell grid-column="1">1.2.2.1</fast-data-grid-cell>
+                    <fast-data-grid-cell grid-column="2">1.2.2.2</fast-data-grid-cell>
+                </fast-data-grid-row>
+            </fast-data-grid>
+        </fast-data-grid-cell>
+    </fast-data-grid-row>
+    <fast-data-grid-row>
+        <fast-data-grid-cell grid-column="1">2.1</fast-data-grid-cell>
+        <fast-data-grid-cell grid-column="2" id="nestedCell2">
+            <fast-data-grid
+                grid-template-columns="1fr 1fr"
+                generate-header="none"
+                no-tabbing="true"
+                style="background-color: darkolivegreen;"
+            >
+                <fast-data-grid-row>
+                    <fast-data-grid-cell grid-column="1">2.2.1.1</fast-data-grid-cell>
+                    <fast-data-grid-cell grid-column="2">2.2.1.2</fast-data-grid-cell>
+                </fast-data-grid-row>
+                <fast-data-grid-row>
+                    <fast-data-grid-cell grid-column="1">2.2.2.1</fast-data-grid-cell>
+                    <fast-data-grid-cell grid-column="2">2.2.2.2</fast-data-grid-cell>
+                </fast-data-grid-row>
+            </fast-data-grid>
+        </fast-data-grid-cell>
+    </fast-data-grid-row>
+</fast-data-grid>

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -643,7 +643,6 @@ export class DataGrid extends FoundationElement {
     // @internal (undocumented)
     handleRowFocus(e: Event): void;
     headerCellItemTemplate?: ViewTemplate;
-    // (undocumented)
     noTabbing: boolean;
     // @internal
     rowElements: HTMLElement[];

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -643,6 +643,8 @@ export class DataGrid extends FoundationElement {
     // @internal (undocumented)
     handleRowFocus(e: Event): void;
     headerCellItemTemplate?: ViewTemplate;
+    // (undocumented)
+    noTabbing: boolean;
     // @internal
     rowElements: HTMLElement[];
     rowElementTag: string;

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.template.ts
@@ -14,7 +14,8 @@ export const dataGridCellTemplate: FoundationElementTemplate<ViewTemplate<
     return html<DataGridCell>`
         <template
             tabindex="-1"
-            role="${x => (x.cellType === "default" ? "gridcell" : x.cellType)}"
+            role="${x =>
+                !x.cellType || x.cellType === "default" ? "gridcell" : x.cellType}"
             class="
             ${x =>
                 x.cellType === "columnheader"

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.template.ts
@@ -14,7 +14,7 @@ export const dataGridCellTemplate: FoundationElementTemplate<ViewTemplate<
     return html<DataGridCell>`
         <template
             tabindex="-1"
-            role="${x => x.cellType ?? "gridcell"}"
+            role="${x => (x.cellType === "default" ? "gridcell" : x.cellType)}"
             class="
             ${x =>
                 x.cellType === "columnheader"

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
@@ -188,7 +188,6 @@ export class DataGridCell extends FoundationElement {
         if (
             e.defaultPrevented ||
             this.columnDefinition === null ||
-            this.columnDefinition === undefined ||
             (this.cellType === DataGridCellTypes.default &&
                 this.columnDefinition.cellInternalFocusQueue !== true) ||
             (this.cellType === DataGridCellTypes.columnHeader &&
@@ -208,9 +207,12 @@ export class DataGridCell extends FoundationElement {
                 }
 
                 switch (this.cellType) {
-                    case DataGridCellTypes.default:
-                        if (this.columnDefinition.cellFocusTargetCallback !== undefined) {
-                            const focusTarget: HTMLElement = this.columnDefinition.cellFocusTargetCallback(
+                    case DataGridCellTypes.columnHeader:
+                        if (
+                            this.columnDefinition.headerCellFocusTargetCallback !==
+                            undefined
+                        ) {
+                            const focusTarget: HTMLElement = this.columnDefinition.headerCellFocusTargetCallback(
                                 this
                             );
                             if (focusTarget !== null) {
@@ -220,12 +222,9 @@ export class DataGridCell extends FoundationElement {
                         }
                         break;
 
-                    case DataGridCellTypes.columnHeader:
-                        if (
-                            this.columnDefinition.headerCellFocusTargetCallback !==
-                            undefined
-                        ) {
-                            const focusTarget: HTMLElement = this.columnDefinition.headerCellFocusTargetCallback(
+                    default:
+                        if (this.columnDefinition.cellFocusTargetCallback !== undefined) {
+                            const focusTarget: HTMLElement = this.columnDefinition.cellFocusTargetCallback(
                                 this
                             );
                             if (focusTarget !== null) {

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
@@ -49,7 +49,7 @@ export class DataGridCell extends FoundationElement {
      * HTML Attribute: cell-type
      */
     @attr({ attribute: "cell-type" })
-    public cellType: DataGridCellTypes;
+    public cellType: DataGridCellTypes = DataGridCellTypes.default;
     private cellTypeChanged(): void {
         if (this.$fastController.isConnected) {
             this.updateCellView();
@@ -99,7 +99,6 @@ export class DataGridCell extends FoundationElement {
 
     private isActiveCell: boolean = false;
     private customCellView: HTMLView | null = null;
-    private isInternalFocused: boolean = false;
 
     /**
      * @internal
@@ -182,7 +181,6 @@ export class DataGridCell extends FoundationElement {
     public handleFocusout(e: FocusEvent): void {
         if (this !== document.activeElement && !this.contains(document.activeElement)) {
             this.isActiveCell = false;
-            this.isInternalFocused = false;
         }
     }
 
@@ -190,6 +188,7 @@ export class DataGridCell extends FoundationElement {
         if (
             e.defaultPrevented ||
             this.columnDefinition === null ||
+            this.columnDefinition === undefined ||
             (this.cellType === DataGridCellTypes.default &&
                 this.columnDefinition.cellInternalFocusQueue !== true) ||
             (this.cellType === DataGridCellTypes.columnHeader &&
@@ -201,7 +200,10 @@ export class DataGridCell extends FoundationElement {
         switch (e.key) {
             case keyEnter:
             case keyFunction2:
-                if (this.isInternalFocused || this.columnDefinition === undefined) {
+                if (
+                    this.contains(document.activeElement) &&
+                    document.activeElement !== this
+                ) {
                     return;
                 }
 
@@ -212,7 +214,6 @@ export class DataGridCell extends FoundationElement {
                                 this
                             );
                             if (focusTarget !== null) {
-                                this.isInternalFocused = true;
                                 focusTarget.focus();
                             }
                             e.preventDefault();
@@ -228,7 +229,6 @@ export class DataGridCell extends FoundationElement {
                                 this
                             );
                             if (focusTarget !== null) {
-                                this.isInternalFocused = true;
                                 focusTarget.focus();
                             }
                             e.preventDefault();
@@ -238,9 +238,11 @@ export class DataGridCell extends FoundationElement {
                 break;
 
             case keyEscape:
-                if (this.isInternalFocused) {
+                if (
+                    this.contains(document.activeElement) &&
+                    document.activeElement !== this
+                ) {
                     this.focus();
-                    this.isInternalFocused = false;
                     e.preventDefault();
                 }
                 break;

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.spec.md
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.spec.md
@@ -121,6 +121,10 @@ Can be either "none", "default" or "sticky" (the `GeneratHeaderOptions` enum). A
 - `grid-template-columns`  
 String that gets applied to the the css gridTemplateColumns attribute of child rows. Corresponds to the [grid-template-columns css attribute](https://developer.mozilla.org/en-US/docs/Web/CSS/grid-template-columns)
 
+- `no-tabbing`
+Boolean, defaults to false.  When true the grid does not add itself to the tab queue.
+Useful when a grid is nested within a parent grid cell.
+
 *properties:*
 - `rowsData`  
 An array of objects that contain the data to be displayed. Each object corresponds to one row.

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.spec.ts
@@ -100,7 +100,7 @@ describe("Data grid", () => {
 
     it("should have a tabIndex of -1 when no-tabbing is true", async () => {
         const {  document, element, connect, disconnect } = await setup();
-        element.setAttribute("no-tabbing", "true");
+        element.noTabbing = true;
         await connect();
 
         expect(element.getAttribute("tabindex")).to.equal("-1");

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.spec.ts
@@ -98,6 +98,16 @@ describe("Data grid", () => {
         await disconnect();
     });
 
+    it("should have a tabIndex of -1 when no-tabbing is true", async () => {
+        const {  document, element, connect, disconnect } = await setup();
+        element.setAttribute("no-tabbing", "true");
+        await connect();
+
+        expect(element.getAttribute("tabindex")).to.equal("-1");
+
+        await disconnect();
+    });
+
     it("should have a tabIndex of -1 when a cell is focused", async () => {
         const { document, element, connect, disconnect } = await setup();
 

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -356,6 +356,10 @@ export class DataGrid extends FoundationElement {
         // only observe if nodes are added or removed
         this.observer.observe(this, { childList: true });
 
+        if (this.noTabbing) {
+            this.setAttribute("tabindex", "-1");
+        }
+
         DOM.queueUpdate(this.queueRowIndexUpdate);
     }
 

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -63,7 +63,7 @@ export interface ColumnDefinition {
      * When headerCellInternalFocusQueue is false this function is called when the cell is first focused
      * to immediately move focus to a cell element, for example a cell that is a checkbox could move
      * focus directly to the checkbox.
-     * When headerCellInternalFocusQueue is true this function is called when the user hits Enter or F2
+     * When ueuheaderCellInternalFocusQe is true this function is called when the user hits Enter or F2
      */
     headerCellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement;
 
@@ -125,6 +125,17 @@ export class DataGrid extends FoundationElement {
         });
         return templateColumns;
     }
+
+    /**
+     *
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: no-tabbing
+     */
+    @attr({ attribute: "no-tabbing", mode: "boolean" })
+    public noTabbing: boolean = false;
+    private noTabbingChangedChanged(): void {}
 
     /**
      *  Whether the grid should automatically generate a header row and its type
@@ -376,7 +387,7 @@ export class DataGrid extends FoundationElement {
      */
     public handleFocusOut(e: FocusEvent): void {
         if (e.relatedTarget === null || !this.contains(e.relatedTarget as Element)) {
-            this.setAttribute("tabIndex", "0");
+            this.setAttribute("tabIndex", this.noTabbing ? "-1" : "0");
         }
     }
 

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -63,7 +63,7 @@ export interface ColumnDefinition {
      * When headerCellInternalFocusQueue is false this function is called when the cell is first focused
      * to immediately move focus to a cell element, for example a cell that is a checkbox could move
      * focus directly to the checkbox.
-     * When ueuheaderCellInternalFocusQe is true this function is called when the user hits Enter or F2
+     * When headerCellInternalFocusQueue is true this function is called when the user hits Enter or F2
      */
     headerCellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement;
 

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -135,7 +135,21 @@ export class DataGrid extends FoundationElement {
      */
     @attr({ attribute: "no-tabbing", mode: "boolean" })
     public noTabbing: boolean = false;
-    private noTabbingChangedChanged(): void {}
+    private noTabbingChanged(): void {
+        if (this.$fastController.isConnected) {
+            if (this.noTabbing) {
+                this.setAttribute("tabIndex", "-1");
+            } else {
+                this.setAttribute(
+                    "tabIndex",
+                    this.contains(document.activeElement) ||
+                        this === document.activeElement
+                        ? "-1"
+                        : "0"
+                );
+            }
+        }
+    }
 
     /**
      *  Whether the grid should automatically generate a header row and its type

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -127,7 +127,8 @@ export class DataGrid extends FoundationElement {
     }
 
     /**
-     *
+     * When true the component will not add itself to the tab queue.
+     * Default is false.
      *
      * @public
      * @remarks

--- a/sites/site-utilities/statics/assets/components/fast-data-grid.schema.json
+++ b/sites/site-utilities/statics/assets/components/fast-data-grid.schema.json
@@ -25,6 +25,12 @@
       "mapsToAttribute": "grid-template-columns",
       "type": "string"
     },
+    "no-tabbing": {
+      "title": "Disable tabbing",
+      "description": "When true the component will not add itself or its children to the tab queue",
+      "mapsToAttribute": "no-tabbing",
+      "type": "boolean"
+    },
     "Slot": {
       "title": "Default slot",
       "description": "The content as data grid rows",


### PR DESCRIPTION
## 📖 Description

Yes, your grids can have grids.

![image](https://user-images.githubusercontent.com/7649425/119442110-15d46480-bcdc-11eb-9368-8fcc48966d76.png)

This pr adds a nested grid example and some minor fixes/changes to data-grid components to get the keyboarding to work correctly (ie. arrow keys to move around the grid, "Enter" to access a child grid, "esc" to move back to the parent).

The one notable change is adding a "no-tabbing" attribute to data grid so that nested grids don't add themselves to the tab queue which is a proposed fix for this issue: https://github.com/microsoft/fast/issues/4739.  

### 🎫 Issues
https://github.com/microsoft/fast/issues/4739

## 👩‍💻 Reviewer Notes


## 📑 Test Plan


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
