### PR TITLE
Fixing DesignToken subscription bug causing runtime error

### DIFF
--- a/change/@microsoft-fast-foundation-8bbee565-8807-431a-a319-0c30a54d82e3.json
+++ b/change/@microsoft-fast-foundation-8bbee565-8807-431a-a319-0c30a54d82e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixing issue where a token would subscribe to itself, causing max-callstack-exceded in certain scenarios",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -498,6 +498,19 @@ describe("A DesignToken", () => {
 
                 removeElement(target);
             });
+
+            it("should support accessing the token for being assigned from the derived value", () => {
+                const tokenA = DesignToken.create<number>("token-a");
+                const parent = addElement();
+                const child = addElement(parent);
+                tokenA.withDefault(6);
+                const recipe = (el: HTMLElement) => tokenA.getValueFor(el.parentElement!) * 2;
+                tokenA.setValueFor(parent, recipe);
+                tokenA.setValueFor(child, recipe);
+
+                expect(tokenA.getValueFor(parent)).to.equal(12);
+                expect(tokenA.getValueFor(child)).to.equal(24);
+            })
         });
         it("should update the CSS custom property of a derived token with a dependency that is a derived token that depends on a third token", async () => {
                 const tokenA = DesignToken.create<number>("token-a");

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -640,11 +640,7 @@ class DesignTokenNode implements Behavior, Subscriber {
                         x.appliedTo.forEach(y => {
                             const node = DesignTokenNode.getOrCreate(y);
 
-                            if (
-                                this !== node &&
-                                this.contains(node) &&
-                                node.getRaw(token) === value
-                            ) {
+                            if (this.contains(node) && node.getRaw(token) === value) {
                                 token.notify(node.target);
                                 node.reflectToCSS(token as CSSDesignToken<T>);
                             }


### PR DESCRIPTION

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR fixes a bug in DesignToken where, when a DesignToken value retrieved a value for the token being set, a maximum-callstack-exceeded error would be thrown. This was happening because the DesignToken would subscribe to changes for itself, causing recursive notification and update processes. 

This change filters out the token being assigned the value from the dependency list, preventing subscription to the token being set.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->