### PR TITLE
feat(fast-components): leverage FoundationElement.compose baseClass

### DIFF
--- a/change/@microsoft-fast-components-85721f69-3559-4dc8-bba1-53bc102f55a5.json
+++ b/change/@microsoft-fast-components-85721f69-3559-4dc8-bba1-53bc102f55a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat(fast-components): leverage FoundationElement.compose baseClass",
+  "packageName": "@microsoft/fast-components",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/anchor/index.ts
+++ b/packages/web-components/fast-components/src/anchor/index.ts
@@ -81,6 +81,7 @@ export const anchorStyles = styles;
  */
 export const fastAnchor = Anchor.compose({
     baseName: "anchor",
+    baseClass: FoundationAnchor,
     template,
     styles,
     shadowOptions: {

--- a/packages/web-components/fast-components/src/avatar/index.ts
+++ b/packages/web-components/fast-components/src/avatar/index.ts
@@ -63,6 +63,7 @@ export const imgTemplate = html<Avatar>`
  */
 export const fastAvatar = Avatar.compose<AvatarOptions>({
     baseName: "avatar",
+    baseClass: FoundationAvatar,
     template,
     styles,
     media: imgTemplate,

--- a/packages/web-components/fast-components/src/button/index.ts
+++ b/packages/web-components/fast-components/src/button/index.ts
@@ -68,6 +68,7 @@ export class Button extends FoundationButton {
  */
 export const fastButton = Button.compose({
     baseName: "button",
+    baseClass: FoundationButton,
     template,
     styles,
     shadowOptions: {

--- a/packages/web-components/fast-components/src/card/index.ts
+++ b/packages/web-components/fast-components/src/card/index.ts
@@ -39,6 +39,7 @@ export class Card extends FoundationCard {
  */
 export const fastCard = Card.compose({
     baseName: "card",
+    baseClass: FoundationCard,
     template,
     styles,
 });

--- a/packages/web-components/fast-components/src/disclosure/index.ts
+++ b/packages/web-components/fast-components/src/disclosure/index.ts
@@ -95,6 +95,7 @@ export const disclosureStyles = styles;
  */
 export const fastDisclosure = Disclosure.compose({
     baseName: "disclosure",
+    baseClass: FoundationDisclosure,
     template,
     styles,
 });

--- a/packages/web-components/fast-components/src/horizontal-scroll/index.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/index.ts
@@ -37,6 +37,7 @@ export class HorizontalScroll extends FoundationHorizontalScroll {
  */
 export const fastHorizontalScroll = HorizontalScroll.compose<HorizontalScrollOptions>({
     baseName: "horizontal-scroll",
+    baseClass: FoundationHorizontalScroll,
     template,
     styles,
     nextFlipper: context => html`

--- a/packages/web-components/fast-components/src/number-field/index.ts
+++ b/packages/web-components/fast-components/src/number-field/index.ts
@@ -57,6 +57,7 @@ export const numberFieldStyles = styles;
  */
 export const fastNumberField = NumberField.compose<NumberFieldOptions>({
     baseName: "number-field",
+    baseClass: FoundationNumberField,
     styles,
     template,
     shadowOptions: {

--- a/packages/web-components/fast-components/src/slider-label/index.ts
+++ b/packages/web-components/fast-components/src/slider-label/index.ts
@@ -36,6 +36,7 @@ export class SliderLabel extends FoundationSliderLabel {
 
 export const fastSliderLabel = SliderLabel.compose({
     baseName: "slider-label",
+    baseClass: FoundationSliderLabel,
     template,
     styles,
 });

--- a/packages/web-components/fast-components/src/text-area/index.ts
+++ b/packages/web-components/fast-components/src/text-area/index.ts
@@ -50,6 +50,7 @@ export class TextArea extends FoundationTextArea {
  */
 export const fastTextArea = TextArea.compose({
     baseName: "text-area",
+    baseClass: FoundationTextArea,
     template,
     styles,
     shadowOptions: {

--- a/packages/web-components/fast-components/src/text-field/index.ts
+++ b/packages/web-components/fast-components/src/text-field/index.ts
@@ -50,6 +50,7 @@ export class TextField extends FoundationTextField {
  */
 export const fastTextField = TextField.compose({
     baseName: "text-field",
+    baseClass: FoundationTextField,
     template,
     styles,
     shadowOptions: {

--- a/packages/web-components/fast-components/src/toolbar/index.ts
+++ b/packages/web-components/fast-components/src/toolbar/index.ts
@@ -40,6 +40,7 @@ export class Toolbar extends FoundationToolbar {
  */
 export const fastToolbar = Toolbar.compose({
     baseName: "toolbar",
+    baseClass: FoundationToolbar,
     template,
     styles,
     shadowOptions: {


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR takes advantage of a recently added feature that enables `FoundationElement.compose(...)` calls to specify an additional `baseClass` to use for tag lookup. Some of our components had subclassed foundation classes resulting in the original foundation class not being associated with the tag. This update addresses this issue and now makes it safe to use `contextFor` against any foundation class.

### 🎫 Issues

n/a

## 👩‍💻 Reviewer Notes

Code changes are pretty simple. I tried to find all the components that had subclassed a foundation class and then add the `baseClass` configuration.

## 📑 Test Plan

The underlying feature is covered in unit tests as are the components themselves. No need real for additional tests in this case.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

These same changes will need to be applied to the Fluent versions of the components. I'm not sure when the timing would be right for that. Seems we might need to wait until after @bheston's branch is merged. Or, it could be done as part of that branch, since it's a simple set of changes.