### PR TITLE
refactor(fixture): mild change to typings to enable typical code pattern

### DIFF
--- a/change/@microsoft-fast-foundation-61f51210-4c16-4b3f-8984-f6a68f6e54d8.json
+++ b/change/@microsoft-fast-foundation-61f51210-4c16-4b3f-8984-f6a68f6e54d8.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "refactor(fixture): mild change to typings to enable typical code pattern",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-61f51210-4c16-4b3f-8984-f6a68f6e54d8.json
+++ b/change/@microsoft-fast-foundation-61f51210-4c16-4b3f-8984-f6a68f6e54d8.json
@@ -1,7 +1,7 @@
 {
-  "type": "minor",
+  "type": "none",
   "comment": "refactor(fixture): mild change to typings to enable typical code pattern",
   "packageName": "@microsoft/fast-foundation",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/packages/web-components/fast-foundation/src/test-utilities/fixture.ts
+++ b/packages/web-components/fast-foundation/src/test-utilities/fixture.ts
@@ -82,7 +82,7 @@ export interface Fixture<TElement = HTMLElement> {
      * Yields control to the caller one Microtask later, in order to
      * ensure that the DOM has settled.
      */
-    connect(): Promise<void>;
+    connect: () => Promise<void>;
 
     /**
      * Removes the {@link Fixture.parent} from the DOM, causing the
@@ -91,7 +91,7 @@ export interface Fixture<TElement = HTMLElement> {
      * Yields control to the caller one Microtask later, in order to
      * ensure that the DOM has settled.
      */
-    disconnect(): Promise<void>;
+    disconnect: () => Promise<void>;
 }
 
 function findElement(view: HTMLView): HTMLElement {


### PR DESCRIPTION
# Pull Request

## 📖 Description

At the request of the community, I've made a small type change to our `fixture` test helper. This should be a non-breaking change but it's technically a change to the API, so I've marked this as "minor" change.

### 🎫 Issues

* Related to #4930  but does not fully address the need yet. See Next Steps below.

## 👩‍💻 Reviewer Notes

This is a change to the shape of the interface only, primarily for the purpose of enabling type-safe destructuring of the `Fixture` interface without lint warnings.

## 📑 Test Plan

Existing tests and TS compilation should suffice in this case.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

To fully address the community need, we should make our testing utilities officially available, along with documentation on the site. There is a challenge of making these utilities available, related to where we put them. At present, they are part of the `fast-foundation` library. This is because they were originally used to write tests for foundation, and they are also dependent on foundation types. To make them available, it would be better to have a `fast-testing` package. However, this creates a circular dependency issue in our monorepo due to the fact that `fast-testing` would depend on `fast-foundation` and `fast-foundation` would depend on `fast-testing`. A solution would be to move *all* of our tests out of our packages into a dedicated test project within the monorepo. This would break the circular dependency, as only the test project would depend on the `fast-testing` package. There are other advantages to this, such as more simply running all tests for the monorepo and better optimizing the test build time. At present, I don't think this is possible, due to the presence of the tooling in our monorepo, which has a different test setup than the packages. However, with our plan to move the tooling out, this would then enable use to move forward. So, steps would be as follows:

1. Move the tooling into its own monorepo
2. Work to ensure that individual test package setup is exactly the same across all packages in the fast monorepo
3. Move all the tests to a central location, probably a `test` folder at the root of the monorepo, and making adjustments to have a single test setup with commands to run "sets" of tests
4. Create the `fast-testing` package and then refactor to base all centralized tests on that package

I'm open to other ideas, but I don't see a way to break the circular dependency between foundation and test without moving the tests. I do think this will yield other benefits as well, especially server build time. It would be a change in workflow, though not to something uncommon (I've followed this pattern in other projects as well.)