### PR TITLE
fix: fix word wrapping bug in html render navigation pill

### DIFF
--- a/change/@microsoft-fast-tooling-a5f7c374-9e8f-42dc-a75d-2b113b0f7d39.json
+++ b/change/@microsoft-fast-tooling-a5f7c374-9e8f-42dc-a75d-2b113b0f7d39.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix word wrapping in htmlrender navigation pill",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.style.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.style.ts
@@ -59,6 +59,7 @@ export const htmlRenderLayerNavigationStyles = (context, definition) => css`
         text-transform: uppercase;
         font-weight: 700;
         color: ${BackgroundColorProperty};
+        white-space: nowrap;
     }
     .hover-layer .pill {
         background-color: ${BackgroundColorProperty};


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
Adding white-space: nowrap style to pill in html render navigation component to prevent pill content from wrapping and potentially covering the selected element.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->