### PR TITLE
convert palettes to normal design tokens

### DIFF
--- a/change/@microsoft-fast-components-506953be-cfe8-43a7-b669-badef6589ce2.json
+++ b/change/@microsoft-fast-components-506953be-cfe8-43a7-b669-badef6589ce2.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "remove css capabilities from palette design tokens",
+  "packageName": "@microsoft/fast-components",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/design-tokens.ts
+++ b/packages/web-components/fast-components/src/design-tokens.ts
@@ -213,12 +213,14 @@ export const typeRampPlus6LineHeight = create<string>(
     "type-ramp-plus6-line-height"
 ).withDefault("72px");
 
-export const neutralPalette = create<PaletteRGB>("neutral-palette").withDefault(
-    PaletteRGB.create(middleGrey)
-);
-export const accentPalette = create<PaletteRGB>("accent-palette").withDefault(
-    PaletteRGB.create(accentBase)
-);
+export const neutralPalette = create<PaletteRGB>({
+    name: "neutral-palette",
+    cssCustomPropertyName: null,
+}).withDefault(PaletteRGB.create(middleGrey));
+export const accentPalette = create<PaletteRGB>({
+    name: "accent-palette",
+    cssCustomPropertyName: null,
+}).withDefault(PaletteRGB.create(accentBase));
 export const fillColor = create<SwatchRGB>("fill-color").withDefault(element => {
     const palette = neutralPalette.getValueFor(element);
     return palette.get(palette.swatches.length - 5);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR updates the `neutralPalette` and `accentPalette` to be `DesignToken`'s instead of `CSSDesignTokens`. Palettes are not intended to be used in CSS so this change prevents interpolation usage in `ElementStyles` and removes emission to CSS custom properties.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->