### PR TITLE
fix: add manual focus on components with delegatesFocus to support firefox

### DIFF
--- a/change/@microsoft-fast-components-ad8eb6c8-9106-4890-ad00-49f44659b24a.json
+++ b/change/@microsoft-fast-components-ad8eb6c8-9106-4890-ad00-49f44659b24a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add function to support programmatic focus for firefox and added test",
+  "packageName": "@microsoft/fast-components",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-components-ad8eb6c8-9106-4890-ad00-49f44659b24a.json
+++ b/change/@microsoft-fast-components-ad8eb6c8-9106-4890-ad00-49f44659b24a.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "add function to support programmatic focus for firefox and added test",
+  "comment": "added fallback function for browsers that do not support delegatesFocus",
   "packageName": "@microsoft/fast-components",
   "email": "khamu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-fast-foundation-3ae546c3-c283-4503-a384-fa5da550a2a9.json
+++ b/change/@microsoft-fast-foundation-3ae546c3-c283-4503-a384-fa5da550a2a9.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "add function to support programmatic focus for firefox and added test",
+  "comment": "added fallback function for browsers that do not support delegatesFocus",
   "packageName": "@microsoft/fast-foundation",
   "email": "khamu@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-fast-foundation-3ae546c3-c283-4503-a384-fa5da550a2a9.json
+++ b/change/@microsoft-fast-foundation-3ae546c3-c283-4503-a384-fa5da550a2a9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "add function to support programmatic focus for firefox and added test",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "khamu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/avatar/avatar.pw.spec.ts
+++ b/packages/web-components/fast-components/src/avatar/avatar.pw.spec.ts
@@ -1,0 +1,52 @@
+import type {
+    Avatar as FASTAvatarType,
+} from "@microsoft/fast-foundation";
+import { expect } from "chai";
+
+type FASTAvatar = HTMLElement & FASTAvatarType;
+
+describe("FASTAvatar", function () {
+    beforeEach(async function () {
+        if (!this.page && !this.browser) {
+            this.skip();
+        }
+
+        this.documentHandle = await this.page.evaluateHandle(() => document);
+
+        this.setupHandle = await this.page.evaluateHandle(
+            (document) => {
+                const element = document.createElement("fast-avatar") as FASTAvatar;
+                element.link = "#";
+                element.shape = "circle";
+                element.fill = "accent primary";
+                element.color = "bar";
+
+                document.body.appendChild(element)
+            },
+            this.documentHandle
+        );
+    });
+
+    afterEach(async function () {
+        if (this.setupHandle) {
+            await this.setupHandle.dispose();
+        }
+    });
+
+    // FASTAvatar should render on the page
+    it("should render on the page", async function () {
+        const element = await this.page.waitForSelector("fast-avatar");
+
+        expect(element).to.exist;
+    });
+
+    it("receive focus when focused programatically", async function () {
+        const element = await this.page.waitForSelector("fast-avatar");
+
+        await this.page.evaluateHandle(element => element.focus(), element)
+
+        expect(await this.page.evaluate(
+            () => document.activeElement?.id
+        )).to.equal(await element.evaluate(node => node.id));
+    });
+});

--- a/packages/web-components/fast-components/src/avatar/avatar.pw.spec.ts
+++ b/packages/web-components/fast-components/src/avatar/avatar.pw.spec.ts
@@ -2,6 +2,7 @@ import type {
     Avatar as FASTAvatarType,
 } from "@microsoft/fast-foundation";
 import { expect } from "chai";
+import type { ElementHandle } from "playwright";
 
 type FASTAvatar = HTMLElement & FASTAvatarType;
 
