### PR TITLE
allow custom Horizontal Scroller flippers to be context-driven Flipper components

### DIFF
--- a/change/@microsoft-fast-components-0af6a2a1-a24b-4f07-9055-37695021d8e6.json
+++ b/change/@microsoft-fast-components-0af6a2a1-a24b-4f07-9055-37695021d8e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "use context.tagFor to generate flippers for horizontal scroller component",
+  "packageName": "@microsoft/fast-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-1e3d00a6-0514-4c68-a817-49672aaa3b0c.json
+++ b/change/@microsoft-fast-foundation-1e3d00a6-0514-4c68-a817-49672aaa3b0c.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "allow context for partials on component compositions",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/horizontal-scroll/index.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/index.ts
@@ -1,5 +1,6 @@
 import { html } from "@microsoft/fast-element";
 import {
+    Flipper,
     HorizontalScroll as FoundationHorizontalScroll,
     HorizontalScrollOptions,
     horizontalScrollTemplate as template,
@@ -38,17 +39,17 @@ export const fastHorizontalScroll = HorizontalScroll.compose<HorizontalScrollOpt
     baseName: "horizontal-scroll",
     template,
     styles,
-    nextFlipper: html`
-        <fast-flipper
+    nextFlipper: context => html`
+        <${context.tagFor(Flipper)}
             @click="${x => x.scrollToNext()}"
             aria-hidden="${x => x.flippersHiddenFromAT}"
-        ></fast-flipper>
+        ></${context.tagFor(Flipper)}>
     `,
-    previousFlipper: html`
-        <fast-flipper
+    previousFlipper: context => html`
+        <${context.tagFor(Flipper)}
             @click="${x => x.scrollToPrevious()}"
             direction="previous"
             aria-hidden="${x => x.flippersHiddenFromAT}"
-        ></fast-flipper>
+        ></${context.tagFor(Flipper)}>
     `,
 });

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1039,6 +1039,11 @@ export class FoundationElementRegistry<TDefinition extends FoundationElementDefi
     readonly type: Constructable<FoundationElement>;
 }
 
