### PR TITLE
fix: resolve an issue where linked data that cannot be dropped on was not allowed to drop

### DIFF
--- a/change/@microsoft-fast-tooling-react-b2a5da63-bda5-4b37-80c9-e6b2ecc5ed00.json
+++ b/change/@microsoft-fast-tooling-react-b2a5da63-bda5-4b37-80c9-e6b2ecc5ed00.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "allow linked data that has no default droppable location to drop onto other drop targets",
+  "packageName": "@microsoft/fast-tooling-react",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-tooling-react/src/navigation/navigation-tree-item.tsx
+++ b/packages/tooling/fast-tooling-react/src/navigation/navigation-tree-item.tsx
@@ -222,7 +222,7 @@ export const DraggableNavigationTreeItem: React.FC<NavigationTreeItemProps> = ({
     });
     const dragSource: ConnectDragSource = drag[1];
     const drop: [{}, DragElementWrapper<any>] = useDrop({
-        accept: [DragDropItemType.linkedData],
+        accept: [DragDropItemType.linkedData, DragDropItemType.linkedDataUndroppable],
         hover(item: DragObjectWithType, monitor: DropTargetMonitor): void {
             /**
              * When the hovered element changes, reset the cached ref and


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change adds the linked data type corresponding to linked data that typically includes elements such as `<img />` and `<input />` which do not contain content to a list of items that now allow it to be dropped.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Build and run Creator application and add an `img` element, and another container element such as `div`, then attempt to drag the `img` into the `div`. This should now be possible.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
As part of the drag and drop core functionality, this is untestable in unit tests.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
