### PR TITLE
Fix example to include fastButton registration

### DIFF
--- a/sites/website/src/docs/design-systems/creating-a-component-library.md
+++ b/sites/website/src/docs/design-systems/creating-a-component-library.md
@@ -139,14 +139,15 @@ Here we provide the base component name of `counter`, which will be combined wit
 
 ### Registering Library Components in an Application
 
-To register the component, an application author will import the registration and register it in their `DesignSystem`, overriding any properties as necessary. For example, if this component had been created for the FAST Frame design system, then the the following code could be used:
+To register the component, an application author will import the registration and register it in their `DesignSystem`, overriding any properties as necessary. For example, if this component had been created for the FAST Frame design system, then the following code could be used:
 
 ```ts
 import { counter } from "your-package";
-import { provideFASTDesignSystem } from "@microsoft/fast-components";
+import { provideFASTDesignSystem, fastButton } from "@microsoft/fast-components";
 
 provideFASTDesignSystem()
     .register(
+        fastButton(),
         counter({ defaultButtonContent: "Please count." })
     );
 ```


### PR DESCRIPTION
# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

This change updates the `counter` example in the Design System documentation to include registering the `fastButton` component (without which, the `buttonTag` reference returns `undefined`).

### 🎫 Issues

None.

## 👩‍💻 Reviewer Notes

See https://discordapp.com/channels/449251231706251264/449251231706251266/879796951355387934 for context.

## 📑 Test Plan

None.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

