### PR TITLE
fix(foundation-element): enable subclassing with customElement decorator

### DIFF
--- a/change/@microsoft-fast-foundation-142496f8-23bc-4ae0-8315-34ab7a5fb8b3.json
+++ b/change/@microsoft-fast-foundation-142496f8-23bc-4ae0-8315-34ab7a5fb8b3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix(foundation-element): enable subclassing with customElement decorator",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-tooling-31e4d861-c660-40a3-94ae-1e0b45aa7f4e.json
+++ b/change/@microsoft-fast-tooling-31e4d861-c660-40a3-94ae-1e0b45aa7f4e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fixing prettier changes",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.template.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.template.ts
@@ -16,7 +16,7 @@ export const HTMLRenderLayerNavigationTemplate: (
                     x.clickPosition.left}px;width:${x =>
                     x.clickPosition.width}px;height:${x => x.clickPosition.height}px"
             >
-            <div class="pill">${x => x.clickPillContent}</div>
+                <div class="pill">${x => x.clickPillContent}</div>
             </div>
             <div
                 class="${x =>

--- a/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
@@ -2,9 +2,8 @@ import { observable } from "@microsoft/fast-element";
 import {
     ActivityType,
     HTMLRenderLayer,
-    OverylayPosition
+    OverylayPosition,
 } from "../html-render-layer/html-render-layer";
-
 
 export class HTMLRenderLayerNavigation extends HTMLRenderLayer {
     @observable

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -412,7 +412,7 @@ export interface ComponentPresentation {
 // @alpha
 export const ComponentPresentation: Readonly<{
     define(tagName: string, presentation: ComponentPresentation, container: Container): void;
-    forTag(tagName: string, element: HTMLElement): ComponentPresentation;
+    forTag(tagName: string, element: HTMLElement): ComponentPresentation | null;
 }>;
 
 // @public
@@ -1180,7 +1180,7 @@ export interface FormAssociatedProxy {
 
 // @alpha
 export class FoundationElement extends FASTElement {
-    protected get $presentation(): ComponentPresentation;
+    protected get $presentation(): ComponentPresentation | null;
     static compose<T extends FoundationElementDefinition = FoundationElementDefinition, K extends Constructable<FoundationElement> = Constructable<FoundationElement>>(this: K, elementDefinition: T): (overrideDefinition?: OverrideFoundationElementDefinition<T>) => FoundationElementRegistry<T, K>;
     connectedCallback(): void;
     styles: ElementStyles | void | null;

--- a/packages/web-components/fast-foundation/src/design-system/component-presentation.ts
+++ b/packages/web-components/fast-foundation/src/design-system/component-presentation.ts
@@ -46,16 +46,16 @@ export const ComponentPresentation = Object.freeze({
         container.register(Registration.instance(key, presentation));
     },
 
-    forTag(tagName: string, element: HTMLElement): ComponentPresentation {
+    forTag(tagName: string, element: HTMLElement): ComponentPresentation | null {
         const key = presentationKeyFromTag(tagName);
         const existing = presentationRegistry.get(key);
 
-        if (!existing) {
+        if (existing === false) {
             const container = DI.findResponsibleContainer(element);
             return container.get<ComponentPresentation>(key);
         }
 
-        return existing;
+        return existing || null;
     },
 });
 

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.spec.ts
@@ -297,4 +297,25 @@ describe("FoundationElement", () => {
             expect(element.shadowRoot).to.be.null;
         });
     });
+
+    describe("subclasses", () => {
+        it("should be able to use the @customElement decorator", async () => {
+            class BaseClass extends FoundationElement {}
+
+            const name = `fast-${uniqueElementName()}`;
+            @customElement({
+                name,
+                template: html`test`
+            })
+            class Subclass extends BaseClass {}
+
+            const { element, parent, connect, disconnect } = await fixture<Subclass>(name);
+
+            await connect();
+
+            expect(element.shadowRoot!.innerHTML).to.equal('test');
+
+            await disconnect();
+        });
+    });
 });

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
@@ -85,14 +85,14 @@ export type OverrideFoundationElementDefinition<
  * @alpha
  */
 export class FoundationElement extends FASTElement {
-    private _presentation: ComponentPresentation | null = null;
+    private _presentation: ComponentPresentation | null | undefined = void 0;
 
     /**
      * A property which resolves the ComponentPresentation instance
      * for the current component.
      */
-    protected get $presentation(): ComponentPresentation {
-        if (this._presentation === null) {
+    protected get $presentation(): ComponentPresentation | null {
+        if (this._presentation === void 0) {
             this._presentation = ComponentPresentation.forTag(this.tagName, this);
         }
 
@@ -132,7 +132,10 @@ export class FoundationElement extends FASTElement {
      * becomes connected to the document.
      */
     connectedCallback() {
-        this.$presentation.applyTo(this);
+        if (this.$presentation !== null) {
+            this.$presentation.applyTo(this);
+        }
+
         super.connectedCallback();
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes an issue with `FoundationElement` that prevented derived classes from being used with the `customElement` decorator when no `ComponentPresentation` exists.

### 🎫 Issues

* Fixes #4794 

## 👩‍💻 Reviewer Notes

Changes are minimal. We needed to be able to identify when there was no `ComponentPresentation` for a tag name and also fallback to normal behavior in that case.

## 📑 Test Plan

A test case was added to cover this scenario.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

None related at this time.