### PR TITLE
fix(allComponents): add missing param to registry

### DIFF
--- a/change/@microsoft-fast-components-c315a99e-78d1-400e-a54e-8bb28884332a.json
+++ b/change/@microsoft-fast-components-c315a99e-78d1-400e-a54e-8bb28884332a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(allComponents): add missing param to registry",
+  "packageName": "@microsoft/fast-components",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -196,7 +196,7 @@ export const allComponents: {
     fastToolbar: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof Toolbar>;
     fastTreeView: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof import("@microsoft/fast-foundation").TreeView>;
     fastTreeItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").TreeItemOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").TreeItemOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
-    register(container?: Container | undefined): void;
+    register(container?: Container | undefined, ...rest: any[]): void;
 };
 
 // @public

--- a/packages/web-components/fast-components/src/custom-elements.ts
+++ b/packages/web-components/fast-components/src/custom-elements.ts
@@ -1,7 +1,7 @@
 /**
  * Export all custom element definitions
  */
-import type { Container, ElementDefinitionContext } from "@microsoft/fast-foundation";
+import type { Container } from "@microsoft/fast-foundation";
 import { fastAccordion, fastAccordionItem } from "./accordion/index";
 import { fastAnchor } from "./anchor/index";
 import { fastAnchoredRegion } from "./anchored-region/index";

--- a/packages/web-components/fast-components/src/custom-elements.ts
+++ b/packages/web-components/fast-components/src/custom-elements.ts
@@ -1,7 +1,7 @@
 /**
  * Export all custom element definitions
  */
-import type { Container } from "@microsoft/fast-foundation";
+import type { Container, ElementDefinitionContext } from "@microsoft/fast-foundation";
 import { fastAccordion, fastAccordionItem } from "./accordion/index";
 import { fastAnchor } from "./anchor/index";
 import { fastAnchoredRegion } from "./anchored-region/index";
@@ -178,7 +178,7 @@ export const allComponents = {
     fastToolbar,
     fastTreeView,
     fastTreeItem,
-    register(container?: Container) {
+    register(container?: Container, ...rest: any[]) {
         if (!container) {
             // preserve backward compatibility with code that loops through
             // the values of this object and calls them as funcs with no args
@@ -190,7 +190,7 @@ export const allComponents = {
                 continue;
             }
 
-            this[key]().register(container);
+            this[key]().register(container, ...rest);
         }
     },
 };


### PR DESCRIPTION
# Pull Request

## 📖 Description

Critical fix for regression in scenarios using `allComponents`.

### 🎫 Issues

No issues. Discovered by the team late lat night.

## 👩‍💻 Reviewer Notes

Small change in the `allComponents` export to pass the registry params through correctly.

## 📑 Test Plan

No tests here. We should really have our automated tests do something with Storybook maybe. It would be good to have a guarantee that the Storybook loads and basic scenarios for all components are exercised.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

We need to make the same change in the Fluent UI Web Components /cc @chrisdholt 