### PR TITLE
chore: update fast-tooling manual test app to not use the design system provider

### DIFF
--- a/packages/tooling/fast-tooling/app/examples/css-layout/index.html
+++ b/packages/tooling/fast-tooling/app/examples/css-layout/index.html
@@ -42,11 +42,7 @@
     </head>
     <body>
         <div id="root">
-            <fast-design-system-provider use-defaults>
-                <fast-tooling-css-layout
-                    id="css-layout-control"
-                ></fast-tooling-css-layout>
-            </fast-design-system-provider>
+            <fast-tooling-css-layout id="css-layout-control"></fast-tooling-css-layout>
             <div class="content">
                 <div class="item">Item 1</div>
                 <div class="item">Item 2</div>

--- a/packages/tooling/fast-tooling/app/examples/css-layout/index.ts
+++ b/packages/tooling/fast-tooling/app/examples/css-layout/index.ts
@@ -1,9 +1,6 @@
-import { FASTDesignSystemProvider, fastSwitch } from "@microsoft/fast-components";
+import { fastSwitch } from "@microsoft/fast-components";
 import { DesignSystem } from "@microsoft/fast-foundation";
 import { fastToolingCSSLayout } from "../../../src/web-components/css-layout";
-
-// Prevent tree shaking
-FASTDesignSystemProvider;
 
 DesignSystem.getOrCreate()
     .withPrefix("fast-tooling")


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
Remove a vestigial reference to the `DesignSystemProvider` in the `@microsoft/fast-tooling` manual test app.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Run the manual test app in `fast-tooling` and there should no longer be errors.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->