### PR TITLE
fix: remove unnecessary check from horizontal-scroll resize handler

### DIFF
--- a/change/@microsoft-fast-foundation-d92cd6d3-d001-44dd-9f7d-cb8bf2463e03.json
+++ b/change/@microsoft-fast-foundation-d92cd6d3-d001-44dd-9f7d-cb8bf2463e03.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "streamline horizontal scroll resize",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -197,22 +197,10 @@ export class HorizontalScroll extends FASTElement {
     private initializeResizeDetector(): void {
         this.disconnectResizeDetector();
         this.resizeDetector = new ((window as unknown) as WindowWithResizeObserver).ResizeObserver(
-            this.handleResize.bind(this)
+            this.resized.bind(this)
         );
         this.resizeDetector.observe(this);
     }
-
-    /**
-     * Handle resize events
-     * @internal
-     */
-    private handleResize = (entries: ResizeObserverEntry[]): void => {
-        entries.forEach((entry: ResizeObserverEntry): void => {
-            if (entry.target === this) {
-                this.resized();
-            }
-        });
-    };
 
     /**
      * Looks for slots and uses child nodes instead


### PR DESCRIPTION
## 📖 Description
Minor tweak to horizontal scroll's resize handler to remove a check on resize observer entries.  With only one component being observed we can assume all callbacks are related to it and run a bit less code (this function can be invoked frequently). 

### 🎫 Issues

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps