### PR TITLE
fix: malformed data grid template

### DIFF
--- a/change/@microsoft-fast-foundation-ec75963d-5f1d-4fec-9c2a-27d2a144fe00.json
+++ b/change/@microsoft-fast-foundation-ec75963d-5f1d-4fec-9c2a-27d2a144fe00.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix malformed templates",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
@@ -24,7 +24,7 @@ export function createDataGridTemplate(prefix: string): ViewTemplate {
         <template
             role="grid"
             tabindex="0"
-            :prefix=${prefix}
+            :prefix="${prefix}"
             :defaultRowItemTemplate="${rowItemTemplate}"
             ${children({
                 property: "rowElements",

--- a/packages/web-components/fast-foundation/src/slider/slider.template.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.template.ts
@@ -31,7 +31,7 @@ export const SliderTemplate: ViewTemplate<Slider> = html`
                 ${ref("thumb")}
                 part="thumb-container"
                 class="thumb-container"
-                style=${x => x.position}
+                style="${x => x.position}"
             >
                 <slot name="thumb"><div class="thumb-cursor"></div></slot>
             </div>


### PR DESCRIPTION
## 📖 Description
Data grid's template had missing quotes around a value binding that caused failures in some deployment scenarios.  Fixing similar issue in slider as well.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
