### PR TITLE
feat: add a list of linked data that cannot be dropped to

### DIFF
--- a/change/@microsoft-fast-tooling-8bafde2b-1ae5-4ac8-9653-f8c7fe7e3527.json
+++ b/change/@microsoft-fast-tooling-8bafde2b-1ae5-4ac8-9653-f8c7fe7e3527.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "address drag and drop issues where the active data dictionary ID was not updated during the removal of linked data",
+  "packageName": "@microsoft/fast-tooling",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-tooling-react-2b12a60b-f7de-4575-84e3-c3148f6b3ef0.json
+++ b/change/@microsoft-fast-tooling-react-2b12a60b-f7de-4575-84e3-c3148f6b3ef0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add a list of linked data that cannot be dropped to",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling-react/app/pages/navigation.tsx
+++ b/packages/tooling/fast-tooling-react/app/pages/navigation.tsx
@@ -22,6 +22,7 @@ export interface NavigationTestPageState {
     types?: DataType[];
     activeDictionaryId: string;
     defaultLinkedDataDroppableDataLocation: boolean;
+    droppableBlocklist: string[];
 }
 
 const CSSpropertyOverrides = {
@@ -61,6 +62,7 @@ class NavigationTestPage extends React.Component<{}, NavigationTestPageState> {
             types: undefined,
             activeDictionaryId: children[1],
             defaultLinkedDataDroppableDataLocation: false,
+            droppableBlocklist: [],
         };
     }
 
