### PR TITLE
fixes an issue where drag and drop was not working in the Form for linked data

### DIFF
--- a/sites/fast-creator/app/creator.tsx
+++ b/sites/fast-creator/app/creator.tsx
@@ -133,7 +133,7 @@ class Creator extends Editor<{}, CreatorState> {
             return (
                 <LinkedDataControl
                     {...config}
-                    onChange={this.handleAddLinkedData(config.onChange)}
+                    onChange={this.handleLinkedDataUpdates(config.onChange)}
                 />
             );
         },
@@ -423,7 +423,9 @@ class Creator extends Editor<{}, CreatorState> {
         );
     };
 
-    private handleAddLinkedData = (onChange): ((e: ControlOnChangeConfig) => void) => {
+    private handleLinkedDataUpdates = (
+        onChange
+    ): ((e: ControlOnChangeConfig) => void) => {
         return (e: ControlOnChangeConfig): void => {
             Object.entries(elementLibraryContents).forEach(
                 ([elementLibraryId, schemaIds]: [string, string[]]) => {
@@ -439,7 +441,10 @@ class Creator extends Editor<{}, CreatorState> {
                                         .componentDictionary[e.value[0].schemaId].example,
                                 ] || e.value,
                         });
-                    } else if (e.linkedDataAction === LinkedDataActionType.remove) {
+                    } else if (
+                        e.linkedDataAction === LinkedDataActionType.remove ||
+                        e.linkedDataAction === LinkedDataActionType.reorder
+                    ) {
                         onChange(e);
                     }
                 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
The `onChange` is currently being overwritten for linked data, specifically to allow for the addition of complex examples. This however did not take into account the reordering of linked data, which this PR fixes.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Add a Card to the Creator and in the form, click on the Card to see the internal components, then attempt to drag and drop the components inside it. This should now allow for them to be reordered.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
