### PR TITLE
fix: forces the css control to respect state changes which involve switching dictionary IDs

### DIFF
--- a/change/@microsoft-fast-tooling-react-278963d3-b9c9-4e80-bb17-e88b4602d7cc.json
+++ b/change/@microsoft-fast-tooling-react-278963d3-b9c9-4e80-bb17-e88b4602d7cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "force the CSS control to respect state changes involving dictionary ID updates",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling-react/app/pages/form.tsx
+++ b/packages/tooling/fast-tooling-react/app/pages/form.tsx
@@ -11,6 +11,7 @@ import {
 import React from "react";
 import {
     AjvMapper,
+    DataDictionary,
     getDataFromSchema,
     MessageSystem,
     MessageSystemType,
@@ -35,6 +36,7 @@ export type componentDataOnChange = (e: React.ChangeEvent<HTMLFormElement>) => v
 export interface FormTestPageState {
     schema: any;
     data: any;
+    dataDictionary: DataDictionary<unknown>;
     navigation: any;
     attributeAssignment?: FormAttributeSettingsMappingToPropertyNames;
     showExtendedControls: boolean;
@@ -142,6 +144,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
                         <CSSControl
                             css={(properties as unknown) as CSSPropertiesDictionary}
                             {...config}
+                            key={`${config.dictionaryId}::${config.dataLocation}`}
                         />
                     );
                 },
@@ -154,6 +157,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
                     return (
                         <CSSControl
                             css={(properties as unknown) as CSSPropertiesDictionary}
+                            key={`${config.dictionaryId}::${config.dataLocation}`}
                             cssControls={[
                                 new CSSStandardControlPlugin({
                                     id: "foo",
@@ -236,6 +240,15 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
         this.state = {
             schema: testConfigs.controlPluginCss.schema,
             data: exampleData,
+            dataDictionary: [
+                {
+                    foo: {
+                        schemaId: testConfigs.controlPluginCss.schema.id,
+                        data: exampleData,
+                    },
+                },
+                "foo",
+            ],
             navigation: void 0,
             showExtendedControls: false,
             inlineErrors: void 0,
@@ -304,7 +317,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
                         </label>
                         <br />
                     </div>
-                    <h2>Data</h2>
+                    <h2>Data Dictionary</h2>
                     <pre
                         style={{
                             padding: "12px",
@@ -312,7 +325,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
                             borderRadius: "4px",
                         }}
                     >
-                        {JSON.stringify(this.state.data, null, 2)}
+                        {JSON.stringify(this.state.dataDictionary, null, 2)}
                     </pre>
                     <h2>Navigation</h2>
                     <pre
@@ -448,6 +461,7 @@ class FormTestPage extends React.Component<{}, FormTestPageState> {
                 if (e.data.data) {
                     this.setState({
                         data: e.data.data,
+                        dataDictionary: e.data.dataDictionary,
                     });
                 }
             case MessageSystemType.navigation:

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/control-plugin.css.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/control-plugin.css.schema.ts
@@ -1,3 +1,5 @@
+import { linkedDataSchema } from "@microsoft/fast-tooling";
+
 export default {
     $schema: "http://json-schema.org/schema#",
     title: "Component with custom CSS controls",
@@ -20,6 +22,10 @@ export default {
                     formControlId: "custom-controls/css",
                 },
             },
+        },
+        children: {
+            title: "Children",
+            ...linkedDataSchema,
         },
     },
 };

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css-ref.props.ts
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css-ref.props.ts
@@ -28,6 +28,16 @@ export interface CSSRefProps {
      * The value of the CSS declaration
      */
     value: string;
+
+    /**
+     * The current dictionary ID
+     */
+    dictionaryId: string;
+
+    /**
+     * The current data location
+     */
+    dataLocation: string;
 }
 
 export interface CSSRefState {

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css-ref.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css-ref.tsx
@@ -51,6 +51,8 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
                                 syntax={syntaxRef}
                                 onChange={this.handleMultipleChange(index)}
                                 value={this.state.values[index]}
+                                dictionaryId={this.props.dictionaryId}
+                                dataLocation={this.props.dataLocation}
                             />
                         );
                     }
@@ -69,6 +71,8 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
                     syntax={(this.props.syntax.ref as CSSPropertyRef[])[this.state.index]}
                     onChange={this.handleChange}
                     value={this.state.values[this.state.index]}
+                    dictionaryId={this.props.dictionaryId}
+                    dataLocation={this.props.dataLocation}
                 />
             ) : null;
 
@@ -103,6 +107,8 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
                         ),
                     ],
                     value: this.props.value,
+                    dictionaryId: this.props.dictionaryId,
+                    dataLocation: this.props.dataLocation,
                 })}
                 {cssRef}
             </div>
@@ -118,6 +124,8 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
                         key: this.props.syntax.ref,
                         handleChange: this.props.onChange,
                         value: this.props.value,