+// Warning: (ae-forgotten-export) The symbol "LazyFoundationOption" needs to be exported by the entry point index.d.ts
+//
+// @public
+export type FoundationElementTemplate<T, K = void> = LazyFoundationOption<T, K & FoundationElementDefinition>;
+
 // @public
 export enum GenerateHeaderOptions {
     // (undocumented)
@@ -1083,12 +1088,12 @@ export class HorizontalScroll extends FoundationElement {
 
 // @public
 export type HorizontalScrollOptions = FoundationElementDefinition & {
-    nextFlipper?: string | SyntheticViewTemplate;
-    previousFlipper?: string | SyntheticViewTemplate;
+    nextFlipper?: FoundationElementTemplate<SyntheticViewTemplate<any, HorizontalScroll>, HorizontalScrollOptions> | SyntheticViewTemplate | string;
+    previousFlipper?: FoundationElementTemplate<SyntheticViewTemplate<any, HorizontalScroll>, HorizontalScrollOptions> | SyntheticViewTemplate | string;
 };
 
 // @public (undocumented)
-export const horizontalScrollTemplate: (context: ElementDefinitionContext, definition: HorizontalScrollOptions) => ViewTemplate<HorizontalScroll>;
+export const horizontalScrollTemplate: FoundationElementTemplate<ViewTemplate<HorizontalScroll>, HorizontalScrollOptions>;
 
 // @public
 export type HorizontalScrollView = "default" | "mobile";

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
@@ -1,10 +1,10 @@
-import { ElementStyles, FASTElement, observable } from "@microsoft/fast-element";
 import type {
     AttributeConfiguration,
     ComposableStyles,
     Constructable,
     ElementViewTemplate,
 } from "@microsoft/fast-element";
+import { ElementStyles, FASTElement, observable } from "@microsoft/fast-element";
 import {
     ComponentPresentation,
     DefaultComponentPresentation,
@@ -67,6 +67,15 @@ export interface FoundationElementDefinition {
      */
     readonly elementOptions?: EagerOrLazyFoundationOption<ElementDefinitionOptions, this>;
 }
+
+/**
+ * A foundation element template function.
+ * @public
+ */
+export type FoundationElementTemplate<T, K = void> = LazyFoundationOption<
+    T,
+    K & FoundationElementDefinition
+>;
 
 /**
  * A set of properties which the component consumer can override during the element registration process.

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
@@ -1,19 +1,22 @@
-import { elements, html, ref, slotted, when } from "@microsoft/fast-element";
-import type { ViewTemplate } from "@microsoft/fast-element";
+import {
+    elements,
+    html,
+    ref,
+    slotted,
+    ViewTemplate,
+    when,
+} from "@microsoft/fast-element";
+import type { FoundationElementTemplate } from "../foundation-element";
 import { endTemplate, startTemplate } from "../patterns";
-import type { ElementDefinitionContext } from "../design-system";
 import type { HorizontalScroll, HorizontalScrollOptions } from "./horizontal-scroll";
 
 /**
  * @public
  */
-export const horizontalScrollTemplate: (
-    context: ElementDefinitionContext,
-    definition: HorizontalScrollOptions
-) => ViewTemplate<HorizontalScroll> = (
-    context: ElementDefinitionContext,
-    definition: HorizontalScrollOptions
-) => html`
+export const horizontalScrollTemplate: FoundationElementTemplate<
+    ViewTemplate<HorizontalScroll>,
+    HorizontalScrollOptions
+> = (context, definition) => html`
     <template
         class="horizontal-scroll"
         @keyup="${(x, c) => x.keyupHandler(c.event as KeyboardEvent)}"
@@ -44,7 +47,9 @@ export const horizontalScrollTemplate: (
                     >
                         <div class="scroll-action">
                             <slot name="previous-flipper">
-                                ${definition.previousFlipper || ""}
+                                ${definition.previousFlipper instanceof Function
+                                    ? definition.previousFlipper(context, definition)
+                                    : definition.previousFlipper ?? ""}
                             </slot>
                         </div>
                     </div>
@@ -55,7 +60,9 @@ export const horizontalScrollTemplate: (
                     >
                         <div class="scroll-action">
                             <slot name="next-flipper">
-                                ${definition.nextFlipper || ""}
+                                ${definition.nextFlipper instanceof Function
+                                    ? definition.nextFlipper(context, definition)
+                                    : definition.nextFlipper ?? ""}
                             </slot>
                         </div>
                     </div>

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -1,9 +1,9 @@
+import type { SyntheticViewTemplate } from "@microsoft/fast-element";
 import {
     attr,
     booleanConverter,
     nullableNumberConverter,
     observable,
-    SyntheticViewTemplate,
 } from "@microsoft/fast-element";
 // TODO: the Resize Observer related files are a temporary stopgap measure until
 // Resize Observer types are pulled into TypeScript, which seems imminent
@@ -13,7 +13,11 @@ import type {
     ConstructibleResizeObserver,
     ResizeObserverClassDefinition,
 } from "../anchored-region/resize-observer";
-import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
+import type {
+    FoundationElementDefinition,
+    FoundationElementTemplate,
+} from "../foundation-element";
+import { FoundationElement } from "../foundation-element";
 
 declare global {
     interface WindowWithResizeObserver extends Window {
@@ -38,8 +42,20 @@ export type ScrollEasing = "linear" | "ease-in" | "ease-out" | "ease-in-out";
  * @public
  */
 export type HorizontalScrollOptions = FoundationElementDefinition & {
-    nextFlipper?: string | SyntheticViewTemplate;
-    previousFlipper?: string | SyntheticViewTemplate;
+    nextFlipper?:
+        | FoundationElementTemplate<
+              SyntheticViewTemplate<any, HorizontalScroll>,
+              HorizontalScrollOptions
+          >
+        | SyntheticViewTemplate
+        | string;
+    previousFlipper?:
+        | FoundationElementTemplate<
+              SyntheticViewTemplate<any, HorizontalScroll>,
+              HorizontalScrollOptions
+          >
+        | SyntheticViewTemplate
+        | string;
 };
 
 /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

Replaces the `<fast-flipper>` components in `<fast-horizontal-scroll>` with `<${context.tagFor(Flipper)}>` by aliasing a new `FoundationElementTemplate` type and extending the types for `nextFlipper` and `previousFlipper`.

## 👩‍💻 Reviewer Notes

This also gives us a reusable base type for all template and CSS functions in the form of `FoundationElementTemplate<T, K = void> = LazyFoundationOption<T, K & FoundationElementDefinition>`.

## 📑 Test Plan

In Storybook, the flippers should still be rendered as `<fast-flipper>` elements for horizonal scrollers.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

The `FoundationElementTemplate` type should be applied to all template and style functions in `fast-foundation` and `fast-components`.