@@ -20,6 +21,7 @@ describe("FASTAvatar", function () {
                 element.shape = "circle";
                 element.fill = "accent primary";
                 element.color = "bar";
+                element.id = "avatar1"
 
                 document.body.appendChild(element)
             },
@@ -41,7 +43,7 @@ describe("FASTAvatar", function () {
     });
 
     it("receive focus when focused programatically", async function () {
-        const element = await this.page.waitForSelector("fast-avatar");
+        const element = await (this.page.waitForSelector("fast-avatar")) as ElementHandle<FASTAvatar>;
 
         await this.page.evaluateHandle(element => element.focus(), element)
 

--- a/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.pw.spec.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/breadcrumb-item.pw.spec.ts
@@ -1,0 +1,50 @@
+import type {
+    BreadcrumbItem as FASTBreadcrumbItemType,
+} from "@microsoft/fast-foundation";
+import { expect } from "chai";
+
+type FASTBreadcrumbItem = HTMLElement & FASTBreadcrumbItemType;
+
+describe("FASTBreadcrumbItem", function () {
+    beforeEach(async function () {
+        if (!this.page && !this.browser) {
+            this.skip();
+        }
+
+        this.documentHandle = await this.page.evaluateHandle(() => document);
+
+        this.setupHandle = await this.page.evaluateHandle(
+            (document) => {
+                const element = document.createElement("fast-breadcrumb-item") as FASTBreadcrumbItem;
+                element.textContent = "Breadcrumb item"
+                element.href = "#";
+
+                document.body.appendChild(element)
+            },
+            this.documentHandle
+        );
+    });
+
+    afterEach(async function () {
+        if (this.setupHandle) {
+            await this.setupHandle.dispose();
+        }
+    });
+
+    // FASTBreadcrumbItem should render on the page
+    it("should render on the page", async function () {
+        const element = await this.page.waitForSelector("fast-breadcrumb-item");
+
+        expect(element).to.exist;
+    });
+
+    it("receive focus when focused programatically", async function () {
+        const element = await this.page.waitForSelector("fast-breadcrumb-item");
+
+        await this.page.evaluateHandle(element => element.focus(), element)
+
+        expect(await this.page.evaluate(
+            () => document.activeElement?.id
+        )).to.equal(await element.evaluate(node => node.id));
+    });
+});

--- a/packages/web-components/fast-components/src/combobox/combobox.pw.spec.ts
+++ b/packages/web-components/fast-components/src/combobox/combobox.pw.spec.ts
@@ -1,0 +1,48 @@
+import type {
+    Combobox as FASTComboboxType,
+} from "@microsoft/fast-foundation";
+import { expect } from "chai";
+
+type FASTCombobox = HTMLElement & FASTComboboxType;
+
+describe("FASTCombobox", function () {
+    beforeEach(async function () {
+        if (!this.page && !this.browser) {
+            this.skip();
+        }
+
+        this.documentHandle = await this.page.evaluateHandle(() => document);
+
+        this.setupHandle = await this.page.evaluateHandle(
+            (document) => {
+                const element = document.createElement("fast-combobox") as FASTCombobox;
+
+                document.body.appendChild(element)
+            },
+            this.documentHandle
+        );
+    });
+
+    afterEach(async function () {
+        if (this.setupHandle) {
+            await this.setupHandle.dispose();
+        }
+    });
+
+    // FASTCombobox should render on the page
+    it("should render on the page", async function () {
+        const element = await this.page.waitForSelector("fast-combobox");
+
+        expect(element).to.exist;
+    });
+
+    it("receive focus when focused programatically", async function () {
+        const element = await this.page.waitForSelector("fast-combobox");
+
+        await this.page.evaluateHandle(element => element.focus(), element)
+
+        expect(await this.page.evaluate(
+            () => document.activeElement?.id
+        )).to.equal(await element.evaluate(node => node.id));
+    });
+});

--- a/packages/web-components/fast-components/src/number-field/number-field.pw.spec.ts
+++ b/packages/web-components/fast-components/src/number-field/number-field.pw.spec.ts
@@ -1,0 +1,48 @@
+import type {
+    NumberField as FASTNumberFieldType,
+} from "@microsoft/fast-foundation";
+import { expect } from "chai";
+
+type FASTNumberField = HTMLElement & FASTNumberFieldType;
+
+describe("FASTNumberField", function () {
+    beforeEach(async function () {
+        if (!this.page && !this.browser) {
+            this.skip();
+        }
+
+        this.documentHandle = await this.page.evaluateHandle(() => document);
+
+        this.setupHandle = await this.page.evaluateHandle(
+            (document) => {
+                const element = document.createElement("fast-number-field") as FASTNumberField;
+
+                document.body.appendChild(element)
+            },
+            this.documentHandle
+        );
+    });
+
+    afterEach(async function () {
+        if (this.setupHandle) {
+            await this.setupHandle.dispose();
+        }
+    });
+
+    // FASTNumberField should render on the page
+    it("should render on the page", async function () {
+        const element = await this.page.waitForSelector("fast-number-field");
+
+        expect(element).to.exist;
+    });
+
+    it("receive focus when focused programatically", async function () {
+        const element = await this.page.waitForSelector("fast-number-field");
+
+        await this.page.evaluateHandle(element => element.focus(), element)
+
+        expect(await this.page.evaluate(
+            () => document.activeElement?.id
+        )).to.equal(await element.evaluate(node => node.id));
+    });
+});

--- a/packages/web-components/fast-components/src/text-area/text-area.pw.spec.ts
+++ b/packages/web-components/fast-components/src/text-area/text-area.pw.spec.ts
@@ -1,0 +1,48 @@
+import type {
+    TextArea as FASTTextAreaType,
+} from "@microsoft/fast-foundation";
+import { expect } from "chai";
+
+type FASTTextArea = HTMLElement & FASTTextAreaType;
+
+describe("FASTTextArea", function () {
+    beforeEach(async function () {
+        if (!this.page && !this.browser) {
+            this.skip();
+        }
+
+        this.documentHandle = await this.page.evaluateHandle(() => document);
+
+        this.setupHandle = await this.page.evaluateHandle(
+            (document) => {
+                const element = document.createElement("fast-text-area") as FASTTextArea;
+
+                document.body.appendChild(element)
+            },
+            this.documentHandle
+        );
+    });
+
+    afterEach(async function () {
+        if (this.setupHandle) {
+            await this.setupHandle.dispose();
+        }
+    });
+
+    // FASTTextArea should render on the page
+    it("should render on the page", async function () {
+        const element = await this.page.waitForSelector("fast-text-area");
+
+        expect(element).to.exist;
+    });
+
+    it("receive focus when focused programatically", async function () {
+        const element = await this.page.waitForSelector("fast-text-area");
+
+        await this.page.evaluateHandle(element => element.focus(), element)
+
+        expect(await this.page.evaluate(
+            () => document.activeElement?.id
+        )).to.equal(await element.evaluate(node => node.id));
+    });
+});

--- a/packages/web-components/fast-components/src/text-field/text-field.pw.spec.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.pw.spec.ts
@@ -1,0 +1,48 @@
+import type {
+    TextField as FASTTextFieldType,
+} from "@microsoft/fast-foundation";
+import { expect } from "chai";
+
+type FASTTextField = HTMLElement & FASTTextFieldType;
+
+describe("FASTTextField", function () {
+    beforeEach(async function () {
+        if (!this.page && !this.browser) {
+            this.skip();
+        }
+
+        this.documentHandle = await this.page.evaluateHandle(() => document);
+
+        this.setupHandle = await this.page.evaluateHandle(
+            (document) => {
+                const element = document.createElement("fast-text-field") as FASTTextField;
+
+                document.body.appendChild(element)
+            },
+            this.documentHandle
+        );
+    });
+
+    afterEach(async function () {
+        if (this.setupHandle) {
+            await this.setupHandle.dispose();
+        }
+    });
+
+    // FASTTextField should render on the page
+    it("should render on the page", async function () {
+        const element = await this.page.waitForSelector("fast-text-field");
+
+        expect(element).to.exist;
+    });
+
+    it("receive focus when focused programatically", async function () {
+        const element = await this.page.waitForSelector("fast-text-field");
+
+        await this.page.evaluateHandle(element => element.focus(), element)
+
+        expect(await this.page.evaluate(
+            () => document.activeElement?.id
+        )).to.equal(await element.evaluate(node => node.id));
+    });
+});

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -169,6 +169,7 @@ export type AutoUpdateMode = "anchor" | "auto";
 export class Avatar extends FoundationElement {
     color: string;
     connectedCallback(): void;
+    control: HTMLAnchorElement;
     fill: string;
     link: string;
     // Warning: (ae-forgotten-export) The symbol "AvatarShape" needs to be exported by the entry point index.d.ts
@@ -2290,6 +2291,8 @@ export const tabTemplate: (context: ElementDefinitionContext, definition: Founda
 export class TextArea extends FormAssociatedTextArea {
     autofocus: boolean;
     cols: number;
+    // @internal (undocumented)
+    connectedCallback(): void;
     // @internal
     control: HTMLTextAreaElement;
     // @internal (undocumented)
@@ -2386,6 +2389,8 @@ export class Toolbar extends FoundationElement {
     clickHandler(e: MouseEvent): boolean | void;
     // @internal (undocumented)
     connectedCallback(): void;
+    // @internal
+    control: HTMLElement;
     // @internal
     direction: Direction;
     // @internal

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -169,6 +169,7 @@ export type AutoUpdateMode = "anchor" | "auto";
 export class Avatar extends FoundationElement {
     color: string;
     connectedCallback(): void;
+    // @internal
     control: HTMLAnchorElement;
     fill: string;
     link: string;
@@ -2389,8 +2390,6 @@ export class Toolbar extends FoundationElement {
     clickHandler(e: MouseEvent): boolean | void;
     // @internal (undocumented)
     connectedCallback(): void;
-    // @internal
-    control: HTMLElement;
     // @internal
     direction: Direction;
     // @internal

--- a/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
@@ -1,4 +1,4 @@
-import { html } from "@microsoft/fast-element";
+import { html, ref } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import type { ElementDefinitionContext } from "../design-system";
 import type { Avatar, AvatarOptions } from "./avatar";
@@ -25,6 +25,7 @@ export const avatarTemplate: (
             part="link"
             href="${x => (x.link ? x.link : void 0)}"
             style="${x => (x.color ? `color: var(--avatar-color-${x.color});` : void 0)}"
+            ${ref("control")}
         >
             <slot name="media" part="media">${definition.media || ""}</slot>
             <slot class="content" part="content"><slot>

--- a/packages/web-components/fast-foundation/src/avatar/avatar.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.ts
@@ -54,6 +54,11 @@ export class Avatar extends FoundationElement {
     @attr public shape: AvatarShape;
 
     /**
+     * References the root element
+     */
+    public control: HTMLAnchorElement;
+
+    /**
      * Internal
      */
     public connectedCallback(): void {
@@ -61,5 +66,25 @@ export class Avatar extends FoundationElement {
         if (!this.shape) {
             this.shape = "circle";
         }
+
+        this.handleUnsupportedDelegatesFocus();
     }
+
+    /**
+     * Overrides the focus call for where delegatesFocus is unsupported.
+     * This check works for Chrome, Edge Chromium, FireFox, and Safari
+     * Relevant PR on the Firefox browser: https://phabricator.services.mozilla.com/D123858
+     */
+    private handleUnsupportedDelegatesFocus = () => {
+        // Check to see if delegatesFocus is supported
+        if (
+            window.ShadowRoot &&
+            !window.ShadowRoot.prototype.hasOwnProperty("delegatesFocus") &&
+            this.$fastController.definition.shadowOptions?.delegatesFocus
+        ) {
+            this.focus = () => {
+                this.control.focus();
+            };
+        }
+    };
 }

--- a/packages/web-components/fast-foundation/src/avatar/avatar.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.ts
@@ -54,7 +54,8 @@ export class Avatar extends FoundationElement {
     @attr public shape: AvatarShape;
 
     /**
-     * References the root element
+     * A reference to the internal input element
+     * @internal
      */
     public control: HTMLAnchorElement;
 

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -19,7 +19,6 @@ export const comboboxTemplate: (
     <template
         autocomplete="${x => x.autocomplete}"
         class="${x => (x.disabled ? "disabled" : "")} ${x => x.position}"
-        tabindex="${x => (!x.disabled ? "0" : null)}"
         aria-disabled="${x => x.ariaDisabled}"
         aria-autocomplete="${x => x.autocomplete}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -281,6 +281,8 @@ export class Combobox extends FormAssociatedCombobox {
         if (this.value) {
             this.initialValue = this.value;
         }
+
+        this.handleUnsupportedDelegatesFocus();
     }
 
     /**
@@ -620,6 +622,24 @@ export class Combobox extends FormAssociatedCombobox {
             this.$emit("change");
         }
     }
+
+    /**
+     * Overrides the focus call for where delegatesFocus is unsupported.
+     * This check works for Chrome, Edge Chromium, FireFox, and Safari
+     * Relevant PR on the Firefox browser: https://phabricator.services.mozilla.com/D123858
+     */
+    private handleUnsupportedDelegatesFocus = () => {
+        // Check to see if delegatesFocus is supported
+        if (
+            window.ShadowRoot &&
+            !window.ShadowRoot.prototype.hasOwnProperty("delegatesFocus") &&
+            this.$fastController.definition.shadowOptions?.delegatesFocus
+        ) {
+            this.focus = () => {
+                this.control.focus();
+            };
+        }
+    };
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -240,6 +240,8 @@ export class NumberField extends FormAssociatedNumberField {
                 this.focus();
             });
         }
+
+        this.handleUnsupportedDelegatesFocus();
     }
 
     /**
@@ -291,6 +293,24 @@ export class NumberField extends FormAssociatedNumberField {
      */
     public handleBlur(): void {
         this.control.value = this.value;
+    }
+
+    /**
+     * Overrides the focus call for where delegatesFocus is unsupported.
+     * This check works for Chrome, Edge Chromium, FireFox, and Safari
+     * Relevant PR on the Firefox browser: https://phabricator.services.mozilla.com/D123858
+     */
+    private handleUnsupportedDelegatesFocus = () => {
+        // Check to see if delegatesFocus is supported
+        if (
+            window.ShadowRoot &&
+            !window.ShadowRoot.prototype.hasOwnProperty("delegatesFocus") &&
+            this.$fastController.definition.shadowOptions?.delegatesFocus
+        ) {
+            this.focus = () => {
+                this.control.focus();
+            };
+        }
     }
 }
 

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -168,6 +168,14 @@ export class TextArea extends FormAssociatedTextArea {
     /**
      * @internal
      */
+    public connectedCallback(): void {
+        super.connectedCallback();
+        this.handleUnsupportedDelegatesFocus();
+    }
+
+    /**
+     * @internal
+     */
     public handleTextInput = (): void => {
         this.value = this.control.value;
     };
@@ -184,6 +192,24 @@ export class TextArea extends FormAssociatedTextArea {
     public handleChange(): void {
         this.$emit("change");
     }
+
+    /**
+     * Overrides the focus call for where delegatesFocus is unsupported.
+     * This check works for Chrome, Edge Chromium, FireFox, and Safari
+     * Relevant PR on the Firefox browser: https://phabricator.services.mozilla.com/D123858
+     */
+    private handleUnsupportedDelegatesFocus = () => {
+        // Check to see if delegatesFocus is supported
+        if (
+            window.ShadowRoot &&
+            !window.ShadowRoot.prototype.hasOwnProperty("delegatesFocus") &&
+            this.$fastController.definition.shadowOptions?.delegatesFocus
+        ) {
+            this.focus = () => {
+                this.control.focus();
+            };
+        }
+    };
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -198,6 +198,8 @@ export class TextField extends FormAssociatedTextField {
                 this.focus();
             });
         }
+
+        this.handleUnsupportedDelegatesFocus();
     }
 
     /**
@@ -220,6 +222,24 @@ export class TextField extends FormAssociatedTextField {
     public handleChange(): void {
         this.$emit("change");
     }
+
+    /**
+     * Overrides the focus call for where delegatesFocus is unsupported.
+     * This check works for Chrome, Edge Chromium, FireFox, and Safari
+     * Relevant PR on the Firefox browser: https://phabricator.services.mozilla.com/D123858
+     */
+    private handleUnsupportedDelegatesFocus = () => {
+        // Check to see if delegatesFocus is supported
+        if (
+            window.ShadowRoot &&
+            !window.ShadowRoot.prototype.hasOwnProperty("delegatesFocus") &&
+            this.$fastController.definition.shadowOptions?.delegatesFocus
+        ) {
+            this.focus = () => {
+                this.control.focus();
+            };
+        }
+    };
 }
 
 /**


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

Added a function to manually set focus on the inner element when delegatesFocus is undefined.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->