### PR TITLE
fix: make resize observer target configurable in html render navigation component

### DIFF
--- a/change/@microsoft-fast-tooling-7856457b-7d8e-4c02-8a8c-25769919cd0c.json
+++ b/change/@microsoft-fast-tooling-7856457b-7d8e-4c02-8a8c-25769919cd0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make resize observer target configurable",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
@@ -71,7 +71,9 @@ export class HTMLRenderLayerNavigation extends HTMLRenderLayer {
 
         this.resizeDetector.observe(
             (this.resizeobserverselector
-                ? document.querySelector(this.resizeobserverselector)
+                ? (this.getRootNode() as Element).querySelector(
+                      this.resizeobserverselector
+                  )
                 : null) ?? document.body
         );
 

--- a/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
@@ -1,4 +1,4 @@
-import { observable } from "@microsoft/fast-element";
+import { attr, observable } from "@microsoft/fast-element";
 import { dataSetName } from "../../message-system/message-system.utilities";
 import {
     ActivityType,
@@ -20,6 +20,16 @@ declare global {
 }
 
 export class HTMLRenderLayerNavigation extends HTMLRenderLayer {
+    /**
+     * Specifies a query selector string for choosing the element to attach
+     * the resize observer to. Defaults to document.body if not supplied.
+     * document.querySelector is used to find the element so the resizeobserverselector
+     * should be specific enough to return only one element, otherwise only the first match
+     * will be used.
+     */
+    @attr
+    public resizeobserverselector: string;
+
     public layerActivityId: string = "NavLayer";
 
     @observable
@@ -59,7 +69,11 @@ export class HTMLRenderLayerNavigation extends HTMLRenderLayer {
             this.handleWindowChange
         );
 
-        this.resizeDetector.observe(document.body);
+        this.resizeDetector.observe(
+            this.resizeobserverselector
+                ? document.querySelector(this.resizeobserverselector)
+                : null ?? document.body
+        );
 
         window.addEventListener("scroll", this.handleWindowChange);
         window.addEventListener("resize", this.handleWindowChange);

--- a/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
+++ b/packages/tooling/fast-tooling/src/web-components/html-render-layer-navigation/html-render-layer-navigation.ts
@@ -70,9 +70,9 @@ export class HTMLRenderLayerNavigation extends HTMLRenderLayer {
         );
 
         this.resizeDetector.observe(
-            this.resizeobserverselector
+            (this.resizeobserverselector
                 ? document.querySelector(this.resizeobserverselector)
-                : null ?? document.body
+                : null) ?? document.body
         );
 
         window.addEventListener("scroll", this.handleWindowChange);

--- a/sites/fast-creator/app/preview/web-components/index.tsx
+++ b/sites/fast-creator/app/preview/web-components/index.tsx
@@ -25,7 +25,10 @@ export class HTMLRenderReact extends React.Component {
     render() {
         return (
             <fast-tooling-html-render ref={this.setRenderRef}>
-                <fast-tooling-html-render-layer-navigation role="htmlrenderlayer"></fast-tooling-html-render-layer-navigation>
+                <fast-tooling-html-render-layer-navigation
+                    role="htmlrenderlayer"
+                    resizeobserverselector="#root .preview"
+                ></fast-tooling-html-render-layer-navigation>
                 <fast-tooling-html-render-layer-inline-edit
                     role="htmlrenderlayer"
                     autoselect


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

Defaulting to the body resulted in scenarios that did not necessarily trigger the resize observer. This PR adds a "resizeobserverselector" attribute to the HTMLRenderNavigation component so that the resize observer target can be specified by the implementing code to ensure that the observer is attached to an element that will resize as content changes.
The new attribute is optional and the component will default to "document.body" if it is not supplied or if the selector specified does not match anything in the document.
This attribute is then used in Creator to specify the containing element which resizes to fit its children and should always trigger the observer whenever the content changes.

### 🎫 Issues
fixes #5063 
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->