### PR TITLE
support default slotted content start end

### DIFF
--- a/change/@microsoft-fast-components-6ac044cd-7329-49d7-a97e-ed9bb5a62b2a.json
+++ b/change/@microsoft-fast-components-6ac044cd-7329-49d7-a97e-ed9bb5a62b2a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add start/end slot definitions to support default slotted content",
+  "packageName": "@microsoft/fast-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-36508b94-303a-41ad-9c37-dfe77c29c392.json
+++ b/change/@microsoft-fast-foundation-36508b94-303a-41ad-9c37-dfe77c29c392.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add start/end slot definitions to support default slotted content",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -209,7 +209,7 @@ export { AnchoredRegion }
 export const anchoredRegionStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const anchorStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
+export const anchorStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").AnchorOptions) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export class Avatar extends Avatar_2 {
@@ -261,7 +261,7 @@ export class Button extends Button_2 {
 export type ButtonAppearance = "accent" | "lightweight" | "neutral" | "outline" | "stealth";
 
 // @public
-export const buttonStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
+export const buttonStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").AnchorOptions) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "Card" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -896,7 +896,7 @@ export type NumberFieldAppearance = "filled" | "outline";
 export const numberFieldStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: NumberFieldOptions) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
-export const optionStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
+export const optionStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").AnchorOptions) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export interface Palette<T extends Swatch = Swatch> {
@@ -1024,7 +1024,7 @@ export const tabPanelStyles: (context: import("@microsoft/fast-foundation").Elem
 export { Tabs }
 
 // @public
-export const tabsStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
+export const tabsStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").AnchorOptions) => import("@microsoft/fast-element").ElementStyles;
 
 // @public
 export const tabStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
@@ -1059,7 +1059,7 @@ export class TextField extends TextField_2 {
 export type TextFieldAppearance = "filled" | "outline";
 
 // @public
-export const textFieldStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
+export const textFieldStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").AnchorOptions) => import("@microsoft/fast-element").ElementStyles;
 
 // Warning: (ae-internal-missing-underscore) The name "Toolbar" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -1070,7 +1070,7 @@ export class Toolbar extends Toolbar_2 {
 }
 
 // @public
-export const toolbarStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
+export const toolbarStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").AnchorOptions) => import("@microsoft/fast-element").ElementStyles;
 
 export { Tooltip }
 

--- a/packages/web-components/fast-components/src/anchor/anchor.styles.ts
+++ b/packages/web-components/fast-components/src/anchor/anchor.styles.ts
@@ -1,8 +1,5 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
-import {
-    ElementDefinitionContext,
-    FoundationElementDefinition,
-} from "@microsoft/fast-foundation";
+import { AnchorOptions, ElementDefinitionContext } from "@microsoft/fast-foundation";
 import {
     AccentButtonStyles,
     BaseButtonStyles,
@@ -15,11 +12,8 @@ import { appearanceBehavior } from "../utilities/behaviors";
 
 export const anchorStyles: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) => ElementStyles = (
-    context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) =>
+    definition: AnchorOptions
+) => ElementStyles = (context: ElementDefinitionContext, definition: AnchorOptions) =>
     css`
         ${BaseButtonStyles}
     `.withBehaviors(

--- a/packages/web-components/fast-components/src/button/button.styles.ts
+++ b/packages/web-components/fast-components/src/button/button.styles.ts
@@ -1,9 +1,9 @@
 import { css, ElementStyles } from "@microsoft/fast-element";
 import {
+    ButtonOptions,
     disabledCursor,
     ElementDefinitionContext,
     forcedColorsStylesheetBehavior,
-    FoundationElementDefinition,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
@@ -24,11 +24,8 @@ import { appearanceBehavior } from "../utilities/behaviors";
 
 export const buttonStyles: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) => ElementStyles = (
-    context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) =>
+    definition: ButtonOptions
+) => ElementStyles = (context: ElementDefinitionContext, definition: ButtonOptions) =>
     css`
         :host([disabled]),
         :host([disabled]:hover),

--- a/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
+++ b/packages/web-components/fast-components/src/listbox-option/listbox-option.styles.ts
@@ -6,6 +6,7 @@ import {
     focusVisible,
     forcedColorsStylesheetBehavior,
     FoundationElementDefinition,
+    ListboxOptionOptions,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
@@ -33,10 +34,10 @@ import { heightNumber } from "../styles/size";
 
 export const optionStyles: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: ListboxOptionOptions
 ) => ElementStyles = (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: ListboxOptionOptions
 ) =>
     css`
     ${display("inline-flex")} :host {

--- a/packages/web-components/fast-components/src/tabs/tabs.styles.ts
+++ b/packages/web-components/fast-components/src/tabs/tabs.styles.ts
@@ -3,7 +3,7 @@ import {
     display,
     ElementDefinitionContext,
     forcedColorsStylesheetBehavior,
-    FoundationElementDefinition,
+    TabsOptions,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
@@ -19,11 +19,8 @@ import { heightNumber } from "../styles/index";
 
 export const tabsStyles: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) => ElementStyles = (
-    context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) =>
+    definition: TabsOptions
+) => ElementStyles = (context: ElementDefinitionContext, definition: TabsOptions) =>
     css`
         ${display("grid")} :host {
             box-sizing: border-box;

--- a/packages/web-components/fast-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.styles.ts
@@ -5,7 +5,7 @@ import {
     ElementDefinitionContext,
     focusVisible,
     forcedColorsStylesheetBehavior,
-    FoundationElementDefinition,
+    TextFieldOptions,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
@@ -31,11 +31,8 @@ import { heightNumber } from "../styles/index";
 
 export const textFieldStyles: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) => ElementStyles = (
-    context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) =>
+    definition: TextFieldOptions
+) => ElementStyles = (context: ElementDefinitionContext, definition: TextFieldOptions) =>
     css`
     ${display("inline-block")} :host {
         font-family: ${bodyFont};

--- a/packages/web-components/fast-components/src/toolbar/toolbar.styles.ts
+++ b/packages/web-components/fast-components/src/toolbar/toolbar.styles.ts
@@ -4,7 +4,7 @@ import {
     ElementDefinitionContext,
     focusVisible,
     forcedColorsStylesheetBehavior,
-    FoundationElementDefinition,
+    ToolbarOptions,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
 import {
@@ -22,11 +22,8 @@ import {
  */
 export const toolbarStyles: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) => ElementStyles = (
-    context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
-) =>
+    definition: ToolbarOptions
+) => ElementStyles = (context: ElementDefinitionContext, definition: ToolbarOptions) =>
     css`
         ${display("inline-flex")} :host {
             --toolbar-item-gap: calc(

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -52,7 +52,7 @@ export interface AccordionItem extends StartEnd {
 }
 
 // @public
-export type AccordionItemOptions = FoundationElementDefinition & {
+export type AccordionItemOptions = FoundationElementDefinition & StartEndOptions & {
     expandedIcon?: string | SyntheticViewTemplate;
     collapsedIcon?: string | SyntheticViewTemplate;
 };
@@ -129,7 +129,10 @@ export type AnchoredRegionPositionLabel = "start" | "insetStart" | "insetEnd" | 
 export const anchoredRegionTemplate: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ViewTemplate<AnchoredRegion>;
 
 // @public
-export const anchorTemplate: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ViewTemplate<Anchor>;
+export type AnchorOptions = FoundationElementDefinition & StartEndOptions;
+
+// @public
+export const anchorTemplate: (context: ElementDefinitionContext, definition: AnchorOptions) => ViewTemplate<Anchor>;
 
 // @public
 export function applyMixins(derivedCtor: any, ...baseCtors: any[]): void;
@@ -230,7 +233,7 @@ export interface BreadcrumbItem extends StartEnd, DelegatesARIALink {
 }
 
 // @public
-export type BreadcrumbItemOptions = FoundationElementDefinition & {
+export type BreadcrumbItemOptions = FoundationElementDefinition & StartEndOptions & {
     separator?: string | SyntheticViewTemplate;
 };
 
@@ -266,7 +269,10 @@ export interface Button extends StartEnd, DelegatesARIAButton {
 }
 
 // @public
-export const buttonTemplate: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ViewTemplate<Button>;
+export type ButtonOptions = FoundationElementDefinition & StartEndOptions;
+
+// @public
+export const buttonTemplate: (context: ElementDefinitionContext, definition: ButtonOptions) => ViewTemplate<Button>;
 
 // @public
 export class Card extends FoundationElement {
@@ -395,7 +401,7 @@ export enum ComboboxAutocomplete {
 }
 
 // @public
-export type ComboboxOptions = FoundationElementDefinition & {
+export type ComboboxOptions = FoundationElementDefinition & StartEndOptions & {
     indicator?: string | SyntheticViewTemplate;
 };
 
@@ -901,7 +907,12 @@ export type ElementDisambiguationCallback = (nameAttempt: string, typeAttempt: C
 export type ElementDisambiguationResult = string | typeof ElementDisambiguation.ignoreDuplicate | typeof ElementDisambiguation.definitionCallbackOnly;
 
 // @public
-export const endTemplate: ViewTemplate<StartEnd>;
+export type EndOptions = {
+    end?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const endTemplate: (context: ElementDefinitionContext, definition: EndOptions) => ViewTemplate<StartEnd>;
 
 // @public
 export interface Factory<T extends Constructable = any> {
@@ -1111,7 +1122,7 @@ export class HorizontalScroll extends FoundationElement {
     }
 
 // @public
-export type HorizontalScrollOptions = FoundationElementDefinition & {
+export type HorizontalScrollOptions = FoundationElementDefinition & StartEndOptions & {
     nextFlipper?: FoundationElementTemplate<SyntheticViewTemplate<any, HorizontalScroll>, HorizontalScrollOptions> | SyntheticViewTemplate | string;
     previousFlipper?: FoundationElementTemplate<SyntheticViewTemplate<any, HorizontalScroll>, HorizontalScrollOptions> | SyntheticViewTemplate | string;
 };
@@ -1260,7 +1271,10 @@ export interface ListboxOption extends StartEnd {
 }
 
 // @public
-export const listboxOptionTemplate: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ViewTemplate<ListboxOption>;
+export type ListboxOptionOptions = FoundationElementDefinition & StartEndOptions;
+
+// @public
+export const listboxOptionTemplate: (context: ElementDefinitionContext, definition: ListboxOptionOptions) => ViewTemplate<ListboxOption>;
 
 // @public
 export enum ListboxRole {
@@ -1356,7 +1370,7 @@ export interface MenuItem extends StartEnd {
 export type MenuItemColumnCount = 0 | 1 | 2;
 
 // @public
-export type MenuItemOptions = FoundationElementDefinition & {
+export type MenuItemOptions = FoundationElementDefinition & StartEndOptions & {
     checkboxIndicator?: string | SyntheticViewTemplate;
     expandCollapseGlyph?: string | SyntheticViewTemplate;
     radioIndicator?: string | SyntheticViewTemplate;
@@ -1425,7 +1439,7 @@ export interface NumberField extends StartEnd, DelegatesARIATextbox {
 }
 
 // @public
-export type NumberFieldOptions = FoundationElementDefinition & {
+export type NumberFieldOptions = FoundationElementDefinition & StartEndOptions & {
     stepDownGlyph?: string | SyntheticViewTemplate;
     stepUpGlyph?: string | SyntheticViewTemplate;
 };
@@ -1672,7 +1686,7 @@ export interface Select extends StartEnd, DelegatesARIASelect {
 }
 
 // @public
-export type SelectOptions = FoundationElementDefinition & {
+export type SelectOptions = FoundationElementDefinition & StartEndOptions & {
     indicator?: string | SyntheticViewTemplate;
 };
 
@@ -1854,7 +1868,15 @@ export class StartEnd {
 }
 
 // @public
-export const startTemplate: ViewTemplate<StartEnd>;
+export type StartEndOptions = StartOptions & EndOptions;
+
+// @public
+export type StartOptions = {
+    start?: string | SyntheticViewTemplate;
+};
+
+// @public
+export const startTemplate: (context: ElementDefinitionContext, definition: StartOptions) => ViewTemplate<StartEnd>;
 
 // @public
 export type StaticDesignTokenValue<T> = T extends Function ? never : T;
@@ -1938,6 +1960,9 @@ export interface Tabs extends StartEnd {
 }
 
 // @public
+export type TabsOptions = FoundationElementDefinition & StartEndOptions;
+
+// @public
 export enum TabsOrientation {
     // (undocumented)
     horizontal = "horizontal",
@@ -1946,7 +1971,7 @@ export enum TabsOrientation {
 }
 
 // @public
-export const tabsTemplate: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ViewTemplate<Tabs>;
+export const tabsTemplate: (context: ElementDefinitionContext, definition: TabsOptions) => ViewTemplate<Tabs>;
 
 // @public
 export const tabTemplate: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ViewTemplate<Tab>;
@@ -2027,7 +2052,10 @@ export interface TextField extends StartEnd, DelegatesARIATextbox {
 }
 
 // @public
-export const textFieldTemplate: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ViewTemplate<TextField>;
+export type TextFieldOptions = FoundationElementDefinition & StartEndOptions;
+
+// @public
+export const textFieldTemplate: (context: ElementDefinitionContext, definition: TextFieldOptions) => ViewTemplate<TextField>;
 
 // @public
 export enum TextFieldType {
@@ -2074,7 +2102,10 @@ export interface Toolbar extends StartEnd, DelegatesARIAToolbar {
 }
 
 // @public
-export const toolbarTemplate: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ViewTemplate<Toolbar>;
+export type ToolbarOptions = FoundationElementDefinition & StartEndOptions;
+
+// @public
+export const toolbarTemplate: (context: ElementDefinitionContext, definition: ToolbarOptions) => ViewTemplate<Toolbar>;
 
 // @public
 export class Tooltip extends FoundationElement {
@@ -2188,7 +2219,7 @@ export interface TreeItem extends StartEnd {
 }
 
 // @public
-export type TreeItemOptions = FoundationElementDefinition & {
+export type TreeItemOptions = FoundationElementDefinition & StartEndOptions & {
     expandCollapseGlyph?: string | SyntheticViewTemplate;
 };
 

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -912,7 +912,10 @@ export type EndOptions = {
 };
 
 // @public
-export const endTemplate: (context: ElementDefinitionContext, definition: EndOptions) => ViewTemplate<StartEnd>;
+export const endSlotTemplate: (context: ElementDefinitionContext, definition: EndOptions) => ViewTemplate<StartEnd>;
+
+// @public @deprecated
+export const endTemplate: ViewTemplate<StartEnd>;
 
 // @public
 export interface Factory<T extends Constructable = any> {
@@ -1876,7 +1879,10 @@ export type StartOptions = {
 };
 
 // @public
-export const startTemplate: (context: ElementDefinitionContext, definition: StartOptions) => ViewTemplate<StartEnd>;
+export const startSlotTemplate: (context: ElementDefinitionContext, definition: StartOptions) => ViewTemplate<StartEnd>;
+
+// @public @deprecated
+export const startTemplate: ViewTemplate<StartEnd>;
 
 // @public
 export type StaticDesignTokenValue<T> = T extends Function ? never : T;

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -1,6 +1,6 @@
 import { html, ref } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import type { AccordionItem, AccordionItemOptions } from "./accordion-item";
 
@@ -38,8 +38,8 @@ export const accordionItemTemplate: (
                     <slot name="heading" part="heading"></slot>
                 </span>
             </button>
-            ${startTemplate(context, definition)}
-            ${endTemplate(context, definition)}
+            ${startSlotTemplate(context, definition)}
+            ${endSlotTemplate(context, definition)}
             <span class="icon" part="icon" aria-hidden="true">
                 <slot name="expanded-icon" part="expanded-icon">
                     ${definition.expandedIcon || ""}

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -38,8 +38,8 @@ export const accordionItemTemplate: (
                     <slot name="heading" part="heading"></slot>
                 </span>
             </button>
-            ${startTemplate}
-            ${endTemplate}
+            ${startTemplate(context, definition)}
+            ${endTemplate(context, definition)}
             <span class="icon" part="icon" aria-hidden="true">
                 <slot name="expanded-icon" part="expanded-icon">
                     ${definition.expandedIcon || ""}

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
@@ -4,17 +4,18 @@ import {
     SyntheticViewTemplate,
 } from "@microsoft/fast-element";
 import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
-import { StartEnd } from "../patterns/start-end";
+import { StartEnd, StartEndOptions } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 
 /**
  * Accordion Item configuration options
  * @public
  */
-export type AccordionItemOptions = FoundationElementDefinition & {
-    expandedIcon?: string | SyntheticViewTemplate;
-    collapsedIcon?: string | SyntheticViewTemplate;
-};
+export type AccordionItemOptions = FoundationElementDefinition &
+    StartEndOptions & {
+        expandedIcon?: string | SyntheticViewTemplate;
+        collapsedIcon?: string | SyntheticViewTemplate;
+    };
 
 /**
  * An individual item in an {@link @microsoft/fast-foundation#(Accordion:class) }.

--- a/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
@@ -1,6 +1,6 @@
 import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import type { Anchor, AnchorOptions } from "./anchor";
 
@@ -48,10 +48,10 @@ export const anchorTemplate: (
         aria-roledescription="${x => x.ariaRoledescription}"
         ${ref("control")}
     >
-        ${startTemplate(context, definition)}
+        ${startSlotTemplate(context, definition)}
         <span class="content" part="content">
             <slot ${slotted("defaultSlottedContent")}></slot>
         </span>
-        ${endTemplate(context, definition)}
+        ${endSlotTemplate(context, definition)}
     </a>
 `;

--- a/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
@@ -2,8 +2,7 @@ import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
-import type { FoundationElementDefinition } from "../foundation-element";
-import type { Anchor } from "./anchor";
+import type { Anchor, AnchorOptions } from "./anchor";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Anchor:class)} component.
@@ -11,10 +10,10 @@ import type { Anchor } from "./anchor";
  */
 export const anchorTemplate: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: AnchorOptions
 ) => ViewTemplate<Anchor> = (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: AnchorOptions
 ) => html`
     <a
         class="control"
@@ -49,10 +48,10 @@ export const anchorTemplate: (
         aria-roledescription="${x => x.ariaRoledescription}"
         ${ref("control")}
     >
-        ${startTemplate}
+        ${startTemplate(context, definition)}
         <span class="content" part="content">
             <slot ${slotted("defaultSlottedContent")}></slot>
         </span>
-        ${endTemplate}
+        ${endTemplate(context, definition)}
     </a>
 `;

