### PR TITLE
Enable step up and step down for number-field when no value

### DIFF
--- a/change/@microsoft-fast-foundation-8e3a0169-909a-47b6-a4f3-284094236272.json
+++ b/change/@microsoft-fast-foundation-8e3a0169-909a-47b6-a4f3-284094236272.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Enable stepping from null values on number-field",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "robarb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -740,6 +740,32 @@ describe("NumberField", () => {
 
             await disconnect();
         });
+
+        it("should increment no value to the step amount", async () => {
+            const { element, connect, disconnect } = await setup();
+            const step = 2;
+            element.step = step;
+            element.stepUp();
+
+            await connect();
+            expect(element.value).to.equal(`${step}`);
+
+            await disconnect();
+        });
+
+        it("should decrement no value to the negative step amount", async () => {
+            const { element, connect, disconnect } = await setup();
+            const step = 2;
+            element.step = step;
+            element.stepDown();
+
+            await connect();
+            expect(element.value).to.equal(`${0 - step}`);
+
+            await disconnect();
+        });
+
+
     });
 
     describe("hide step", () => {

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -193,7 +193,7 @@ export class NumberField extends FormAssociatedNumberField {
      * @public
      */
     public stepUp(): void {
-        const stepUpValue = this.step + parseFloat(this.value);
+        const stepUpValue = this.step + (parseFloat(this.value) || 0);
         this.value = this.getValidValue(stepUpValue);
 
         this.$emit("input");
@@ -205,7 +205,7 @@ export class NumberField extends FormAssociatedNumberField {
      * @public
      */
     public stepDown(): void {
-        const stepDownValue = parseFloat(this.value) - this.step;
+        const stepDownValue = (parseFloat(this.value) || 0) - this.step;
         this.value = this.getValidValue(stepDownValue);
 
         this.$emit("input");


### PR DESCRIPTION
# Pull Request

## 📖 Description

Number-field does not step up or step down when there is no value set. Step up and step down use the value or 0 if value is  undefined.

### 🎫 Issues

https://github.com/microsoft/fast/issues/4840

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->