### PR TITLE
fix: set set baseLayerLuminance according to fillColor

### DIFF
--- a/change/@microsoft-fast-components-292ddd91-67af-49c5-8911-fde8eca3e3ea.json
+++ b/change/@microsoft-fast-components-292ddd91-67af-49c5-8911-fde8eca3e3ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "set baseLayerLuminance according to fillColor",
+  "packageName": "@microsoft/fast-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/.storybook/preview-head.html
+++ b/packages/web-components/fast-components/.storybook/preview-head.html
@@ -5,7 +5,6 @@
         display: flex;
         flex-direction: column;
         height: 100%;
-        background-color: var(--fill-color);
     }
     #root {
         padding: 20px;

--- a/packages/web-components/fast-components/.storybook/preview.js
+++ b/packages/web-components/fast-components/.storybook/preview.js
@@ -1,5 +1,18 @@
 import "../src/index-rollup";
+import * as FAST from "../src/index-rollup";
+import { parseColor } from "@microsoft/fast-colors";
 
 export const parameters = {
     layout: "fullscreen",
 };
+
+const root = document.body;
+
+// By default, we grab the current background color to set the fillColor token.
+// This value can be changed to see the components in light mode.
+const backgroundColor = getComputedStyle(root).backgroundColor;
+
+FAST.fillColor.setValueFor(root, FAST.SwatchRGB.from(parseColor(backgroundColor)));
+
+root.style.backgroundColor = FAST.fillColor.createCSS();
+root.style.color = FAST.neutralForegroundRest.createCSS();

--- a/packages/web-components/fast-components/src/design-tokens.ts
+++ b/packages/web-components/fast-components/src/design-tokens.ts
@@ -1,29 +1,30 @@
 import { DesignToken } from "@microsoft/fast-foundation";
 import { Direction } from "@microsoft/fast-web-utilities";
 import { Palette, PaletteRGB } from "./color/palette";
-import { Swatch } from "./color/swatch";
+import { InteractiveSwatchSet } from "./color/recipe";
 import { accentFill as accentFillAlgorithm } from "./color/recipes/accent-fill";
 import { accentForeground as accentForegroundAlgorithm } from "./color/recipes/accent-foreground";
-import { foregroundOnAccent as foregroundOnAccentAlgorithm } from "./color/recipes/foreground-on-accent";
-import { neutralFill as neutralFillAlgorithm } from "./color/recipes/neutral-fill";
-import { neutralFillInput as neutralFillInputAlgorithm } from "./color/recipes/neutral-fill-input";
-import { neutralFillLayer as neutralFillLayerAlgorithm } from "./color/recipes/neutral-fill-layer";
-import { neutralFillStealth as neutralFillStealthAlgorithm } from "./color/recipes/neutral-fill-stealth";
-import { neutralFillContrast as neutralFillContrastAlgorithm } from "./color/recipes/neutral-fill-contrast";
 import {
     focusStrokeInner as focusStrokeInnerAlgorithm,
     focusStrokeOuter as focusStrokeOuterAlgorithm,
 } from "./color/recipes/focus-stroke";
+import { foregroundOnAccent as foregroundOnAccentAlgorithm } from "./color/recipes/foreground-on-accent";
+import { neutralFill as neutralFillAlgorithm } from "./color/recipes/neutral-fill";
+import { neutralFillContrast as neutralFillContrastAlgorithm } from "./color/recipes/neutral-fill-contrast";
+import { neutralFillInput as neutralFillInputAlgorithm } from "./color/recipes/neutral-fill-input";
+import { neutralFillLayer as neutralFillLayerAlgorithm } from "./color/recipes/neutral-fill-layer";
+import { neutralFillStealth as neutralFillStealthAlgorithm } from "./color/recipes/neutral-fill-stealth";
 import { neutralForeground as neutralForegroundAlgorithm } from "./color/recipes/neutral-foreground";
 import { neutralForegroundHint as neutralForegroundHintAlgorithm } from "./color/recipes/neutral-foreground-hint";
