### PR TITLE
fix: use await to import the registration script to prevent fast components from being preloaded

### DIFF
--- a/sites/fast-creator/app/configs/fast/library.fast.ts
+++ b/sites/fast-creator/app/configs/fast/library.fast.ts
@@ -48,7 +48,6 @@ import {
     fastTextAreaTag,
     fastTextFieldTag,
 } from "./library.fast.tags";
-import { registerFASTComponents } from "./library.fast.registry";
 export const fastComponentId = "fast-components";
 
 export const fastComponentLibrary: WebComponentLibraryDefinition = {
@@ -58,7 +57,9 @@ export const fastComponentLibrary: WebComponentLibraryDefinition = {
     import: async () => {
         await import("./library.fast.import");
     },
-    register: registerFASTComponents,
+    register: async () => {
+        (await import("./library.fast.registry")).registerFASTComponents();
+    },
     componentDictionary: {
         [fastComponentSchemas[fastAnchorTag].$id]: {
             displayName: fastComponentSchemas[fastAnchorTag].title,

--- a/sites/fast-creator/app/configs/fluent-ui/library.fluent-ui.ts
+++ b/sites/fast-creator/app/configs/fluent-ui/library.fluent-ui.ts
@@ -48,7 +48,6 @@ import {
     fluentTextAreaTag,
     fluentTextFieldTag,
 } from "./library.fluent-ui.tags";
-import { registerFluentUIComponents } from "./library.fluent-ui.registry";
 export const fluentUIComponentId = "fluent-ui-components";
 
 export const fluentUIComponentLibrary: WebComponentLibraryDefinition = {
@@ -58,7 +57,9 @@ export const fluentUIComponentLibrary: WebComponentLibraryDefinition = {
     import: async () => {
         await import("./library.fluent-ui.import");
     },
-    register: registerFluentUIComponents,
+    register: async () => {
+        (await import("./library.fluent-ui.registry")).registerFluentUIComponents();
+    },
     componentDictionary: {
         [fluentUIComponentSchemas[fluentAnchorTag].$id]: {
             displayName: fluentUIComponentSchemas[fluentAnchorTag].title,

--- a/sites/fast-creator/app/preview/preview.tsx
+++ b/sites/fast-creator/app/preview/preview.tsx
@@ -20,7 +20,6 @@ import {
     nativeElementDefinitions,
 } from "@microsoft/site-utilities";
 import { classNames, Direction } from "@microsoft/fast-web-utilities";
-import { mapFASTComponentsDesignSystem } from "../configs/fast/library.fast.design-system.mapping";
 import { mapFluentUIComponentsDesignSystem } from "../configs/fluent-ui/library.fluent-ui.design-system.mapping";
 import { elementLibraries } from "../configs";
 import {

--- a/sites/fast-creator/app/preview/webpack.common.js
+++ b/sites/fast-creator/app/preview/webpack.common.js
@@ -4,6 +4,7 @@ const path = require("path");
 const { CleanWebpackPlugin } = require("clean-webpack-plugin");
 const HtmlWebpackPlugin = require("html-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
+const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 
 const appDir = path.resolve(__dirname, "./");
 const outDir = path.resolve(__dirname, "./www");
@@ -68,6 +69,10 @@ module.exports = {
             title: "FAST Creator Preview",
             inject: "body",
             template: path.resolve(appDir, "index.html"),
+        }),
+        new BundleAnalyzerPlugin({
+            // Remove this to inspect bundle sizes.
+            analyzerMode: "disabled",
         }),
     ],
 };

--- a/sites/fast-creator/app/webpack.common.js
+++ b/sites/fast-creator/app/webpack.common.js
@@ -6,6 +6,7 @@ const CopyPlugin = require("copy-webpack-plugin");
 const MonacoWebpackPlugin = require("monaco-editor-webpack-plugin");
 const MiniCssExtractPlugin = require("mini-css-extract-plugin");
 const manifest = require("@microsoft/site-utilities/src/curated-html.json").join("");
+const { BundleAnalyzerPlugin } = require("webpack-bundle-analyzer");
 
 const appDir = path.resolve(__dirname, "./");
 const outDir = path.resolve(__dirname, "./www");
@@ -94,6 +95,10 @@ module.exports = {
             // available options are documented at https://github.com/Microsoft/monaco-editor-webpack-plugin#options
             languages: ["html"],
             features: ["format", "coreCommands", "codeAction", "suggest"],
+        }),
+        new BundleAnalyzerPlugin({
+            // Remove this to inspect bundle sizes.
+            analyzerMode: "disabled",
         }),
     ],
 };


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change fixes an async issue that occurs when FAST components are loaded before the default Fluent UI components in the Creator application. This does not fix the issue where both libraries existing together causes style inconsistencies because of the CSS variable naming overlap. That will be resolved by a future task for name-spacing the CSS variables.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Run the Creator build script to create a production build of the application, then copy to the new `www` folder the `server.js` file in the `@microsoft/site-utilities/statics/server/server.js` and remove lines `22-37` and `49-57`. Also copy the `@microsoft/site-utilities/statics/server/package.json` file. Then run `npm i` and `node server.js`. This should run on `localhost:7001` and should show that the styling async loading issue is resolved when you add a `Card`. The text should no longer be white.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.