### PR TITLE
fix: export tooltipStyles

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -34,12 +34,15 @@ dist/
 www/
 storybook-static
 
-#Ignore Mac .DS_Store
+# Ignore Mac .DS_Store
 .DS_Store
 
-#Ignore VSCode in Root
+# Ignore VSCode in Root
 /.vscode/
 /.vs/
+
+# Ignore Intellij IDEA
+.idea
 
 # tmp directories
 .tmp/

--- a/change/@microsoft-fast-components-2fce415d-b7f2-4b76-9488-de81582a65ef.json
+++ b/change/@microsoft-fast-components-2fce415d-b7f2-4b76-9488-de81582a65ef.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: export tooltipStyles",
+  "packageName": "@microsoft/fast-components",
+  "email": "derekdon@protonmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -1062,6 +1062,9 @@ export const toolbarStyles: (context: import("@microsoft/fast-foundation").Eleme
 
 export { Tooltip }
 
+// @public
+export const tooltipStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
+
 export { TreeItem }
 
 // @public

--- a/packages/web-components/fast-components/src/tooltip/index.ts
+++ b/packages/web-components/fast-components/src/tooltip/index.ts
@@ -21,3 +21,9 @@ export const fastTooltip = Tooltip.compose({
  * @public
  */
 export { Tooltip };
+
+/**
+ * Styles for Tooltip
+ * @public
+ */
+export const tooltipStyles = styles;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Ensure the tooltip's styles are exported like in the other components. Also adds .gitignore entry for .idea directory (Intellij's IDEA). 

Note: My original PR closed after force pushing a rebase. That PR appeared to be stuck on a build / approval step, perhaps because a master merge commit creeped in.

### 🎫 Issues

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.