### PR TITLE
fixed: high contrast pass to fix missing and wrong forced color keywords

### DIFF
--- a/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
+++ b/packages/web-components/fast-components/src/accordion-item/accordion-item.styles.ts
@@ -140,6 +140,10 @@ export const accordionItemStyles = (context, definition) =>
             .button:${focusVisible}::before {
                 border-color: ${SystemColors.Highlight};
             }
+            :host slot[name="collapsed-icon"],
+            :host([expanded]) slot[name="expanded-icon"] {
+                fill: ${SystemColors.ButtonText};
+            }
         `
         )
     );

--- a/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.styles.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.styles.ts
@@ -121,8 +121,13 @@ export const breadcrumbItemStyles = (context, definition) =>
 `.withBehaviors(
         forcedColorsStylesheetBehavior(
             css`
-                .control:hover .content::before {
+                .control:hover .content::before,
+                .control:${focusVisible} .content::before {
                     background: ${SystemColors.LinkText};
+                }
+                .start,
+                .end {
+                    fill: ${SystemColors.ButtonText};
                 }
             `
         )

--- a/packages/web-components/fast-components/src/button/button.styles.ts
+++ b/packages/web-components/fast-components/src/button/button.styles.ts
@@ -35,7 +35,9 @@ export const buttonStyles = (context, definition) =>
         forcedColorsStylesheetBehavior(
             css`
                 :host([disabled]),
-                :host([disabled]) .control {
+                :host([disabled]) .control,
+                :host([disabled]:hover),
+                :host([disabled]:active) {
                     forced-color-adjust: none;
                     background-color: ${SystemColors.ButtonFace};
                     border-color: ${SystemColors.GrayText};

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -348,6 +348,15 @@ export const menuItemStyles = (context, definition) =>
             :host([aria-checked="true"]) .radio-indicator {
                 background: ${SystemColors.Highlight};
             }
+
+            ::slotted([slot="end"]:not(svg)) {
+                color: ${SystemColors.ButtonText};
+            }
+
+            :host(:hover) ::slotted([slot="end"]:not(svg)),
+            :host(:${focusVisible}) ::slotted([slot="end"]:not(svg)) {
+                color: ${SystemColors.HighlightText};
+            }
         `
         ),
 

--- a/packages/web-components/fast-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/fast-components/src/number-field/number-field.styles.ts
@@ -205,6 +205,9 @@ export const numberFieldStyles = (context, definition) =>
                     border-color: ${SystemColors.Highlight};
                     box-shadow: 0 0 0 1px ${SystemColors.Highlight} inset;
                 }
+                input::placeholder {
+                    color: ${SystemColors.GrayText};
+                }
             `
         )
     );

--- a/packages/web-components/fast-components/src/radio/radio.styles.ts
+++ b/packages/web-components/fast-components/src/radio/radio.styles.ts
@@ -145,7 +145,7 @@ export const radioStyles = (context, definition) =>
         forcedColorsStylesheetBehavior(
             css`
             .control,
-            :host([checked]:not([disabled])) .control {
+            :host([aria-checked="true"]:not([disabled])) .control {
                 forced-color-adjust: none;
                 border-color: ${SystemColors.FieldText};
                 background: ${SystemColors.Field};
@@ -154,17 +154,17 @@ export const radioStyles = (context, definition) =>
                 border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.Field};
             }