--- a/packages/web-components/fast-foundation/src/anchor/anchor.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.ts
@@ -1,7 +1,17 @@
 import { attr, observable } from "@microsoft/fast-element";
-import { FoundationElement } from "../foundation-element";
-import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
+import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
+import {
+    ARIAGlobalStatesAndProperties,
+    StartEnd,
+    StartEndOptions,
+} from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
+
+/**
+ * Anchor configuration options
+ * @public
+ */
+export type AnchorOptions = FoundationElementDefinition & StartEndOptions;
 
 /**
  * An Anchor Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
@@ -26,9 +26,9 @@ export const breadcrumbItemTemplate: (
         ${when(
             x => !x.href,
             html<BreadcrumbItem>`
-                ${startTemplate}
+                ${startTemplate(context, definition)}
                 <slot></slot>
-                ${endTemplate}
+                ${endTemplate(context, definition)}
             `
         )}
         ${when(

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
@@ -1,7 +1,7 @@
 import { html, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { anchorTemplate } from "../anchor";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import type { BreadcrumbItem, BreadcrumbItemOptions } from "./breadcrumb-item";
 
@@ -26,9 +26,9 @@ export const breadcrumbItemTemplate: (
         ${when(
             x => !x.href,
             html<BreadcrumbItem>`
-                ${startTemplate(context, definition)}
+                ${startSlotTemplate(context, definition)}
                 <slot></slot>
-                ${endTemplate(context, definition)}
+                ${endSlotTemplate(context, definition)}
             `
         )}
         ${when(

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.ts
@@ -1,16 +1,17 @@
 import { observable, SyntheticViewTemplate } from "@microsoft/fast-element";
 import type { FoundationElementDefinition } from "../foundation-element";
 import { Anchor, DelegatesARIALink } from "../anchor";
-import { StartEnd } from "../patterns/index";
+import { StartEnd, StartEndOptions } from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
 
 /**
  * Breadcrumb Item configuration options
  * @public
  */
