### PR TITLE
fix: resolve the expanded navigation items mismatch after triggering the expand trigger then a navigation message

### DIFF
--- a/change/@microsoft-fast-tooling-react-1112709a-9e25-478a-ae24-6285dc69fcf6.json
+++ b/change/@microsoft-fast-tooling-react-1112709a-9e25-478a-ae24-6285dc69fcf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "resolve the expanded navigation items mismatch after triggering the expand trigger then a navigation message",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling-react/src/navigation/navigation.tsx
+++ b/packages/tooling/fast-tooling-react/src/navigation/navigation.tsx
@@ -127,22 +127,19 @@ class Navigation extends Foundation<
         activeDictionaryId: string,
         activeNavigationConfigId: string
     ): Set<string> {
+        const updatedDictionaryItemConfigItems = new Set(
+            this.state.expandedNavigationConfigItems[activeDictionaryId]
+        );
+
         if (this.state.expandedNavigationConfigItems[activeDictionaryId] === undefined) {
             return new Set([activeNavigationConfigId]);
-        } else if (
-            this.state.expandedNavigationConfigItems[activeDictionaryId].has(
-                activeNavigationConfigId
-            )
-        ) {
-            this.state.expandedNavigationConfigItems[activeDictionaryId].delete(
-                activeNavigationConfigId
-            );
-            return this.state.expandedNavigationConfigItems[activeDictionaryId];
+        } else if (updatedDictionaryItemConfigItems.has(activeNavigationConfigId)) {
+            updatedDictionaryItemConfigItems.delete(activeNavigationConfigId);
+            return updatedDictionaryItemConfigItems;
         }
 
-        return this.state.expandedNavigationConfigItems[activeDictionaryId].add(
-            activeNavigationConfigId
-        );
+        updatedDictionaryItemConfigItems.add(activeNavigationConfigId);
+        return updatedDictionaryItemConfigItems;
     }
 
     /**
@@ -442,11 +439,16 @@ class Navigation extends Foundation<
 
     private getParentElement(dictionaryId: string): { [key: string]: Set<string> } {
         if (this.state.dataDictionary[0][dictionaryId].parent) {
-            let parentDictionaryItem =
-                this.state.expandedNavigationConfigItems[dictionaryId] || new Set([""]);
-
             const parentDictionaryId = this.state.dataDictionary[0][dictionaryId].parent
                 .id;
+            const parentDictionaryItem = this.state.expandedNavigationConfigItems[
+                parentDictionaryId
+            ]
+                ? new Set([
+                      "",
+                      ...this.state.expandedNavigationConfigItems[parentDictionaryId],
+                  ])
+                : new Set([""]);
             const parentDictionaryItemDataLocations: Set<string> = new Set(
                 this.state.dataDictionary[0][dictionaryId].parent.dataLocation.split(".")
             );


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change fixes an issue where the expand/collapse states were not reflecting previous states triggered in the Navigation after a navigation message is received.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
On Creator try the following:
1. Add A Card (Fluent UI)
2. Expand the div
3. Expand the Card
4. Collapse the Card
5. Collapse the div
6. Use the canvas to select the paragraph

You should see the Navigation does not open up to the location. Next try this on this branch and you should see that logic working.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Unit tests have been added.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.