### PR TITLE
fix di parent container resolution in shadow DOM

### DIFF
--- a/change/@microsoft-fast-foundation-5d4aa7c3-730c-45e4-b755-7b98c5d6f889.json
+++ b/change/@microsoft-fast-foundation-5d4aa7c3-730c-45e4-b755-7b98c5d6f889.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ensure host element of a shadowed element can be resolved",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/di/di.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.spec.ts
@@ -12,6 +12,7 @@ import {
 } from "./di";
 import chai, { expect } from "chai";
 import spies from "chai-spies";
+import { customElement, FASTElement, html, ref } from "@microsoft/fast-element";
 
 chai.use(spies);
 
@@ -47,6 +48,24 @@ describe(`The DI object`, function () {
 
             const parentContainer = DI.getOrCreateDOMContainer(parent);
             const childContainer = DI.getOrCreateDOMContainer(child);
+
+            expect(DI.findResponsibleContainer(child)).equal(parentContainer);
+        });
+
+        it(`finds the host for a shadowed element by default`, function () {
+
+            @customElement({name: "test-child"})
+            class TestChild extends FASTElement {}
+            @customElement({name: "test-parent", template: html`<test-child ${ref("child")}></test-child>`}) 
+            class TestParent extends FASTElement {
+                public child: TestChild;
+            }
+
+            const parent = document.createElement("test-parent") as TestParent;
+            document.body.appendChild(parent);
+            const child = parent.child;
+
+            const parentContainer = DI.getOrCreateDOMContainer(parent);
 
             expect(DI.findResponsibleContainer(child)).equal(parentContainer);
         });

--- a/packages/web-components/fast-foundation/src/di/di.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.spec.ts
@@ -53,7 +53,6 @@ describe(`The DI object`, function () {
         });
 
         it(`finds the host for a shadowed element by default`, function () {
-
             @customElement({name: "test-child"})
             class TestChild extends FASTElement {}
             @customElement({name: "test-parent", template: html`<test-child ${ref("child")}></test-child>`}) 

--- a/packages/web-components/fast-foundation/src/di/di.ts
+++ b/packages/web-components/fast-foundation/src/di/di.ts
@@ -1153,7 +1153,7 @@ export class ContainerImpl implements Container {
             owner.addEventListener(
                 DILocateParentEventType,
                 (e: CustomEvent<DOMParentLocatorEventDetail>) => {
-                    if (e.target !== this.owner) {
+                    if (e.composedPath()[0] !== this.owner) {
                         e.detail.container = this;
                         e.stopImmediatePropagation();
                     }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR fixes a bug in DI parent container resolution logic. Parent resolution uses event target comparison to ensure that a container doesn't resolve itself, however that logic does not account for the fact that the event is re-targeted to the host element after escaping the shadow DOM.

This PR changes this logic to check the first index of `Event.composedPath()` to inspect the the actual element that dispatched the event.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->