-export type BreadcrumbItemOptions = FoundationElementDefinition & {
-    separator?: string | SyntheticViewTemplate;
-};
+export type BreadcrumbItemOptions = FoundationElementDefinition &
+    StartEndOptions & {
+        separator?: string | SyntheticViewTemplate;
+    };
 
 /**
  * A Breadcrumb Item Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/button/button.template.ts
+++ b/packages/web-components/fast-foundation/src/button/button.template.ts
@@ -1,9 +1,8 @@
 import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import type { FoundationElementDefinition } from "../foundation-element";
 import type { ElementDefinitionContext } from "../design-system";
-import type { Button } from "./button";
+import type { Button, ButtonOptions } from "./button";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Button:class)} component.
@@ -11,10 +10,10 @@ import type { Button } from "./button";
  */
 export const buttonTemplate: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: ButtonOptions
 ) => ViewTemplate<Button> = (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: ButtonOptions
 ) => html`
     <button
         class="control"
@@ -53,10 +52,10 @@ export const buttonTemplate: (
         aria-roledescription="${x => x.ariaRoledescription}"
         ${ref("control")}
     >
-        ${startTemplate}
+        ${startTemplate(context, definition)}
         <span class="content" part="content">
             <slot ${slotted("defaultSlottedContent")}></slot>
         </span>
-        ${endTemplate}
+        ${endTemplate(context, definition)}
     </button>
 `;