@@ -154,6 +156,16 @@ class NavigationTestPage extends React.Component<{}, NavigationTestPageState> {
                     <label htmlFor={"assignDefaultLinkedDataDatalocation"}>
                         Assign "children" as default data location
                     </label>
+                    <br />
+                    <input
+                        type={"checkbox"}
+                        id={"assignDroppableBlocklist"}
+                        onChange={this.handleSetDroppableBlocklist}
+                        value={this.state.droppableBlocklist}
+                    />
+                    <label htmlFor={"assignDroppableBlocklist"}>
+                        Assign linked data without a default slot to the blocklist
+                    </label>
                 </fieldset>
                 {this.renderAllLinkedData()}
                 <ModularNavigation
@@ -164,6 +176,7 @@ class NavigationTestPage extends React.Component<{}, NavigationTestPageState> {
                             ? "children"
                             : void 0
                     }
+                    droppableBlocklist={this.state.droppableBlocklist}
                 />
 
                 <pre>{JSON.stringify(this.state.types, null, 2)}</pre>
@@ -205,6 +218,13 @@ class NavigationTestPage extends React.Component<{}, NavigationTestPageState> {
         this.setState({
             defaultLinkedDataDroppableDataLocation: !this.state
                 .defaultLinkedDataDroppableDataLocation,
+        });
+    };
+
+    private handleSetDroppableBlocklist = (e: React.ChangeEvent): void => {
+        this.setState({
+            droppableBlocklist:
+                this.state.droppableBlocklist.length > 0 ? [] : [noChildrenSchema.$id],
         });
     };
 

--- a/packages/tooling/fast-tooling-react/app/pages/navigation/children.schema.ts
+++ b/packages/tooling/fast-tooling-react/app/pages/navigation/children.schema.ts
@@ -6,6 +6,7 @@ export default {
     description: "A test component's schema definition.",
     type: "object",
     id: "children",
+    $id: "children",
     properties: {
         object: {
             title: "Object",

--- a/packages/tooling/fast-tooling-react/app/pages/navigation/no-children.schema.ts
+++ b/packages/tooling/fast-tooling-react/app/pages/navigation/no-children.schema.ts
@@ -4,6 +4,7 @@ export default {
     description: "A test component's schema definition.",
     type: "object",
     id: "no-children",
+    $id: "no-children",
     properties: {
         text: {
             title: "Text",

--- a/packages/tooling/fast-tooling-react/src/form/form.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/form.tsx
@@ -175,6 +175,9 @@ class Form extends React.Component<
                 this.setState({
                     data: e.data.data,
                     dataDictionary: e.data.dataDictionary,
+                    activeDictionaryId: e.data?.activeDictionaryId
+                        ? e.data.activeDictionaryId
+                        : this.state.activeDictionaryId,
                     navigation: e.data.navigation,
                     navigationDictionary: e.data.navigationDictionary,
                     options: e.data.options,

--- a/packages/tooling/fast-tooling-react/src/navigation/navigation-tree-item.tsx
+++ b/packages/tooling/fast-tooling-react/src/navigation/navigation-tree-item.tsx
@@ -11,7 +11,7 @@ import {
     useDrag,
     useDrop,
 } from "react-dnd";
-import { HoverLocation } from "./navigation.props";
+import { getHoverLocation, refNode } from "./navigation-tree-item.utilities";
 
 function editableOverlay(
     className: string,
@@ -234,47 +234,16 @@ export const DraggableNavigationTreeItem: React.FC<NavigationTreeItemProps> = ({
                 cachedRefBoundingClientRect = ref.getBoundingClientRect() as DOMRect;
             }
 
-            const dragItemOffsetY: number = monitor.getClientOffset().y;
-            let hoverLocation: HoverLocation = HoverLocation.center;
-
-            /**
-             * Divide the height of the clientRect into thirds, if its the top third the item should be placed before
-             * the hovered item, if it is the bottom third it should be placed after
-             */
-            const thirdOfTheDropedItemBoundingClientRect =
-                cachedRefBoundingClientRect.height / 3;
-            if (
-                cachedRefBoundingClientRect.y +
-                    thirdOfTheDropedItemBoundingClientRect * 2 <
-                dragItemOffsetY
-            ) {
-                hoverLocation = HoverLocation.after;
-            } else if (
-                cachedRefBoundingClientRect.y >
-                dragItemOffsetY - thirdOfTheDropedItemBoundingClientRect
-            ) {
-                hoverLocation = HoverLocation.before;
-            }
-
-            dragHover(type, dictionaryId, navigationConfigId, index, hoverLocation);
+            dragHover(
+                type,
+                dictionaryId,
+                navigationConfigId,
+                index,
+                getHoverLocation(type, monitor, cachedRefBoundingClientRect)
+            );
         },
     });
     const dropTarget: ConnectDropTarget = drop[1];
-
-    function refNode(node: HTMLSpanElement | HTMLAnchorElement): React.ReactElement {
-        switch (type) {
-            case DragDropItemType.linkedData:
-                return dragSource(dropTarget(node)); // this source can be dragged and dropped
-            case DragDropItemType.linkedDataUndroppable:
-                return dragSource(node); // this source can be dragged but not dropped
-            case DragDropItemType.linkedDataContainer:
-            case DragDropItemType.rootLinkedData:
-                return dropTarget(node); // this source can be dropped on but not dragged
-            case DragDropItemType.undraggableUndroppable:
-            case DragDropItemType.rootLinkedDataUndroppable:
-                return;
-        }
-    }
 
     return treeItem(
         handleClick,
@@ -295,7 +264,7 @@ export const DraggableNavigationTreeItem: React.FC<NavigationTreeItemProps> = ({
         inputRef,
         (node: HTMLSpanElement): React.ReactElement => {
             ref = node;
-            return refNode(node);
+            return refNode(node, type, dragSource, dropTarget);
         }
     );
 };

--- a/packages/tooling/fast-tooling-react/src/navigation/navigation-tree-item.utilities.spec.ts
+++ b/packages/tooling/fast-tooling-react/src/navigation/navigation-tree-item.utilities.spec.ts
@@ -1,0 +1,254 @@
+import "../__tests__/mocks/match-media";
+import { DragDropItemType } from "./navigation-tree-item.props";
+import { getHoverLocation, refNode } from "./navigation-tree-item.utilities";
+import { HoverLocation } from "./navigation.props";
+
+describe("getHoverLocation", () => {
+    describe("when the type is linked-data", () => {
+        test("should get the hover location before the hovered item", () => {
+            expect(
+                getHoverLocation(
+                    DragDropItemType.linkedData,
+                    {
+                        getClientOffset: () => {
+                            return {
+                                y: 10,
+                            };
+                        },
+                    } as any,
+                    {
+                        height: 36,
+                        y: 0,
+                    } as any
+                )
+            ).toEqual(HoverLocation.before);
+        });
+        test("should get the hover location after the hovered item", () => {
+            expect(
+                getHoverLocation(
+                    DragDropItemType.linkedData,
+                    {
+                        getClientOffset: () => {
+                            return {
+                                y: 34,
+                            };
+                        },
+                    } as any,
+                    {
+                        height: 36,
+                        y: 0,
+                    } as any
+                )
+            ).toEqual(HoverLocation.after);
+        });
+        test("should get the hovered location in the center of the hovered item", () => {
+            expect(
+                getHoverLocation(
+                    DragDropItemType.linkedData,
+                    {
+                        getClientOffset: () => {
+                            return {
+                                y: 15,
+                            };
+                        },
+                    } as any,
+                    {
+                        height: 36,
+                        y: 0,
+                    } as any
+                )
+            ).toEqual(HoverLocation.center);
+        });
+    });
+    describe("when the type is linked-data-undroppable", () => {
+        test("should get the hover location before the hovered item", () => {
+            expect(
+                getHoverLocation(
+                    DragDropItemType.linkedDataUndroppable,
+                    {
+                        getClientOffset: () => {
+                            return {
+                                y: 10,
+                            };
+                        },
+                    } as any,
+                    {
+                        height: 36,
+                        y: 0,
+                    } as any
+                )
+            ).toEqual(HoverLocation.before);
+        });
+        test("should get the hover location after the hovered item", () => {
+            expect(
+                getHoverLocation(
+                    DragDropItemType.linkedDataUndroppable,
+                    {
+                        getClientOffset: () => {
+                            return {
+                                y: 19,
+                            };
+                        },
+                    } as any,
+                    {
+                        height: 36,
+                        y: 0,
+                    } as any
+                )
+            ).toEqual(HoverLocation.after);
+        });
+    });
+    describe("when the type is root-linked-data", () => {
+        test("should get the hovered location in the center of the hovered item", () => {
+            expect(
+                getHoverLocation(
+                    DragDropItemType.rootLinkedData,
+                    {
+                        getClientOffset: () => {
+                            return {
+                                y: 19,
+                            };
+                        },
+                    } as any,
+                    {
+                        height: 36,
+                        y: 0,
+                    } as any
+                )
+            ).toEqual(HoverLocation.center);
+        });
+    });
+    describe("when the type is linked-data-container", () => {
+        test("should get the hovered location in the center of the hovered item", () => {
+            expect(
+                getHoverLocation(
+                    DragDropItemType.linkedDataContainer,
+                    {
+                        getClientOffset: () => {
+                            return {
+                                y: 19,
+                            };
+                        },
+                    } as any,
+                    {
+                        height: 36,
+                        y: 0,
+                    } as any
+                )
+            ).toEqual(HoverLocation.center);
+        });
+    });
+});
+
+describe("refNode", () => {
+    test("should return a draggable & droppable React.Element when a item type is linkedData", () => {
+        function dragSource(dropTarget: any): any {
+            const wrapper = document.createElement("div");
+            wrapper.appendChild(dropTarget);
+
+            return wrapper;
+        }
+        function dropTarget(node: any): any {
+            return node;
+        }
+        const ref = refNode(
+            document.createElement("span"),
+            DragDropItemType.linkedData,
+            dragSource,
+            dropTarget
+        );
+        expect(ref instanceof HTMLDivElement).toEqual(true);
+        expect((ref as any).querySelector("span")).not.toEqual(null);
+    });
+    test("should return a draggable & droppable React.Element when a item type is linkedDataUndroppable", () => {
+        function dragSource(dropTarget: any): any {
+            const wrapper = document.createElement("div");
+            wrapper.appendChild(dropTarget);
+
+            return wrapper;
+        }
+        function dropTarget(node: any): any {
+            return node;
+        }
+        const ref = refNode(
+            document.createElement("span"),
+            DragDropItemType.linkedDataUndroppable,
+            dragSource,
+            dropTarget
+        );
+        expect(ref instanceof HTMLDivElement).toEqual(true);
+        expect((ref as any).querySelector("span")).not.toEqual(null);
+    });
+    test("should return an droppable but undraggable React.Element when a item type is rootLinkedData", () => {
+        function dragSource(dropTarget: any): any {
+            const wrapper = document.createElement("div");
+            wrapper.appendChild(dropTarget);
+
+            return wrapper;
+        }
+        function dropTarget(node: any): any {
+            return node;
+        }
+        const ref = refNode(
+            document.createElement("span"),
+            DragDropItemType.rootLinkedData,
+            dragSource,
+            dropTarget
+        );
+        expect(ref instanceof HTMLSpanElement).toEqual(true);
+    });
+    test("should return an droppable but undraggable React.Element when a item type is linkedDataContainer", () => {
+        function dragSource(dropTarget: any): any {
+            const wrapper = document.createElement("div");
+            wrapper.appendChild(dropTarget);
+
+            return wrapper;
+        }
+        function dropTarget(node: any): any {
+            return node;
+        }
+        const ref = refNode(
+            document.createElement("span"),
+            DragDropItemType.linkedDataContainer,
+            dragSource,
+            dropTarget
+        );
+        expect(ref instanceof HTMLSpanElement).toEqual(true);
+    });
+    test("should return an undraggable & undroppable React.Element when a item type is undraggableUndroppable", () => {
+        function dragSource(dropTarget: any): any {
+            const wrapper = document.createElement("div");
+            wrapper.appendChild(dropTarget);
+
+            return wrapper;
+        }
+        function dropTarget(node: any): any {
+            return node;
+        }
+        const ref = refNode(
+            document.createElement("span"),
+            DragDropItemType.undraggableUndroppable,
+            dragSource,
+            dropTarget
+        );
+        expect(ref).toEqual(void 0);
+    });
+    test("should return an undraggable & undroppable React.Element when a item type is rootLinkedDataUndroppable", () => {
+        function dragSource(dropTarget: any): any {
+            const wrapper = document.createElement("div");
+            wrapper.appendChild(dropTarget);
+
+            return wrapper;
+        }
+        function dropTarget(node: any): any {
+            return node;
+        }
+        const ref = refNode(
+            document.createElement("span"),
+            DragDropItemType.rootLinkedDataUndroppable,
+            dragSource,
+            dropTarget
+        );
+        expect(ref).toEqual(void 0);
+    });
+});

--- a/packages/tooling/fast-tooling-react/src/navigation/navigation-tree-item.utilities.ts
+++ b/packages/tooling/fast-tooling-react/src/navigation/navigation-tree-item.utilities.ts
@@ -1,0 +1,69 @@
+import { ConnectDragSource, ConnectDropTarget, DropTargetMonitor } from "react-dnd";
+import { DragDropItemType } from "./navigation-tree-item.props";
+import { HoverLocation } from "./navigation.props";
+
+export function refNode(
+    node: HTMLSpanElement | HTMLAnchorElement,
+    type: DragDropItemType,
+    dragSource: ConnectDragSource,
+    dropTarget: ConnectDropTarget
+): React.ReactElement {
+    switch (type) {
+        case DragDropItemType.linkedData:
+        case DragDropItemType.linkedDataUndroppable:
+            return dragSource(dropTarget(node)); // this source can be dragged and dropped
+        case DragDropItemType.linkedDataContainer:
+        case DragDropItemType.rootLinkedData:
+            return dropTarget(node); // this source can be dropped on but not dragged
+        case DragDropItemType.undraggableUndroppable:
+        case DragDropItemType.rootLinkedDataUndroppable:
+            return;
+    }
+}
+
+export function getHoverLocation(
+    type: DragDropItemType,
+    monitor: DropTargetMonitor,
+    cachedRefBoundingClientRect: DOMRect
+): HoverLocation {
+    const dragItemOffsetY: number = monitor.getClientOffset().y;
+    let hoverLocation: HoverLocation = HoverLocation.center;
+
+    if (type === DragDropItemType.linkedDataUndroppable) {
+        /**
+         * For linked data that cannot be dropped on, it should halve the clientRect so
+         * items can be dropped before and after but not on the linked data
+         */
+
+        if (
+            cachedRefBoundingClientRect.y + cachedRefBoundingClientRect.height / 2 <
+            dragItemOffsetY
+        ) {
+            hoverLocation = HoverLocation.after;
+        } else {
+            hoverLocation = HoverLocation.before;
+        }
+    } else if (type === DragDropItemType.linkedData) {
+        /**
+         * For linked data that can be dropped on, divide the height of the clientRect into thirds,
+         * if its the top third the item should be placed before the hovered item, if it is the
+         * bottom third it should be placed after
+         */
+        const thirdOfTheDropedItemBoundingClientRect =
+            cachedRefBoundingClientRect.height / 3;
+
+        if (
+            cachedRefBoundingClientRect.y + thirdOfTheDropedItemBoundingClientRect * 2 <
+            dragItemOffsetY
+        ) {
+            hoverLocation = HoverLocation.after;
+        } else if (
+            cachedRefBoundingClientRect.y + thirdOfTheDropedItemBoundingClientRect >
+            dragItemOffsetY
+        ) {
+            hoverLocation = HoverLocation.before;
+        }
+    }
+
+    return hoverLocation;
+}

--- a/packages/tooling/fast-tooling-react/src/navigation/navigation.props.ts
+++ b/packages/tooling/fast-tooling-react/src/navigation/navigation.props.ts
@@ -22,6 +22,49 @@ export enum HoverLocation {
     after = "after",
 }
 
+export interface LinkedDataLocationConfig {
+    /**
+     * Dictionary key
+     */
+    0: string;
+
+    /**
+     * Navigation config key
+     */
+    1: string;
+
+    /**
+     * The index
+     */
+    2: number;
+}
+
+export type LinkedDataLocation = XOR<LinkedDataLocationConfig, null>;
+
+export interface HoveredItemConfig {
+    /**
+     * The type of the hovered item
+     */
+    0: DragDropItemType;
+
+    /**
+     * The dictionary ID
+     */
+    1: string;
+
+    /**
+     * The navigation config ID
+     */
+    2: string;
+
+    /**
+     * The location of the hover
+     */
+    3: HoverLocation;
+}
+
+export type HoveredItem = XOR<HoveredItemConfig, null>;
+
 interface TextEditing {
     /**
      * The dictionary ID of the current text being edited
@@ -73,47 +116,12 @@ export interface NavigationState {
     /**
      * The linked datas location
      */
-    linkedDataLocation: {
-        /**
-         * Dictionary key
-         */
-        0: string;
-
-        /**
-         * Navigation config key
-         */
-        1: string;
-
-        /**
-         * The index
-         */
-        2: number;
-    } | null;
+    linkedDataLocation: LinkedDataLocation;
 
     /**
      * The item being hovered
      */
-    hoveredItem: {
-        /**
-         * The type of the hovered item
-         */
-        0: DragDropItemType;
-
-        /**
-         * The dictionary ID
-         */
-        1: string;
-
-        /**
-         * The navigation config ID
-         */
-        2: string;
-
-        /**
-         * The location of the hover
-         */
-        3: HoverLocation;
-    } | null;
+    hoveredItem: HoveredItem;
 }
 
 export interface TreeNavigation {
@@ -156,6 +164,12 @@ export interface NavigationHandledProps {
      * @alpha
      */
     defaultLinkedDataDroppableDataLocation?: string;
+
+    /**
+     * An array of schema IDs that can't be dropped to
+     * @alpha
+     */
+    droppableBlocklist?: string[];
 }
 
 export type NavigationProps = NavigationHandledProps;

--- a/packages/tooling/fast-tooling-react/src/navigation/navigation.utilities.spec.ts
+++ b/packages/tooling/fast-tooling-react/src/navigation/navigation.utilities.spec.ts
@@ -1,0 +1,652 @@
+import "../__tests__/mocks/match-media";
+import {
+    MessageSystemDataTypeAction,
+    MessageSystemType,
+    NavigationConfigDictionary,
+} from "@microsoft/fast-tooling";
+import { DragDropItemType } from "./navigation-tree-item.props";
+import { HoverLocation } from "./navigation.props";
+import {
+    getDragEndMessage,
+    getDraggableItemClassName,
+    getDragHoverState,
+    getDragStartMessage,
+    getDragStartState,
+} from "./navigation.utilities";
+
+const defaultClassNameArgs: { [key: string]: any } = {
+    isCollapsible: false,
+    isDraggable: false,
+    isDroppable: false,
+    dictionaryId: "foo",
+    navigationConfigId: "bar",
+    hoveredItem: null,
+    activeDictionaryId: "bat",
+    activeNavigationConfigId: "baz",
+    defaultLinkedDataDroppableDataLocation: "",
+    navigationItem: "navigationItem",
+    navigationItemExpandable: "navigationItemExpandable",
+    navigationItemActive: "navigationItemActive",
+    navigationItemDraggable: "navigationItemDraggable",
+    navigationItemDroppable: "navigationItemDroppable",
+    navigationItemHover: "navigationItemHover",
+    navigationItemHoverAfter: "navigationItemHoverAfter",
+    navigationItemHoverBefore: "navigationItemHoverBefore",
+};
+
+/**
+ * Gets class names for navigation items
+ */
+describe("getDraggableItemClassName", () => {
+    test("should return only the base class name", () => {
+        expect(
+            getDraggableItemClassName(
+                defaultClassNameArgs.isCollapsible,
+                defaultClassNameArgs.isDraggable,
+                defaultClassNameArgs.isDroppable,
+                defaultClassNameArgs.dictionaryId,
+                defaultClassNameArgs.navigationConfigId,
+                defaultClassNameArgs.hoveredItem,
+                defaultClassNameArgs.activeDictionaryId,
+                defaultClassNameArgs.activeNavigationConfigId,
+                defaultClassNameArgs.defaultLinkedDataDroppableDataLocation,
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(defaultClassNameArgs.navigationItem);
+    });
+    test("should return the class names for a collapsible node", () => {
+        expect(
+            getDraggableItemClassName(
+                true,
+                defaultClassNameArgs.isDraggable,
+                defaultClassNameArgs.isDroppable,
+                defaultClassNameArgs.dictionaryId,
+                defaultClassNameArgs.navigationConfigId,
+                defaultClassNameArgs.hoveredItem,
+                defaultClassNameArgs.activeDictionaryId,
+                defaultClassNameArgs.activeNavigationConfigId,
+                defaultClassNameArgs.defaultLinkedDataDroppableDataLocation,
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(
+            `${defaultClassNameArgs.navigationItem} ${defaultClassNameArgs.navigationItemExpandable}`
+        );
+    });
+    test("should return the class names for a draggable node", () => {
+        expect(
+            getDraggableItemClassName(
+                defaultClassNameArgs.isCollapsible,
+                true,
+                defaultClassNameArgs.isDroppable,
+                defaultClassNameArgs.dictionaryId,
+                defaultClassNameArgs.navigationConfigId,
+                defaultClassNameArgs.hoveredItem,
+                defaultClassNameArgs.activeDictionaryId,
+                defaultClassNameArgs.activeNavigationConfigId,
+                defaultClassNameArgs.defaultLinkedDataDroppableDataLocation,
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(
+            `${defaultClassNameArgs.navigationItem} ${defaultClassNameArgs.navigationItemDraggable}`
+        );
+    });
+    test("should return the class names for a droppable node", () => {
+        expect(
+            getDraggableItemClassName(
+                defaultClassNameArgs.isCollapsible,
+                defaultClassNameArgs.isDraggable,
+                true,
+                defaultClassNameArgs.dictionaryId,
+                defaultClassNameArgs.navigationConfigId,
+                defaultClassNameArgs.hoveredItem,
+                defaultClassNameArgs.activeDictionaryId,
+                defaultClassNameArgs.activeNavigationConfigId,
+                defaultClassNameArgs.defaultLinkedDataDroppableDataLocation,
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(
+            `${defaultClassNameArgs.navigationItem} ${defaultClassNameArgs.navigationItemDroppable}`
+        );
+    });
+    test("should return the class names for an active node", () => {
+        expect(
+            getDraggableItemClassName(
+                defaultClassNameArgs.isCollapsible,
+                defaultClassNameArgs.isDraggable,
+                defaultClassNameArgs.isDroppable,
+                "",
+                "foo",
+                defaultClassNameArgs.hoveredItem,
+                "",
+                "foo",
+                defaultClassNameArgs.defaultLinkedDataDroppableDataLocation,
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(
+            `${defaultClassNameArgs.navigationItem} ${defaultClassNameArgs.navigationItemActive}`
+        );
+    });
+    test("should return the class names for a hovered node if it is a container", () => {
+        expect(
+            getDraggableItemClassName(
+                defaultClassNameArgs.isCollapsible,
+                defaultClassNameArgs.isDraggable,
+                defaultClassNameArgs.isDroppable,
+                "foo",
+                "bar",
+                [
+                    DragDropItemType.linkedDataContainer,
+                    "foo",
+                    "bar",
+                    HoverLocation.center,
+                ],
+                defaultClassNameArgs.activeDictionaryId,
+                defaultClassNameArgs.activeNavigationConfigId,
+                defaultClassNameArgs.defaultLinkedDataDroppableDataLocation,
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(
+            `${defaultClassNameArgs.navigationItem} ${defaultClassNameArgs.navigationItemHover}`
+        );
+    });
+    test("should return the class names for a hovered node if it is linked data", () => {
+        expect(
+            getDraggableItemClassName(
+                defaultClassNameArgs.isCollapsible,
+                defaultClassNameArgs.isDraggable,
+                defaultClassNameArgs.isDroppable,
+                "foo",
+                "bar",
+                [DragDropItemType.linkedData, "foo", "bar", HoverLocation.center],
+                defaultClassNameArgs.activeDictionaryId,
+                defaultClassNameArgs.activeNavigationConfigId,
+                "bat",
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(
+            `${defaultClassNameArgs.navigationItem} ${defaultClassNameArgs.navigationItemHover}`
+        );
+    });
+    test("should return the class names for a hovered node if it is root linked data", () => {
+        expect(
+            getDraggableItemClassName(
+                defaultClassNameArgs.isCollapsible,
+                defaultClassNameArgs.isDraggable,
+                defaultClassNameArgs.isDroppable,
+                "foo",
+                "bar",
+                [DragDropItemType.rootLinkedData, "foo", "bar", HoverLocation.center],
+                defaultClassNameArgs.activeDictionaryId,
+                defaultClassNameArgs.activeNavigationConfigId,
+                "bat",
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(
+            `${defaultClassNameArgs.navigationItem} ${defaultClassNameArgs.navigationItemHover}`
+        );
+    });
+    test("should return the class names for a node when hovering before the node", () => {
+        expect(
+            getDraggableItemClassName(
+                defaultClassNameArgs.isCollapsible,
+                defaultClassNameArgs.isDraggable,
+                defaultClassNameArgs.isDroppable,
+                defaultClassNameArgs.dictionaryId,
+                defaultClassNameArgs.navigationConfigId,
+                [DragDropItemType.linkedData, "foo", "bar", HoverLocation.before],
+                defaultClassNameArgs.activeDictionaryId,
+                defaultClassNameArgs.activeNavigationConfigId,
+                defaultClassNameArgs.defaultLinkedDataDroppableDataLocation,
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(
+            `${defaultClassNameArgs.navigationItem} ${defaultClassNameArgs.navigationItemHoverBefore}`
+        );
+    });
+    test("should return the class names for a node when hovering after the node", () => {
+        expect(
+            getDraggableItemClassName(
+                defaultClassNameArgs.isCollapsible,
+                defaultClassNameArgs.isDraggable,
+                defaultClassNameArgs.isDroppable,
+                defaultClassNameArgs.dictionaryId,
+                defaultClassNameArgs.navigationConfigId,
+                [DragDropItemType.linkedData, "foo", "bar", HoverLocation.after],
+                defaultClassNameArgs.activeDictionaryId,
+                defaultClassNameArgs.activeNavigationConfigId,
+                defaultClassNameArgs.defaultLinkedDataDroppableDataLocation,
+                defaultClassNameArgs.navigationItem,
+                defaultClassNameArgs.navigationItemExpandable,
+                defaultClassNameArgs.navigationItemActive,
+                defaultClassNameArgs.navigationItemDraggable,
+                defaultClassNameArgs.navigationItemDroppable,
+                defaultClassNameArgs.navigationItemHover,
+                defaultClassNameArgs.navigationItemHoverAfter,
+                defaultClassNameArgs.navigationItemHoverBefore
+            )
+        ).toEqual(
+            `${defaultClassNameArgs.navigationItem} ${defaultClassNameArgs.navigationItemHoverAfter}`
+        );
+    });
+});
+
+/**
+ * Gets the draggable state when drag starts
+ */
+describe("getDragStartState", () => {
+    test("should return a drag start state with linked data and linked data location", () => {
+        expect(
+            getDragStartState(
+                "foo",
+                2,
+                [
+                    {
+                        root: {
+                            schemaId: "a",
+                            data: {
+                                children: [
+                                    {
+                                        id: "foo",
+                                    },
+                                ],
+                            },
+                        },
+                        foo: {
+                            schemaId: "b",
+                            parent: {
+                                id: "root",
+                                dataLocation: "children",
+                            },
+                            data: "Hello world",
+                        },
+                    },
+                    "root",
+                ],
+                [
+                    {
+                        foo: [
+                            {
+                                "": {
+                                    parentDictionaryItem: {
+                                        id: "root",
+                                        dataLocation: "children",
+                                    },
+                                } as any,
+                            },
+                            "",
+                        ],
+                    },
+                    "root",
+                ]
+            )
+        ).toEqual({
+            linkedData: [
+                {
+                    data: "Hello world",
+                    linkedData: [],
+                    schemaId: "b",
+                },
+            ],
+            linkedDataLocation: ["root", "children", 2],
+        });
+    });
+});
+
+/**
+ * Gets the draggable message when drag starts
+ */
+describe("getDragStartMessage", () => {
+    test("should get a message to remove linked data of the dragging linked data when drag starts", () => {
+        const dictionaryId = "foo";
+        const parentDictionaryId = "bat";
+        const dataLocation = "foo-datalocation";
+        const navigationId = "bar";
+        const navigationDictionary: NavigationConfigDictionary = [
+            {
+                [dictionaryId]: [
+                    {
+                        bar: {
+                            parentDictionaryItem: {
+                                id: parentDictionaryId,
+                                dataLocation,
+                            },
+                            data: "Hello world",
+                        } as any,
+                    },
+                    "bar",
+                ],
+                bat: [
+                    {
+                        [dataLocation]: {
+                            data: [
+                                {
+                                    id: dictionaryId,
+                                },
+                            ],
+                        } as any,
+                    },
+                    "baz",
+                ],
+            },
+            "",
+        ];
+
+        expect(
+            getDragStartMessage(dictionaryId, navigationId, navigationDictionary)
+        ).toEqual({
+            type: MessageSystemType.data,
+            action: MessageSystemDataTypeAction.removeLinkedData,
+            dictionaryId: parentDictionaryId,
+            dataLocation,
+            linkedData: [
+                {
+                    id: dictionaryId,
+                },
+            ],
+            options: {
+                originatorId: navigationId,
+            },
+        });
+    });
+});
+
+/**
+ * Gets the draggable message when drag ends
+ */
+describe("getDragEndMessage", () => {
+    test("should get a message to add linked data back where it originated if no item has been hovered when drag ends", () => {
+        expect(
+            getDragEndMessage(
+                "",
+                null,
+                [
+                    {
+                        id: "foo",
+                    } as any,
+                ],
+                ["a", "b", 1],
+                ""
+            )
+        ).toEqual({
+            action: "add-linked-data",
+            dataLocation: "b",
+            dictionaryId: "a",
+            index: 1,
+            linkedData: [
+                {
+                    id: "foo",
+                },
+            ],
+            options: {
+                originatorId: "",
+            },
+            type: "data",
+        });
+    });
+    test("should get a message to add linked data to the last valid hovered item when drag ends", () => {
+        expect(
+            getDragEndMessage(
+                "",
+                [DragDropItemType.linkedData, "children", "", HoverLocation.center],
+                [
+                    {
+                        id: "foo",
+                    } as any,
+                ],
+                ["a", "b", 1],
+                "children"
+            )
+        ).toEqual({
+            action: "add-linked-data",
+            dataLocation: "b",
+            dictionaryId: "a",
+            index: 1,
+            linkedData: [
+                {
+                    id: "foo",
+                },
+            ],
+            options: {
+                originatorId: "",
+            },
+            type: "data",
+        });
+    });
+});
+
+/**
+ * Gets the draggable state when drag hovers
+ */
+describe("getDragHoverState", () => {
+    test("should get the state when hovering over the center of a valid navigation item", () => {
+        const dictionaryId = "foo";
+        const parentDictionaryId = "bat";
+        const dataLocation = "foo-datalocation";
+        const navigationConfigId = "bar";
+        const defaultDataLocationForDroppedItems = "children";
+        const navigationDictionary: NavigationConfigDictionary = [
+            {
+                [dictionaryId]: [
+                    {
+                        bar: {
+                            parentDictionaryItem: {
+                                id: parentDictionaryId,
+                                dataLocation,
+                            },
+                            data: "Hello world",
+                        } as any,
+                    },
+                    "bar",
+                ],
+                bat: [
+                    {
+                        [dataLocation]: {
+                            data: [
+                                {
+                                    id: dictionaryId,
+                                },
+                            ],
+                        } as any,
+                    },
+                    "baz",
+                ],
+            },
+            "",
+        ];
+        expect(
+            getDragHoverState(
+                dictionaryId,
+                navigationConfigId,
+                DragDropItemType.linkedData,
+                HoverLocation.center,
+                0,
+                [DragDropItemType.linkedData, "", "", HoverLocation.center],
+                navigationDictionary,
+                defaultDataLocationForDroppedItems
+            )
+        ).toEqual({
+            hoveredItem: [
+                DragDropItemType.linkedData,
+                dictionaryId,
+                navigationConfigId,
+                HoverLocation.center,
+            ],
+            linkedDataLocation: [dictionaryId, defaultDataLocationForDroppedItems, 1],
+        });
+    });
+    test("should get the state when hovering before a valid navigation item", () => {
+        const dictionaryId = "foo";
+        const parentDictionaryId = "bat";
+        const dataLocation = "foo-datalocation";
+        const navigationConfigId = "bar";
+        const defaultDataLocationForDroppedItems = "children";
+        const navigationDictionary: NavigationConfigDictionary = [
+            {
+                [dictionaryId]: [
+                    {
+                        bar: {
+                            parentDictionaryItem: {
+                                id: parentDictionaryId,
+                                dataLocation,
+                            },
+                            data: "Hello world",
+                        } as any,
+                    },
+                    "bar",
+                ],
+                bat: [
+                    {
+                        [dataLocation]: {
+                            data: [
+                                {
+                                    id: dictionaryId,
+                                },
+                            ],
+                        } as any,
+                    },
+                    "baz",
+                ],
+            },
+            "",
+        ];
+        expect(
+            getDragHoverState(
+                dictionaryId,
+                navigationConfigId,
+                DragDropItemType.linkedData,
+                HoverLocation.before,
+                0,
+                [DragDropItemType.linkedData, "", "", HoverLocation.before],
+                navigationDictionary,
+                defaultDataLocationForDroppedItems
+            )
+        ).toEqual({
+            hoveredItem: [
+                DragDropItemType.linkedData,
+                dictionaryId,
+                navigationConfigId,
+                HoverLocation.before,
+            ],
+            linkedDataLocation: [parentDictionaryId, dataLocation, 0],
+        });
+    });
+    test("should get the state when hovering after a valid navigation item", () => {
+        const dictionaryId = "foo";
+        const parentDictionaryId = "bat";
+        const dataLocation = "foo-datalocation";
+        const navigationConfigId = "bar";
+        const defaultDataLocationForDroppedItems = "children";
+        const navigationDictionary: NavigationConfigDictionary = [
+            {
+                [dictionaryId]: [
+                    {
+                        bar: {
+                            parentDictionaryItem: {
+                                id: parentDictionaryId,
+                                dataLocation,
+                            },
+                            data: "Hello world",
+                        } as any,
+                    },
+                    "bar",
+                ],
+                bat: [
+                    {
+                        [dataLocation]: {
+                            data: [
+                                {
+                                    id: dictionaryId,
+                                },
+                            ],
+                        } as any,
+                    },
+                    "baz",
+                ],
+            },
+            "",
+        ];
+        expect(
+            getDragHoverState(
+                dictionaryId,
+                navigationConfigId,
+                DragDropItemType.linkedData,
+                HoverLocation.after,
+                0,
+                [DragDropItemType.linkedData, "", "", HoverLocation.after],
+                navigationDictionary,
+                defaultDataLocationForDroppedItems
+            )
+        ).toEqual({
+            hoveredItem: [
+                DragDropItemType.linkedData,
+                dictionaryId,
+                navigationConfigId,
+                HoverLocation.after,
+            ],
+            linkedDataLocation: [parentDictionaryId, dataLocation, 1],
+        });
+    });
+});

--- a/packages/tooling/fast-tooling-react/src/navigation/navigation.utilities.ts
+++ b/packages/tooling/fast-tooling-react/src/navigation/navigation.utilities.ts
@@ -1,0 +1,240 @@
+import {
+    Data,
+    DataDictionary,
+    getLinkedData,
+    LinkedData,
+    MessageSystemDataTypeAction,
+    MessageSystemIncoming,
+    MessageSystemType,
+    NavigationConfigDictionary,
+} from "@microsoft/fast-tooling";
+import { XOR } from "@microsoft/fast-tooling/dist/dts/data-utilities/type.utilities";
+import {
+    HoveredItem,
+    HoverLocation,
+    LinkedDataLocationConfig,
+    NavigationState,
+} from "./navigation.props";
+import { DragDropItemType } from "./navigation-tree-item.props";
+
+export function getDraggableItemClassName(
+    isCollapsible: boolean,
+    isDraggable: boolean,
+    isDroppable: boolean,
+    dictionaryId: string,
+    navigationConfigId: string,
+    hoveredItem: any,
+    activeDictionaryId: string,
+    activeNavigationConfigId: string,
+    defaultLinkedDataDroppableDataLocation: string,
+    navigationItem: string,
+    navigationItemExpandable: string,
+    navigationItemActive: string,
+    navigationItemDraggable: string,
+    navigationItemDroppable: string,
+    navigationItemHover: string,
+    navigationItemHoverAfter: string,
+    navigationItemHoverBefore: string
+): string {
+    let className: string = navigationItem;
+
+    if (isCollapsible) {
+        className += ` ${navigationItemExpandable}`;
+    }
+
+    if (
+        activeDictionaryId === dictionaryId &&
+        activeNavigationConfigId === navigationConfigId
+    ) {
+        className += ` ${navigationItemActive}`;
+    }
+
+    if (isDraggable) {
+        className += ` ${navigationItemDraggable}`;
+    }
+
+    if (isDroppable) {
+        className += ` ${navigationItemDroppable}`;
+    }
+
+    if (
+        hoveredItem !== null &&
+        hoveredItem[1] === dictionaryId &&
+        hoveredItem[2] === navigationConfigId
+    ) {
+        if (
+            hoveredItem[0] === DragDropItemType.linkedDataContainer ||
+            ((hoveredItem[0] === DragDropItemType.linkedData ||
+                hoveredItem[0] === DragDropItemType.rootLinkedData) &&
+                defaultLinkedDataDroppableDataLocation &&
+                hoveredItem[3] === HoverLocation.center)
+        ) {
+            className += ` ${navigationItemHover}`;
+        } else if (
+            hoveredItem[0] === DragDropItemType.linkedData ||
+            hoveredItem[0] === DragDropItemType.linkedDataUndroppable
+        ) {
+            if (hoveredItem[3] === HoverLocation.after) {
+                className += ` ${navigationItemHoverAfter}`;
+            } else {
+                className += ` ${navigationItemHoverBefore}`;
+            }
+        }
+    }
+
+    return className;
+}
+
+export function getDragStartState(
+    dictionaryId: string,
+    index: number,
+    dataDictionary: DataDictionary<unknown>,
+    navigationDictionary: NavigationConfigDictionary
+): Pick<NavigationState, "linkedData" | "linkedDataLocation"> {
+    return {
+        linkedData: getLinkedData(dataDictionary, [dictionaryId]),
+        linkedDataLocation: [
+            navigationDictionary[0][dictionaryId][0][
+                navigationDictionary[0][dictionaryId][1]
+            ].parentDictionaryItem.id,
+            navigationDictionary[0][dictionaryId][0][
+                navigationDictionary[0][dictionaryId][1]
+            ].parentDictionaryItem.dataLocation,
+            index,
+        ],
+    };
+}
+
+export function getDragStartMessage(
+    dictionaryId: string,
+    navigationId: string,
+    navigationDictionary: NavigationConfigDictionary
+): MessageSystemIncoming {
+    return {
+        type: MessageSystemType.data,
+        action: MessageSystemDataTypeAction.removeLinkedData,
+        dictionaryId:
+            navigationDictionary[0][dictionaryId][0][
+                navigationDictionary[0][dictionaryId][1]
+            ].parentDictionaryItem.id,
+        dataLocation:
+            navigationDictionary[0][dictionaryId][0][
+                navigationDictionary[0][dictionaryId][1]
+            ].parentDictionaryItem.dataLocation,
+        linkedData: navigationDictionary[0][
+            navigationDictionary[0][dictionaryId][0][
+                navigationDictionary[0][dictionaryId][1]
+            ].parentDictionaryItem.id
+        ][0][
+            navigationDictionary[0][dictionaryId][0][
+                navigationDictionary[0][dictionaryId][1]
+            ].parentDictionaryItem.dataLocation
+        ].data.filter((value: LinkedData) => {
+            return value.id === dictionaryId;
+        }),
+        options: {
+            originatorId: navigationId,
+        },
+    };
+}
+
+export function getDragEndMessage(
+    navigationId: string,
+    hoveredItem: HoveredItem,
+    linkedData: Data<unknown>[],
+    linkedDataLocation: LinkedDataLocationConfig,
+    defaultLinkedDataDroppableDataLocation: XOR<string, undefined>
+): MessageSystemIncoming {
+    if (hoveredItem === null) {
+        return {
+            type: MessageSystemType.data,
+            action: MessageSystemDataTypeAction.addLinkedData,
+            linkedData,
+            dictionaryId: linkedDataLocation[0],
+            dataLocation: linkedDataLocation[1],
+            index: linkedDataLocation[2],
+            options: {
+                originatorId: navigationId,
+            },
+        };
+    }
+
+    const dropOntoLinkedData: boolean =
+        (linkedDataLocation[1] === "" ||
+            linkedDataLocation[1] === defaultLinkedDataDroppableDataLocation) &&
+        defaultLinkedDataDroppableDataLocation &&
+        hoveredItem[3] === HoverLocation.center;
+
+    return {
+        type: MessageSystemType.data,
+        action: MessageSystemDataTypeAction.addLinkedData,
+        linkedData: linkedData,
+        dictionaryId: linkedDataLocation[0],
+        dataLocation: dropOntoLinkedData
+            ? defaultLinkedDataDroppableDataLocation
+            : linkedDataLocation[1],
+        index: dropOntoLinkedData ? void 0 : linkedDataLocation[2],
+        options: {
+            originatorId: navigationId,
+        },
+    };
+}
+
+export function getDragHoverState(
+    dictionaryId: string,
+    navigationConfigId: string,
+    type: DragDropItemType,
+    location: HoverLocation,
+    index: number,
+    hoveredItem: HoveredItem,
+    navigationDictionary: NavigationConfigDictionary,
+    defaultLinkedDataDroppableDataLocation: XOR<string, undefined>
+): Pick<NavigationState, "hoveredItem" | "linkedDataLocation"> {
+    let parentDictionaryId: string = dictionaryId;
+    let parentDataLocation: string =
+        navigationDictionary[0][dictionaryId][0][navigationConfigId].relativeDataLocation;
+    const isLinkedDataContainer: boolean = type === DragDropItemType.linkedDataContainer;
+    const isDroppableLinkedData: boolean =
+        type === DragDropItemType.linkedData || type === DragDropItemType.rootLinkedData;
+
+    if (
+        isDroppableLinkedData &&
+        defaultLinkedDataDroppableDataLocation &&
+        location === HoverLocation.center
+    ) {
+        parentDataLocation = defaultLinkedDataDroppableDataLocation;
+    } else if (
+        !isLinkedDataContainer &&
+        navigationDictionary[0][dictionaryId][0][navigationConfigId]
+            .parentDictionaryItem !== undefined
+    ) {
+        parentDataLocation =
+            navigationDictionary[0][dictionaryId][0][navigationConfigId]
+                .parentDictionaryItem.dataLocation;
+        parentDictionaryId =
+            navigationDictionary[0][dictionaryId][0][navigationConfigId]
+                .parentDictionaryItem.id;
+    }
+
+    if (
+        hoveredItem === null ||
+        dictionaryId !== hoveredItem[1] ||
+        navigationConfigId !== hoveredItem[2] ||
+        location !== hoveredItem[3]
+    ) {
+        return {
+            hoveredItem: [type, dictionaryId, navigationConfigId, location],
+            linkedDataLocation: [
+                parentDictionaryId,
+                parentDataLocation,
+                isLinkedDataContainer
+                    ? undefined
+                    : location === HoverLocation.before
+                    ? index
+                    : index + 1,
+            ],
+        };
+    }
+
+    return;
+}

--- a/packages/tooling/fast-tooling/src/data-utilities/index.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/index.ts
@@ -1,6 +1,7 @@
 export * from "./array";
 export * from "./duplicate";
 export * from "./generate";
+export * from "./html-element";
 export * from "./location";
 export * from "./mapping";
 export * from "./relocate";

--- a/packages/tooling/fast-tooling/src/data-utilities/relocate.spec.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/relocate.spec.ts
@@ -3,6 +3,7 @@ import { expect } from "chai";
 import {
     getDataUpdatedWithoutSourceData,
     getDataUpdatedWithSourceData,
+    getNextActiveParentDictionaryId,
 } from "./relocate";
 import { DataType } from "./types";
 
@@ -143,5 +144,160 @@ describe("getDataUpdatedWithoutSourceData", () => {
         expect(updatedData).to.deep.equal({
             foo: ["bat"],
         });
+    });
+});
+
+/**
+ * Gets the next active dictionary ID when linked data is being removed
+ */
+describe("getNextActiveParentDictionaryId", () => {
+    it("should get the current active dictionary ID if the active dictionary ID is not being removed", () => {
+        expect(
+            getNextActiveParentDictionaryId(
+                "foo",
+                ["bat"],
+                [
+                    {
+                        bar: {
+                            schemaId: "",
+                            data: {
+                                Children: [
+                                    {
+                                        id: "foo",
+                                    },
+                                    {
+                                        id: "bat",
+                                    },
+                                ],
+                            },
+                        },
+                        foo: {
+                            schemaId: "",
+                            parent: {
+                                id: "bar",
+                                dataLocation: "Children",
+                            },
+                            data: "Hello world",
+                        },
+                        bat: {
+                            schemaId: "",
+                            parent: {
+                                id: "bar",
+                                dataLocation: "Children",
+                            },
+                            data: "Hello pluto",
+                        },
+                    },
+                    "bar",
+                ]
+            )
+        ).to.equal("foo");
+    });
+    it("should get the next active parent dictionary ID if the current active dictionary ID's parent is not being removed", () => {
+        expect(
+            getNextActiveParentDictionaryId(
+                "foo",
+                ["foo"],
+                [
+                    {
+                        bar: {
+                            schemaId: "",
+                            data: {
+                                Children: [
+                                    {
+                                        id: "foo",
+                                    },
+                                ],
+                            },
+                        },
+                        foo: {
+                            schemaId: "",
+                            parent: {
+                                id: "bar",
+                                dataLocation: "Children",
+                            },
+                            data: "Hello world",
+                        },
+                    },
+                    "bar",
+                ]
+            )
+        ).to.equal("bar");
+    });
+    it("should get the next active parent dictionary ID if the current active dictionary ID's parent is being removed", () => {
+        expect(
+            getNextActiveParentDictionaryId(
+                "foo",
+                ["baz", "foo"],
+                [
+                    {
+                        bar: {
+                            schemaId: "",
+                            data: {
+                                Children: [
+                                    {
+                                        id: "baz",
+                                    },
+                                ],
+                            },
+                        },
+                        baz: {
+                            schemaId: "",
+                            parent: {
+                                id: "bar",
+                                dataLocation: "Children",
+                            },
+                            data: {
+                                Children: [
+                                    {
+                                        id: "foo",
+                                    },
+                                ],
+                            },
+                        },
+                        foo: {
+                            schemaId: "",
+                            parent: {
+                                id: "baz",
+                                dataLocation: "Children",
+                            },
+                            data: "Hello world",
+                        },
+                    },
+                    "bar",
+                ]
+            )
+        ).to.equal("bar");
+    });
+    it("should return the root ID even if it removal of the ID is being attempted", () => {
+        expect(
+            getNextActiveParentDictionaryId(
+                "foo",
+                ["bar", "foo"],
+                [
+                    {
+                        bar: {
+                            schemaId: "",
+                            data: {
+                                Children: [
+                                    {
+                                        id: "foo",
+                                    },
+                                ],
+                            },
+                        },
+                        foo: {
+                            schemaId: "",
+                            parent: {
+                                id: "bar",
+                                dataLocation: "Children",
+                            },
+                            data: "Hello world",
+                        },
+                    },
+                    "bar",
+                ]
+            )
+        ).to.equal("bar");
     });
 });

--- a/packages/tooling/fast-tooling/src/data-utilities/relocate.ts
+++ b/packages/tooling/fast-tooling/src/data-utilities/relocate.ts
@@ -4,6 +4,7 @@
  */
 
 import { cloneDeep, get, set, unset } from "lodash-es";
+import { DataDictionary } from "../message-system";
 import { normalizeDataLocationToDotNotation } from "./location";
 import { DataType } from "./types";
 
@@ -190,4 +191,25 @@ export function getDataUpdatedWithoutSourceData(
     }
 
     return clonedData;
+}
+
+export function getNextActiveParentDictionaryId(
+    activeDictionaryId: string,
+    dictionaryIdsToBeRemoved: string[],
+    dataDictionary: DataDictionary<unknown>
+): string {
+    const updatedActiveDictionaryId: string = activeDictionaryId;
+
+    if (
+        dataDictionary[1] !== activeDictionaryId &&
+        dictionaryIdsToBeRemoved.includes(activeDictionaryId)
+    ) {
+        return getNextActiveParentDictionaryId(
+            dataDictionary[0][activeDictionaryId].parent.id,
+            dictionaryIdsToBeRemoved,
+            dataDictionary
+        );
+    }
+
+    return updatedActiveDictionaryId;
 }

--- a/packages/tooling/fast-tooling/src/message-system/message-system.utilities.props.ts
+++ b/packages/tooling/fast-tooling/src/message-system/message-system.utilities.props.ts
@@ -321,6 +321,12 @@ export interface RemoveLinkedDataDataMessageOutgoing<TConfig = {}>
     type: MessageSystemType.data;
     action: MessageSystemDataTypeAction.removeLinkedData;
     data: unknown;
+    /**
+     * The current active dictionary ID, which may change depending on
+     * whether the current active dictionary ID at the time of linked data removal
+     * was contained in the removed linked data
+     */
+    activeDictionaryId: string;
     dataDictionary: DataDictionary<unknown>;
     navigation: NavigationConfig;
     navigationDictionary: NavigationConfigDictionary;

--- a/sites/fast-creator/app/web-components/index.tsx
+++ b/sites/fast-creator/app/web-components/index.tsx
@@ -24,6 +24,7 @@ import {
     fastToolingFile,
     fastToolingFileActionObjectUrl,
     MessageSystem,
+    voidElements,
 } from "@microsoft/fast-tooling";
 import {
     ControlConfig,
@@ -318,6 +319,7 @@ export function renderNavigationTabs(
                     messageSystem={fastMessageSystem}
                     types={[DataType.object]}
                     defaultLinkedDataDroppableDataLocation={"Slot"}
+                    droppableBlocklist={voidElements}
                 />
             </fast-tab-panel>
             <fast-tab-panel id={NavigationId.libraries + "Panel"}>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

This pull request serves a few purposes:
- Adds a list of linked data that cannot be dropped to via schema IDs
- Fixes a drag and drop reordering bug that did not update the active data dictionary ID if the active data dictionary ID was contained in the removed linked data list

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Resolves #5071
Resolves #5067

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Build the project and `yarn start` in the Creator site. Attempt to add a few cards, drag and drop them onto various nodes. You should see that the `img` tag which cannot contain content cannot be dropped on. Additionally the run time errors that would occur when the active dictionary id was inside the dragged item should no longer occur.
 
## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Unit tests have been added. Additionally a refactor has been done in the `<Navigation />` component to allow for individually unit testing the drag and drop functionality as it is assumed at this time to be impossible to have automated tests in browser.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.