### PR TITLE
fix: address an issue where the first character typed results in the cursor moving to the end of the text

### DIFF
--- a/change/@microsoft-fast-tooling-react-824af1fa-8dd2-450a-88a2-395ddc649c97.json
+++ b/change/@microsoft-fast-tooling-react-824af1fa-8dd2-450a-88a2-395ddc649c97.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "address an issue where the first character typed results in the cursor moving to the end of the text",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling-react/src/form/controls/control.textarea.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.textarea.tsx
@@ -6,15 +6,17 @@ import { TextareaControlProps } from "./control.textarea.props";
 import { TextareaControlClassNameContract } from "./control.textarea.style";
 import { classNames } from "@microsoft/fast-web-utilities";
 import { isDefault } from "./utilities/form";
-import { formId } from "../form";
-import { ajvValidationId } from "@microsoft/fast-tooling";
+
+export interface TextareaControlState {
+    isFocused: boolean;
+}
 
 /**
  * Form control definition
  */
 class TextareaControl extends React.Component<
     TextareaControlProps & ManagedClasses<TextareaControlClassNameContract>,
-    {}
+    TextareaControlState
 > {
     public static displayName: string = "TextareaControl";
 
@@ -23,6 +25,16 @@ class TextareaControl extends React.Component<
     > = {
         managedClasses: {},
     };
+
+    constructor(
+        props: TextareaControlProps & ManagedClasses<TextareaControlClassNameContract>
+    ) {
+        super(props);
+
+        this.state = {
+            isFocused: false,
+        };
+    }
 
     public render(): React.ReactNode {
         return (
@@ -45,8 +57,8 @@ class TextareaControl extends React.Component<
                 onChange={this.handleChange()}
                 disabled={this.props.disabled}
                 ref={this.props.elementRef as React.Ref<HTMLTextAreaElement>}
-                onFocus={this.props.reportValidity}
-                onBlur={this.props.updateValidity}
+                onFocus={this.handleFocus}
+                onBlur={this.handleBlur}
                 required={this.props.required}
             />
         );
@@ -58,11 +70,8 @@ class TextareaControl extends React.Component<
 
     private getValue(): string {
         // Return undefined to allow typing anywhere other than the end of the string
-        if (
-            this.props.messageSystemOptions &&
-            (this.props.messageSystemOptions.originatorId === formId ||
-                this.props.messageSystemOptions.originatorId === ajvValidationId)
-        ) {
+        // when the typing is occuring in the textarea
+        if (this.state.isFocused) {
             return;
         }
 
@@ -72,6 +81,22 @@ class TextareaControl extends React.Component<
             ? this.props.default
             : "";
     }
+
+    private handleFocus = (e: React.FocusEvent<HTMLTextAreaElement>): void => {
+        this.props.reportValidity();
+
+        this.setState({
+            isFocused: true,
+        });
+    };
+
+    private handleBlur = (e: React.FocusEvent<HTMLTextAreaElement>): void => {
+        this.props.updateValidity();
+
+        this.setState({
+            isFocused: false,
+        });
+    };
 
     private handleChange = (): ((e: React.ChangeEvent<HTMLTextAreaElement>) => void) => {
         return (e: React.ChangeEvent<HTMLTextAreaElement>): void => {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

While the previous fix for this issue worked when the `<Form />` was implemented on it's own, adding multiple services to the `MessageSystem` resulted in the first character typed into the textarea sending the cursor to the end of the string no matter where the text was entered. This prevents the rerender issue by not updating the value of the textarea while the user is typing inside.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Open the fast-tooling-react manual test app and navigate to "form and navigation", this demonstrates the fix.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->