### PR TITLE
fixes CSSDesignToken dependent-property emission

### DIFF
--- a/change/@microsoft-fast-foundation-c4073daf-4cce-41ca-99ef-7e116a739c04.json
+++ b/change/@microsoft-fast-foundation-c4073daf-4cce-41ca-99ef-7e116a739c04.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix css custom property emission for dependent DesignToken properties",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -503,20 +503,6 @@ class DesignTokenNode<T extends { createCSS?(): string }> {
      */
     public get value(): T {
         return this.resolveRealValue();
-        // try {
-        //     return this.resolveRealValue();
-        // } catch (e) {
-        //     if (!childToParent.has(this)) {
-        //         const parent = this.findParentNode();
-
-        //         if (parent) {
-        //             parent.appendChild(this);
-        //             return this.resolveRealValue();
-        //         }
-        //     }
-
-        //     throw e;
-        // }
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -349,7 +349,7 @@ class DesignTokenNode<T extends { createCSS?(): string }> {
             current = childToParent.get(current);
         } while (current !== undefined);
 
-        // If there is no parent, resolve try to resolve parent and try again.
+        // If there is no parent, try to resolve parent and try again.
         if (!childToParent.has(this)) {
             const parent = this.findParentNode();
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request
Fixes an issues where dependent CSS custom properties would not be written when a dependent value was changed.

## 📖 Description
DesignToken internals uses a fast-element behavior bound to the CustomElement for which nodes are created to track DOM hierarchy. In some cases, a token value for which other properties use as a dependency can be set for a custom element prior to Controller connection, meaning DOM hierarchy isn't being tracked yet for that element (behaviors not bound).

To guard against this case, the `value` getter would lazily resolve the parent node if no parent existed in the child -> parent map. However, setting dependent tokens goes down a slightly different code-path to retrieve the *rawValue* instead of the value, meaning this guard was being skipped for token dependencies, causing custom properties not to get written if the element's Controller was not yet connected (and the parent node resolved).

This PR moves the lazy-resolution of the parent node from the `value` getter to the `rawValue` getter so that we can get jit resolution of the node value in the case when the element isn't finished initializing. 

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->