### PR TITLE
fix an issue where the schema dictionary was not loading in the component explorer

### DIFF
--- a/sites/fast-component-explorer/app/explorer.props.ts
+++ b/sites/fast-component-explorer/app/explorer.props.ts
@@ -76,7 +76,7 @@ export interface ExplorerState extends EditorState {
     /**
      * The schema dictionary
      */
-    schemaDictionary?: SchemaDictionary;
+    schemaDictionary: SchemaDictionary;
 
     /**
      * The active pivot tab

--- a/sites/fast-component-explorer/app/explorer.tsx
+++ b/sites/fast-component-explorer/app/explorer.tsx
@@ -86,6 +86,7 @@ class Explorer extends Editor<ExplorerProps, ExplorerState> {
             previewReady: false,
             activeDictionaryId: componentLinkedDataId,
             dataDictionary: this.getScenarioData(componentConfig, selectedScenarioIndex),
+            schemaDictionary,
             activePivotTab: "code",
             mobileFormVisible: false,
             mobileNavigationVisible: false,
@@ -275,7 +276,7 @@ class Explorer extends Editor<ExplorerProps, ExplorerState> {
             this.fastMessageSystem.postMessage({
                 type: MessageSystemType.initialize,
                 dataDictionary,
-                schemaDictionary,
+                schemaDictionary: this.state.schemaDictionary,
             });
 
             this.setState(

--- a/sites/fast-creator/app/creator.props.ts
+++ b/sites/fast-creator/app/creator.props.ts
@@ -113,7 +113,7 @@ export interface ProjectFile {
     /**
      * The schema dictionary
      */
-    schemaDictionary?: SchemaDictionary;
+    schemaDictionary: SchemaDictionary;
 
     /**
      * Preview background transparency

--- a/sites/site-utilities/src/components/editor/editor.props.ts
+++ b/sites/site-utilities/src/components/editor/editor.props.ts
@@ -4,7 +4,7 @@ import { Direction } from "@microsoft/fast-web-utilities";
 
 /* eslint-disable-next-line @typescript-eslint/no-empty-interface */
 export interface EditorState {
-    schemaDictionary?: SchemaDictionary;
+    schemaDictionary: SchemaDictionary;
     dataDictionary: DataDictionary<unknown>;
     viewerWidth: number;
     viewerHeight: number;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This fixes a runtime error that was preventing the Component Explorer from loading. Ultimately the schema dictionary was not tied to state and not being passed on via the Editor abstract component, causing a crash from within the Monaco Editor utilities that parse the DataDictionary.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
It is recommended to run both the Creator and Component Explorer to check for any unexpected runtime errors.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.