### PR TITLE
update to content security policy for images and fonts

### DIFF
--- a/sites/site-utilities/statics/server/server.js
+++ b/sites/site-utilities/statics/server/server.js
@@ -24,9 +24,11 @@ if (process.env.WEBSITE_HOSTNAME.indexOf("create") > -1) {
         helmet.contentSecurityPolicy({
             directives: {
                 defaultSrc: ["'self'"],
-                fontSrc: ["'self' use.typekit.net static.fast.design c.s-microsoft.com"],
+                fontSrc: [
+                    "'self' static2.sharepointonline.com use.typekit.net static.fast.design c.s-microsoft.com",
+                ],
                 frameAncestors: [`'self' ${process.env.FRAME_ANCESTOR_PARTNER}`],
-                imgSrc: ["'self' data: *.fast.design via.placeholder.com"],
+                imgSrc: ["'self' blob: data: *.fast.design via.placeholder.com"],
                 scriptSrc: ["'self' 'unsafe-eval'"],
                 styleSrc: ["'self' https: 'unsafe-inline'"],
             },


### PR DESCRIPTION
# Pull Request

## 📖 Description
The staging site for creator results in a broken image displayed in the preview when you should be seeing the image you selected.

If you open the dev tools and look in the “Console” tab you will see the following security error:
Refused to load the image 'blob:https://stage.create.fast.design/27f23914-383c-4b3d-ae7a-db881cf66402' because it violates the following Content Security Policy directive: "img-src 'self' data: *.fast.design via.placeholder.com".
 
After a quick search around the nets I saw that the solution is to add “blob:” to the Content Security Policy.
 <!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
CSP Policy requires additional `blob:` configuration.

## 👩‍💻 Reviewer Notes

In the header it should look like this:
img-src 'self' blob: data: *.fast.design via.placeholder.com;
 
Instead of this:
img-src 'self' data: *.fast.design via.placeholder.com;


## 📑 Test Plan
https://stage.create.fast.design/
 
**Steps to Repo and Test:**
Open creator and add an image to the workspace by click the “Add” dropdown under the “Default slot”. Type “img” and press enter.
Click the image in the preview and then click the “Add Image” button in the right panel. Select any image file on your computer (.png, .gif or .jpg).



## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->