--- a/packages/web-components/fast-foundation/src/button/button.template.ts
+++ b/packages/web-components/fast-foundation/src/button/button.template.ts
@@ -1,6 +1,6 @@
 import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import type { Button, ButtonOptions } from "./button";
 
@@ -52,10 +52,10 @@ export const buttonTemplate: (
         aria-roledescription="${x => x.ariaRoledescription}"
         ${ref("control")}
     >
-        ${startTemplate(context, definition)}
+        ${startSlotTemplate(context, definition)}
         <span class="content" part="content">
             <slot ${slotted("defaultSlottedContent")}></slot>
         </span>
-        ${endTemplate(context, definition)}
+        ${endSlotTemplate(context, definition)}
     </button>
 `;

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -1,7 +1,18 @@
 import { attr, observable } from "@microsoft/fast-element";
-import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
+import {
+    ARIAGlobalStatesAndProperties,
+    StartEnd,
+    StartEndOptions,
+} from "../patterns/index";
 import { applyMixins } from "../utilities/apply-mixins";
+import type { FoundationElementDefinition } from "../foundation-element";
 import { FormAssociatedButton } from "./button.form-associated";
+
+/**
+ * Button configuration options
+ * @public
+ */
+export type ButtonOptions = FoundationElementDefinition & StartEndOptions;
 
 /**
  * A Button Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -26,7 +26,7 @@ export const comboboxTemplate: (
         @focusout="${(x, c) => x.focusoutHandler(c.event as FocusEvent)}"
     >
         <div class="control" part="control">
-            ${startTemplate}
+            ${startTemplate(context, definition)}
             <slot name="control">
                 <input
                     class="selected-value"
@@ -52,7 +52,7 @@ export const comboboxTemplate: (
                     </slot>
                 </div>
             </slot>
-            ${endTemplate}
+            ${endTemplate(context, definition)}
         </div>
         <div
             aria-disabled="${x => x.disabled}"

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -1,7 +1,7 @@
 import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { Listbox } from "../listbox/listbox";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import type { Combobox, ComboboxOptions } from "./combobox";
 
@@ -26,7 +26,7 @@ export const comboboxTemplate: (
         @focusout="${(x, c) => x.focusoutHandler(c.event as FocusEvent)}"
     >
         <div class="control" part="control">
-            ${startTemplate(context, definition)}
+            ${startSlotTemplate(context, definition)}
             <slot name="control">
                 <input
                     class="selected-value"
@@ -52,7 +52,7 @@ export const comboboxTemplate: (
                     </slot>
                 </div>
             </slot>
-            ${endTemplate(context, definition)}
+            ${endSlotTemplate(context, definition)}
         </div>
         <div
             aria-disabled="${x => x.disabled}"

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -8,7 +8,7 @@ import { limit } from "@microsoft/fast-web-utilities";
 import uniqueId from "lodash-es/uniqueId";
 import type { ListboxOption } from "../listbox-option/listbox-option";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
-import { StartEnd } from "../patterns/start-end";
+import { StartEnd, StartEndOptions } from "../patterns/start-end";
 import { SelectPosition, SelectRole } from "../select/select.options";
 import { applyMixins } from "../utilities/apply-mixins";
 import type { FoundationElementDefinition } from "../foundation-element";
@@ -19,9 +19,10 @@ import { ComboboxAutocomplete } from "./combobox.options";
  * Combobox configuration options
  * @public
  */
-export type ComboboxOptions = FoundationElementDefinition & {
-    indicator?: string | SyntheticViewTemplate;
-};
+export type ComboboxOptions = FoundationElementDefinition &
+    StartEndOptions & {
+        indicator?: string | SyntheticViewTemplate;
+    };
 
 /**
  * A Combobox Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
@@ -7,7 +7,7 @@ import {
     when,
 } from "@microsoft/fast-element";
 import type { FoundationElementTemplate } from "../foundation-element";
-import { endTemplate, startTemplate } from "../patterns";
+import { endSlotTemplate, startSlotTemplate } from "../patterns";
 import type { HorizontalScroll, HorizontalScrollOptions } from "./horizontal-scroll";
 
 /**
@@ -21,7 +21,7 @@ export const horizontalScrollTemplate: FoundationElementTemplate<
         class="horizontal-scroll"
         @keyup="${(x, c) => x.keyupHandler(c.event as KeyboardEvent)}"
     >
-        ${startTemplate(context, definition)}
+        ${startSlotTemplate(context, definition)}
         <div class="scroll-area">
             <div
                 class="scroll-view"
@@ -69,6 +69,6 @@ export const horizontalScrollTemplate: FoundationElementTemplate<
                 `
             )}
         </div>
-        ${endTemplate(context, definition)}
+        ${endSlotTemplate(context, definition)}
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
@@ -21,7 +21,7 @@ export const horizontalScrollTemplate: FoundationElementTemplate<
         class="horizontal-scroll"
         @keyup="${(x, c) => x.keyupHandler(c.event as KeyboardEvent)}"
     >
-        ${startTemplate}
+        ${startTemplate(context, definition)}
         <div class="scroll-area">
             <div
                 class="scroll-view"
