### PR TITLE
add input event to select component

### DIFF
--- a/change/@microsoft-fast-components-37c9c837-7aa1-47ad-b9a7-940d05914708.json
+++ b/change/@microsoft-fast-components-37c9c837-7aa1-47ad-b9a7-940d05914708.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "select should emit an input event before the change event",
+  "packageName": "@microsoft/fast-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-79bb3762-27aa-4243-b274-6cfa916eabbe.json
+++ b/change/@microsoft-fast-foundation-79bb3762-27aa-4243-b274-6cfa916eabbe.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "select should emit an input event before the change event",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/package.json
+++ b/packages/web-components/fast-components/package.json
@@ -46,8 +46,8 @@
     "test-chrome:verbose": "karma start karma.conf.js --browsers=ChromeHeadlessOpt --single-run --coverage --reporter=mocha",
     "test-chrome:watch": "karma start karma.conf.js --browsers=ChromeHeadlessOpt --coverage --watch-extensions js",
     "test-chrome": "karma start karma.conf.js --browsers=ChromeHeadlessOpt --single-run --coverage",
-    "test-chromium:pw": "cross-env PLAYWRIGHT_BROWSER=chromium && yarn test-pw:full",
-    "test-firefox:pw": "cross-env PLAYWRIGHT_BROWSER=firefox && yarn test-pw:full",
+    "test-chromium:pw": "yarn cross-env PLAYWRIGHT_BROWSER=chromium yarn test-pw:full",
+    "test-firefox:pw": "yarn cross-env PLAYWRIGHT_BROWSER=firefox yarn test-pw:full",
     "test-firefox:verbose": "karma start karma.conf.js --browsers=FirefoxHeadless --single-run --coverage --reporter=mocha",
     "test-firefox": "karma start karma.conf.js --browsers=FirefoxHeadless --single-run --coverage",
     "test-node:verbose": "mocha --reporter spec --exit dist/esm/__test__/setup-node.js './dist/esm/**/*.spec.js'",
@@ -55,7 +55,7 @@
     "test-node": "mocha --reporter min --exit dist/esm/__test__/setup-node.js './dist/esm/**/*.spec.js'",
     "test-pw:full": "yarn clean:test && yarn build:pw && yarn test-pw",
     "test-pw": "mocha --config ./__test__/.mocharc.json ./__test__/**/*.spec.js",
-    "test-webkit:pw": "cross-env PLAYWRIGHT_BROWSER=webkit && yarn test-pw:full",
+    "test-webkit:pw": "yarn cross-env PLAYWRIGHT_BROWSER=webkit yarn test-pw:full",
     "test": "yarn test-chrome:verbose && yarn validate-component-definitions && yarn doc:ci"
   },
   "devDependencies": {

--- a/packages/web-components/fast-components/src/select/select.pw.spec.ts
+++ b/packages/web-components/fast-components/src/select/select.pw.spec.ts
@@ -1,3 +1,4 @@
+import { ArrowKeys } from "@microsoft/fast-web-utilities";
 import type {
     ListboxOption as FASTOption,
     Select as FASTSelectType,
@@ -186,6 +187,36 @@ describe("FASTSelect", function () {
 
                 expect(await element.evaluate(node => node.open)).to.be.false;
             });
+        });
+    });
+
+    describe("should emit an event when focused and receives keyboard interaction", function () {
+        describe("while closed", function () {
+            for (const direction of Object.values(ArrowKeys)) {
+                describe(`via ${direction} key`, function () {
+                    for (const eventName of ["change", "input"]) {
+                        it(`of type '${eventName}'`, async function () {
+                            const element = (await this.page.waitForSelector(
+                                "fast-select"
+                            )) as ElementHandle<FASTSelect>;
+
+                            await this.page.exposeFunction("sendEvent", type =>
+                                expect(type).to.equal(eventName)
+                            );
+
+                            await element.evaluate((node, eventName) => {
+                                node.addEventListener(
+                                    eventName,
+                                    async (e: CustomEvent) =>
+                                        await window["sendEvent"](e.type)
+                                );
+                            }, eventName);
+
+                            await element.press(direction);
+                        });
+                    }
+                });
+            }
         });
     });
 

--- a/packages/web-components/fast-foundation/src/select/select.spec.md
+++ b/packages/web-components/fast-foundation/src/select/select.spec.md
@@ -59,7 +59,10 @@ Extends [`listbox`](../listbox/listbox.spec.md) and [form associated custom elem
 
 *Events*:
 
-- `change` - emits when the `value` is changed via user interaction.
+|Event|description|bubbles|composed|
+|-|-|-|-|
+|`input`|emits when the `value` is changed via user interaction.|yes|yes|
+|`change`|emits when the `value` is changed via user interaction.|yes|no|
 
 *Slots*:
 

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -105,7 +105,11 @@ export class Select extends FormAssociatedSelect {
         }
 
         if (shouldEmit) {
-            this.$emit("change");
+            this.$emit("input");
+            this.$emit("change", this, {
+                bubbles: true,
+                composed: undefined,
+            });
         }
     }
 
@@ -271,8 +275,11 @@ export class Select extends FormAssociatedSelect {
             return;
         }
 
-        if (!this.options || !this.options.includes(focusTarget as ListboxOption)) {
+        if (!this.options?.includes(focusTarget as ListboxOption)) {
             this.open = false;
+            if (this.indexWhenOpened !== this.selectedIndex) {
+                this.updateValue(true);
+            }
         }
     }
 
@@ -355,6 +362,7 @@ export class Select extends FormAssociatedSelect {
 
         if (!this.open && this.indexWhenOpened !== this.selectedIndex) {
             this.updateValue(true);
+            this.indexWhenOpened = this.selectedIndex;
         }
 
         return true;


### PR DESCRIPTION
# Pull Request

## 📖 Description

* Ensures that the `<fast-select>` component emits an `input` event (bubbles, composed) right before it emits a `change` event (bubbles, not composed) when the value is changed via user interaction.
* Fixes an issue where custom events weren't being emitted under a certain navigation scenario. See the Test Plan section for more info.
* Fixes the Playwright script commands in `fast-components`.

## 👩‍💻 Reviewer Notes

* I marked this as a "minor" change and not a "patch" since some existing project might be expecting `change` to be composed.

## 📑 Test Plan

To test the scenario mentioned above:

1. Add an event listener in the console to track the `change` or `input` events on the `<fast-select>`.
2. Open the `<fast-select>` by clicking it or via keyboard interaction.
3. Change the selected option and close the element.
4. Use keyboard navigation to focus the element if focus was lost.
5. Use the arrow keys to change the selected option while the element is closed.
6. Use the arrow keys to change the selected option back to the same option chosen in step 2.

The element should emit `input` and `change` events each time the selected option changes.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->