### PR TITLE
feat: add tooltips to the CSS layout radio buttons

### DIFF
--- a/change/@microsoft-fast-tooling-0189f240-d3ac-4189-9118-a88f6f2fb223.json
+++ b/change/@microsoft-fast-tooling-0189f240-d3ac-4189-9118-a88f6f2fb223.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add tooltips to the CSS layout radio buttons",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling/app/examples/css-layout/index.ts
+++ b/packages/tooling/fast-tooling/app/examples/css-layout/index.ts
@@ -1,7 +1,7 @@
-import { fastSwitch } from "@microsoft/fast-components";
+import { fastSwitch, fastTooltip } from "@microsoft/fast-components";
 import { DesignSystem } from "@microsoft/fast-foundation";
 import { fastToolingCSSLayout } from "../../../src/web-components/css-layout";
 
 DesignSystem.getOrCreate()
     .withPrefix("fast-tooling")
-    .register(fastSwitch(), fastToolingCSSLayout());
+    .register(fastSwitch(), fastTooltip(), fastToolingCSSLayout());

--- a/packages/tooling/fast-tooling/src/web-components/css-layout/css-layout.spec.ts
+++ b/packages/tooling/fast-tooling/src/web-components/css-layout/css-layout.spec.ts
@@ -1,4 +1,4 @@
-import { fastSwitch } from "@microsoft/fast-components";
+import { fastSwitch, fastTooltip } from "@microsoft/fast-components";
 import { DOM } from "@microsoft/fast-element";
 import { DesignSystem } from "@microsoft/fast-foundation";
 import { expect } from "chai";