@@ -69,6 +69,6 @@ export const horizontalScrollTemplate: FoundationElementTemplate<
                 `
             )}
         </div>
-        ${endTemplate}
+        ${endTemplate(context, definition)}
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -18,6 +18,7 @@ import type {
     FoundationElementTemplate,
 } from "../foundation-element";
 import { FoundationElement } from "../foundation-element";
+import type { StartEndOptions } from "../patterns";
 
 declare global {
     interface WindowWithResizeObserver extends Window {
@@ -41,22 +42,23 @@ export type ScrollEasing = "linear" | "ease-in" | "ease-out" | "ease-in-out";
  * Horizontal scroll configuration options
  * @public
  */
-export type HorizontalScrollOptions = FoundationElementDefinition & {
-    nextFlipper?:
-        | FoundationElementTemplate<
-              SyntheticViewTemplate<any, HorizontalScroll>,
-              HorizontalScrollOptions
-          >
-        | SyntheticViewTemplate
-        | string;
-    previousFlipper?:
-        | FoundationElementTemplate<
-              SyntheticViewTemplate<any, HorizontalScroll>,
-              HorizontalScrollOptions
-          >
-        | SyntheticViewTemplate
-        | string;
-};
+export type HorizontalScrollOptions = FoundationElementDefinition &
+    StartEndOptions & {
+        nextFlipper?:
+            | FoundationElementTemplate<
+                  SyntheticViewTemplate<any, HorizontalScroll>,
+                  HorizontalScrollOptions
+              >
+            | SyntheticViewTemplate
+            | string;
+        previousFlipper?:
+            | FoundationElementTemplate<
+                  SyntheticViewTemplate<any, HorizontalScroll>,
+                  HorizontalScrollOptions
+              >
+            | SyntheticViewTemplate
+            | string;
+    };
 
 /**
  * A HorizontalScroll Custom HTML Element

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
@@ -1,6 +1,6 @@
 import { html } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import type { ListboxOption, ListboxOptionOptions } from "./listbox-option";
 
@@ -21,10 +21,10 @@ export const listboxOptionTemplate: (
             x.disabled ? "disabled" : ""}"
         role="option"
     >
-        ${startTemplate(context, definition)}
+        ${startSlotTemplate(context, definition)}
         <span class="content" part="content">
             <slot></slot>
         </span>
-        ${endTemplate(context, definition)}
+        ${endSlotTemplate(context, definition)}
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
@@ -1,9 +1,8 @@
 import { html } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import type { FoundationElementDefinition } from "../foundation-element";
 import type { ElementDefinitionContext } from "../design-system";
-import type { ListboxOption } from "./listbox-option";
+import type { ListboxOption, ListboxOptionOptions } from "./listbox-option";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(ListboxOption:class)} component.
@@ -11,10 +10,10 @@ import type { ListboxOption } from "./listbox-option";
  */
 export const listboxOptionTemplate: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: ListboxOptionOptions
 ) => ViewTemplate<ListboxOption> = (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: ListboxOptionOptions
 ) => html`
     <template
         aria-selected="${x => x.selected}"
@@ -22,10 +21,10 @@ export const listboxOptionTemplate: (
             x.disabled ? "disabled" : ""}"
         role="option"
     >
-        ${startTemplate}
+        ${startTemplate(context, definition)}
         <span class="content" part="content">
             <slot></slot>
         </span>
-        ${endTemplate}
+        ${endTemplate(context, definition)}
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
@@ -1,8 +1,14 @@
 import { attr, observable, Observable } from "@microsoft/fast-element";
 import { isHTMLElement } from "@microsoft/fast-web-utilities";
-import { StartEnd } from "../patterns/start-end";
+import { StartEnd, StartEndOptions } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
-import { FoundationElement } from "../foundation-element";
+import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
+
+/**
+ * Listbox option configuration options
+ * @public
+ */
+export type ListboxOptionOptions = FoundationElementDefinition & StartEndOptions;
 
 /**
  * Determines if the element is a {@link (ListboxOption:class)}

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -57,11 +57,11 @@ export const menuItemTemplate: (
                 `
             )}
         </div>
-        ${startTemplate}
+        ${startTemplate(context, definition)}
         <span class="content" part="content">
             <slot></slot>
         </span>
-        ${endTemplate}
+        ${endTemplate(context, definition)}
         ${when(
             x => x.hasSubmenu,
             html<MenuItem>`

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -1,7 +1,7 @@
 import { html, ref, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { AnchoredRegion } from "../anchored-region";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import { MenuItemRole } from "./menu-item";
 import type { MenuItem, MenuItemOptions } from "./menu-item";
@@ -57,11 +57,11 @@ export const menuItemTemplate: (
                 `
             )}
         </div>
-        ${startTemplate(context, definition)}
+        ${startSlotTemplate(context, definition)}
         <span class="content" part="content">
             <slot></slot>
         </span>
-        ${endTemplate(context, definition)}
+        ${endSlotTemplate(context, definition)}
         ${when(
             x => x.hasSubmenu,
             html<MenuItem>`

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -9,7 +9,7 @@ import {
 import type { AnchoredRegion } from "../anchored-region";
 import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
 import type { Menu } from "../menu/menu";
-import { StartEnd } from "../patterns/start-end";
+import { StartEnd, StartEndOptions } from "../patterns/start-end";
 import { getDirection } from "../utilities/";
 import { applyMixins } from "../utilities/apply-mixins";
 import { MenuItemRole } from "./menu-item.options";
@@ -26,11 +26,12 @@ export type MenuItemColumnCount = 0 | 1 | 2;
  * Menu Item configuration options
  * @public
  */
-export type MenuItemOptions = FoundationElementDefinition & {
-    checkboxIndicator?: string | SyntheticViewTemplate;
-    expandCollapseGlyph?: string | SyntheticViewTemplate;
-    radioIndicator?: string | SyntheticViewTemplate;
-};
+export type MenuItemOptions = FoundationElementDefinition &
+    StartEndOptions & {
+        checkboxIndicator?: string | SyntheticViewTemplate;
+        expandCollapseGlyph?: string | SyntheticViewTemplate;
+        radioIndicator?: string | SyntheticViewTemplate;
+    };
 
 /**
  * A Switch Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
@@ -1,6 +1,6 @@
 import { html, ref, slotted, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "../patterns";
+import { endSlotTemplate, startSlotTemplate } from "../patterns";
 import type { ElementDefinitionContext } from "../design-system";
 import type { NumberField, NumberFieldOptions } from "./number-field";
 
@@ -27,7 +27,7 @@ export const numberFieldTemplate: (
             <slot ${slotted("defaultSlottedNodes")}></slot>
         </label>
         <div class="root" part="root">
-            ${startTemplate(context, definition)}
+            ${startSlotTemplate(context, definition)}
             <input
                 class="control"
                 part="control"
@@ -92,7 +92,7 @@ export const numberFieldTemplate: (
                     </div>
                 `
             )}
-            ${endTemplate(context, definition)}
+            ${endSlotTemplate(context, definition)}
         </div>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
@@ -27,7 +27,7 @@ export const numberFieldTemplate: (
             <slot ${slotted("defaultSlottedNodes")}></slot>
         </label>
         <div class="root" part="root">
-            ${startTemplate}
+            ${startTemplate(context, definition)}
             <input
                 class="control"
                 part="control"
@@ -92,7 +92,7 @@ export const numberFieldTemplate: (
                     </div>
                 `
             )}
-            ${endTemplate}
+            ${endTemplate(context, definition)}
         </div>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -6,7 +6,7 @@ import {
     SyntheticViewTemplate,
 } from "@microsoft/fast-element";
 import { keyArrowDown, keyArrowUp } from "@microsoft/fast-web-utilities";
-import { StartEnd } from "../patterns/index";
+import { StartEnd, StartEndOptions } from "../patterns/index";
 import { applyMixins } from "../utilities/index";
 import type { FoundationElementDefinition } from "../foundation-element";
 import { DelegatesARIATextbox } from "../text-field/index";
@@ -16,10 +16,11 @@ import { FormAssociatedNumberField } from "./number-field.form-associated";
  * Number Field configuration options
  * @public
  */
