### PR TITLE
add custom fast-frame controls for browsers with eyedropper support

### DIFF
--- a/change/@microsoft-fast-foundation-48486c53-f43c-4a50-addc-b5ec1f19a59a.json
+++ b/change/@microsoft-fast-foundation-48486c53-f43c-4a50-addc-b5ec1f19a59a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "use class method for radio click handler property",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1499,7 +1499,7 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     checked: boolean;
     checkedAttribute: boolean;
     // @internal (undocumented)
-    clickHandler: (e: MouseEvent) => void;
+    clickHandler(e: MouseEvent): boolean | void;
     // @internal (undocumented)
     connectedCallback(): void;
     defaultChecked: boolean | undefined;

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -204,9 +204,9 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     /**
      * @internal
      */
-    public clickHandler = (e: MouseEvent): void => {
+    public clickHandler(e: MouseEvent): boolean | void {
         if (!this.disabled && !this.readOnly && !this.checked) {
             this.checked = true;
         }
-    };
+    }
 }

--- a/sites/fast-website/package.json
+++ b/sites/fast-website/package.json
@@ -9,6 +9,7 @@
   "devDependencies": {
     "@babel/core": "^7.12.13",
     "@babel/preset-env": "^7.12.13",
+    "@fluentui/svg-icons": "^1.1.139",
     "@microsoft/fast-components": "^2.9.0",
     "@microsoft/fast-element": "^1.5.1",
     "@microsoft/fast-foundation": "^2.12.0",

--- a/sites/fast-website/src/app/components/color-swatch/color-swatch.styles.ts
+++ b/sites/fast-website/src/app/components/color-swatch/color-swatch.styles.ts
@@ -1,24 +1,26 @@
-import { css } from "@microsoft/fast-element";
 import {
+    accentFillRest,
     bodyFont,
     controlCornerRadius,
     density,
     designUnit,
     disabledOpacity,
     focusStrokeOuter,
+    foregroundOnAccentRest,
     neutralForegroundRest,
     neutralStrokeHover,
     neutralStrokeRest,
     strokeWidth,
 } from "@microsoft/fast-components";
 import { heightNumber } from "@microsoft/fast-components/dist/esm/styles/size";
-import { SystemColors } from "@microsoft/fast-web-utilities";
+import { css } from "@microsoft/fast-element";
 import {
-    display,
-    forcedColorsStylesheetBehavior,
-    focusVisible,
     disabledCursor,
+    display,
+    focusVisible,
+    forcedColorsStylesheetBehavior,
 } from "@microsoft/fast-foundation";
+import { SystemColors } from "@microsoft/fast-web-utilities";
 
 export const ColorSwatchStyles = css`
 ${display("inline-flex")} :host {
@@ -26,18 +28,15 @@ ${display("inline-flex")} :host {
     align-items: center;
     outline: none;
     margin: calc(${designUnit} * 1px) 0;
-    ${
-        /*
-         * Chromium likes to select label text or the default slot when
-         * the radio button is clicked. Maybe there is a better solution here?
-         */ ""
-    } user-select: none;
+    user-select: none;
     position: relative;
     flex-direction: row;
     transition: all 0.2s ease-in-out;
 }
 
 .control {
+    background: ${accentFillRest};
+    color: ${neutralForegroundRest};
     position: relative;
     width: calc(var(--input-size) * 1px);
     height: calc(var(--input-size) * 1px);
@@ -55,14 +54,13 @@ ${display("inline-flex")} :host {
 .label {
     font-family: ${bodyFont};
     color: ${neutralForegroundRest};
-    ${
-        /* Need to discuss with Brian how HorizontalSpacingNumber can work. https://github.com/microsoft/fast/issues/2766 */ ""
-    } padding-inline-start: calc(${designUnit} * 2px + 2px);
+    /* TODO: Need to discuss with Brian how HorizontalSpacingNumber can work.
+        https://github.com/microsoft/fast/issues/2766 */
+    padding-inline-start: calc(${designUnit} * 2px + 2px);
     margin-inline-end: calc(${designUnit} * 2px + 2px);
     cursor: pointer;
-    ${
-        /* Font size is temporary - replace when adaptive typography is figured out */ ""
-    } font-size: calc(1rem + (${density} * 2px));
+    /* TODO: adaptive typography https://github.com/microsoft/fast/issues/2432 */
+    font-size: calc(1rem + (${density} * 2px));
 }
 
 .checked-indicator {
@@ -77,6 +75,14 @@ ${display("inline-flex")} :host {
     border: 1px solid ${neutralForegroundRest};
     opacity: 0;
     pointer-events: none;
+}
+
+::slotted([slot="checked-indicator"]) {
+    align-items: center;
+    color: ${foregroundOnAccentRest};
+    display: flex;
+    fill: currentColor;
+    justify-content: center;
 }
 
 .control:hover {

--- a/sites/fast-website/src/app/components/color-swatch/color-swatch.template.ts
+++ b/sites/fast-website/src/app/components/color-swatch/color-swatch.template.ts
@@ -1,11 +1,12 @@
-import { html, when, slotted } from "@microsoft/fast-element";
+import { html, slotted } from "@microsoft/fast-element";
+import { whitespaceFilter } from "@microsoft/fast-foundation";
 import { ColorSwatch } from "./color-swatch";
 
 export const ColorSwatchTemplate = html<ColorSwatch>`
     <template
         role="radio"
-        class="${x => (x.checked ? "checked" : "")} ${x =>
-            x.readOnly ? "readonly" : ""}"
+        class="${x =>
+            [x.checked && "checked", x.readOnly && "readonly"].filter(Boolean).join("")}"
         aria-checked="${x => x.checked}"
         aria-required="${x => x.required}"
         aria-disabled="${x => x.disabled}"
