### PR TITLE
Fix slider dragging when the page is scrolled

### DIFF
--- a/change/@microsoft-fast-foundation-d4f9da07-0a67-4f40-b421-91e72097c3cb.json
+++ b/change/@microsoft-fast-foundation-d4f9da07-0a67-4f40-b421-91e72097c3cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix slider dragging when page is scrolled",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "corylaviska@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -422,8 +422,8 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
                 : (e as MouseEvent);
         const eventValue: number =
             this.orientation === Orientation.horizontal
-                ? sourceEvent.pageX - this.trackLeft
-                : sourceEvent.pageY;
+                ? sourceEvent.pageX - document.documentElement.scrollLeft - this.trackLeft
+                : sourceEvent.pageY - document.documentElement.scrollTop;
 
         this.value = `${this.calculateNewValue(eventValue)}`;
     };
@@ -469,8 +469,8 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
 
             const controlValue: number =
                 this.orientation === Orientation.horizontal
-                    ? e.pageX - this.trackLeft
-                    : e.pageY;
+                    ? e.pageX - document.documentElement.scrollLeft - this.trackLeft
+                    : e.pageY - document.documentElement.scrollTop;
 
             this.value = `${this.calculateNewValue(controlValue)}`;
         }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes a bug that affects dragging the slider when the page is scrolled. This affects both horizontal and vertical orientations.

### 🎫 Issues

Dragging the slider's handle doesn't account for scrolling. This is most apparent in the vertical orientation, but also affects horizontal sliders.

The GIF demonstrates a vertical slider in two phases: working as expected, then incorrectly after scrolling.

![CleanShot 2021-08-17 at 11 10 36](https://user-images.githubusercontent.com/55639/129752547-d568b8be-5270-4b8b-96ed-da9cf38e646a.gif)

## 👩‍💻 Reviewer Notes

To replicate the bug:

- Visit https://explore.fast.design/components/fast-slider
- From the dropdown, select "Vertical with labels"
- Resize the fixture container so the example scrolls
- Move the scrollbar slightly down
- Try to move the slider
- The thumb will be offset by the amount you've scrolled

It's harder to test the horizontal orientation since it expands/contracts with the container.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

N/A