-export type NumberFieldOptions = FoundationElementDefinition & {
-    stepDownGlyph?: string | SyntheticViewTemplate;
-    stepUpGlyph?: string | SyntheticViewTemplate;
-};
+export type NumberFieldOptions = FoundationElementDefinition &
+    StartEndOptions & {
+        stepDownGlyph?: string | SyntheticViewTemplate;
+        stepUpGlyph?: string | SyntheticViewTemplate;
+    };
 
 /**
  * A Number Field Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/patterns/start-end.ts
+++ b/packages/web-components/fast-foundation/src/patterns/start-end.ts
@@ -54,11 +54,18 @@ export class StartEnd {
  */
 export const endTemplate: (
     context: ElementDefinitionContext,
-    definition: StartOptions
-) => ViewTemplate<StartEnd> = (context: ElementDefinitionContext, definition) => html`
-    <span part="end" ${ref("endContainer")}>
+    definition: EndOptions
+) => ViewTemplate<StartEnd> = (
+    context: ElementDefinitionContext,
+    definition: EndOptions
+) => html`
+    <span
+        part="end"
+        ${ref("endContainer")}
+        class=${x => (definition.end ? "end" : void 0)}
+    >
         <slot name="end" ${ref("end")} @slotchange="${x => x.handleEndContentChange()}">
-            ${definition.start || ""}
+            ${definition.end || ""}
         </slot>
     </span>
 `;
@@ -71,18 +78,22 @@ export const endTemplate: (
  */
 export const startTemplate: (
     context: ElementDefinitionContext,
-    definition: EndOptions
+    definition: StartOptions
 ) => ViewTemplate<StartEnd> = (
     context: ElementDefinitionContext,
-    definition: EndOptions
+    definition: StartOptions
 ) => html`
-    <span part="start" ${ref("startContainer")}>
+    <span
+        part="start"
+        ${ref("startContainer")}
+        class="${x => (definition.start ? "start" : void 0)}"
+    >
         <slot
             name="start"
             ${ref("start")}
             @slotchange="${x => x.handleStartContentChange()}"
         >
-            ${definition.end || ""}
+            ${definition.start || ""}
         </slot>
     </span>
 `;

--- a/packages/web-components/fast-foundation/src/patterns/start-end.ts
+++ b/packages/web-components/fast-foundation/src/patterns/start-end.ts
@@ -52,7 +52,7 @@ export class StartEnd {
  *
  * @public
  */
-export const endTemplate: (
+export const endSlotTemplate: (
     context: ElementDefinitionContext,
     definition: EndOptions
 ) => ViewTemplate<StartEnd> = (
@@ -76,7 +76,7 @@ export const endTemplate: (
  *
  * @public
  */
-export const startTemplate: (
+export const startSlotTemplate: (
     context: ElementDefinitionContext,
     definition: StartOptions
 ) => ViewTemplate<StartEnd> = (
@@ -95,5 +95,39 @@ export const startTemplate: (
         >
             ${definition.start || ""}
         </slot>
+    </span>
+`;
+
+/**
+ * The template for the end element.
+ * For use with {@link StartEnd}
+ *
+ * @public
+ * @deprecated - use endSlotTemplate
+ */
+export const endTemplate: ViewTemplate<StartEnd> = html`
+    <span part="end" ${ref("endContainer")}>
+        <slot
+            name="end"
+            ${ref("end")}
+            @slotchange="${x => x.handleEndContentChange()}"
+        ></slot>
+    </span>
+`;
+
+/**
+ * The template for the start element.
+ * For use with {@link StartEnd}
+ *
+ * @public
+ * @deprecated - use startSlotTemplate
+ */
+export const startTemplate: ViewTemplate<StartEnd> = html`
+    <span part="start" ${ref("startContainer")}>
+        <slot
+            name="start"
+            ${ref("start")}
+            @slotchange="${x => x.handleStartContentChange()}"
+        ></slot>
     </span>
 `;

--- a/packages/web-components/fast-foundation/src/patterns/start-end.ts
+++ b/packages/web-components/fast-foundation/src/patterns/start-end.ts
@@ -1,5 +1,28 @@
-import { html, ref } from "@microsoft/fast-element";
+import { html, ref, SyntheticViewTemplate } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
+import type { ElementDefinitionContext } from "../design-system";
+
+/**
+ * Start configuration options
+ * @public
+ */
+export type StartOptions = {
+    start?: string | SyntheticViewTemplate;
+};
+
+/**
+ * End configuration options
+ * @public
+ */
+export type EndOptions = {
+    end?: string | SyntheticViewTemplate;
+};
+
+/**
+ * Start/End configuration options
+ * @public
+ */
+export type StartEndOptions = StartOptions & EndOptions;
 
 /**
  * A mixin class implementing start and end elements.
@@ -29,13 +52,14 @@ export class StartEnd {
  *
  * @public
  */
-export const endTemplate: ViewTemplate<StartEnd> = html`
+export const endTemplate: (
+    context: ElementDefinitionContext,
+    definition: StartOptions
+) => ViewTemplate<StartEnd> = (context: ElementDefinitionContext, definition) => html`
     <span part="end" ${ref("endContainer")}>
-        <slot
-            name="end"
-            ${ref("end")}
-            @slotchange="${x => x.handleEndContentChange()}"
-        ></slot>
+        <slot name="end" ${ref("end")} @slotchange="${x => x.handleEndContentChange()}">
+            ${definition.start || ""}
+        </slot>
     </span>
 `;
 
@@ -45,12 +69,20 @@ export const endTemplate: ViewTemplate<StartEnd> = html`
  *
  * @public
  */
-export const startTemplate: ViewTemplate<StartEnd> = html`
+export const startTemplate: (
+    context: ElementDefinitionContext,
+    definition: EndOptions
+) => ViewTemplate<StartEnd> = (
+    context: ElementDefinitionContext,
+    definition: EndOptions
+) => html`
     <span part="start" ${ref("startContainer")}>
         <slot
             name="start"
             ${ref("start")}
             @slotchange="${x => x.handleStartContentChange()}"