@@ -7,7 +7,7 @@ import { fastToolingCSSLayout } from ".";
 
 async function setup() {
     const { element, connect, disconnect } = await fixture(fastToolingCSSLayout(), {
-        designSystem: DesignSystem.getOrCreate().register(fastSwitch()),
+        designSystem: DesignSystem.getOrCreate().register(fastSwitch(), fastTooltip()),
     });
 
     return { element, connect, disconnect };
@@ -64,6 +64,35 @@ describe("CSSLayout", () => {
 
         await disconnect();
     });
+    it("should contain a tooltip for a flex-direction value that matches it's id attribute", async () => {
+        const { element, connect, disconnect } = await setup();
+        let css = "";
+
+        await connect();
+
+        const toggle = element.shadowRoot?.querySelector("fast-switch");
+        const toggleEvent = new Event("click", {} as MouseEventInit);
+
+        element.addEventListener("change", (e: any) => {
+            css = e.target.value;
+        });
+
+        toggle.dispatchEvent(toggleEvent);
+
+        await DOM.nextUpdate();
+
+        const input = element.shadowRoot?.querySelector(
+            "input[name='flex-direction']"
+        ) as HTMLInputElement;
+        const tooltip = element.shadowRoot?.querySelector(
+            "input[name='flex-direction'] + fast-tooltip"
+        );
+
+        expect(input.getAttribute("id")).to.equal(tooltip.getAttribute("anchor"));
+        expect(tooltip.textContent.trim()).to.equal("row");
+
+        await disconnect();
+    });
     it("should emit an updated flex-direction value when the flex-direction value is updated", async () => {
         const { element, connect, disconnect } = await setup();
         let css = "";
@@ -90,6 +119,35 @@ describe("CSSLayout", () => {
         await DOM.nextUpdate();
 
         expect(css).to.equal("display: flex; flex-direction: row;");
+
+        await disconnect();
+    });
+    it("should contain a tooltip for a justify-content value that matches it's id attribute", async () => {
+        const { element, connect, disconnect } = await setup();
+        let css = "";
+
+        await connect();
+
+        const toggle = element.shadowRoot?.querySelector("fast-switch");
+        const toggleEvent = new Event("click", {} as MouseEventInit);
+
+        element.addEventListener("change", (e: any) => {
+            css = e.target.value;
+        });
+
+        toggle.dispatchEvent(toggleEvent);
+
+        await DOM.nextUpdate();
+
+        const input = element.shadowRoot?.querySelector(
+            "input[name='justify-content']"
+        ) as HTMLInputElement;
+        const tooltip = element.shadowRoot?.querySelector(
+            "input[name='justify-content'] + fast-tooltip"
+        );
+
+        expect(input.getAttribute("id")).to.equal(tooltip.getAttribute("anchor"));
+        expect(tooltip.textContent.trim()).to.equal("flex-start");
 
         await disconnect();
     });
@@ -122,6 +180,35 @@ describe("CSSLayout", () => {
 
         await disconnect();
     });
+    it("should contain a tooltip for a align-content value that matches it's id attribute", async () => {
+        const { element, connect, disconnect } = await setup();
+        let css = "";
+
+        await connect();
+
+        const toggle = element.shadowRoot?.querySelector("fast-switch");
+        const toggleEvent = new Event("click", {} as MouseEventInit);
+
+        element.addEventListener("change", (e: any) => {
+            css = e.target.value;
+        });
+
+        toggle.dispatchEvent(toggleEvent);
+
+        await DOM.nextUpdate();
+
+        const input = element.shadowRoot?.querySelector(
+            "input[name='align-content']"
+        ) as HTMLInputElement;
+        const tooltip = element.shadowRoot?.querySelector(
+            "input[name='align-content'] + fast-tooltip"
+        );
+
+        expect(input.getAttribute("id")).to.equal(tooltip.getAttribute("anchor"));
+        expect(tooltip.textContent.trim()).to.equal("flex-start");
+
+        await disconnect();
+    });
     it("should emit an updated align-content value when the align-content value is updated", async () => {
         const { element, connect, disconnect } = await setup();
         let css = "";
@@ -148,6 +235,35 @@ describe("CSSLayout", () => {
         await DOM.nextUpdate();
 
         expect(css).to.equal("display: flex; align-content: flex-start;");
+
+        await disconnect();
+    });
+    it("should contain a tooltip for a align-items value that matches it's id attribute", async () => {
+        const { element, connect, disconnect } = await setup();
+        let css = "";
+
+        await connect();
+
+        const toggle = element.shadowRoot?.querySelector("fast-switch");
+        const toggleEvent = new Event("click", {} as MouseEventInit);
+
+        element.addEventListener("change", (e: any) => {
+            css = e.target.value;
+        });
+
+        toggle.dispatchEvent(toggleEvent);
+
+        await DOM.nextUpdate();
+
+        const input = element.shadowRoot?.querySelector(
+            "input[name='align-items']"
+        ) as HTMLInputElement;
+        const tooltip = element.shadowRoot?.querySelector(
+            "input[name='align-items'] + fast-tooltip"
+        );
+
+        expect(input.getAttribute("id")).to.equal(tooltip.getAttribute("anchor"));
+        expect(tooltip.textContent.trim()).to.equal("flex-start");
 
         await disconnect();
     });
@@ -245,6 +361,35 @@ describe("CSSLayout", () => {
         await DOM.nextUpdate();
 
         expect(css).to.equal("display: flex; column-gap: 5px;");
+
+        await disconnect();
+    });
+    it("should contain a tooltip for a flex-wrap value that matches it's id attribute", async () => {
+        const { element, connect, disconnect } = await setup();
+        let css = "";
+
+        await connect();
+
+        const toggle = element.shadowRoot?.querySelector("fast-switch");
+        const toggleEvent = new Event("click", {} as MouseEventInit);
+
+        element.addEventListener("change", (e: any) => {
+            css = e.target.value;
+        });
+
+        toggle.dispatchEvent(toggleEvent);
+
+        await DOM.nextUpdate();
+
+        const input = element.shadowRoot?.querySelector(
+            "input[name='flex-wrap']"
+        ) as HTMLInputElement;
+        const tooltip = element.shadowRoot?.querySelector(
+            "input[name='flex-wrap'] + fast-tooltip"
+        );
+
+        expect(input.getAttribute("id")).to.equal(tooltip.getAttribute("anchor"));
+        expect(tooltip.textContent.trim()).to.equal("wrap");
 
         await disconnect();
     });

--- a/packages/tooling/fast-tooling/src/web-components/css-layout/css-layout.styles.ts
+++ b/packages/tooling/fast-tooling/src/web-components/css-layout/css-layout.styles.ts
@@ -84,6 +84,7 @@ export const cssLayoutStyles = css`
         border: 3px solid #1b1b1b;
         position: relative;
         height: 24px;
+        max-width: 24px;
     }
 
     .control-radio-region .active {

--- a/packages/tooling/fast-tooling/src/web-components/css-layout/css-layout.template.ts
+++ b/packages/tooling/fast-tooling/src/web-components/css-layout/css-layout.template.ts
@@ -1,3 +1,4 @@
+import { Tooltip } from "@microsoft/fast-components";
 import { html, repeat } from "@microsoft/fast-element";
 import { ElementDefinitionContext, Switch } from "@microsoft/fast-foundation";
 import { CSSLayout } from "./css-layout";
@@ -553,8 +554,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         html<string, CSSLayout>`
                             <div
                                 class="${(x, c) => c.parent.flexDirectionName} ${x =>
-                                    x} ${(x, c) =>
-                                    x === c.parent.flexDirectionValue ? "active" : ""}"
+                            x} ${(x, c) =>
+                            x === c.parent.flexDirectionValue ? "active" : ""}"
                             >
                                 ${x =>
                                     x === "row"
@@ -565,6 +566,11 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                         ? flexDirectionColumn
                                         : flexDirectionColumnReverse}
                                 <input
+                                    id="${(x, c) =>
+                                        c.parent.getInputId(
+                                            c.parent.flexDirectionName,
+                                            x
+                                        )}"
                                     type="radio"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.flexDirectionName}"
@@ -577,6 +583,15 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event
                                         )}"
                                 />
