### PR TITLE
Explain DesignToken does not work with volatile bindings

### DIFF
--- a/change/@microsoft-fast-foundation-7ce173bf-8b3d-421d-b51c-5d8decc92f9c.json
+++ b/change/@microsoft-fast-foundation-7ce173bf-8b3d-421d-b51c-5d8decc92f9c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "force non-volatile binding and update docs to explain that DesignToken does not support volatile bindings",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -361,7 +361,7 @@ class DesignTokenBindingObserver<T> {
         public readonly token: DesignTokenImpl<T>,
         public readonly node: DesignTokenNode
     ) {
-        this.observer = Observable.binding(source, this);
+        this.observer = Observable.binding(source, this, false);
 
         // This is a little bit hacky because it's using internal APIs of BindingObserverImpl.
         // BindingObserverImpl queues updates to batch it's notifications which doesn't work for this

--- a/sites/website/src/docs/design-systems/design-tokens.md
+++ b/sites/website/src/docs/design-systems/design-tokens.md
@@ -205,7 +205,8 @@ specialColor.setValueFor(target, () => themeManager.theme === "blue" ? "#0000FF"
 themeManager.theme = "red"; // Forces the derived tokens to re-evaluate and CSS custom properties to update if applicable
 ```
 
-
+> Note: *volatile* token values that conditionally access DesignTokens or other observable properties are currently not supported by DesignToken. If you need to use conditionals,
+ensure all DesignTokens or observable properties are accessed outside of conditional blocks. See (Observables and State)[/docs/fast-element/observables-and-state#observable-features] for more information.
 ## Aliasing Design Tokens
 
 In some design systems, Design Tokens may have complex hierarchies with tokens referencing other tokens. This can be accomplished by setting a Design Token to another Design Token.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
DesignToken doesn't support volatile bindings because DesignToken relies on knowing which DesignTokens are accessed by the token so that subscriptions can be hooked up to know when dependencies change throughout the DOM. If DesignTokens are conditionally accessed, DesignToken can't be sure it has collected all dependencies. These dependencies are only aggregated once on initial evaluation to avoid excessive subscription / unsubscription code-paths.

This PR forces non-volatile bindings when creating the binding, preventing Observable from sometimes going down the volatile code-path. It also updates documentation to explain that DesignToken derived token values don't support volatile expressions.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->