-        ></slot>
+        >
+            ${definition.end || ""}
+        </slot>
     </span>
 `;

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -1,7 +1,7 @@
 import { html, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { Listbox } from "../listbox/listbox";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import type { Select, SelectOptions } from "./select";
 
@@ -37,7 +37,7 @@ export const selectTemplate: (
             role="button"
             ?disabled="${x => x.disabled}"
         >
-            ${startTemplate(context, definition)}
+            ${startSlotTemplate(context, definition)}
             <slot name="button-container">
                 <div class="selected-value" part="selected-value">
                     <slot name="selected-value">${x => x.displayValue}</slot>
@@ -48,7 +48,7 @@ export const selectTemplate: (
                     </slot>
                 </div>
             </slot>
-            ${endTemplate(context, definition)}
+            ${endSlotTemplate(context, definition)}
         </div>
         <div
             aria-disabled="${x => x.disabled}"

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -37,7 +37,7 @@ export const selectTemplate: (
             role="button"
             ?disabled="${x => x.disabled}"
         >
-            ${startTemplate}
+            ${startTemplate(context, definition)}
             <slot name="button-container">
                 <div class="selected-value" part="selected-value">
                     <slot name="selected-value">${x => x.displayValue}</slot>
@@ -48,7 +48,7 @@ export const selectTemplate: (
                     </slot>
                 </div>
             </slot>
-            ${endTemplate}
+            ${endTemplate(context, definition)}
         </div>
         <div
             aria-disabled="${x => x.disabled}"

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -7,7 +7,7 @@ import {
 import type { FoundationElementDefinition } from "../foundation-element";
 import type { ListboxOption } from "../listbox-option/listbox-option";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
-import { StartEnd } from "../patterns/start-end";
+import { StartEnd, StartEndOptions } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 import { FormAssociatedSelect } from "./select.form-associated";
 import { SelectPosition, SelectRole } from "./select.options";
@@ -16,9 +16,10 @@ import { SelectPosition, SelectRole } from "./select.options";
  * Select configuration options
  * @public
  */
-export type SelectOptions = FoundationElementDefinition & {
-    indicator?: string | SyntheticViewTemplate;
-};
+export type SelectOptions = FoundationElementDefinition &
+    StartEndOptions & {
+        indicator?: string | SyntheticViewTemplate;
+    };
 
 /**
  * A Select Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
@@ -1,9 +1,8 @@
 import { html, ref, slotted, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end";
-import type { FoundationElementDefinition } from "../foundation-element";
 import type { ElementDefinitionContext } from "../design-system";
-import type { Tabs } from "./tabs";
+import type { Tabs, TabsOptions } from "./tabs";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Tabs:class)} component.
@@ -11,13 +10,13 @@ import type { Tabs } from "./tabs";
  */
 export const tabsTemplate: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: TabsOptions
 ) => ViewTemplate<Tabs> = (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: TabsOptions
 ) => html`
     <template class="${x => x.orientation}">
-        ${startTemplate}
+        ${startTemplate(context, definition)}
         <div class="tablist" part="tablist" role="tablist">
             <slot class="tab" name="tab" part="tab" ${slotted("tabs")}></slot>
 
