### PR TITLE
feat: update the monaco adapter, html render and html render layer and react Form to update their stored schema dictionaries when the schema dictionary has new schemas added to it

### DIFF
--- a/change/@microsoft-fast-tooling-7e4138ca-555e-4abf-91cb-25d06ed5202a.json
+++ b/change/@microsoft-fast-tooling-7e4138ca-555e-4abf-91cb-25d06ed5202a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update the monaco adapter, html render and html render layer and react Form to update their stored schema dictionaries when the schema dictionary has new schemas added to it",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-tooling-react-79408c15-77a8-4b44-9352-9ebc89854343.json
+++ b/change/@microsoft-fast-tooling-react-79408c15-77a8-4b44-9352-9ebc89854343.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "update the monaco adapter, html render and html render layer and react Form to update their stored schema dictionaries when the schema dictionary has new schemas added to it",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling-react/src/form/form.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/form.tsx
@@ -196,6 +196,11 @@ class Form extends React.Component<
                     options: e.data.options,
                 });
                 break;
+            case MessageSystemType.schemaDictionary:
+                this.setState({
+                    schemaDictionary: e.data.schemaDictionary,
+                });
+                break;
         }
     };
 

--- a/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.spec.ts
+++ b/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.spec.ts
@@ -603,7 +603,7 @@ xdescribe("MonacoAdapter", () => {
                             $id: "span",
                             type: "object",
                             mapsToTagName: "span",
-                        }
+                        },
                     ],
                 },
             } as any);

--- a/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.spec.ts
+++ b/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.spec.ts
@@ -7,6 +7,7 @@ import {
     Register,
 } from "../message-system";
 import { mapDataDictionaryToMonacoEditorHTML } from "../data-utilities/monaco";
+import { MessageSystemSchemaDictionaryTypeAction } from "../message-system/message-system.utilities.props";
 import {
     findDictionaryIdParents,
     findUpdatedDictionaryId,
@@ -547,6 +548,68 @@ xdescribe("MonacoAdapter", () => {
             },
             root,
         ]);
+    });
+    it("should change the schema dictionary when a schema dictionary event is fired", () => {
+        const dataDictionary: DataDictionary<unknown> = [
+            {
+                div: {
+                    schemaId: "div",
+                    data: {},
+                },
+            },
+            "div",
+        ];
+        const schemaDictionary = {
+            div: {
+                id: "div",
+                $id: "div",
+                type: "object",
+                mapsToTagName: "div",
+            },
+        };
+        const messageSystem = new MessageSystem({
+            webWorker: "",
+        });
+        const monacoAdapter = new MonacoAdapter({
+            messageSystem,
+            actions: [],
+        });
+
+        messageSystem["register"].forEach((registeredItem: Register) => {
+            registeredItem.onMessage({
+                data: {
+                    type: MessageSystemType.initialize,
+                    dataDictionary,
+                    schemaDictionary,
+                },
+            } as any);
+        });
+
+        expect(Object.keys(monacoAdapter["schemaDictionary"])).to.have.length(1);
+
+        messageSystem["register"].forEach((registeredItem: Register) => {
+            registeredItem.onMessage({
+                data: {
+                    type: MessageSystemType.schemaDictionary,
+                    action: MessageSystemSchemaDictionaryTypeAction.add,
+                    schemas: [
+                        {
+                            id: "text",
+                            $id: "text",
+                            type: "string",
+                        },
+                        {
+                            id: "span",
+                            $id: "span",
+                            type: "object",
+                            mapsToTagName: "span",
+                        }
+                    ],
+                },
+            } as any);
+        });
+
+        expect(Object.keys(monacoAdapter["schemaDictionary"])).to.have.length(3);
     });
 });
 

--- a/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.ts
+++ b/packages/tooling/fast-tooling/src/message-system-service/monaco-adapter.service.ts
@@ -132,6 +132,9 @@ export class MonacoAdapter extends MessageSystemService<
             case MessageSystemType.navigation:
                 this.dictionaryId = e.data.activeDictionaryId;
                 break;
+            case MessageSystemType.schemaDictionary:
+                this.schemaDictionary = e.data.schemaDictionary;
+                break;
         }
     };
 

--- a/packages/tooling/fast-tooling/src/web-components/html-render-layer/html-render-layer.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render-layer/html-render-layer.ts
@@ -62,6 +62,9 @@ export abstract class HTMLRenderLayer extends FoundationElement {
                 this.dataDictionary = e.data.dataDictionary;
                 this.schemaDictionary = e.data.schemaDictionary;
             }
+            if (e.data.type === MessageSystemType.schemaDictionary) {
+                this.schemaDictionary = e.data.schemaDictionary;
+            }
         }
     };
 

--- a/packages/tooling/fast-tooling/src/web-components/html-render/html-render.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render/html-render.ts
@@ -15,6 +15,7 @@ import {
     DataDictionary,
     MessageSystem,
     MessageSystemNavigationTypeAction,
+    MessageSystemSchemaDictionaryTypeAction,
     MessageSystemType,
     SchemaDictionary,
 } from "../../message-system";
@@ -167,6 +168,15 @@ export class HTMLRender extends FoundationElement {
                             null
                         );
                     }
+                }
+            }
+            if (
+                e.data.type === MessageSystemType.schemaDictionary &&
+                (!e.data.options ||
+                    e.data.options.originatorId !== this.messageOriginatorId)
+            ) {
+                if (e.data.action === MessageSystemSchemaDictionaryTypeAction.add) {
+                    this.schemaDictionary = e.data.schemaDictionary;
                 }
             }
         }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change adds the functionality from #4933 to the following services and components:
- `@microsoft/fast-tooling` - `MonacoAdapter`
- - `@microsoft/fast-tooling` - `<html-render>`
- - `@microsoft/fast-tooling` - `<html-render-layer>`
- `@microsoft/fast-tooling-react` - `Form`

Relies on the completion of #4933 to pass the build.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
The current testing is added to the `MonacoAdapter` only as the other tests are currently failing due to async issues when running them in the browser context.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.