@@ -13,19 +14,21 @@ export const ColorSwatchTemplate = html<ColorSwatch>`
         @keypress="${(x, c) => x.keypressHandler(c.event as KeyboardEvent)}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
     >
-        <div part="control" class="control" style="background: ${x => x.backgroundColor}">
+        <div part="control" class="control">
             <slot name="checked-indicator">
                 <div part="checked-indicator" class="checked-indicator"></div>
             </slot>
         </div>
         <label
             part="label"
-            class="${x =>
-                x.defaultSlottedNodes && x.defaultSlottedNodes.length
-                    ? "label"
-                    : "label label-hidden"}"
+            class="label ${x => (!x.defaultSlottedNodes?.length ? "label-hidden" : "")}"
         >
-            <slot ${slotted("defaultSlottedNodes")}></slot>
+            <slot
+                ${slotted({
+                    property: "defaultSlottedNodes",
+                    filter: whitespaceFilter,
+                })}
+            ></slot>
         </label>
     </template>
 `;

--- a/sites/fast-website/src/app/components/color-swatch/color-swatch.ts
+++ b/sites/fast-website/src/app/components/color-swatch/color-swatch.ts
@@ -1,10 +1,79 @@
+import { parseColorHexRGB } from "@microsoft/fast-colors";
+import { accentPalette, PaletteRGB } from "@microsoft/fast-components";
 import { attr, observable } from "@microsoft/fast-element";
 import { Radio } from "@microsoft/fast-foundation";
+import { keyEnter } from "@microsoft/fast-web-utilities";
+
+export declare interface ColorSelectionResult {
+    sRGBHex: string;
+}
+
+export declare class EyeDropper {
+    constructor();
+    public open(): Promise<ColorSelectionResult>;
+}
 
 export class ColorSwatch extends Radio {
-    @attr({ attribute: "background-color" })
-    public backgroundColor: string = "#F33378";
+    private palette: PaletteRGB;
 
     @observable
     public defaultSlottedNodes: Node[];
+
+    private eyedropper: EyeDropper;
+
+    @attr({
+        attribute: "custom-value",
+        mode: "boolean",
+    })
+    customValue: boolean = false;
+
+    constructor() {
+        super();
+
+        if ("EyeDropper" in globalThis) {
+            this.eyedropper = new EyeDropper();
+        }
+    }
+
+    connectedCallback() {
+        super.connectedCallback();
+
+        if (this.eyedropper && this.customValue) {
+            this.addEventListener("keydown", this.keydownHandler);
+        }
+    }
+
+    public keydownHandler(e: KeyboardEvent): boolean | void {
+        if (e.key === keyEnter) {
+            this.getColorFromEyeDropper();
+        }
+    }
+
+    public clickHandler(e: MouseEvent): boolean | void {
+        if (!this.customValue || !this.eyedropper) {
+            return super.clickHandler(e);
+        }
+
+        this.getColorFromEyeDropper().then(() => {
+            return super.clickHandler(e);
+        });
+    }
+
+    public async getColorFromEyeDropper() {
+        try {
+            const colorSelectionResult = await this.eyedropper.open();
+            this.value = colorSelectionResult.sRGBHex;
+            this.$emit("change");
+        } catch (err) {
+            console.log(err);
+        }
+    }
+
+    public valueChanged(prev: unknown, next: string): void {
+        const parsedColor = parseColorHexRGB(next);
+        if (parsedColor) {
+            this.palette = PaletteRGB.from(parsedColor);
+            accentPalette.setValueFor(this, this.palette);
+        }
+    }
 }