@@ -32,7 +31,7 @@ export const tabsTemplate: (
                 `
             )}
         </div>
-        ${endTemplate}
+        ${endTemplate(context, definition)}
         <div class="tabpanel">
             <slot name="tabpanel" part="tabpanel" ${slotted("tabpanels")}></slot>
         </div>

--- a/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
@@ -1,6 +1,6 @@
 import { html, ref, slotted, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import type { Tabs, TabsOptions } from "./tabs";
 
@@ -16,7 +16,7 @@ export const tabsTemplate: (
     definition: TabsOptions
 ) => html`
     <template class="${x => x.orientation}">
-        ${startTemplate(context, definition)}
+        ${startSlotTemplate(context, definition)}
         <div class="tablist" part="tablist" role="tablist">
             <slot class="tab" name="tab" part="tab" ${slotted("tabs")}></slot>
 
@@ -31,7 +31,7 @@ export const tabsTemplate: (
                 `
             )}
         </div>
-        ${endTemplate(context, definition)}
+        ${endSlotTemplate(context, definition)}
         <div class="tabpanel">
             <slot name="tabpanel" part="tabpanel" ${slotted("tabpanels")}></slot>
         </div>

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -8,9 +8,15 @@ import {
     keyCodeHome,
     wrapInBounds,
 } from "@microsoft/fast-web-utilities";
-import { StartEnd } from "../patterns/start-end";
+import { StartEnd, StartEndOptions } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
-import { FoundationElement } from "../foundation-element";
+import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
+
+/**
+ * Tabs option configuration options
+ * @public
+ */
+export type TabsOptions = FoundationElementDefinition & StartEndOptions;
 
 /**
  * The orientation of the {@link @microsoft/fast-foundation#(Tabs:class)} component

--- a/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
@@ -2,9 +2,8 @@ import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns";
 import { whitespaceFilter } from "../utilities";
-import type { FoundationElementDefinition } from "../foundation-element";
 import type { ElementDefinitionContext } from "../design-system";
-import type { TextField } from "./text-field";
+import type { TextField, TextFieldOptions } from "./text-field";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(TextField:class)} component.
@@ -12,10 +11,10 @@ import type { TextField } from "./text-field";
  */
 export const textFieldTemplate: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: TextFieldOptions
 ) => ViewTemplate<TextField> = (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: TextFieldOptions
 ) => html`
     <template
         class="
@@ -35,7 +34,7 @@ export const textFieldTemplate: (
             ></slot>
         </label>
         <div class="root" part="root">
-            ${startTemplate}
+            ${startTemplate(context, definition)}
             <input
                 class="control"
                 part="control"
@@ -76,7 +75,7 @@ export const textFieldTemplate: (
                 aria-roledescription="${x => x.ariaRoledescription}"
                 ${ref("control")}
             />
-            ${endTemplate}
+            ${endTemplate(context, definition)}
         </div>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
@@ -1,6 +1,6 @@
 import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "../patterns";
+import { endSlotTemplate, startSlotTemplate } from "../patterns";
 import { whitespaceFilter } from "../utilities";
 import type { ElementDefinitionContext } from "../design-system";
 import type { TextField, TextFieldOptions } from "./text-field";
@@ -34,7 +34,7 @@ export const textFieldTemplate: (
             ></slot>
         </label>
         <div class="root" part="root">
-            ${startTemplate(context, definition)}
+            ${startSlotTemplate(context, definition)}
             <input
                 class="control"
                 part="control"
@@ -75,7 +75,7 @@ export const textFieldTemplate: (
                 aria-roledescription="${x => x.ariaRoledescription}"
                 ${ref("control")}
             />
-            ${endTemplate(context, definition)}
+            ${endSlotTemplate(context, definition)}
         </div>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -1,10 +1,21 @@
 import { attr, DOM, nullableNumberConverter, observable } from "@microsoft/fast-element";
-import { ARIAGlobalStatesAndProperties, StartEnd } from "../patterns/index";
+import {
+    ARIAGlobalStatesAndProperties,
+    StartEnd,
+    StartEndOptions,
+} from "../patterns/index";
 import { applyMixins } from "../utilities/index";
+import type { FoundationElementDefinition } from "../foundation-element";
 import { FormAssociatedTextField } from "./text-field.form-associated";
 import { TextFieldType } from "./text-field.options";
 
 export { TextFieldType };
+
+/**
+ * Text field configuration options
+ * @public
+ */
+export type TextFieldOptions = FoundationElementDefinition & StartEndOptions;
 
 /**
  * A Text Field Custom HTML Element.

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.template.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.template.ts
@@ -1,9 +1,8 @@
 import { elements, html, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import type { FoundationElementDefinition } from "../foundation-element";
 import type { ElementDefinitionContext } from "../design-system";
 import { endTemplate, startTemplate } from "../patterns";
-import type { Toolbar } from "./toolbar";
+import type { Toolbar, ToolbarOptions } from "./toolbar";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Toolbar:class)} component.
@@ -12,10 +11,10 @@ import type { Toolbar } from "./toolbar";
  */
 export const toolbarTemplate: (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: ToolbarOptions
 ) => ViewTemplate<Toolbar> = (
     context: ElementDefinitionContext,
-    definition: FoundationElementDefinition
+    definition: ToolbarOptions
 ) => html`
     <template
         aria-label="${x => x.ariaLabel}"
@@ -29,14 +28,14 @@ export const toolbarTemplate: (
     >
         <slot name="label"></slot>
         <div class="positioning-region" part="positioning-region">
-            ${startTemplate}
+            ${startTemplate(context, definition)}
             <slot
                 ${slotted({
                     filter: elements(),
                     property: "slottedItems",
                 })}
             ></slot>
-            ${endTemplate}
+            ${endTemplate(context, definition)}
         </div>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.template.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.template.ts
@@ -1,7 +1,7 @@
 import { elements, html, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import type { ElementDefinitionContext } from "../design-system";
-import { endTemplate, startTemplate } from "../patterns";
+import { endSlotTemplate, startSlotTemplate } from "../patterns";
 import type { Toolbar, ToolbarOptions } from "./toolbar";
 
 /**
@@ -28,14 +28,14 @@ export const toolbarTemplate: (
     >
         <slot name="label"></slot>
         <div class="positioning-region" part="positioning-region">
-            ${startTemplate(context, definition)}
+            ${startSlotTemplate(context, definition)}
             <slot
                 ${slotted({
                     filter: elements(),
                     property: "slottedItems",
                 })}
             ></slot>
-            ${endTemplate(context, definition)}
+            ${endSlotTemplate(context, definition)}
         </div>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
@@ -1,11 +1,17 @@
 import { attr, FASTElement, observable, Observable } from "@microsoft/fast-element";
 import { ArrowKeys, Direction, limit, Orientation } from "@microsoft/fast-web-utilities";
 import { isFocusable } from "tabbable";
-import { FoundationElement } from "../foundation-element";
+import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
-import { StartEnd } from "../patterns/start-end";
+import { StartEnd, StartEndOptions } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 import { getDirection } from "../utilities/direction";
+
+/**
+ * Toolbar configuration options
+ * @public
+ */
+export type ToolbarOptions = FoundationElementDefinition & StartEndOptions;
 
 /**
  * A map for directionality derived from keyboard input strings,

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -1,6 +1,6 @@
 import { children, elements, html, ref, slotted, when } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "../patterns/start-end";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
 import type { ElementDefinitionContext } from "../design-system";
 import type { TreeItem, TreeItemOptions } from "./tree-item";
 
@@ -52,9 +52,9 @@ export const treeItemTemplate: (
                         </div>
                     `
                 )}
-                ${startTemplate(context, definition)}
+                ${startSlotTemplate(context, definition)}
                 <slot></slot>
-                ${endTemplate(context, definition)}
+                ${endSlotTemplate(context, definition)}
             </div>
         </div>
         ${when(

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -52,9 +52,9 @@ export const treeItemTemplate: (
                         </div>
                     `
                 )}
-                ${startTemplate}
+                ${startTemplate(context, definition)}
                 <slot></slot>
-                ${endTemplate}
+                ${endTemplate(context, definition)}
             </div>
         </div>
         ${when(

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -14,7 +14,7 @@ import {
     keyCodeArrowUp,
     keyCodeEnter,
 } from "@microsoft/fast-web-utilities";
-import { StartEnd } from "../patterns/start-end";
+import { StartEnd, StartEndOptions } from "../patterns/start-end";
 import type { TreeView } from "../tree-view";
 import { applyMixins } from "../utilities/apply-mixins";
 import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
@@ -33,9 +33,10 @@ export function isTreeItemElement(el: Element): el is HTMLElement {
  * Tree Item configuration options
  * @public
  */
-export type TreeItemOptions = FoundationElementDefinition & {
-    expandCollapseGlyph?: string | SyntheticViewTemplate;
-};
+export type TreeItemOptions = FoundationElementDefinition &
+    StartEndOptions & {
+        expandCollapseGlyph?: string | SyntheticViewTemplate;
+    };
 
 /**
  * A Tree item Custom HTML Element.

--- a/yarn.lock
+++ b/yarn.lock
@@ -13947,7 +13947,7 @@ jss@^9.8.0, jss@^9.8.7:
     array-includes "^3.1.2"
     object.assign "^4.1.2"
 
-jszip@^3.5.0:
+jszip@^3.1.3:
   version "3.7.1"
   resolved "https://registry.yarnpkg.com/jszip/-/jszip-3.7.1.tgz#bd63401221c15625a1228c556ca8a68da6fda3d9"
   integrity sha512-ghL0tz1XG9ZEmRMcEN2vt7xabrDdqHHeykgARpmZ0BiIctWxM47Vt63ZO2dnp4QYt/xJVLLy5Zv1l/xRdh2byg==


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR adds support for adding default slotted content to start/end slots where supported. To enable this we did need to add new types for certain control options.

The original templates have been marked as deprecated and the new templates have been named to specify they are *slot* templates. All components have been updated to use the new templates.

Closes #5116 

### 🎫 Issues
When providing default slotted content to start/end the assignedNodes() array is empty so to accommodate this I've done an initial pass to set the `start` class by default if the definition exists. From my testing, the slotchange will still fire and remove if necessary.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
<s>The change to the template as a function to support definition is *breaking*. To offset this, we could update the template name and use it internally within our components while maintaining the existing start and end templates until the next major version where they can be removed. Thoughts welcome here on how to best support both.</s>