+                        dictionaryId: this.props.dictionaryId,
+                        dataLocation: this.props.dataLocation,
                     });
                 case "type":
                     return renderTypeControl({
@@ -125,6 +133,8 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
                         key: this.props.syntax.ref,
                         handleChange: this.props.onChange,
                         value: this.props.value,
+                        dictionaryId: this.props.dictionaryId,
+                        dataLocation: this.props.dataLocation,
                     });
                 case "syntax":
                     return renderSyntaxControl({
@@ -132,6 +142,8 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
                         key: this.props.syntax.ref,
                         handleChange: this.props.onChange,
                         value: this.props.value,
+                        dictionaryId: this.props.dictionaryId,
+                        dataLocation: this.props.dataLocation,
                     });
                 case "property":
                     const propertyKey: string = this.props.syntax.ref.slice(2, -2);
@@ -149,6 +161,8 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
                             key: this.props.syntax.ref,
                             handleChange: this.props.onChange,
                             value: this.props.value,
+                            dictionaryId: this.props.dictionaryId,
+                            dataLocation: this.props.dataLocation,
                         });
                     }
                 default:
@@ -161,6 +175,8 @@ export class CSSRef extends React.Component<CSSRefProps, CSSRefState> {
                 syntax={this.props.syntax.ref[0]}
                 onChange={this.handleChange}
                 value={this.props.value}
+                dictionaryId={this.props.dictionaryId}
+                dataLocation={this.props.dataLocation}
             />
         );
     }

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.tsx
@@ -99,6 +99,8 @@ class CSSControl extends React.Component<
                     onChange={this.handleOnChange(cssPropertyName)}
                     mapsToProperty={cssPropertyName}
                     value={cssPropertyValue}
+                    dictionaryId={this.props.dictionaryId}
+                    dataLocation={this.props.dataLocation}
                 />
             </fieldset>
         );

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.property.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.property.tsx
@@ -27,6 +27,8 @@ export function renderPropertyControl(
                     syntax={config.syntax}
                     onChange={config.handleChange}
                     value={config.value}
+                    dictionaryId={config.dictionaryId}
+                    dataLocation={config.dataLocation}
                 />
             );
     }

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.props.ts
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.props.ts
@@ -24,6 +24,16 @@ export interface RenderControlConfig {
      * The current value
      */
     value: string;
+
+    /**
+     * The current dictionary ID
+     */
+    dictionaryId: string;
+
+    /**
+     * The current data location
+     */
+    dataLocation: string;
 }
 
 export interface RenderRefControlConfig extends RenderControlConfig {

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.syntax.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.syntax.tsx
@@ -274,6 +274,8 @@ export function renderSyntaxControl(config: RenderRefControlConfig): React.React
                     syntax={syntaxes[config.ref.ref.slice(1, -1) as string].value}
                     onChange={config.handleChange}
                     value={config.value}
+                    dictionaryId={config.dictionaryId}
+                    dataLocation={config.dataLocation}
                 />
             );
     }

--- a/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/custom-controls/control.css.utilities.tsx
@@ -49,7 +49,7 @@ export function renderTextInput(config: RenderRefControlConfig): React.ReactNode
     return (
         <fast-text-field
             {...{
-                key: config.key,
+                key: `${config.dictionaryId}::${config.dataLocation}`,
                 events: {
                     input: getInputChangeHandler(config.handleChange),
                 },
@@ -67,7 +67,7 @@ export function renderNumber(config: RenderRefControlConfig): React.ReactNode {
     return (
         <fast-number-field
             {...{
-                key: config.key,
+                key: `${config.dictionaryId}::${config.dataLocation}`,
                 events: {
                     input: getInputChangeHandler(config.handleChange),
                 },
@@ -85,7 +85,7 @@ export function renderInteger(config: RenderRefControlConfig): React.ReactNode {
     return (
         <fast-number-field
             {...{
-                key: config.key,
+                key: `${config.dictionaryId}::${config.dataLocation}`,
                 events: {
                     input: getInputChangeHandler(config.handleChange),
                 },
@@ -147,7 +147,7 @@ export function renderSelection(config: RenderSelectControlConfig): React.ReactN
 
     return (
         <fast-select
-            key={config.key}
+            key={`${config.dictionaryId}::${config.dataLocation}`}
             events={{
                 change: getSelectionChangeHandler(config.handleChange),
             }}
@@ -157,7 +157,7 @@ export function renderSelection(config: RenderSelectControlConfig): React.ReactN
                     <fast-option
                         {...{
                             value: `${option.value}`,
-                            key: option.key,
+                            key: `${config.dictionaryId}::${config.dataLocation}::${option.key}`,
                             ...(`${option.value}` === currentValue
                                 ? {
                                       selected: "",
@@ -193,7 +193,7 @@ function getColorPickerChangeHandler(
 export function renderColorPicker(config: RenderRefControlConfig): React.ReactNode {
     return (
         <color-picker
-            key={config.key}
+            key={`${config.dictionaryId}::${config.dataLocation}`}
             value={config.value}
             events={{
                 change: getColorPickerChangeHandler(config.handleChange),


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This solves an issue where switching between dictionary IDs (aka in the component nesting structure as seen in the Creator app) would not cause the CSS controls to update. This is fixed using the `key` prop which constructs a unique `key` from a `dictionaryId` and a `dataLocation`.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
The manual testing app has been updated to reflect this change, simply add a new css control, change the CSS values and navigate between the two dictionary items.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
As previously stated, this alpha component does not have a testing strategy at present since Jest/Enzyme errors. This will need to be addressed in a more comprehensive manner by either switching test suites or adding integration tests.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->