--- a/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
+++ b/sites/fast-website/src/app/components/fast-frame/fast-frame.template.ts
@@ -1,4 +1,6 @@
-import { html, ref, repeat } from "@microsoft/fast-element";
+import EyedropperIcon from "@fluentui/svg-icons/icons/eyedropper_20_filled.svg";
+import { ColorHSL, hslToRGB } from "@microsoft/fast-colors";
+import { html, ref, repeat, when } from "@microsoft/fast-element";
 import ContextIcon from "svg/icon-context.svg";
 import ContrastIcon from "svg/icon-contrast.svg";
 import DownloadIcon from "svg/icon-download.svg";
@@ -6,7 +8,6 @@ import PaletteIcon from "svg/icon-palette.svg";
 import PlayIcon from "svg/icon-play.svg";
 import SwatchesIcon from "svg/icon-swatches.svg";
 import { FastFrame } from "./fast-frame";
-import { ColorHSL, hslToRGB } from "@microsoft/fast-colors";
 
 export const FastFrameTemplate = html<FastFrame>`
     <template>
@@ -76,10 +77,24 @@ export const FastFrameTemplate = html<FastFrame>`
                                             tabindex="0"
                                             aria-label="neutral color ${x => x}"
                                             value="${x => x}"
-                                            background-color="${x => x}"
                                             checked="${(x, c) =>
                                                 x === c.parent.previewNeutralPalette[0]}"
                                         ></site-color-swatch>
+                                    `
+                                )}
+                                ${when(
+                                    x => "EyeDropper" in globalThis,
+                                    html`
+                                        <site-color-swatch
+                                            tabindex="0"
+                                            value="#000"
+                                            custom-value
+                                            aria-label="custom neutral color"
+                                        >
+                                            <div slot="checked-indicator">
+                                                ${EyedropperIcon}
+                                            </div>
+                                        </site-color-swatch>
                                     `
                                 )}
                             </fast-radio-group>
@@ -93,16 +108,29 @@ export const FastFrameTemplate = html<FastFrame>`
                             >
                                 ${repeat(
                                     x => x.previewAccentPalette,
-
                                     html<string>`
                                         <site-color-swatch
                                             tabindex="0"
                                             aria-label="accent color ${x => x}"
                                             value="${x => x}"
-                                            background-color="${x => x}"
                                             checked="${(x, c) =>
                                                 x === c.parent.previewAccentPalette[0]}"
                                         ></site-color-swatch>
+                                    `
+                                )}
+                                ${when(
+                                    x => "EyeDropper" in globalThis,
+                                    html`
+                                        <site-color-swatch
+                                            tabindex="0"
+                                            value="#000"
+                                            custom-value
+                                            aria-label="custom accent color"
+                                        >
+                                            <div slot="checked-indicator">
+                                                ${EyedropperIcon}
+                                            </div>
+                                        </site-color-swatch>
                                     `
                                 )}
                             </fast-radio-group>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1782,6 +1782,11 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@fluentui/svg-icons@^1.1.139":
+  version "1.1.139"
+  resolved "https://registry.yarnpkg.com/@fluentui/svg-icons/-/svg-icons-1.1.139.tgz#7a3d13733ecc030dfdec41f400cd6bbc4dd1c3c1"
+  integrity sha512-Ar+jMcSaPcR9wBbsBfJbEiS2jhruz7uITyAALGuiXVAL0VwW2fCYwoBGV+b7uN/bdbIxkeaHZWx2PIfN8xH4Fw==
+
 "@fluentui/web-components@^1.2.3":
   version "1.2.3"
   resolved "https://registry.yarnpkg.com/@fluentui/web-components/-/web-components-1.2.3.tgz#d2737e9a8a1ae6dab4cfc064921464fb521bf141"


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds two color swatch options to the Colors panel on the website when the [EyeDropper API](https://github.com/MicrosoftEdge/MSEdgeExplainers/blob/main/EyeDropper/explainer.md) is available in the browser. This change also updates the `clickHandler` method on the Radio class to be a class method instead of a property.

![Screenshot 2021-09-08 161310](https://user-images.githubusercontent.com/863023/132599020-e1b2e2a8-a235-4610-9401-309d883dc12d.png)

## 👩‍💻 Reviewer Notes

* If the browser doesn't support the EyeDropper API, the two extra radio inputs won't be displayed.
* The actual controls that appear on the mouse cursor when `eyedropper.open()` is invoked is entirely handled by the browser.

## 📑 Test Plan

1. Run the homepage project in `sites/fast-website` (`yarn start`)
2. Browse to the page in either Edge or Chrome Canary 95 or higher.
3. Click the Colors panel in the Fast Frame section of the homepage.
4. Activate the eyedropper selector:
    * With the mouse: click either the neutral or accent eyedropper radio.
    * With the keyboard: use the tab key to navigate to the neutral or accent radio group. Then, use arrow keys to select the Eyedropper radio. Press `Enter` to activate the eyedropper selector.
5. Hover the mouse over the desired area on the screen and click.
6. Observe that the respective choice is applied. For the accent color, the Hue and Saturation sliders should update to match the selected value.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