+                                <${context.tagFor(Tooltip)}
+                                    anchor="${(x, c) =>
+                                        c.parent.getInputId(
+                                            c.parent.flexDirectionName,
+                                            x
+                                        )}"
+                                >
+                                    ${x => x}
+                                </${context.tagFor(Tooltip)}>
                             </div>
                         `
                     )}
@@ -590,8 +605,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         html<string, CSSLayout>`
                             <div
                                 class="${(x, c) => c.parent.justifyContentName} ${x =>
-                                    x} ${(x, c) =>
-                                    x === c.parent.justifyContentValue ? "active" : ""}"
+                            x} ${(x, c) =>
+                            x === c.parent.justifyContentValue ? "active" : ""}"
                             >
                                 ${x =>
                                     x === "flex-start"
@@ -606,6 +621,11 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                         ? justifyContentSpaceBetween
                                         : justifyContentSpaceEvenly}
                                 <input
+                                    id="${(x, c) =>
+                                        c.parent.getInputId(
+                                            c.parent.justifyContentName,
+                                            x
+                                        )}"
                                     type="radio"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.justifyContentName}"
@@ -618,6 +638,15 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event
                                         )}"
                                 />
+                                <${context.tagFor(Tooltip)}
+                                    anchor="${(x, c) =>
+                                        c.parent.getInputId(
+                                            c.parent.justifyContentName,
+                                            x
+                                        )}"
+                                >
+                                    ${x => x}
+                                </${context.tagFor(Tooltip)}>
                             </div>
                         `
                     )}
@@ -631,8 +660,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         html<string, CSSLayout>`
                             <div
                                 class="${(x, c) => c.parent.alignContentName} ${x =>
-                                    x} ${(x, c) =>
-                                    x === c.parent.alignContentValue ? "active" : ""}"
+                            x} ${(x, c) =>
+                            x === c.parent.alignContentValue ? "active" : ""}"
                             >
                                 ${x =>
                                     x === "flex-start"
@@ -649,6 +678,11 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                         ? alignContentSpaceEvenly
                                         : alignContentStretch}
                                 <input
+                                    id="${(x, c) =>
+                                        c.parent.getInputId(
+                                            c.parent.alignContentName,
+                                            x
+                                        )}"
                                     type="radio"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.alignContentName}"
@@ -661,6 +695,15 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event
                                         )}"
                                 />
+                                <${context.tagFor(Tooltip)}
+                                    anchor="${(x, c) =>
+                                        c.parent.getInputId(
+                                            c.parent.alignContentName,
+                                            x
+                                        )}"
+                                >
+                                    ${x => x}
+                                </${context.tagFor(Tooltip)}>
                             </div>
                         `
                     )}
@@ -674,9 +717,9 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         html<string, CSSLayout>`
                             <div
                                 class="${(x, c) => c.parent.alignItemsName} ${x => x} ${(
-                                    x,
-                                    c
-                                ) => (x === c.parent.alignItemsValue ? "active" : "")}"
+                            x,
+                            c
+                        ) => (x === c.parent.alignItemsValue ? "active" : "")}"
                             >
                                 ${x =>
                                     x === "flex-start"
@@ -687,6 +730,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                         ? alignItemsCenter
                                         : alignItemsStretch}
                                 <input
