### PR TITLE
Fix select border styles when control is active

### DIFF
--- a/change/@microsoft-fast-components-a91fa2e5-2e89-428c-9816-1c67bca53902.json
+++ b/change/@microsoft-fast-components-a91fa2e5-2e89-428c-9816-1c67bca53902.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix select border styles when control is active",
+  "packageName": "@microsoft/fast-components",
+  "email": "corylaviska@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/select/select.styles.ts
+++ b/packages/web-components/fast-components/src/select/select.styles.ts
@@ -126,15 +126,14 @@ export const selectStyles: (
     :host(:not([disabled])) .control:active {
         background: ${neutralFillInputActive};
         border-color: ${accentFillActive};
+        border-radius: calc(${controlCornerRadius} * 1px);
     }
 
-    :host([open][position="above"]) .listbox,
-    :host([open][position="below"]) .control {
+    :host([open][position="above"]) .listbox {
         border-bottom-left-radius: 0;
         border-bottom-right-radius: 0;
     }
 
-    :host([open][position="above"]) .control,
     :host([open][position="below"]) .listbox {
         border-top-left-radius: 0;
         border-top-right-radius: 0;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes a subtle style bug when the select component is active. In the GIF, observe any of the corners as the mouse is depressed.

Before
![before](https://user-images.githubusercontent.com/55639/127402243-3111da95-6923-48a4-8d83-3e309e1e6a6c.gif)

After
![after](https://user-images.githubusercontent.com/55639/127402050-de7df2e5-cc43-4967-888a-2ddf0a63323f.gif)

Not sure if this is something that makes sense to test for at this point — let me know what you think.

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->