### PR TITLE
feat: add a utility to convert inline css styles to a property dictionary

### DIFF
--- a/change/@microsoft-fast-tooling-fd33301a-07d3-42b3-ba44-a66b1a277bd3.json
+++ b/change/@microsoft-fast-tooling-fd33301a-07d3-42b3-ba44-a66b1a277bd3.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add a utility to convert inline css styles to a property dictionary",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.mdn-data.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.mdn-data.spec.ts
@@ -4,6 +4,7 @@ import {
     CombinatorType,
     mapCombinatorType,
     mapCSSGroups,
+    mapCSSInlineStyleToCSSPropertyDictionary,
     mapCSSProperties,
     mapCSSSyntaxes,
     mapMixedCombinatorTypes,
@@ -998,5 +999,49 @@ describe("mapMixedCombinatorTypes", () => {
         const syntax1: string =
             "foo | [ [ bar | baz ] || [ qux | quux | quuz | corge | grault ] ] | garply";
         expect(mapMixedCombinatorTypes(syntax1)).to.equal(syntax1);
+    });
+});
+
+describe("mapCSSInlineStyleToCSSPropertyDictionary", () => {
+    it("should return an empty dictionary if the style is an empty string", () => {
+        expect(mapCSSInlineStyleToCSSPropertyDictionary("")).to.deep.equal({});
+    });
+    it("should return a dictionary with one item if the style contains one style item without an ending semi-colon", () => {
+        expect(
+            mapCSSInlineStyleToCSSPropertyDictionary("background-color: red")
+        ).to.deep.equal({
+            "background-color": "red",
+        });
+    });
+    it("should return a dictionary with one item if the style contains one style item with an ending semi-colon", () => {
+        expect(
+            mapCSSInlineStyleToCSSPropertyDictionary("background-color: red;")
+        ).to.deep.equal({
+            "background-color": "red",
+        });
+    });
+    it("should return a dictionary with multiple items if the style contains multiple items", () => {
+        expect(
+            mapCSSInlineStyleToCSSPropertyDictionary(
+                "background-color: red; border: 1px solid black; color: #FFFFFF; transform: translate(120px, 50%);"
+            )
+        ).to.deep.equal({
+            "background-color": "red",
+            border: "1px solid black",
+            color: "#FFFFFF",
+            transform: "translate(120px, 50%)",
+        });
+    });
+    it("should return a dictionary with multiple items with inconsistent spacing", () => {
+        expect(
+            mapCSSInlineStyleToCSSPropertyDictionary(
+                "background-color: red;  border: 1px solid black;color: #FFFFFF; transform: translate(120px, 50%)  "
+            )
+        ).to.deep.equal({
+            "background-color": "red",
+            border: "1px solid black",
+            color: "#FFFFFF",
+            transform: "translate(120px, 50%)",
+        });
     });
 });

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.mdn-data.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.mdn-data.ts
@@ -1208,3 +1208,27 @@ export function mapCSSSyntaxes(mdnCSS: MDNCSS): CSSSyntaxDictionary {
             {}
         );
 }
+
+/**
+ * Converts an inline CSS string to a property dictionary data format
+ */
+export function mapCSSInlineStyleToCSSPropertyDictionary(
+    style: string
+): CSSPropertiesDictionary {
+    const cssPropertyDictionary = {};
+
+    if (style) {
+        const cssDeclarations = style.split(";");
+        cssDeclarations.forEach((cssDeclaration: string) => {
+            const cssPropertyAndValue = cssDeclaration.split(":");
+
+            if (cssPropertyAndValue.length === 2) {
+                cssPropertyDictionary[
+                    cssPropertyAndValue[0].trim()
+                ] = cssPropertyAndValue[1].trim();
+            }
+        });
+    }
+
+    return cssPropertyDictionary;
+}

--- a/packages/tooling/fast-tooling/src/data-utilities/mapping.mdn-data.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/mapping.mdn-data.ts
@@ -1218,8 +1218,7 @@ export function mapCSSInlineStyleToCSSPropertyDictionary(
     const cssPropertyDictionary = {};
 
     if (style) {
-        const cssDeclarations = style.split(";");
-        cssDeclarations.forEach((cssDeclaration: string) => {
+        style.split(";").forEach((cssDeclaration: string) => {
             const cssPropertyAndValue = cssDeclaration.split(":");
 
             if (cssPropertyAndValue.length === 2) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change adds a small utility to convert inline style strings to a CSS declaration dictionary.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Unit tests have been added.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->