### PR TITLE
feat: detect if user have set preventDefault on fast-button

### DIFF
--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -150,7 +150,7 @@ export class Button extends FormAssociatedButton {
     /**
      * Submits the parent form
      */
-    private handleSubmission = () => {
+    private handleSubmission = (e: Event) => {
         if (!this.form) {
             return;
         }
@@ -161,22 +161,28 @@ export class Button extends FormAssociatedButton {
             this.attachProxy();
         }
 
-        // Browser support for requestSubmit is not comprehensive
-        // so click the proxy if it isn't supported
-        typeof this.form.requestSubmit === "function"
-            ? this.form.requestSubmit(this.proxy)
-            : this.proxy.click();
+        setTimeout(() => {
+            if (e.defaultPrevented) return;
 
-        if (!attached) {
-            this.detachProxy();
-        }
+            // Browser support for requestSubmit is not comprehensive
+            // so click the proxy if it isn't supported
+            typeof this.form?.requestSubmit === "function"
+                ? this.form.requestSubmit(this.proxy)
+                : this.proxy.click();
+
+            if (!attached) {
+                this.detachProxy();
+            }
+        });
     };
 
     /**
      * Resets the parent form
      */
-    private handleFormReset = () => {
-        this.form?.reset();
+    private handleFormReset = (e: Event) => {
+        setTimeout(() => {
+            !e.defaultPrevented && this.form?.reset();
+        });
     };
 
     public control: HTMLButtonElement;

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -1,4 +1,4 @@
-import { attr, observable } from "@microsoft/fast-element";
+import { attr, observable, DOM } from "@microsoft/fast-element";
 import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
 import { FormAssociatedButton } from "./button.form-associated";
@@ -161,7 +161,7 @@ export class Button extends FormAssociatedButton {
             this.attachProxy();
         }
 
-        setTimeout(() => {
+        DOM.queueUpdate(() => {
             if (e.defaultPrevented) return;
 
             // Browser support for requestSubmit is not comprehensive
@@ -180,7 +180,7 @@ export class Button extends FormAssociatedButton {
      * Resets the parent form
      */
     private handleFormReset = (e: Event) => {
-        setTimeout(() => {
+        DOM.queueUpdate(() => {
             !e.defaultPrevented && this.form?.reset();
         });
     };


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, `please` read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request
set timeout to detect if user have set `preventDefault` for fast-button, so that we can cancel the next actions, which just like the native button can prevent event (say as submit a form) at anytime.

## 📖 Description
I notice that, the native button can prevent default (like submit a form) anytime, but fast-button can't.

So I add a  setTimeout to detect if user have set `preventDefault` for fast-button, so that we can cancel the next actions, which just like the native button can prevent event (say as submit a form) at anytime.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
addEventListener `click` after `DOMContentLoaded` and set `e.preventDefault()`

```html
<form action="#">
  <input type="text" name="text" />
  <fast-button type="submit" id="btn">submit</fast-button>
</form>
```

```js
document.querySelector('#btn').addEventListener('click', (e) => {
  e.preventDefault()
})
```
click the submit button will submit form as well.

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
I think html spec should provide a better way to detect `preventDefault` on custom element define lifetime. but now `setTimeout` look like is the best choice.