### PR TITLE
fix: when orientation changes, the styles are updated properly on tab chil…

### DIFF
--- a/change/@microsoft-fast-foundation-2272e849-e24e-4830-a4ef-71149530ca0d.json
+++ b/change/@microsoft-fast-foundation-2272e849-e24e-4830-a4ef-71149530ca0d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "made orientation changed update child tab styles",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "marjon@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2095,6 +2095,8 @@ export class Tabs extends FoundationElement {
     connectedCallback(): void;
     orientation: TabsOrientation;
     // @internal (undocumented)
+    orientationChanged(): void;
+    // @internal (undocumented)
     showActiveIndicator: boolean;
     // @internal (undocumented)
     tabpanels: HTMLElement[];

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -42,7 +42,16 @@ export class Tabs extends FoundationElement {
      */
     @attr
     public orientation: TabsOrientation = TabsOrientation.horizontal;
-
+    /**
+     * @internal
+     */
+    public orientationChanged(): void {
+        if (this.$fastController.isConnected) {
+            this.setTabs();
+            this.setTabPanels();
+            this.handleActiveIndicatorPosition();
+        }
+    }
     /**
      * The id of the active tab
      *
@@ -162,7 +171,11 @@ export class Tabs extends FoundationElement {
     }
 
     private setTabs = (): void => {
-        const gridProperty: string = this.isHorizontal() ? "gridColumn" : "gridRow";
+        const gridHorizontalProperty: string = "grid-column";
+        const gridVerticalProperty: string = "grid-row";
+        const gridProperty: string = this.isHorizontal()
+            ? gridHorizontalProperty
+            : gridVerticalProperty;
         this.tabIds = this.getTabIds();
         this.tabpanelIds = this.getTabPanelIds();
         this.activeTabIndex = this.getActiveIndex();
@@ -193,6 +206,11 @@ export class Tabs extends FoundationElement {
                     this.activetab = tab;
                 }
             }
+
+            // If the original property isn't emptied out,
+            // the next set will morph into a grid-area style setting that is not what we want
+            tab.style[gridHorizontalProperty] = "";
+            tab.style[gridVerticalProperty] = "";
             tab.style[gridProperty] = `${index + 1}`;
             !this.isHorizontal()
                 ? tab.classList.add("vertical")

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -171,8 +171,8 @@ export class Tabs extends FoundationElement {
     }
 
     private setTabs = (): void => {
-        const gridHorizontalProperty: string = "grid-column";
-        const gridVerticalProperty: string = "grid-row";
+        const gridHorizontalProperty: string = "gridColumn";
+        const gridVerticalProperty: string = "gridRow";
         const gridProperty: string = this.isHorizontal()
             ? gridHorizontalProperty
             : gridVerticalProperty;


### PR DESCRIPTION
# Pull Request

## 📖 Description

When the orientation attribute changes we want the styles to be updated for the child tabs as it is necessary to maintain the proper grid css settings for vertical or horizontal mode. In the process of adding orientation changed functionality another issue was discovered whereby setting tab.style[gridProperty] was actually translated to grid-area and caused the tabs to be misaligned so that is also fixed in this PR by explicitly emptying grid-colum and grid-row before setting the new value.

before:
![Screen Shot 2021-09-24 at 8 55 12 AM](https://user-images.githubusercontent.com/25805778/134706914-77e9af40-d624-46d6-9b54-4da1672d4a03.png)


### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->