### PR TITLE
feat: allow an autocomplete in the form to use an alias

### DIFF
--- a/packages/tooling/fast-tooling-react/README.md
+++ b/packages/tooling/fast-tooling-react/README.md
@@ -21,13 +21,13 @@ The tooling available in FAST Tooling React can be used together to create UI fo
         - [Disabled](#disabled)
         - [Examples & default](#examples-&-default)
         - [Badges](#badges)
+        - [Alias](#alias)
         - [Dictionaries](#dictionaries)
     - [Categories](#categories)
     - [JSON schema keywords](#json-schema-keywords)
         - [oneOf & anyOf](#oneof-&-anyof)
         - [Enums](#enums)
         - [allOf & $ref](#allof-&-ref)
-    - [Categories](#categories)
 - [Navigation](#navigation)
     - [Include data types](#include-data-types)
 - [Navigation Menu](#navigation-menu)
@@ -466,6 +466,10 @@ Example:
     "badgeDescription": "Setting this field will cause adverse effects"
 }
 ```
+
+#### Alias
+
+Occasionally the `title` provided by the JSON schema may not be enough information for the `Form` component, if an additional `alias` property is provided, this will be used as the linked data control label. In Chromium based browsers this will show both, and both the `title` text and `alias` text will autocomplete. In Firefox however, this will result in only showing the `alias`, so ensure that the `alias` text contains enough information to be easily autocompleted by a user.
 
 #### Dictionaries
 

--- a/packages/tooling/fast-tooling-react/src/__tests__/schemas/children.schema.ts
+++ b/packages/tooling/fast-tooling-react/src/__tests__/schemas/children.schema.ts
@@ -3,6 +3,7 @@ import { linkedDataSchema } from "@microsoft/fast-tooling";
 export default {
     $schema: "http://json-schema.org/schema#",
     title: "Component with children",
+    alias: "With Children",
     description: "A test component's schema definition.",
     type: "object",
     id: "children",

--- a/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
+++ b/packages/tooling/fast-tooling-react/src/form/controls/control.linked-data.tsx
@@ -89,7 +89,13 @@ class LinkedDataControl extends React.Component<
     private renderFilteredLinkedDataOptions(): React.ReactNode {
         return Object.entries(this.props.schemaDictionary).map(
             ([key, value]: [string, any]): React.ReactNode => {
-                return <option key={key} value={value.title} />;
+                return (
+                    <option
+                        key={key}
+                        value={value.title}
+                        label={typeof value.alias === "string" ? value.alias : void 0}
+                    />
+                );
             }
         );
     }

--- a/sites/site-utilities/src/schemas/definition-mapper.ts
+++ b/sites/site-utilities/src/schemas/definition-mapper.ts
@@ -16,6 +16,23 @@ const fastComponentExtendedSchemas: { [key: string]: any } = {};
 const fluentUIComponentExtendedSchemas: { [key: string]: any } = {};
 const nativeElementExtendedSchemas: { [key: string]: any } = {};
 
+const headingAlias: string = "Heading level";
+const alias: { [key: string]: string } = {
+    h1: `${headingAlias} 1`,
+    h2: `${headingAlias} 2`,
+    h3: `${headingAlias} 3`,
+    h4: `${headingAlias} 4`,
+    h5: `${headingAlias} 5`,
+    h6: `${headingAlias} 6`,
+    p: "Paragraph",
+    hr: "Thematic Break (Horizontal Rule)",
+    ol: "Ordered list",
+    ul: "Unordered list",
+    li: "List item",
+    div: "Container",
+    a: "Hyperlink",
+};
+
 function mapToJSONSchemas(
     definitions: { [key: string]: WebComponentDefinition },
     schemas: { [key: string]: any },
@@ -26,7 +43,14 @@ function mapToJSONSchemas(
             mapWebComponentDefinitionToJSONSchema(definition).forEach(
                 (definitionTagItem: any) => {
                     const jsonSchema = definitionTagItem;
-                    schemas[jsonSchema.$id] = jsonSchema;
+                    schemas[jsonSchema.$id] = {
+                        ...jsonSchema,
+                        ...(alias[jsonSchema.$id]
+                            ? {
+                                  alias: alias[jsonSchema.$id],
+                              }
+                            : {}),
+                    };
 
                     if (libraryName) {
                         schemas[jsonSchema.$id].title = `${


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change adds an `alias` property as an option when scanning JSON schema. This will allow linked data to show additional information in the linked data control and allow aliases to autocomplete text that is typed by a user.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Resolves #5134

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Read through the documentation addition for the README.md and ensure that it makes sense, also build the project and run the Creator to see the changes. You should be able to type "image" to bring up the "img" element.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Unit test added.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.