-            :host([checked]:not([disabled])) .control:hover,
-            :host([checked]:not([disabled])) .control:active {
+            :host([aria-checked="true"]:not([disabled])) .control:hover,
+            :host([aria-checked="true"]:not([disabled])) .control:active {
                 border-color: ${SystemColors.Highlight};
                 background: ${SystemColors.Highlight};
             }
-            :host([checked]) .checked-indicator {
+            :host([aria-checked="true"]) .checked-indicator {
                 background: ${SystemColors.Highlight};
                 fill: ${SystemColors.Highlight};
             }
-            :host([checked]:not([disabled])) .control:hover .checked-indicator,
-            :host([checked]:not([disabled])) .control:active .checked-indicator {
+            :host([aria-checked="true"]:not([disabled])) .control:hover .checked-indicator,
+            :host([aria-checked="true"]:not([disabled])) .control:active .checked-indicator {
                 background: ${SystemColors.HighlightText};
                 fill: ${SystemColors.HighlightText};
             }
@@ -172,7 +172,7 @@ export const radioStyles = (context, definition) =>
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
-            :host([checked]:${focusVisible}:not([disabled])) .control {
+            :host([aria-checked="true"]:${focusVisible}:not([disabled])) .control {
                 border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 2px ${SystemColors.Field}, 0 0 0 4px ${SystemColors.FieldText};
             }
@@ -184,12 +184,12 @@ export const radioStyles = (context, definition) =>
                 color: ${SystemColors.GrayText};
             }
             :host([disabled]) .control,
-            :host([checked][disabled]) .control:hover, .control:active {
+            :host([aria-checked="true"][disabled]) .control:hover, .control:active {
                 background: ${SystemColors.Field};
                 border-color: ${SystemColors.GrayText};
             }
             :host([disabled]) .checked-indicator,
-            :host([checked][disabled]) .control:hover .checked-indicator {
+            :host([aria-checked="true"][disabled]) .control:hover .checked-indicator {
                 fill: ${SystemColors.GrayText};
                 background: ${SystemColors.GrayText};
             }

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -193,14 +193,15 @@ export const AccentButtonStyles = css`
                 color: ${SystemColors.HighlightText};
             }
 
-            :host([appearance="accent"]) .control:hover {
+            :host([appearance="accent"]) .control:hover,
+            :host([appearance="accent"]:active) .control:active {
                 background: ${SystemColors.HighlightText};
                 border-color: ${SystemColors.Highlight};
                 color: ${SystemColors.Highlight};
             }
 
             :host([appearance="accent"]) .control:${focusVisible} {
-                border-color: ${SystemColors.HighlightText};
+                border-color: ${SystemColors.Highlight};
                 box-shadow: 0 0 0 calc(${focusStrokeWidth} * 1px) ${SystemColors.HighlightText} inset;
             }
 
@@ -219,7 +220,7 @@ export const AccentButtonStyles = css`
 
             :host([appearance="accent"][href]) .control:${focusVisible} {
                 border-color: ${SystemColors.LinkText};
-                box-shadow: 0 0 0 calc(${focusStrokeWidth} * 1px) ${SystemColors.LinkText} inset;
+                box-shadow: 0 0 0 calc(${focusStrokeWidth} * 1px) ${SystemColors.HighlightText} inset;
             }
         `
     )

--- a/packages/web-components/fast-components/src/tab/tab.styles.ts
+++ b/packages/web-components/fast-components/src/tab/tab.styles.ts
@@ -140,6 +140,12 @@ export const tabStyles = (context, definition) =>
                 border-color: ${SystemColors.ButtonText};
                 box-shadow: none;
             }
+            :host([disabled]),
+            :host([disabled]:hover) {
+                opacity: 1;
+                color: ${SystemColors.GrayText};
+                background: ${SystemColors.ButtonFace};
+            }
         `
         )
     );

--- a/packages/web-components/fast-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.styles.ts
@@ -174,6 +174,9 @@ export const textFieldStyles = (context, definition) =>
                     border-color: ${SystemColors.Highlight};
                     box-shadow: 0 0 0 1px ${SystemColors.Highlight} inset;
                 }
+                input::placeholder {
+                    color: ${SystemColors.GrayText};
+                }
             `
         )
     );


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
Fixed high contrast regression on the components. 

accordion-item - fixed expand and collapsed icons
![image](https://user-images.githubusercontent.com/37851220/123295045-386bc000-d4ca-11eb-8a7f-ee76bd48a8dc.png)
anchor - fixed missing border on focus
![image](https://user-images.githubusercontent.com/37851220/123295599-b4660800-d4ca-11eb-9a70-01a9d208b754.png)
breadcrumb-item - fixed icon color and missing underline focus indicator
![image](https://user-images.githubusercontent.com/37851220/123295323-75d04d80-d4ca-11eb-9658-eb5da9cb6396.png)
![image](https://user-images.githubusercontent.com/37851220/123296379-71586480-d4cb-11eb-9906-541aea9a09d9.png)
button - fixed missing border color on focus and update background on active state
![image](https://user-images.githubusercontent.com/37851220/123295775-e4151000-d4ca-11eb-9629-46e398d67aaf.png)
![image](https://user-images.githubusercontent.com/37851220/123296797-d0b67480-d4cb-11eb-9945-a35a55386a59.png)
menu-item - fixed the color on the `end` content
![image](https://user-images.githubusercontent.com/37851220/123295946-09a21980-d4cb-11eb-99d7-0cff72eacf00.png)
radio - fixed checked and focus states
![image](https://user-images.githubusercontent.com/37851220/123297754-b8932500-d4cc-11eb-98e6-8f790c84ffd8.png)
tab - fixed disabled color
![image](https://user-images.githubusercontent.com/37851220/123295410-8aace100-d4ca-11eb-91c3-417f4e1a03a8.png)
number-field and text-field - fixed placeholder text to be disabled color
![image](https://user-images.githubusercontent.com/37851220/123298492-67376580-d4cd-11eb-9fb8-7f8f6f7ad053.png)

 
### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->