### PR TITLE
throw an error when comments in CSS contain expressions

### DIFF
--- a/build/transform-fragments.js
+++ b/build/transform-fragments.js
@@ -1,3 +1,4 @@
+/* eslint-env node */
 /* eslint-disable @typescript-eslint/explicit-function-return-type, @typescript-eslint/typedef */
 
 /**
@@ -15,7 +16,7 @@ export function transformHTMLFragment(data) {
  * Reduces extra spaces in CSS tagged templates.
  *
  * Breakdown of this regex:
- *   (?:\s*\/\*(?:.|\s)+?\*\/\s*)  Remove comments (non-capturing)
+ *   (?:\s*\/\*(?:[\s\S])+?\*\/\s*)  Remove comments (non-capturing)
  *   (?:;)\s+(?=\})  Remove semicolons and spaces followed by property list end (non-capturing)
  *   \s+(?=\{)  Remove spaces before property list start (non-capturing)
  *   (?<=:)\s+  Remove spaces after property declarations (non-capturing)
@@ -25,8 +26,12 @@ export function transformHTMLFragment(data) {
  * @returns string
  */
 export function transformCSSFragment(data) {
+    if (/\/\*(?![\s\S]*\*\/)[\s\S]*/g.test(data)) {
+        throw new Error("Unterminated comment found in CSS tagged template literal");
+    }
+
     return data.replace(
-        /(?:\s*\/\*(?:.|\s)+?\*\/\s*)|(?:;)\s+(?=\})|\s+(?=\{)|(?<=:)\s+|\s*([{};,])\s*/g,
+        /(?:\s*\/\*(?:[\s\S])+?\*\/\s*)|(?:;)\s+(?=\})|\s+(?=\{)|(?<=:)\s+|\s*([{};,])\s*/g,
         "$1"
     );
 }

--- a/change/@microsoft-fast-components-468df205-aa0e-4ab9-b585-90413eabada2.json
+++ b/change/@microsoft-fast-components-468df205-aa0e-4ab9-b585-90413eabada2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Remove commented CSS",
+  "packageName": "@microsoft/fast-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

The CSS transform function can fail if a CSS comment contains an expression:

```css
/* this is a comment with an ${expression} in its contents */
```

This comment gets handled by the AST by splitting it up into parts:
1. `/* this is a comment with an `
2. the evaluation of `expression`
3. ` in its contents */`

Each string chunk (1 and 3) is sent to the `transformCSSFragment` function to be compressed, though since 1 starts with a comment and ends without closing, it can't be determined if there's an expression following or if it's the last chunk. In either scenario, the string is invalid and should throw an error when encountered.

### 🎫 Issues

## 👩‍💻 Reviewer Notes

Comments in CSS blocks should not contain `${expressions}` to avoid this issue. Rather than leaving these situations alone (not compressing them), it's better to remove the expression from the comment. Any expression, whether in a comment or not, will be treated as a standard JavaScript expression tag, and its contents won't be removed at build time.

## 📑 Test Plan

When running `yarn`, the build should complete successfully.

This function can be tested by:

- inserting a comment containing an expression into a CSS template literal
   ```css
   /* ${""} */
   ```
- ending a CSS template literal with an unclosed comment
   ```ts
   css`
       /* unterminated comment
   `;
   ```


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->