### PR TITLE
fix: the linked data removal button and the dropdown arrow will not display over absolutely positioned controls

### DIFF
--- a/change/@microsoft-fast-tooling-react-fbee675a-1a4c-4b60-b649-f29822f1c2b7.json
+++ b/change/@microsoft-fast-tooling-react-fbee675a-1a4c-4b60-b649-f29822f1c2b7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "the linked data removal button and the dropdown arrow will not display over absolutely positioned controls",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling-react/src/style/utilities.ts
+++ b/packages/tooling/fast-tooling-react/src/style/utilities.ts
@@ -145,7 +145,6 @@ export const selectSpanStyle: CSSRules<{}> = {
         position: "absolute",
         top: "9px",
         right: "4px",
-        zIndex: "1",
         borderLeft: "3px solid transparent",
         borderRight: "3px solid transparent",
         borderTop: `3px solid ${textColorCSSProperty}`,
@@ -244,7 +243,6 @@ export const removeItemStyle: CSSRules<{}> = {
     padding: "0",
     width: "20px",
     height: "20px",
-    zIndex: "1",
     borderRadius: borderRadiusCSSProperty,
     ...applyFocusVisible({
         ...insetStrongBoxShadow(accentColorCSSProperty),


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change was done because other controls that may be loaded into the `Form` component might be absolutely positioned with dropdown's. One example being used in the Creator is the `color-picker`. This fixes the issue by removing extraneous `z-index` values from the offending UI elements.

Note the "_" before the "G" in the right portion of the dropdown and the down arrow overlapping the "B".

Before:
![Screen Shot 2021-08-24 at 12 14 23 PM](https://user-images.githubusercontent.com/7559015/130676172-fb868d10-f7d3-49d9-8c96-f7c0f19e2b1c.png)

After:
![Screen Shot 2021-08-24 at 12 06 35 PM](https://user-images.githubusercontent.com/7559015/130675936-4b2341f0-0be3-4bc2-a932-4d8d80f2ad91.png)

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Resolves #5101

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Run the Creator and add a Card, then click on the color picker to see the screenshots above.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
No tests at this time as it is a visual bug.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.