### PR TITLE
fix type issue for FoundationElementTemplate

### DIFF
--- a/change/@microsoft-fast-foundation-84ca8ddb-ca59-43d3-a8cf-c6da286230da.json
+++ b/change/@microsoft-fast-foundation-84ca8ddb-ca59-43d3-a8cf-c6da286230da.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix type issue for FoundationElementTemplate",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1082,7 +1082,7 @@ export class FoundationElementRegistry<TDefinition extends FoundationElementDefi
 // Warning: (ae-forgotten-export) The symbol "LazyFoundationOption" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type FoundationElementTemplate<T, K = void> = LazyFoundationOption<T, K & FoundationElementDefinition>;
+export type FoundationElementTemplate<T, K extends FoundationElementDefinition = FoundationElementDefinition> = LazyFoundationOption<T, K>;
 
 // @public
 export enum GenerateHeaderOptions {

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
@@ -79,10 +79,10 @@ export interface FoundationElementDefinition {
  * A foundation element template function.
  * @public
  */
-export type FoundationElementTemplate<T, K = void> = LazyFoundationOption<
+export type FoundationElementTemplate<
     T,
-    K & FoundationElementDefinition
->;
+    K extends FoundationElementDefinition = FoundationElementDefinition
+> = LazyFoundationOption<T, K>;
 
 /**
  * A set of properties which the component consumer can override during the element registration process.


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes the `TS2344` errors caused by an type incompatibility:

```
Type 'K & FoundationElementDefinition' does not satisfy the constraint 'FoundationElementDefinition'.
Types of property 'template' are incompatible.
```

### 🎫 Issues

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

The error should not be present in either `packages/web-components/fast-foundation/dist/fast-foundation.d.ts` or `packages/web-components/fast-foundation/dist/dts/foundation-element/foundation-element.d.ts` after building.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
