### PR TITLE
feat: convert FAST component library to be a dynamic import

### DIFF
--- a/sites/fast-creator/app/configs/library.fast.import.ts
+++ b/sites/fast-creator/app/configs/library.fast.import.ts
@@ -1,0 +1,6 @@
+import * as FASTComponents from "@microsoft/fast-components";
+
+/**
+ * Prevent tree-shaking
+ */
+FASTComponents;

--- a/sites/fast-creator/app/configs/library.fast.ts
+++ b/sites/fast-creator/app/configs/library.fast.ts
@@ -47,15 +47,17 @@ import {
     fastTextAreaTag,
     fastTextFieldTag,
 } from "./library.fast.tags";
-
-export const importScriptLocation = "fast-components.min.js";
+import { registerFASTComponents } from "./library.fast.registry";
 export const fastComponentId = "fast-components";
 
 export const fastComponentLibrary: WebComponentLibraryDefinition = {
     id: fastComponentId,
     displayName: "FAST Components",
     optional: true,
-    import: `./${importScriptLocation}`,
+    import: async () => {
+        await import("./library.fast.import");
+    },
+    register: registerFASTComponents,
     componentDictionary: {
         [fastComponentSchemas[fastAnchorTag].$id]: {
             displayName: fastComponentSchemas[fastAnchorTag].title,

--- a/sites/fast-creator/app/configs/typings.ts
+++ b/sites/fast-creator/app/configs/typings.ts
@@ -43,7 +43,12 @@ export interface WebComponentLibraryDefinition extends NativeElementLibraryDefin
     /**
      * The script location
      */
-    import: string;
+    import: () => void;
+
+    /**
+     * Register web components within this function
+     */
+    register: () => void;
 }
 
 export type ElementLibraryDefinition =

--- a/sites/fast-creator/app/utilities/shared.ts
+++ b/sites/fast-creator/app/utilities/shared.ts
@@ -4,3 +4,9 @@
  */
 
 export const designTokensLinkedDataId: string = "design-tokens";
+export const rootOriginatorId: string = "originator::root";
+export const previewOriginatorId: string = "originator::preview";
+export enum CustomMessageSystemActions {
+    libraryAdd = "library::add",
+    libraryAdded = "library::added",
+}

--- a/sites/fast-creator/tsconfig.json
+++ b/sites/fast-creator/tsconfig.json
@@ -1,7 +1,7 @@
 {
     "compilerOptions": {
         "moduleResolution": "node",
-        "module": "ES6",
+        "module": "esnext",
         "target": "ES6",
         "baseUrl": "./",
         "jsx": "react",


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This PR adds logic where adding the FAST components library prompts the preview application to dynamically load and register components from the library. Without this action the components have not been included and will not render.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Run the Creator application and try to add a Card, this should not render correctly as the components have not been imported and registered. Then add the FAST components library using the button in the Libraries tab, the Card should render correctly. Additionally you can add the library first then the card, this should result in the correct rendering of the Card.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
- Make the components unavailable to be added until the library they are comprised of are added
- Add in the Fluent UI component library using the same methods the FAST library inclusion is employing