### PR TITLE
fix: active indicator not animating when keyboarding

### DIFF
--- a/change/@microsoft-fast-foundation-5cf07db0-9c1c-4d0d-9a01-eb155212e068.json
+++ b/change/@microsoft-fast-foundation-5cf07db0-9c1c-4d0d-9a01-eb155212e068.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix: active indicator keyboarding issue in tabs",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2085,7 +2085,7 @@ export const tabPanelTemplate: (context: ElementDefinitionContext, definition: F
 export class Tabs extends FoundationElement {
     activeid: string;
     // @internal (undocumented)
-    activeidChanged(): void;
+    activeidChanged(oldValue: any, newValue: any): void;
     activeindicator: boolean;
     // @internal (undocumented)
     activeIndicatorRef: HTMLElement;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2085,7 +2085,7 @@ export const tabPanelTemplate: (context: ElementDefinitionContext, definition: F
 export class Tabs extends FoundationElement {
     activeid: string;
     // @internal (undocumented)
-    activeidChanged(oldValue: any, newValue: any): void;
+    activeidChanged(oldValue: string, newValue: string): void;
     activeindicator: boolean;
     // @internal (undocumented)
     activeIndicatorRef: HTMLElement;

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -64,12 +64,14 @@ export class Tabs extends FoundationElement {
     /**
      * @internal
      */
-    public activeidChanged(): void {
+    public activeidChanged(oldValue: string, newValue: string): void {
         if (
             this.$fastController.isConnected &&
             this.tabs.length <= this.tabpanels.length
         ) {
-            this.prevActiveTabIndex = this.tabs.indexOf(this.activetab);
+            this.prevActiveTabIndex = this.tabs.findIndex(
+                (item: HTMLElement) => item.id === oldValue
+            );
             this.setTabs();
             this.setTabPanels();
             this.handleActiveIndicatorPosition();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
active indicator not animating when keyboarding.
Active indicator animates when, new tab is clicked, keyboarding (left, right, down, up, home and end), when activeId `attr` is changed.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->