### PR TITLE
Updated to contrast-based palette

### DIFF
--- a/change/@microsoft-fast-colors-aab7ebc5-03bf-415e-9e08-f95280414752.json
+++ b/change/@microsoft-fast-colors-aab7ebc5-03bf-415e-9e08-f95280414752.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated to contrast-based palette",
+  "packageName": "@microsoft/fast-colors",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-components-a5b1c895-d684-4fd7-9005-ef0a2419c0e4.json
+++ b/change/@microsoft-fast-components-a5b1c895-d684-4fd7-9005-ef0a2419c0e4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Updated to contrast-based palette",
+  "packageName": "@microsoft/fast-components",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/fast-colors/docs/api-report.md
+++ b/packages/utilities/fast-colors/docs/api-report.md
@@ -332,7 +332,7 @@ export class ColorXYZ {
     readonly z: number;
 }
 
-// @public
+// @public @deprecated
 export class ComponentStateColorPalette {
     constructor(config?: ComponentStateColorPaletteConfig);
     // (undocumented)

--- a/packages/utilities/fast-colors/src/component-state-color-palette.ts
+++ b/packages/utilities/fast-colors/src/component-state-color-palette.ts
@@ -25,6 +25,7 @@ export interface ComponentStateColorPaletteConfig {
 /**
  * Creates a color palette for UI components
  * @public
+ * @deprecated This is a very specific palette for the utilities package. ColorPalette is the closest replacement.
  */
 export class ComponentStateColorPalette {
     public static readonly defaultPaletteConfig: ComponentStateColorPaletteConfig = {

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -1312,8 +1312,8 @@ export const verticalSliderLabelStyles: ElementStyles;
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/color/palette.d.ts:48:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
-// dist/dts/color/palette.d.ts:49:5 - (ae-forgotten-export) The symbol "from" needs to be exported by the entry point index.d.ts
+// dist/dts/color/palette.d.ts:71:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
+// dist/dts/color/palette.d.ts:72:5 - (ae-forgotten-export) The symbol "from" needs to be exported by the entry point index.d.ts
 // dist/dts/custom-elements.d.ts:74:5 - (ae-incompatible-release-tags) The symbol "fastButton" is marked as @public, but its signature references "Button" which is marked as @internal
 // dist/dts/custom-elements.d.ts:86:5 - (ae-incompatible-release-tags) The symbol "fastCard" is marked as @public, but its signature references "Card" which is marked as @internal
 // dist/dts/custom-elements.d.ts:92:5 - (ae-incompatible-release-tags) The symbol "fastDesignSystemProvider" is marked as @public, but its signature references "DesignSystemProvider" which is marked as @internal

--- a/packages/web-components/fast-components/src/color/palette.ts
+++ b/packages/web-components/fast-components/src/color/palette.ts
@@ -8,33 +8,12 @@ import {
     labToRGB,
     rgbToHSL,
     rgbToLAB,
-    rgbToRelativeLuminance,
+    roundToPrecisionSmall,
 } from "@microsoft/fast-colors";
 import { isSwatchRGB, Swatch, SwatchRGB } from "./swatch";
 import { binarySearch } from "./utilities/binary-search";
 import { directionByIsDark } from "./utilities/direction-by-is-dark";
 import { contrast, RelativeLuminance } from "./utilities/relative-luminance";
-
-/**
- * Options to tailer the generation of the color palette.
- * @public
- */
-export interface PaletteOptions {
-    /**
-     * Increases the saturation of a color in the palette if it would otherwise be lower than the source color.
-     */
-    bumpSaturation: boolean;
-
-    /**
-     * The minimum amount of contrast between steps in the palette.
-     */
-    stepContrast: number;
-}
-
-const defaultPaletteOptions: PaletteOptions = {
-    bumpSaturation: true,
-    stepContrast: 1.06,
-};
 
 /**
  * A collection of {@link Swatch} instances
@@ -68,6 +47,38 @@ export interface Palette<T extends Swatch = Swatch> {
     get(index: number): T;
 }
 
+/**
+ * Options to tailor the generation of the color palette.
+ * @public
+ */
+export interface PaletteRGBOptions {
+    /**
+     * The minimum amount of contrast between steps in the palette. Default 1.05.
+     * Recommended increments by hundredths.
+     */
+    stepContrast: number;
+
+    /**
+     * Multiplier for increasing step contrast as the swatches darken. Default 0.
+     * Recommended increments by hundredths.
+     */
+    stepContrastRamp: number;
+
+    /**
+     * Whether to keep the exact source color in the target palette. Default false.
+     * Only recommended when the exact color is required and used in stateful interaction recipes like hover.
+     * Note that custom recipes can still access the source color even if it's not in the ramp,
+     * but turning this on will potentially increase the contrast between steps toward the ends of the palette.
+     */
+    preserveSource: boolean;
+}
+
+const defaultPaletteRGBOptions: PaletteRGBOptions = {
+    stepContrast: 1.05,
+    stepContrastRamp: 0,
+    preserveSource: false,
+};
+
 /** @public */
 export type PaletteRGB = Palette<SwatchRGB>;
 
@@ -96,9 +107,12 @@ function create(rOrSource: SwatchRGB | number, g?: number, b?: number): PaletteR
  * Creates a PaletteRGB from a source color object.
  * @param source - The source color
  */
-function from(source: SwatchRGB, options?: Partial<PaletteOptions>): PaletteRGB;
-function from(source: Record<"r" | "g" | "b", number>): PaletteRGB;
-function from(source: any, options?: Partial<PaletteOptions>): PaletteRGB {
+function from(source: SwatchRGB, options?: Partial<PaletteRGBOptions>): PaletteRGB;
+function from(
+    source: Record<"r" | "g" | "b", number>,
+    options?: Partial<PaletteRGBOptions>
+): PaletteRGB;
+function from(source: any, options?: Partial<PaletteRGBOptions>): PaletteRGB {
     return isSwatchRGB(source)
         ? PaletteRGBImpl.from(source, options)
         : PaletteRGBImpl.from(SwatchRGB.create(source.r, source.g, source.b), options);
@@ -205,24 +219,10 @@ class PaletteRGBImpl implements Palette<SwatchRGB> {
     }
 
     /**
-     * Gets the color with the requested or darker luminance.
-     * @param lum Max requested luminance
-     * @param palette Palette to search
-     * @returns
-     */
-    private static maxRelativeLuminance(
-        lum: number,
-        palette: ColorRGBA64[]
-    ): ColorRGBA64 {
-        const color = palette.find(clr => rgbToRelativeLuminance(clr) <= lum);
-        return color || palette[palette.length - 1];
-    }
-
-    /**
      * Bump the saturation if it falls below the reference color saturation.
      * @param reference Color with target saturation
      * @param color Color to check and bump if below target saturation
-     * @returns
+     * @returns Original or adjusted color
      */
     private static saturationBump(
         reference: ColorRGBA64,
@@ -249,28 +249,37 @@ class PaletteRGBImpl implements Palette<SwatchRGB> {
         return 2 * inputval; //from 0in = 0out to 0.5in = 1.0out
     }
 
-    private static createSaturationPalette(
-        baseColor: ColorRGBA64,
-        bumpSaturation: boolean
-    ): ColorRGBA64[] {
-        const targetPalette: ColorRGBA64[] = [];
+    /**
+     * Create a palette following the desired curve and many steps to build a smaller palette from.
+     * @param source The source swatch to create a palette from
+     * @returns The palette
+     */
+    private static createHighResolutionPalette(source: SwatchRGB): PaletteRGBImpl {
+        const swatches: SwatchRGB[] = [];
 
-        const labBaseColor = rgbToLAB(baseColor);
-        const lab0 = labToRGB(new ColorLAB(0, labBaseColor.a, labBaseColor.b)).clamp();
-        const lab50 = labToRGB(new ColorLAB(50, labBaseColor.a, labBaseColor.b)).clamp();
-        const lab100 = labToRGB(
-            new ColorLAB(100, labBaseColor.a, labBaseColor.b)
-        ).clamp();
+        const labSource = rgbToLAB(ColorRGBA64.fromObject(source)!.roundToPrecision(4));
+        const lab0 = labToRGB(new ColorLAB(0, labSource.a, labSource.b))
+            .clamp()
+            .roundToPrecision(4);
+        const lab50 = labToRGB(new ColorLAB(50, labSource.a, labSource.b))
+            .clamp()
+            .roundToPrecision(4);
+        const lab100 = labToRGB(new ColorLAB(100, labSource.a, labSource.b))
+            .clamp()
+            .roundToPrecision(4);
         const rgbMin = new ColorRGBA64(0, 0, 0);
         const rgbMax = new ColorRGBA64(1, 1, 1);
 
-        // 257 levels total
-        for (let l = 114; l >= -14; l -= 0.5) {
+        const lAbove = lab100.equalValue(rgbMax) ? 0 : 14;
+        const lBelow = lab0.equalValue(rgbMin) ? 0 : 14;
+
+        // 257 levels max, depending on whether lab0 or lab100 are black or white respectively.
+        for (let l = 100 + lAbove; l >= 0 - lBelow; l -= 0.5) {
             let rgb: ColorRGBA64;
 
             if (l < 0) {
                 // For L less than 0, scale from black to L=0
-                const percentFromRgbMinToLab0 = l / 14 + 1;
+                const percentFromRgbMinToLab0 = l / lBelow + 1;
                 rgb = interpolateRGB(percentFromRgbMinToLab0, rgbMin, lab0);
             } else if (l <= 50) {
                 // For L less than 50, we scale from L=0 to the base color
@@ -280,53 +289,146 @@ class PaletteRGBImpl implements Palette<SwatchRGB> {
                 rgb = interpolateRGB(PaletteRGBImpl.ramp(l), lab50, lab100);
             } else {
                 // For L greater than 100, scale from L=100 to white
-                const percentFromLab100ToRgbMax = (l - 100.0) / 14;
+                const percentFromLab100ToRgbMax = (l - 100.0) / lAbove;
                 rgb = interpolateRGB(percentFromLab100ToRgbMax, lab100, rgbMax);
             }
 
-            if (bumpSaturation) {
-                rgb = PaletteRGBImpl.saturationBump(lab50, rgb);
-            }
-            rgb = rgb.roundToPrecision(4);
+            rgb = PaletteRGBImpl.saturationBump(lab50, rgb).roundToPrecision(4);
 
-            targetPalette.push(rgb);
+            swatches.push(SwatchRGB.from(rgb));
         }
 
-        return targetPalette;
+        return new PaletteRGBImpl(source, swatches);
     }
 
-    private static createColorPaletteByContrast(
-        baseColor: ColorRGBA64,
-        options: PaletteOptions
-    ): ColorRGBA64[] {
-        const referencePalette: ColorRGBA64[] = PaletteRGBImpl.createSaturationPalette(
-            baseColor,
-            options.bumpSaturation
+    /**
+     * Adjust one end of the contrast-based palette so it doesn't abruptly fall to black (or white).
+     * @param swatchContrast Function to get the target contrast for the next swatch
+     * @param referencePalette The high resolution palette
+     * @param targetPalette The contrast-based palette to adjust
+     * @param direction The end to adjust
+     */
+    private static adjustEnd(
+        swatchContrast: (swatch: SwatchRGB) => number,
+        referencePalette: PaletteRGBImpl,
+        targetPalette: SwatchRGB[],
+        direction: 1 | -1
+    ) {
+        // Careful with the use of referencePalette as only the refSwatches is reversed.
+        const refSwatches =
+            direction === -1
+                ? referencePalette.swatches
+                : referencePalette.reversedSwatches;
+        const refIndex = (swatch: SwatchRGB) => {
+            const index = referencePalette.closestIndexOf(swatch);
+            return direction === 1 ? referencePalette.lastIndex - index : index;
+        };
+
+        // Only operates on the 'end' end of the array, so flip if we're adjusting the 'beginning'
+        if (direction === 1) {
+            targetPalette.reverse();
+        }
+
+        const targetContrast = swatchContrast(targetPalette[targetPalette.length - 2]);
+        const actualContrast = roundToPrecisionSmall(
+            contrast(
+                targetPalette[targetPalette.length - 1],
+                targetPalette[targetPalette.length - 2]
+            ),
+            2
         );
+        if (actualContrast < targetContrast) {
+            // Remove last swatch if not sufficient contrast
+            targetPalette.pop();
 
-        const targetPalette: ColorRGBA64[] = [];
-        targetPalette.push(referencePalette[0]);
+            // Distribute to the last swatch
+            const safeSecondSwatch = referencePalette.colorContrast(
+                refSwatches[referencePalette.lastIndex],
+                targetContrast,
+                undefined,
+                direction
+            );
+            const safeSecondRefIndex = refIndex(safeSecondSwatch);
+            const targetSwatchCurrentRefIndex = refIndex(
+                targetPalette[targetPalette.length - 2]
+            );
+            const swatchesToSpace = safeSecondRefIndex - targetSwatchCurrentRefIndex;
+            let space = 1;
+            for (
+                let i = targetPalette.length - swatchesToSpace - 1;
+                i < targetPalette.length;
+                i++
+            ) {
+                const currentRefIndex = refIndex(targetPalette[i]);
+                const nextRefIndex =
+                    i === targetPalette.length - 1
+                        ? referencePalette.lastIndex
+                        : currentRefIndex + space;
+                targetPalette[i] = refSwatches[nextRefIndex];
+                space++;
+            }
+        }
 
-        const steppedLum = (lum: number) => (lum + 0.05) / options.stepContrast - 0.05;
+        if (direction === 1) {
+            targetPalette.reverse();
+        }
+    }
 
-        let lum: number = 1;
+    /**
+     * Generate a palette with consistent minimum contrast between swatches.
+     * @param source The source color
+     * @param options Palette generation options
+     * @returns A palette meeting the requested contrast between swatches.
+     */
+    private static createColorPaletteByContrast(
+        source: SwatchRGB,
+        options: PaletteRGBOptions
+    ): SwatchRGB[] {
+        const referencePalette = PaletteRGBImpl.createHighResolutionPalette(source);
+
+        // Ramp function to increase contrast as the swatches get darker
+        const nextContrast = (swatch: SwatchRGB) => {
+            const c =
+                options.stepContrast +
+                options.stepContrast *
+                    (1 - swatch.relativeLuminance) *
+                    options.stepContrastRamp;
+            return roundToPrecisionSmall(c, 2);
+        };
+
+        const swatches: SwatchRGB[] = [];
+
+        // Start with the source color or the light end color
+        let ref = options.preserveSource ? source : referencePalette.swatches[0];
+        swatches.push(ref);
+
+        // Add swatches with contrast toward dark
         do {
-            lum = steppedLum(lum);
-            const peekLum = steppedLum(lum);
-            // TODO: average the drop to black
-            if (peekLum < 0) {
-                lum = 0;
-            }
+            const targetContrast = nextContrast(ref);
+            ref = referencePalette.colorContrast(ref, targetContrast, undefined, 1);
+            swatches.push(ref);
+        } while (ref.relativeLuminance > 0);
 
-            const refRgb = PaletteRGBImpl.maxRelativeLuminance(lum, referencePalette);
-            if (lum > 0) {
-                lum = rgbToRelativeLuminance(refRgb);
-            }
+        // Add swatches with contrast toward light
+        if (options.preserveSource) {
+            ref = source;
+            do {
+                // This is off from the dark direction because `ref` here is the darker swatch, probably subtle
+                const targetContrast = nextContrast(ref);
+                ref = referencePalette.colorContrast(ref, targetContrast, undefined, -1);
+                swatches.unshift(ref);
+            } while (ref.relativeLuminance < 1);
+        }
 
-            targetPalette.push(refRgb);
-        } while (lum > 0);
+        // Validate dark end
+        this.adjustEnd(nextContrast, referencePalette, swatches, -1);
 
-        return targetPalette;
+        // Validate light end
+        if (options.preserveSource) {
+            this.adjustEnd(nextContrast, referencePalette, swatches, 1);
+        }
+
+        return swatches;
     }
 
     /**
@@ -334,20 +436,15 @@ class PaletteRGBImpl implements Palette<SwatchRGB> {
      * @param source - The source swatch to create a palette from
      * @returns
      */
-    static from(source: SwatchRGB, options?: Partial<PaletteOptions>): PaletteRGB {
+    static from(source: SwatchRGB, options?: Partial<PaletteRGBOptions>): PaletteRGB {
         const opts =
             options === void 0 || null
-                ? defaultPaletteOptions
-                : { ...defaultPaletteOptions, ...options };
+                ? defaultPaletteRGBOptions
+                : { ...defaultPaletteRGBOptions, ...options };
 
         return new PaletteRGBImpl(
             source,
-            Object.freeze(
-                PaletteRGBImpl.createColorPaletteByContrast(
-                    ColorRGBA64.fromObject(source)!,
-                    opts
-                ).map(x => SwatchRGB.from(x))
-            )
+            Object.freeze(PaletteRGBImpl.createColorPaletteByContrast(source, opts))
         );
     }
 }

--- a/packages/web-components/fast-components/src/color/palette.ts
+++ b/packages/web-components/fast-components/src/color/palette.ts
@@ -1,13 +1,40 @@
 import {
     clamp,
+    ColorHSL,
+    ColorLAB,
     ColorRGBA64,
-    ComponentStateColorPalette,
-    parseColorHexRGB,
+    hslToRGB,
+    interpolateRGB,
+    labToRGB,
+    rgbToHSL,
+    rgbToLAB,
+    rgbToRelativeLuminance,
 } from "@microsoft/fast-colors";
 import { isSwatchRGB, Swatch, SwatchRGB } from "./swatch";
 import { binarySearch } from "./utilities/binary-search";
 import { directionByIsDark } from "./utilities/direction-by-is-dark";
 import { contrast, RelativeLuminance } from "./utilities/relative-luminance";
+
+/**
+ * Options to tailer the generation of the color palette.
+ * @public
+ */
+export interface PaletteOptions {
+    /**
+     * Increases the saturation of a color in the palette if it would otherwise be lower than the source color.
+     */
+    bumpSaturation: boolean;
+
+    /**
+     * The minimum amount of contrast between steps in the palette.
+     */
+    stepContrast: number;
+}
+
+const defaultPaletteOptions: PaletteOptions = {
+    bumpSaturation: true,
+    stepContrast: 1.06,
+};
 
 /**
  * A collection of {@link Swatch} instances
@@ -69,12 +96,12 @@ function create(rOrSource: SwatchRGB | number, g?: number, b?: number): PaletteR
  * Creates a PaletteRGB from a source color object.
  * @param source - The source color
  */
-function from(source: SwatchRGB): PaletteRGB;
+function from(source: SwatchRGB, options?: Partial<PaletteOptions>): PaletteRGB;
 function from(source: Record<"r" | "g" | "b", number>): PaletteRGB;
-function from(source: any): PaletteRGB {
+function from(source: any, options?: Partial<PaletteOptions>): PaletteRGB {
     return isSwatchRGB(source)
-        ? PaletteRGBImpl.from(source)
-        : PaletteRGBImpl.from(SwatchRGB.create(source.r, source.g, source.b));
+        ? PaletteRGBImpl.from(source, options)
+        : PaletteRGBImpl.from(SwatchRGB.create(source.r, source.g, source.b), options);
 }
 /** @public */
 export const PaletteRGB = Object.freeze({
@@ -178,22 +205,148 @@ class PaletteRGBImpl implements Palette<SwatchRGB> {
     }
 
     /**
+     * Gets the color with the requested or darker luminance.
+     * @param lum Max requested luminance
+     * @param palette Palette to search
+     * @returns
+     */
+    private static maxRelativeLuminance(
+        lum: number,
+        palette: ColorRGBA64[]
+    ): ColorRGBA64 {
+        const color = palette.find(clr => rgbToRelativeLuminance(clr) <= lum);
+        return color || palette[palette.length - 1];
+    }
+
+    /**
+     * Bump the saturation if it falls below the reference color saturation.
+     * @param reference Color with target saturation
+     * @param color Color to check and bump if below target saturation
+     * @returns
+     */
+    private static saturationBump(
+        reference: ColorRGBA64,
+        color: ColorRGBA64
+    ): ColorRGBA64 {
+        const hslReference = rgbToHSL(reference);
+        const saturationTarget = hslReference.s;
+        const hslColor = rgbToHSL(color);
+        if (hslColor.s < saturationTarget) {
+            const hslNew = new ColorHSL(hslColor.h, saturationTarget, hslColor.l);
+            return hslToRGB(hslNew);
+        }
+        return color;
+    }
+
+    /**
+     * Scales input from 0 to 100 to 0 to 0.5.
+     * @param l Input number, 0 to 100
+     * @returns Output number, 0 to 0.5
+     */
+    private static ramp(l: number) {
+        const inputval = l / 100;
+        if (inputval > 0.5) return (inputval - 0.5) / 0.5; //from 0.500001in = 0.00000001out to 1.0in = 1.0out
+        return 2 * inputval; //from 0in = 0out to 0.5in = 1.0out
+    }
+
+    private static createSaturationPalette(
+        baseColor: ColorRGBA64,
+        bumpSaturation: boolean
+    ): ColorRGBA64[] {
+        const targetPalette: ColorRGBA64[] = [];
+
+        const labBaseColor = rgbToLAB(baseColor);
+        const lab0 = labToRGB(new ColorLAB(0, labBaseColor.a, labBaseColor.b)).clamp();
+        const lab50 = labToRGB(new ColorLAB(50, labBaseColor.a, labBaseColor.b)).clamp();
+        const lab100 = labToRGB(
+            new ColorLAB(100, labBaseColor.a, labBaseColor.b)
+        ).clamp();
+        const rgbMin = new ColorRGBA64(0, 0, 0);
+        const rgbMax = new ColorRGBA64(1, 1, 1);
+
+        // 257 levels total
+        for (let l = 114; l >= -14; l -= 0.5) {
+            let rgb: ColorRGBA64;
+
+            if (l < 0) {
+                // For L less than 0, scale from black to L=0
+                const percentFromRgbMinToLab0 = l / 14 + 1;
+                rgb = interpolateRGB(percentFromRgbMinToLab0, rgbMin, lab0);
+            } else if (l <= 50) {
+                // For L less than 50, we scale from L=0 to the base color
+                rgb = interpolateRGB(PaletteRGBImpl.ramp(l), lab0, lab50);
+            } else if (l <= 100) {
+                // For L less than 100, scale from the base color to L=100
+                rgb = interpolateRGB(PaletteRGBImpl.ramp(l), lab50, lab100);
+            } else {
+                // For L greater than 100, scale from L=100 to white
+                const percentFromLab100ToRgbMax = (l - 100.0) / 14;
+                rgb = interpolateRGB(percentFromLab100ToRgbMax, lab100, rgbMax);
+            }
+
+            if (bumpSaturation) {
+                rgb = PaletteRGBImpl.saturationBump(lab50, rgb);
+            }
+            rgb = rgb.roundToPrecision(4);
+
+            targetPalette.push(rgb);
+        }
+
+        return targetPalette;
+    }
+
+    private static createColorPaletteByContrast(
+        baseColor: ColorRGBA64,
+        options: PaletteOptions
+    ): ColorRGBA64[] {
+        const referencePalette: ColorRGBA64[] = PaletteRGBImpl.createSaturationPalette(
+            baseColor,
+            options.bumpSaturation
+        );
+
+        const targetPalette: ColorRGBA64[] = [];
+        targetPalette.push(referencePalette[0]);
+
+        const steppedLum = (lum: number) => (lum + 0.05) / options.stepContrast - 0.05;
+
+        let lum: number = 1;
+        do {
+            lum = steppedLum(lum);
+            const peekLum = steppedLum(lum);
+            // TODO: average the drop to black
+            if (peekLum < 0) {
+                lum = 0;
+            }
+
+            const refRgb = PaletteRGBImpl.maxRelativeLuminance(lum, referencePalette);
+            if (lum > 0) {
+                lum = rgbToRelativeLuminance(refRgb);
+            }
+
+            targetPalette.push(refRgb);
+        } while (lum > 0);
+
+        return targetPalette;
+    }
+
+    /**
      * Create a color palette from a provided swatch
      * @param source - The source swatch to create a palette from
      * @returns
      */
-    static from(source: SwatchRGB): PaletteRGB {
+    static from(source: SwatchRGB, options?: Partial<PaletteOptions>): PaletteRGB {
+        const opts =
+            options === void 0 || null
+                ? defaultPaletteOptions
+                : { ...defaultPaletteOptions, ...options };
+
         return new PaletteRGBImpl(
             source,
             Object.freeze(
-                new ComponentStateColorPalette({
-                    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-                    baseColor: ColorRGBA64.fromObject(source)!,
-                }).palette.map(x => {
-                    /* eslint-disable-next-line @typescript-eslint/no-non-null-assertion */
-                    const _x = parseColorHexRGB(x.toStringHexRGB())!;
-                    return SwatchRGB.create(_x.r, _x.g, _x.b);
-                })
+                PaletteRGBImpl.createColorPaletteByContrast(
+                    ColorRGBA64.fromObject(source)!,
+                    opts
+                ).map(x => SwatchRGB.from(x))
             )
         );
     }

--- a/packages/web-components/fast-components/src/color/recipes/neutral-layer.spec.ts
+++ b/packages/web-components/fast-components/src/color/recipes/neutral-layer.spec.ts
@@ -1,6 +1,5 @@
 import { expect } from "chai";
 import { PaletteRGB } from "../palette";
-import { StandardLuminance } from "../utilities/base-layer-luminance";
 import { middleGrey } from "../utilities/color-constants";
 import { neutralLayerFloating } from './neutral-layer-floating';
 import { neutralLayer1 } from "./neutral-layer-1";
@@ -12,6 +11,9 @@ import { SwatchRGB } from "../swatch";
 const neutralPalette = PaletteRGB.from(middleGrey);
 
 const layerDelta = 3;
+
+const lightModeLuminance = 1;
+const darkModeLuminance = 0.23;
 
 const enum NeutralPaletteLightModeOffsets {
     L1 = 0,
@@ -30,43 +32,43 @@ const enum NeutralPaletteDarkModeOffsets {
 describe("neutralLayer", (): void => {
     describe("1", (): void => {
         it("should return values from 1 when in light mode", (): void => {
-            expect(neutralLayer1(neutralPalette, StandardLuminance.LightMode).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L1).toColorString())
+            expect(neutralLayer1(neutralPalette, lightModeLuminance).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L1).toColorString())
         });
         it("should return values from 1 when in dark mode", (): void => {
-            expect(neutralLayer1(neutralPalette, StandardLuminance.DarkMode).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L1).toColorString())
+            expect(neutralLayer1(neutralPalette, darkModeLuminance).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L1).toColorString())
         });
     });
 
     describe("2", (): void => {
         it("should return values from 2 when in light mode", (): void => {
-            expect(neutralLayer2(neutralPalette, StandardLuminance.LightMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L2).toColorString())
+            expect(neutralLayer2(neutralPalette, lightModeLuminance, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L2).toColorString())
         });
         it("should return values from 2 when in dark mode", (): void => {
-            expect(neutralLayer2(neutralPalette, StandardLuminance.DarkMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L2).toColorString())
+            expect(neutralLayer2(neutralPalette, darkModeLuminance, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L2).toColorString())
         });
     });
 
     describe("3", (): void => {
         it("should return values from 3 when in light mode", (): void => {
-            expect(neutralLayer3(neutralPalette, StandardLuminance.LightMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L3).toColorString())
+            expect(neutralLayer3(neutralPalette, lightModeLuminance, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L3).toColorString())
         });
         it("should return values from 3 when in dark mode", (): void => {
-            expect(neutralLayer3(neutralPalette, StandardLuminance.DarkMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L3).toColorString())
+            expect(neutralLayer3(neutralPalette, darkModeLuminance, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L3).toColorString())
         });
     });
 
     describe("4", (): void => {
         it("should return values from 4 when in light mode", (): void => {
-            expect(neutralLayer4(neutralPalette, StandardLuminance.LightMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L4).toColorString())
+            expect(neutralLayer4(neutralPalette, lightModeLuminance, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L4).toColorString())
         });
         it("should return values from 4 when in dark mode", (): void => {
-            expect(neutralLayer4(neutralPalette, StandardLuminance.DarkMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L4).toColorString())
+            expect(neutralLayer4(neutralPalette, darkModeLuminance, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L4).toColorString())
         });
     });
 
     describe("neutralLayerFloating", (): void => {
         it("should return a color from the neutral palette", (): void => {
-            expect(neutralPalette.swatches.includes(neutralLayerFloating(neutralPalette, StandardLuminance.LightMode, layerDelta) as SwatchRGB)).to.be.true;
+            expect(neutralPalette.swatches.includes(neutralLayerFloating(neutralPalette, lightModeLuminance, layerDelta) as SwatchRGB)).to.be.true;
         });
     });
 });

--- a/packages/web-components/fast-components/src/color/recipes/neutral-layer.spec.ts
+++ b/packages/web-components/fast-components/src/color/recipes/neutral-layer.spec.ts
@@ -2,16 +2,16 @@ import { expect } from "chai";
 import { PaletteRGB } from "../palette";
 import { StandardLuminance } from "../utilities/base-layer-luminance";
 import { middleGrey } from "../utilities/color-constants";
-import {
-    neutralLayerFloating
-} from './neutral-layer-floating';
+import { neutralLayerFloating } from './neutral-layer-floating';
 import { neutralLayer1 } from "./neutral-layer-1";
 import { neutralLayer2 } from "./neutral-layer-2";
 import { neutralLayer3 } from "./neutral-layer-3";
 import { neutralLayer4 } from "./neutral-layer-4";
 import { SwatchRGB } from "../swatch";
 
-const neutralPalette = PaletteRGB.create(middleGrey);
+const neutralPalette = PaletteRGB.from(middleGrey);
+
+const layerDelta = 3;
 
 const enum NeutralPaletteLightModeOffsets {
     L1 = 0,
@@ -21,52 +21,52 @@ const enum NeutralPaletteLightModeOffsets {
 }
 
 const enum NeutralPaletteDarkModeOffsets {
-    L1 = 89,
-    L2 = 92,
-    L3 = 95,
-    L4 = 98,
+    L1 = 44,
+    L2 = 47,
+    L3 = 50,
+    L4 = 53,
 }
 
 describe("neutralLayer", (): void => {
     describe("1", (): void => {
         it("should return values from 1 when in light mode", (): void => {
-            expect(neutralLayer1(neutralPalette, StandardLuminance.LightMode)).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L1))
+            expect(neutralLayer1(neutralPalette, StandardLuminance.LightMode).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L1).toColorString())
         });
         it("should return values from 1 when in dark mode", (): void => {
-            expect(neutralLayer1(neutralPalette, StandardLuminance.DarkMode)).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L1))
+            expect(neutralLayer1(neutralPalette, StandardLuminance.DarkMode).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L1).toColorString())
         });
     });
 
     describe("2", (): void => {
         it("should return values from 2 when in light mode", (): void => {
-            expect(neutralLayer2(neutralPalette, StandardLuminance.LightMode, 3, 7, 10, 5)).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L2))
+            expect(neutralLayer2(neutralPalette, StandardLuminance.LightMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L2).toColorString())
         });
         it("should return values from 2 when in dark mode", (): void => {
-            expect(neutralLayer2(neutralPalette, StandardLuminance.DarkMode, 3, 7, 10, 5)).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L2))
+            expect(neutralLayer2(neutralPalette, StandardLuminance.DarkMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L2).toColorString())
         });
     });
 
     describe("3", (): void => {
         it("should return values from 3 when in light mode", (): void => {
-            expect(neutralLayer3(neutralPalette, StandardLuminance.LightMode, 3, 7, 10, 5)).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L3))
+            expect(neutralLayer3(neutralPalette, StandardLuminance.LightMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L3).toColorString())
         });
         it("should return values from 3 when in dark mode", (): void => {
-            expect(neutralLayer3(neutralPalette, StandardLuminance.DarkMode, 3, 7, 10, 5)).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L3))
+            expect(neutralLayer3(neutralPalette, StandardLuminance.DarkMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L3).toColorString())
         });
     });
 
     describe("4", (): void => {
         it("should return values from 4 when in light mode", (): void => {
-            expect(neutralLayer4(neutralPalette, StandardLuminance.LightMode, 3, 7, 10, 5)).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L4))
+            expect(neutralLayer4(neutralPalette, StandardLuminance.LightMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteLightModeOffsets.L4).toColorString())
         });
         it("should return values from 4 when in dark mode", (): void => {
-            expect(neutralLayer4(neutralPalette, StandardLuminance.DarkMode, 3, 7, 10, 5)).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L4))
+            expect(neutralLayer4(neutralPalette, StandardLuminance.DarkMode, layerDelta, 7, 10, 5).toColorString()).to.equal(neutralPalette.get(NeutralPaletteDarkModeOffsets.L4).toColorString())
         });
     });
 
     describe("neutralLayerFloating", (): void => {
         it("should return a color from the neutral palette", (): void => {
-            expect(neutralPalette.swatches.includes(neutralLayerFloating(neutralPalette, StandardLuminance.LightMode, 3) as SwatchRGB)).to.be.true;
+            expect(neutralPalette.swatches.includes(neutralLayerFloating(neutralPalette, StandardLuminance.LightMode, layerDelta) as SwatchRGB)).to.be.true;
         });
     });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

Updated the palette generation algorithm to maintain the amount of contrast between steps in the ramp rather than fill a fixed number of steps.

As the steps are used for interaction states in components, the fact that the perceived brightness between colors varies across the luminance spectrum, this makes it harder to achieve the same "feel" between light and dark mode. This change uses the closest known mathematical representation of how humans see color and brightness to keep the changes more consistent.

Also, this opens Adaptive Contrast we've been wanting to support for a while, by providing an easy parameter to adjust the amount of contrast between steps. This works best for some recipes, particularly fills. For instance, a neutral button fill will visibly have more contrast as you increase the scale, which applies to any difference between states as well like from rest to hover. It's less noticeable on something smaller like a stroke color. Also it doesn't solve the "increased contrast" design of potentially _adding_ outlines where there weren't any before. That's why it's a step toward the end goal for now, but definitely something we'll keep working on.

### 🎫 Issues

## 👩‍💻 Reviewer Notes

Easiest to see the palette and recipe values in Color Explorer, but can be tested in the components/Storybook as well. The initial values should be very similar to the previous colors, with one difference being more saturated colors especially in the light end. You should notice colors maintaining more of their base feel, for instance, yellow will stay more warm and less muddy as you get darker.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.