+                                    id="${(x, c) =>
+                                        c.parent.getInputId(c.parent.alignItemsName, x)}"
                                     type="radio"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.alignItemsName}"
@@ -698,6 +743,12 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event
                                         )}"
                                 />
+                                <${context.tagFor(Tooltip)}
+                                    anchor="${(x, c) =>
+                                        c.parent.getInputId(c.parent.alignItemsName, x)}"
+                                >
+                                    ${x => x}
+                                </${context.tagFor(Tooltip)}>
                             </div>
                         `
                     )}
@@ -749,9 +800,9 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                         html<string, CSSLayout>`
                             <div
                                 class="${(x, c) => c.parent.flexWrapName} ${x => x} ${(
-                                    x,
-                                    c
-                                ) => (x === c.parent.flexWrapValue ? "active" : "")}"
+                            x,
+                            c
+                        ) => (x === c.parent.flexWrapValue ? "active" : "")}"
                             >
                                 ${x =>
                                     x === "wrap"
@@ -760,6 +811,8 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                         ? flexWrapWrapReverse
                                         : flexWrapNoWrap}
                                 <input
+                                    id="${(x, c) =>
+                                        c.parent.getInputId(c.parent.flexWrapName, x)}"
                                     type="radio"
                                     aria-label="${x => x}"
                                     name="${(x, c) => c.parent.flexWrapName}"
@@ -771,6 +824,12 @@ export const cssLayoutTemplate = (context: ElementDefinitionContext) => html<CSS
                                             c.event
                                         )}"
                                 />
+                                <${context.tagFor(Tooltip)}
+                                    anchor="${(x, c) =>
+                                        c.parent.getInputId(c.parent.flexWrapName, x)}"
+                                >
+                                    ${x => x}
+                                </${context.tagFor(Tooltip)}>
                             </div>
                         `
                     )}

--- a/packages/tooling/fast-tooling/src/web-components/css-layout/css-layout.ts
+++ b/packages/tooling/fast-tooling/src/web-components/css-layout/css-layout.ts
@@ -1,5 +1,6 @@
 import { observable } from "@microsoft/fast-element";
 import { mapCSSInlineStyleToCSSPropertyDictionary } from "../../data-utilities/mapping.mdn-data";
+import { fastToolingPrefix } from "../utilities";
 import { FormAssociatedCSSLayout } from "./css-layout.form-associated";
 import {
     alignContentOptions,
@@ -178,6 +179,13 @@ export class CSSLayout extends FormAssociatedCSSLayout {
 
         this.onChange(this.getCSSLayoutDictionary());
         this.$emit("change");
+    }
+
+    /**
+     * Returns a string using a pattern to create an input ID
+     */
+    public getInputId(cssPropertyName: string, cssPropertyValue: string): string {
+        return `${fastToolingPrefix}-${cssPropertyName}-${cssPropertyValue}`;
     }
 
     /**

--- a/packages/tooling/fast-tooling/src/web-components/utilities/constants.ts
+++ b/packages/tooling/fast-tooling/src/web-components/utilities/constants.ts
@@ -1,0 +1,1 @@
+export const fastToolingPrefix: string = "fast-tooling";

--- a/packages/tooling/fast-tooling/src/web-components/utilities/index.ts
+++ b/packages/tooling/fast-tooling/src/web-components/utilities/index.ts
@@ -1,0 +1,1 @@
+export * from "./constants";

--- a/sites/fast-creator/app/web-components/index.tsx
+++ b/sites/fast-creator/app/web-components/index.tsx
@@ -11,6 +11,7 @@ import {
     fastTabPanel,
     fastTabs,
     fastTextField,
+    fastTooltip,
 } from "@microsoft/fast-components";
 import { Select } from "@microsoft/fast-foundation";
 import { componentCategories, downChevron, upChevron } from "@microsoft/site-utilities";
@@ -56,6 +57,7 @@ DesignSystem.getOrCreate().register(
     fastSwitch(),
     fastTabPanel(),
     fastTextField(),
+    fastTooltip(),
     fastToolingColorPicker({ prefix: "fast-tooling" }),
     fastToolingCSSLayout({ prefix: "fast-tooling" }),
     fastToolingFile({ prefix: "fast-tooling" }),


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change adds tooltips for the radio buttons in the FAST tooling CSS layout control.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Closes #5065

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
This can be seen either by running the test application in the fast-tooling package or by building the entire project and running the Creator application in the sites folder.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Unit tests added.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
