### PR TITLE
Add up/down support to number field

### DIFF
--- a/change/@microsoft-fast-foundation-6ed466c1-f107-4f38-9b7d-87527dbfdeab.json
+++ b/change/@microsoft-fast-foundation-6ed466c1-f107-4f38-9b7d-87527dbfdeab.json
@@ -1,6 +1,0 @@
-{
-  "type": "minor",
-  "packageName": "@microsoft/fast-foundation",
-  "email": "corylaviska@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/change/@microsoft-fast-foundation-6ed466c1-f107-4f38-9b7d-87527dbfdeab.json
+++ b/change/@microsoft-fast-foundation-6ed466c1-f107-4f38-9b7d-87527dbfdeab.json
@@ -1,0 +1,6 @@
+{
+  "type": "minor",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "corylaviska@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-f40d1c3b-d5e2-4839-a156-db8a57cc0068.json
+++ b/change/@microsoft-fast-foundation-f40d1c3b-d5e2-4839-a156-db8a57cc0068.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add up/down key support to number-field",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "corylaviska@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
@@ -34,6 +34,7 @@ export const numberFieldTemplate: (
                 id="control"
                 @input="${x => x.handleTextInput()}"
                 @change="${x => x.handleChange()}"
+                @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
                 ?autofocus="${x => x.autofocus}"
                 ?disabled="${x => x.disabled}"
                 list="${x => x.list}"

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -261,6 +261,24 @@ export class NumberField extends FormAssociatedNumberField {
     public handleChange(): void {
         this.$emit("change");
     }
+
+    /**
+     * Handles the internal control's `keydown` event
+     * @internal
+     */
+    public handleKeyDown(event: KeyboardEvent): boolean {
+        if (event.key === "ArrowUp") {
+            this.stepUp();
+            return false;
+        }
+
+        if (event.key === "ArrowDown") {
+            this.stepDown();
+            return false;
+        }
+
+        return true;
+    }
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds support for pressing the up/down arrow keys to step the number field up/down. I'm considering it a "bug" rather than a feature since this brings the FAST component to parity with `<input type="number">`.

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

- Open the number field demo
- Focus on any number field
- Press up/down
- Verify min/max/step are honored

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