-import { neutralLayerCardContainer as neutralLayerCardContainerAlgorithm } from "./color/recipes/neutral-layer-card-container";
-import { neutralLayerFloating as neutralLayerFloatingAlgorithm } from "./color/recipes/neutral-layer-floating";
 import { neutralLayer1 as neutralLayer1Algorithm } from "./color/recipes/neutral-layer-1";
 import { neutralLayer2 as neutralLayer2Algorithm } from "./color/recipes/neutral-layer-2";
 import { neutralLayer3 as neutralLayer3Algorithm } from "./color/recipes/neutral-layer-3";
 import { neutralLayer4 as neutralLayer4Algorithm } from "./color/recipes/neutral-layer-4";
+import { neutralLayerCardContainer as neutralLayerCardContainerAlgorithm } from "./color/recipes/neutral-layer-card-container";
+import { neutralLayerFloating as neutralLayerFloatingAlgorithm } from "./color/recipes/neutral-layer-floating";
 import { neutralStroke as neutralStrokeAlgorithm } from "./color/recipes/neutral-stroke";
 import { neutralStrokeDivider as neutralStrokeDividerAlgorithm } from "./color/recipes/neutral-stroke-divider";
+import { Swatch } from "./color/swatch";
 import { StandardLuminance } from "./color/utilities/base-layer-luminance";
 import { accentBase, middleGrey } from "./color/utilities/color-constants";
 import { InteractiveSwatchSet } from "./color/recipe";

--- a/packages/web-components/fast-components/src/design-tokens.ts
+++ b/packages/web-components/fast-components/src/design-tokens.ts
@@ -27,7 +27,7 @@ import { neutralStrokeDivider as neutralStrokeDividerAlgorithm } from "./color/r
 import { Swatch } from "./color/swatch";
 import { StandardLuminance } from "./color/utilities/base-layer-luminance";
 import { accentBase, middleGrey } from "./color/utilities/color-constants";
-import { InteractiveSwatchSet } from "./color/recipe";
+import { isDark } from "./color/utilities/is-dark";
 
 /** @public */
 export interface Recipe<T> {
@@ -56,10 +56,6 @@ export const baseHeightMultiplier = create<number>("base-height-multiplier").wit
 export const baseHorizontalSpacingMultiplier = create<number>(
     "base-horizontal-spacing-multiplier"
 ).withDefault(3);
-/** @public */
-export const baseLayerLuminance = create<number>("base-layer-luminance").withDefault(
-    StandardLuminance.DarkMode
-);
 /** @public */
 export const controlCornerRadius = create<number>("control-corner-radius").withDefault(4);
 /** @public */
@@ -300,6 +296,15 @@ export const fillColor = create<Swatch>("fill-color").withDefault(element => {
     const palette = neutralPalette.getValueFor(element);
     return palette.get(palette.swatches.length - 5);
 });
+
+/** @public */
+export const baseLayerLuminance = create<number>(
+    "base-layer-luminance"
+).withDefault((element: HTMLElement) =>
+    isDark(fillColor.getValueFor(element))
+        ? StandardLuminance.DarkMode
+        : StandardLuminance.LightMode
+);
 
 enum ContrastTarget {
     normal = 4.5,


### PR DESCRIPTION
# Pull Request

## 📖 Description

Sets the default value for `baseLayerLuminance` to use the `fillColor`, to determine if light or dark mode should be set.

### 🎫 Issues

Fixes #5060.

## 👩‍💻 Reviewer Notes

I'm not 100% familiar with the new design system, so this may not be the most solid approach to setting the default `baseLayerLuminance`.

## 📑 Test Plan

To confirm this work, the line in `.storybook/preview.js` can be changed to any color value:

```js
const backgroundColor = "#FFF";
```

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

Tests should be added so that the light/dark mode luminance is set properly in various situations.

An added bonus: once we update Storybook and add `@storybook/addons-essential`, we will be able to hook into SB's built-in functionality for changing the background color.