### PR TITLE
update tsdoc for exported registrations

### DIFF
--- a/change/@microsoft-fast-components-007fde61-ff65-47d4-9842-257d615f9d37.json
+++ b/change/@microsoft-fast-components-007fde61-ff65-47d4-9842-257d615f9d37.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update code comments for primary exports of fast-components",
+  "packageName": "@microsoft/fast-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-components/src/accordion-item/index.ts
+++ b/packages/web-components/fast-components/src/accordion-item/index.ts
@@ -6,13 +6,13 @@ import {
 import { accordionItemStyles as styles } from "./accordion-item.styles";
 
 /**
- * The FAST Accordion Item Element. Implements {@link @microsoft/fast-foundation#AccordionItem},
- * {@link @microsoft/fast-foundation#accordionItemTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#AccordionItem} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#accordionItemTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-accordion-item\>
+ * Generates HTML Element: \<fast-accordion-item\>
  */
 export const fastAccordionItem = AccordionItem.compose<AccordionItemOptions>({
     baseName: "accordion-item",

--- a/packages/web-components/fast-components/src/accordion/index.ts
+++ b/packages/web-components/fast-components/src/accordion/index.ts
@@ -10,7 +10,7 @@ export * from "../accordion-item/index";
  *
  * @public
  * @remarks
- * Generatese the HTML Element: \<fast-accordion\>
+ * Generates the HTML Element: \<fast-accordion\>
  */
 export const fastAccordion = Accordion.compose({
     baseName: "accordion",

--- a/packages/web-components/fast-components/src/accordion/index.ts
+++ b/packages/web-components/fast-components/src/accordion/index.ts
@@ -4,13 +4,13 @@ import { accordionStyles as styles } from "./accordion.styles";
 export * from "../accordion-item/index";
 
 /**
- * The FAST Accordion Element. Implements {@link @microsoft/fast-foundation#Accordion},
- * {@link @microsoft/fast-foundation#accordionTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Accordion} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#accordionTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-accordion\>
+ * Generatese the HTML Element: \<fast-accordion\>
  */
 export const fastAccordion = Accordion.compose({
     baseName: "accordion",

--- a/packages/web-components/fast-components/src/anchor/index.ts
+++ b/packages/web-components/fast-components/src/anchor/index.ts
@@ -69,13 +69,13 @@ export class Anchor extends FoundationAnchor {
 export const anchorStyles = styles;
 
 /**
- * The FAST Anchor Element. Implements {@link @microsoft/fast-foundation#Anchor},
- * {@link @microsoft/fast-foundation#anchorTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Anchor} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#anchorTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-anchor\>
+ * Generates HTML Element: \<fast-anchor\>
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/anchored-region/index.ts
+++ b/packages/web-components/fast-components/src/anchored-region/index.ts
@@ -5,13 +5,13 @@ import {
 import { anchoredRegionStyles as styles } from "./anchored-region.styles";
 
 /**
- * The FAST AnchoredRegion Element. Implements {@link @microsoft/fast-foundation#AnchoredRegion},
- * {@link @microsoft/fast-foundation#anchoredRegionTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#AnchoredRegion} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#anchoredRegionTemplate}
  *
  *
  * @beta
  * @remarks
- * HTML Element: \<fast-anchored-region\>
+ * Generates HTML Element: \<fast-anchored-region\>
  */
 export const fastAnchoredRegion = AnchoredRegion.compose({
     baseName: "anchored-region",

--- a/packages/web-components/fast-components/src/avatar/index.ts
+++ b/packages/web-components/fast-components/src/avatar/index.ts
@@ -53,13 +53,13 @@ export const imgTemplate = html<Avatar>`
 `;
 
 /**
- *  The FAST Avatar Element. Implements {@link @microsoft/fast-foundation#Avatar},
+ * A function that returns a {@link @microsoft/fast-foundation#Avatar} registration for configuring the component with a DesignSystem.
  *  {@link @microsoft/fast-foundation#AvatarTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-avatar\>
+ * Generates HTML Element: \<fast-avatar\>
  */
 export const fastAvatar = Avatar.compose<AvatarOptions>({
     baseName: "avatar",

--- a/packages/web-components/fast-components/src/badge/index.ts
+++ b/packages/web-components/fast-components/src/badge/index.ts
@@ -2,13 +2,13 @@ import { Badge, badgeTemplate as template } from "@microsoft/fast-foundation";
 import { badgeStyles as styles } from "./badge.styles";
 
 /**
- * The FAST Badge Element. Implements {@link @microsoft/fast-foundation#Badge},
- * {@link @microsoft/fast-foundation#badgeTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Badge} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#badgeTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-badge\>
+ * Generates HTML Element: \<fast-badge\>
  */
 export const fastBadge = Badge.compose({
     baseName: "badge",

--- a/packages/web-components/fast-components/src/breadcrumb-item/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/index.ts
@@ -6,13 +6,13 @@ import {
 import { breadcrumbItemStyles as styles } from "./breadcrumb-item.styles";
 
 /**
- * The FAST BreadcrumbItem Element. Implements {@link @microsoft/fast-foundation#BreadcrumbItem},
- * {@link @microsoft/fast-foundation#breadcrumbItemTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#BreadcrumbItem} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#breadcrumbItemTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-breadcrumb-item\>
+ * Generates HTML Element: \<fast-breadcrumb-item\>
  */
 export const fastBreadcrumbItem = BreadcrumbItem.compose<BreadcrumbItemOptions>({
     baseName: "breadcrumb-item",

--- a/packages/web-components/fast-components/src/breadcrumb/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb/index.ts
@@ -2,13 +2,13 @@ import { Breadcrumb, breadcrumbTemplate as template } from "@microsoft/fast-foun
 import { breadcrumbStyles as styles } from "./breadcrumb.styles";
 
 /**
- * The FAST Breadcrumb Element. Implements {@link @microsoft/fast-foundation#Breadcrumb},
- * {@link @microsoft/fast-foundation#breadcrumbTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Breadcrumb} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#breadcrumbTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-breadcrumb\>
+ * Generates HTML Element: \<fast-breadcrumb\>
  */
 export const fastBreadcrumb = Breadcrumb.compose({
     baseName: "breadcrumb",

--- a/packages/web-components/fast-components/src/button/index.ts
+++ b/packages/web-components/fast-components/src/button/index.ts
@@ -56,13 +56,13 @@ export class Button extends FoundationButton {
 }
 
 /**
- * The FAST Button Element. Implements {@link @microsoft/fast-foundation#Button},
- * {@link @microsoft/fast-foundation#buttonTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Button} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#buttonTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-button\>
+ * Generates HTML Element: \<fast-button\>
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/card/index.ts
+++ b/packages/web-components/fast-components/src/card/index.ts
@@ -29,13 +29,13 @@ export class Card extends FoundationCard {
 }
 
 /**
- * The FAST Card Element. Implements {@link @microsoft/fast-foundation#Card},
- * {@link @microsoft/fast-foundation#CardTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Card} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#CardTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-card\>
+ * Generates HTML Element: \<fast-card\>
  */
 export const fastCard = Card.compose({
     baseName: "card",

--- a/packages/web-components/fast-components/src/checkbox/index.ts
+++ b/packages/web-components/fast-components/src/checkbox/index.ts
@@ -6,13 +6,13 @@ import {
 import { checkboxStyles as styles } from "./checkbox.styles";
 
 /**
- * The FAST Checkbox Element. Implements {@link @microsoft/fast-foundation#Checkbox},
- * {@link @microsoft/fast-foundation#checkboxTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Checkbox} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#checkboxTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-checkbox\>
+ * Generates HTML Element: \<fast-checkbox\>
  */
 export const fastCheckbox = Checkbox.compose<CheckboxOptions>({
     baseName: "checkbox",

--- a/packages/web-components/fast-components/src/combobox/index.ts
+++ b/packages/web-components/fast-components/src/combobox/index.ts
@@ -6,12 +6,12 @@ import {
 import { comboboxStyles as styles } from "./combobox.styles";
 
 /**
- * The FAST Combobox Custom Element. Implements {@link @microsoft/fast-foundation#Combobox},
- * {@link @microsoft/fast-foundation#comboboxTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Combobox} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#comboboxTemplate}
  *
  * @public
  * @remarks
- * HTML Element: \<fast-combobox\>
+ * Generates HTML Element: \<fast-combobox\>
  *
  */
 export const fastCombobox = Combobox.compose<ComboboxOptions>({

--- a/packages/web-components/fast-components/src/data-grid/index.ts
+++ b/packages/web-components/fast-components/src/data-grid/index.ts
@@ -11,11 +11,11 @@ import { DataGridRowStyles as rowStyles } from "./data-grid-row.styles";
 import { DataGridCellStyles as cellStyles } from "./data-grid-cell.styles";
 
 /**
- * The FAST Data Grid Cell Element.
+ * A function that returns a {@link @microsoft/fast-foundation#DataGridCell} registration for configuring the component with a DesignSystem.
  *
  * @public
  * @remarks
- * HTML Element: \<fast-data-grid-cell\>
+ * Generates HTML Element: \<fast-data-grid-cell\>
  */
 export const fastDataGridCell = DataGridCell.compose({
     baseName: "data-grid-cell",
@@ -30,11 +30,11 @@ export const fastDataGridCell = DataGridCell.compose({
 export const dataGridCellStyles = cellStyles;
 
 /**
- * The FAST Data Grid Row Element.
+ * A function that returns a {@link @microsoft/fast-foundation#DataGridRow} registration for configuring the component with a DesignSystem.
  *
  * @public
  * @remarks
- * HTML Element: \<fast-data-grid-row\>
+ * Generates HTML Element: \<fast-data-grid-row\>
  */
 export const fastDataGridRow = DataGridRow.compose({
     baseName: "data-grid-row",
@@ -49,11 +49,11 @@ export const fastDataGridRow = DataGridRow.compose({
 export const dataGridRowStyles = rowStyles;
 
 /**
- * The FAST Data Grid Element.
+ * A function that returns a {@link @microsoft/fast-foundation#DataGrid} registration for configuring the component with a DesignSystem.
  *
  * @public
  * @remarks
- * HTML Element: \<fast-data-grid\>
+ * Generates HTML Element: \<fast-data-grid\>
  */
 export const fastDataGrid = DataGrid.compose({
     baseName: "data-grid",

--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -1025,8 +1025,7 @@ class DesignSystemProvider extends FoundationElement {
 }
 
 /**
- * The FAST Design System Provider Element.
- *
+A function that returns a {@link @microsoft/fast-foundation#DesignSystemProvider} registration for configuring the component with a DesignSystem. *
  * @public
  * @remarks
  * Generates HTML Element: \<fast-design-system-provider\>

--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -1029,7 +1029,7 @@ class DesignSystemProvider extends FoundationElement {
  *
  * @public
  * @remarks
- * HTML Element: \<fast-design-system-provider\>
+ * Generates HTML Element: \<fast-design-system-provider\>
  */
 export const fastDesignSystemProvider = DesignSystemProvider.compose({
     baseName: "design-system-provider",

--- a/packages/web-components/fast-components/src/dialog/index.ts
+++ b/packages/web-components/fast-components/src/dialog/index.ts
@@ -2,13 +2,13 @@ import { Dialog, dialogTemplate as template } from "@microsoft/fast-foundation";
 import { dialogStyles as styles } from "./dialog.styles";
 
 /**
- * The FAST Dialog Element. Implements {@link @microsoft/fast-foundation#Dialog},
- * {@link @microsoft/fast-foundation#dialogTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Dialog} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#dialogTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-dialog\>
+ * Generates HTML Element: \<fast-dialog\>
  */
 export const fastDialog = Dialog.compose({
     baseName: "dialog",

--- a/packages/web-components/fast-components/src/disclosure/index.ts
+++ b/packages/web-components/fast-components/src/disclosure/index.ts
@@ -84,13 +84,13 @@ export class Disclosure extends FoundationDisclosure {
 export const disclosureStyles = styles;
 
 /**
- * The FAST Disclosure Element. Implements {@link @microsoft/fast-foundation#Disclosure},
- * {@link @microsoft/fast-foundation#disclosureTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Disclosure} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#disclosureTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-Disclosure\>
+ * Generates HTML Element: \<fast-Disclosure\>
  *
  */
 export const fastDisclosure = Disclosure.compose({

--- a/packages/web-components/fast-components/src/divider/index.ts
+++ b/packages/web-components/fast-components/src/divider/index.ts
@@ -2,13 +2,13 @@ import { Divider, dividerTemplate as template } from "@microsoft/fast-foundation
 import { dividerStyles as styles } from "./divider.styles";
 
 /**
- * The FAST Divider Element. Implements {@link @microsoft/fast-foundation#Divider},
- * {@link @microsoft/fast-foundation#dividerTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Divider} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#dividerTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-divider\>
+ * Generates HTML Element: \<fast-divider\>
  */
 export const fastDivider = Divider.compose({
     baseName: "divider",

--- a/packages/web-components/fast-components/src/flipper/index.ts
+++ b/packages/web-components/fast-components/src/flipper/index.ts
@@ -6,13 +6,13 @@ import {
 import { flipperStyles as styles } from "./flipper.styles";
 
 /**
- * The FAST Flipper Element. Implements {@link @microsoft/fast-foundation#Flipper},
- * {@link @microsoft/fast-foundation#flipperTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Flipper} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#flipperTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-flipper\>
+ * Generates HTML Element: \<fast-flipper\>
  */
 export const fastFlipper = Flipper.compose<FlipperOptions>({
     baseName: "flipper",

--- a/packages/web-components/fast-components/src/horizontal-scroll/index.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/index.ts
@@ -26,13 +26,13 @@ export class HorizontalScroll extends FoundationHorizontalScroll {
 }
 
 /**
- * The FAST HorizontalScroll Element. Implements {@link @microsoft/fast-foundation#HorizontalScroll},
- * {@link @microsoft/fast-foundation#horizontalScrollTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#HorizontalScroll} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#horizontalScrollTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-horizontal-scroll\>
+ * Generates HTML Element: \<fast-horizontal-scroll\>
  */
 export const fastHorizontalScroll = HorizontalScroll.compose<HorizontalScrollOptions>({
     baseName: "horizontal-scroll",

--- a/packages/web-components/fast-components/src/listbox-option/index.ts
+++ b/packages/web-components/fast-components/src/listbox-option/index.ts
@@ -5,13 +5,13 @@ import {
 import { optionStyles as styles } from "./listbox-option.styles";
 
 /**
- * The FAST option Custom Element. Implements {@link @microsoft/fast-foundation#ListboxOption}
- * {@link @microsoft/fast-foundation#listboxOptionTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#ListboxOption} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#listboxOptionTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-option\>
+ * Generates HTML Element: \<fast-option\>
  *
  */
 export const fastOption = ListboxOption.compose({

--- a/packages/web-components/fast-components/src/listbox/index.ts
+++ b/packages/web-components/fast-components/src/listbox/index.ts
@@ -2,13 +2,13 @@ import { Listbox, listboxTemplate as template } from "@microsoft/fast-foundation
 import { listboxStyles as styles } from "./listbox.styles";
 
 /**
- * The FAST listbox Custom Element. Implements, {@link @microsoft/fast-foundation#Listbox}
- * {@link @microsoft/fast-foundation#listboxTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Listbox} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#listboxTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-listbox\>
+ * Generates HTML Element: \<fast-listbox\>
  *
  */
 export const fastListbox = Listbox.compose({

--- a/packages/web-components/fast-components/src/menu-item/index.ts
+++ b/packages/web-components/fast-components/src/menu-item/index.ts
@@ -6,13 +6,13 @@ import {
 import { menuItemStyles as styles } from "./menu-item.styles";
 
 /**
- * The FAST Menu Item Element. Implements {@link @microsoft/fast-foundation#MenuItem},
- * {@link @microsoft/fast-foundation#menuItemTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#MenuItem} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#menuItemTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-menu-item\>
+ * Generates HTML Element: \<fast-menu-item\>
  */
 export const fastMenuItem = MenuItem.compose<MenuItemOptions>({
     baseName: "menu-item",

--- a/packages/web-components/fast-components/src/menu/index.ts
+++ b/packages/web-components/fast-components/src/menu/index.ts
@@ -2,13 +2,13 @@ import { Menu, menuTemplate as template } from "@microsoft/fast-foundation";
 import { menuStyles as styles } from "./menu.styles";
 
 /**
- * The FAST Menu Element. Implements {@link @microsoft/fast-foundation#Menu},
- * {@link @microsoft/fast-foundation#menuTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Menu} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#menuTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-menu\>
+ * Generates HTML Element: \<fast-menu\>
  */
 export const fastMenu = Menu.compose({
     baseName: "menu",

--- a/packages/web-components/fast-components/src/number-field/index.ts
+++ b/packages/web-components/fast-components/src/number-field/index.ts
@@ -45,13 +45,13 @@ export class NumberField extends FoundationNumberField {
 export const numberFieldStyles = styles;
 
 /**
- * The FAST Number Field Custom Element. Implements {@link @microsoft/fast-foundation#NumberField},
- * {@link @microsoft/fast-foundation#numberFieldTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#NumberField} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#numberFieldTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-number-field\>
+ * Generates HTML Element: \<fast-number-field\>
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/progress-ring/index.ts
+++ b/packages/web-components/fast-components/src/progress-ring/index.ts
@@ -6,13 +6,13 @@ import {
 import { progressRingStyles as styles } from "./progress-ring.styles";
 
 /**
- * The FAST Progress Ring Element. Implements {@link @microsoft/fast-foundation#BaseProgress},
- * {@link @microsoft/fast-foundation#progressRingTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#BaseProgress} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#progressRingTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-progress-ring\>
+ * Generates HTML Element: \<fast-progress-ring\>
  */
 export const fastProgressRing = Progress.compose<ProgressRingOptions>({
     baseName: "progress-ring",

--- a/packages/web-components/fast-components/src/progress/index.ts
+++ b/packages/web-components/fast-components/src/progress/index.ts
@@ -6,13 +6,13 @@ import {
 import { progressStyles as styles } from "./progress.styles";
 
 /**
- * The FAST Progress Element. Implements {@link @microsoft/fast-foundation#BaseProgress},
- * {@link @microsoft/fast-foundation#progressTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#BaseProgress} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#progressTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-progress\>
+ * Generates HTML Element: \<fast-progress\>
  */
 export const fastProgress = Progress.compose<ProgressOptions>({
     baseName: "progress",

--- a/packages/web-components/fast-components/src/radio-group/index.ts
+++ b/packages/web-components/fast-components/src/radio-group/index.ts
@@ -2,13 +2,13 @@ import { RadioGroup, radioGroupTemplate as template } from "@microsoft/fast-foun
 import { radioGroupStyles as styles } from "./radio-group.styles";
 
 /**
- * The FAST Radio Group Element. Implements {@link @microsoft/fast-foundation#RadioGroup},
- * {@link @microsoft/fast-foundation#radioGroupTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#RadioGroup} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#radioGroupTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-radio-group\>
+ * Generates HTML Element: \<fast-radio-group\>
  */
 export const fastRadioGroup = RadioGroup.compose({
     baseName: "radio-group",

--- a/packages/web-components/fast-components/src/radio/index.ts
+++ b/packages/web-components/fast-components/src/radio/index.ts
@@ -6,7 +6,7 @@ import {
 import { radioStyles as styles } from "./radio.styles";
 
 /**
- * A function that returns a {@link @microsoft/fast-foundation#Radioi} registration for configuring the component with a DesignSystem.
+ * A function that returns a {@link @microsoft/fast-foundation#Radio} registration for configuring the component with a DesignSystem.
  * Implements {@link @microsoft/fast-foundation#radioTemplate}
  *
  *

--- a/packages/web-components/fast-components/src/radio/index.ts
+++ b/packages/web-components/fast-components/src/radio/index.ts
@@ -6,13 +6,13 @@ import {
 import { radioStyles as styles } from "./radio.styles";
 
 /**
- * The FAST Radio Element. Implements {@link @microsoft/fast-foundation#Radio},
- * {@link @microsoft/fast-foundation#radioTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Radioi} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#radioTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-radio\>
+ * Generates HTML Element: \<fast-radio\>
  */
 export const fastRadio = Radio.compose<RadioOptions>({
     baseName: "radio",

--- a/packages/web-components/fast-components/src/select/index.ts
+++ b/packages/web-components/fast-components/src/select/index.ts
@@ -6,13 +6,13 @@ import {
 import { selectStyles as styles } from "./select.styles";
 
 /**
- * The FAST select Custom Element. Implements, {@link @microsoft/fast-foundation#Select}
- * {@link @microsoft/fast-foundation#selectTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Select} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#selectTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-select\>
+ * Generates HTML Element: \<fast-select\>
  *
  */
 export const fastSelect = Select.compose<SelectOptions>({

--- a/packages/web-components/fast-components/src/skeleton/index.ts
+++ b/packages/web-components/fast-components/src/skeleton/index.ts
@@ -2,13 +2,13 @@ import { Skeleton, skeletonTemplate as template } from "@microsoft/fast-foundati
 import { skeletonStyles as styles } from "./skeleton.styles";
 
 /**
- * The FAST Skeleton Element. Implements {@link @microsoft/fast-foundation#Skeleton},
- * {@link @microsoft/fast-foundation#skeletonTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Skeleton} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#skeletonTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-skeleton\>
+ * Generates HTML Element: \<fast-skeleton\>
  */
 export const fastSkeleton = Skeleton.compose({
     baseName: "skeleton",

--- a/packages/web-components/fast-components/src/slider-label/index.ts
+++ b/packages/web-components/fast-components/src/slider-label/index.ts
@@ -25,13 +25,13 @@ export class SliderLabel extends FoundationSliderLabel {
 }
 
 /**
- * The FAST Slider Label Custom Element. Implements {@link @microsoft/fast-foundation#(SliderLabel:class)},
- * {@link @microsoft/fast-foundation#sliderLabelTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#SliderLabel} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#sliderLabelTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-slider-label\>
+ * Generates HTML Element: \<fast-slider-label\>
  */
 
 export const fastSliderLabel = SliderLabel.compose({

--- a/packages/web-components/fast-components/src/slider/index.ts
+++ b/packages/web-components/fast-components/src/slider/index.ts
@@ -6,13 +6,13 @@ import {
 import { sliderStyles as styles } from "./slider.styles";
 
 /**
- * The FAST Slider Custom Element. Implements {@link @microsoft/fast-foundation#(Slider:class)},
- * {@link @microsoft/fast-foundation#sliderTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Slider} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#sliderTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-slider\>
+ * Generates HTML Element: \<fast-slider\>
  */
 export const fastSlider = Slider.compose<SliderOptions>({
     baseName: "slider",

--- a/packages/web-components/fast-components/src/switch/index.ts
+++ b/packages/web-components/fast-components/src/switch/index.ts
@@ -6,13 +6,13 @@ import {
 import { switchStyles as styles } from "./switch.styles";
 
 /**
- * The FAST Switch Custom Element. Implements {@link @microsoft/fast-foundation#Switch},
- * {@link @microsoft/fast-foundation#switchTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Switch} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#switchTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-switch\>
+ * Generates HTML Element: \<fast-switch\>
  */
 export const fastSwitch = Switch.compose<SwitchOptions>({
     baseName: "switch",

--- a/packages/web-components/fast-components/src/tab-panel/index.ts
+++ b/packages/web-components/fast-components/src/tab-panel/index.ts
@@ -2,13 +2,13 @@ import { TabPanel, tabPanelTemplate as template } from "@microsoft/fast-foundati
 import { tabPanelStyles as styles } from "./tab-panel.styles";
 
 /**
- * The FAST Tab Panel Custom Element. Implements {@link @microsoft/fast-foundation#TabPanel},
- * {@link @microsoft/fast-foundation#tabPanelTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#TabPanel} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#tabPanelTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tab-panel\>
+ * Generates HTML Element: \<fast-tab-panel\>
  */
 export const fastTabPanel = TabPanel.compose({
     baseName: "tab-panel",

--- a/packages/web-components/fast-components/src/tab/index.ts
+++ b/packages/web-components/fast-components/src/tab/index.ts
@@ -2,13 +2,13 @@ import { Tab, tabTemplate as template } from "@microsoft/fast-foundation";
 import { tabStyles as styles } from "./tab.styles";
 
 /**
- * The FAST Tab Custom Element. Implements {@link @microsoft/fast-foundation#Tab},
- * {@link @microsoft/fast-foundation#tabTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Tab} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#tabTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tab\>
+ * Generates HTML Element: \<fast-tab\>
  */
 export const fastTab = Tab.compose({
     baseName: "tab",

--- a/packages/web-components/fast-components/src/tabs/index.ts
+++ b/packages/web-components/fast-components/src/tabs/index.ts
@@ -2,13 +2,13 @@ import { Tabs, tabsTemplate as template } from "@microsoft/fast-foundation";
 import { tabsStyles as styles } from "./tabs.styles";
 
 /**
- * The FAST Tabs Custom Element. Implements {@link @microsoft/fast-foundation#Tabs},
- * {@link @microsoft/fast-foundation#tabsTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Tabs} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#tabsTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tabs\>
+ * Generates HTML Element: \<fast-tabs\>
  */
 export const fastTabs = Tabs.compose({
     baseName: "tabs",

--- a/packages/web-components/fast-components/src/text-area/index.ts
+++ b/packages/web-components/fast-components/src/text-area/index.ts
@@ -38,13 +38,13 @@ export class TextArea extends FoundationTextArea {
 }
 
 /**
- * The FAST Text Area Custom Element. Implements {@link @microsoft/fast-foundation#TextArea},
- * {@link @microsoft/fast-foundation#textAreaTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#TextArea} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#textAreaTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-text-area\>
+ * Generates HTML Element: \<fast-text-area\>
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/text-field/index.ts
+++ b/packages/web-components/fast-components/src/text-field/index.ts
@@ -38,13 +38,13 @@ export class TextField extends FoundationTextField {
 }
 
 /**
- * The FAST Text Field Custom Element. Implements {@link @microsoft/fast-foundation#TextField},
- * {@link @microsoft/fast-foundation#textFieldTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#TextField} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#textFieldTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-text-field\>
+ * Generates HTML Element: \<fast-text-field\>
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/toolbar/index.ts
+++ b/packages/web-components/fast-components/src/toolbar/index.ts
@@ -34,7 +34,8 @@ export class Toolbar extends FoundationToolbar {
  *
  * @public
  * @remarks
- * HTML Element: `<fast-toolbar>`
+ *
+ * Generates HTML Element: \<fast-toolbar\>
  *
  */
 export const fastToolbar = Toolbar.compose({

--- a/packages/web-components/fast-components/src/toolbar/index.ts
+++ b/packages/web-components/fast-components/src/toolbar/index.ts
@@ -29,8 +29,8 @@ export class Toolbar extends FoundationToolbar {
 }
 
 /**
- * The FAST toolbar Custom Element. Implements {@link @microsoft/fast-foundation#Toolbar},
- * {@link @microsoft/fast-foundation#ToolbarTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Toolbar} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#ToolbarTemplate}
  *
  * @public
  * @remarks

--- a/packages/web-components/fast-components/src/tooltip/index.ts
+++ b/packages/web-components/fast-components/src/tooltip/index.ts
@@ -2,13 +2,13 @@ import { tooltipTemplate as template, Tooltip } from "@microsoft/fast-foundation
 import { tooltipStyles as styles } from "./tooltip.styles";
 
 /**
- * The FAST Tooltip Custom Element. Implements {@link @microsoft/fast-foundation#Tooltip},
- * {@link @microsoft/fast-foundation#tooltipTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#Tooltip} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#tooltipTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tooltip\>
+ * Generates HTML Element: \<fast-tooltip\>
  */
 export const fastTooltip = Tooltip.compose({
     baseName: "tooltip",

--- a/packages/web-components/fast-components/src/tree-item/index.ts
+++ b/packages/web-components/fast-components/src/tree-item/index.ts
@@ -6,13 +6,13 @@ import {
 import { treeItemStyles as styles } from "./tree-item.styles";
 
 /**
- * The FAST tree item Custom Element. Implements, {@link @microsoft/fast-foundation#TreeItem}
- * {@link @microsoft/fast-foundation#treeItemTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#TreeItem} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#treeItemTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tree-item\>
+ * Generates HTML Element: \<fast-tree-item\>
  *
  */
 export const fastTreeItem = TreeItem.compose<TreeItemOptions>({

--- a/packages/web-components/fast-components/src/tree-view/index.ts
+++ b/packages/web-components/fast-components/src/tree-view/index.ts
@@ -2,13 +2,13 @@ import { treeViewTemplate as template, TreeView } from "@microsoft/fast-foundati
 import { treeViewStyles as styles } from "./tree-view.styles";
 
 /**
- * The FAST tree view Custom Element. Implements, {@link @microsoft/fast-foundation#TreeView}
- * {@link @microsoft/fast-foundation#treeViewTemplate}
+ * A function that returns a {@link @microsoft/fast-foundation#TreeView} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#treeViewTemplate}
  *
  *
  * @public
  * @remarks
- * HTML Element: \<fast-tree-view\>
+ * Generates HTML Element: \<fast-tree-view\>
  *
  */
 export const fastTreeView = TreeView.compose({


### PR DESCRIPTION
# Pull Request

## 📖 Description
The previous export from `fast-components` was an element. With the latest changes in vNext, that's changed to be a registration for a design system. This updates comments to better reflect that implementation.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->