### PR TITLE
fix: anchored region should always update on attribute changes

### DIFF
--- a/change/@microsoft-fast-components-b8677c46-55aa-464f-8eb7-cf7bd2892177.json
+++ b/change/@microsoft-fast-components-b8677c46-55aa-464f-8eb7-cf7bd2892177.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "anchored region force update",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-69ddc58a-8577-4cbd-9ad6-a5046d58f9e7.json
+++ b/change/@microsoft-fast-foundation-69ddc58a-8577-4cbd-9ad6-a5046d58f9e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "anchored region force update",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/.storybook/preview-head.html
+++ b/packages/web-components/fast-components/.storybook/preview-head.html
@@ -10,14 +10,14 @@
     #root {
         padding: 20px;
     }
-    #root > h1,
-    #root > h2,
-    #root > h3,
-    #root > h4,
-    #root > h5,
-    #root > h6,
-    #root > p,
-    #root > span {
+    #root h1,
+    #root h2,
+    #root h3,
+    #root h4,
+    #root h5,
+    #root h6,
+    #root p,
+    #root span {
         color: var(--neutral-foreground-rest);
     }
 </style>

--- a/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
+++ b/packages/web-components/fast-components/src/anchored-region/anchored-region.stories.ts
@@ -114,23 +114,8 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
     }
 });
 
-const providerStyles = `
-fast-design-system-provider {
-    height: 100%;
-    overflow: hidden;
-    display: flex;
-    flex-direction: column;
-}
-`;
-
 export default {
     title: "Anchored Region",
-    decorators: [
-        Story => `
-            <style>${providerStyles}</style>
-            ${Story()}
-        `,
-    ],
 };
 
 export const AnchoredRegion = () => AnchoredRegionTemplate;

--- a/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
+++ b/packages/web-components/fast-components/src/anchored-region/fixtures/base.html
@@ -1,1844 +1,1873 @@
-<div
-    style="
-        margin: 20px;
-        position: fixed;
-        height: 100px;
-        width: calc(100% - 60px);
-        box-sizing: border-box;
-        background: black;
-        border-color: white;
-        border: 2px solid;
-        overflow: hidden;
-        display: grid;
-        grid-template-rows: 1fr;
-        grid-template-columns: 1fr auto auto;
-        z-index: 10;
-    "
-    id="fixed-header"
->
+<div style="height: 100%; overflow: hidden; display: flex; flex-direction: column;">
     <div
         style="
-            grid-column: 1 / 3;
-            line-height: 60%;
-            height: 50px;
-            padding: 0 8px;
-            white-space: nowrap;
-        "
-    >
-        <h1>
-            Anchored region
-        </h1>
-    </div>
-    <fast-button
-        id="anchor-header-menu-fixed"
-        style="grid-row: 2; margin: 8px 10px; height: 30px; width: 200px; grid-column: 2;"
-    >
-        Fixed size menu
-    </fast-button>
-    <fast-tooltip position="top" anchor="anchor-header-menu-fixed" style="z-index: 1000;">
-        This menu is of fixed height and avoids the performance cost of resizing itself.
-    </fast-tooltip>
-    <fast-button
-        id="anchor-header-menu-scaling"
-        style="grid-row: 2; margin: 8px 10px; height: 30px; width: 200px; grid-column: 3;"
-    >
-        Scaling menu
-    </fast-button>
-    <fast-tooltip
-        position="top"
-        anchor="anchor-header-menu-scaling"
-        style="z-index: 1000;"
-    >
-        <span style="max-width: 200px;">
-            This menu scales with the parent document and gains scrollbars when it needs
-            to.
-        </span>
-    </fast-tooltip>
-    <fast-anchored-region
-        style="display: none;"
-        id="header-menu-fixed"
-        anchor="anchor-header-menu-fixed"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none; overflow-y: auto;"
-        id="header-menu-scaling"
-        anchor="anchor-header-menu-scaling"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="fill"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>William Hartnell</fast-option>
-            <fast-option>Patrick Troughton</fast-option>
-            <fast-option>Jon Pertwee</fast-option>
-            <fast-option>Tom Baker</fast-option>
-            <fast-option>Peter Davidson</fast-option>
-            <fast-option>Colin Baker</fast-option>
-            <fast-option>Sylvester McCoy</fast-option>
-            <fast-option>Paul McGann</fast-option>
-            <fast-option>Christopher Eccleston</fast-option>
-            <fast-option>David Tenant</fast-option>
-            <fast-option>Matt Smith</fast-option>
-            <fast-option>Peter Capaldi</fast-option>
-            <fast-option>Jodie Whittaker</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-</div>
-
-<div style="overflow: auto; height: 100%; padding: 140px 20px; position: relative;">
-    <h2>
-        About
-    </h2>
-    <span>
-        The "anchored-region" component is a container that can position itself relative
-        to another html element in the same document referred to as the "anchor".
-        Additionally, the component can choose its position based on the available space
-        between the anchor element and the a "viewport" element (the document is used as
-        viewport if not otherwise specified).
-        <p>
-            An anchored-region is primarily intended to be used as the positioning element
-            within other components like tooltips or flyout menus.
-        </p>
-        Note that this page contains way more instances of anchored-region than is
-        expected in a normal scenario. Authors should consider performance impacts of many
-        instances.
-    </span>
-
-    <h2>
-        Header samples
-    </h2>
-    <span>
-        This header element of this page has position:fixed and overflow: hidden. The
-        flyout menus contained within it are wrapped in anchored regions with
-        "fixed-placement" set to "true" which allows the menus render outside the bounds
-        of the parent header when it would otherwise be clipped. Click the buttons to open
-        the menus, resize the browser to see repositioning/resizing.
-    </span>
-
-    <h2>
-        Position updates
-    </h2>
-    <span>
-        The component always calculates its position on screen when it is first placed in
-        the dom, when its properties/attributes are changed, when the anchor element
-        resizes and when the component's update() function is invoked. Authors can use the
-        component's "auto-update-mode" attribute to "auto" which triggers additional
-        positioning checks on window resize, viewport resize and any scroll event in the
-        window.
-        <p>
-            Position checks stive to be efficient but authors should be conscious of
-            possible performance impacts of having many instances running.
-        </p>
-
-        <p>
-            It should be noted that anchored-region's method of checking position uses
-            intersection observer callbacks which avoids some expensive function calls but
-            introduces a frame delay in getting results. This causes an unavoidable 1
-            frame delay in repositioning when layouts change. Because regions positioned
-            "absolute" vs "fixed" require fewer position corrections this lag is less
-            evident in that case.
-        </p>
-    </span>
-
-    <h2>Positioning options</h2>
-    <span>
-        Authors can specify the default positions of an anchored region relative to its
-        anchor on both the horizontal and vertical axis. A "locktodefault" option forces
-        this position regardless of available space on the other side of the anchor.
-    </span>
-
-    <div
-        id="anchor-pos1"
-        style="
-            height: 120px;
-            width: 120px;
-            background: grey;
-            margin: 200px;
-            padding: 12px;
-        "
-    >
-        anchor
-    </div>
-    <fast-anchored-region
-        anchor="anchor-pos1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            top/left
-        </div>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        anchor="anchor-pos1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="right"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            top/right
-        </div>
-    </fast-anchored-region>
-    <fast-anchored-region
-        anchor="anchor-pos1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            bottom/left
-        </div>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        anchor="anchor-pos1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="right"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            bottom/right
-        </div>
-    </fast-anchored-region>
-
-    <h2>Inset</h2>
-    <span>
-        Setting "inset on a particular axis changes the anchor point from the outer edge,
-        to the inner edge. The anchored region always grows "away" from the edge it is
-        anchored to (a "top" oriented region would always grow upwards if it were to get
-        taller).
-    </span>
-
-    <div
-        id="anchor-pos2"
-        style="
-            height: 260px;
-            width: 260px;
-            background: grey;
-            margin: 40px 160px;
-            padding: 12px;
-        "
-    >
-        anchor
-    </div>
-    <fast-anchored-region
-        anchor="anchor-pos2"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-inset="true"
-        vertical-inset="true"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            inset top/
-            <br />
-            inset left
-        </div>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        anchor="anchor-pos2"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="right"
-        horizontal-inset="true"
-        vertical-inset="true"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            inset top/
-            <br />
-            inset right
-        </div>
-    </fast-anchored-region>
-    <fast-anchored-region
-        anchor="anchor-pos2"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-inset="true"
-        vertical-inset="true"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            inset bottom/
-            <br />
-            inset left
-        </div>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        anchor="anchor-pos2"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="right"
-        horizontal-inset="true"
-        vertical-inset="true"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            inset bottom/
-            <br />
-            inset right
-        </div>
-    </fast-anchored-region>
-
-    <h2>Dynamic positioning</h2>
-    <span>
-        An anchored region can "flip" its position relative to its anchor based on
-        available space when its positioning mode is set to "dynamic".
-    </span>
-
-    <div
-        id="viewport-dyn1"
-        style="
-            height: 400px;
-            width: 80%;
-            margin-top: 20px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
-        "
-    >
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <div
-                id="anchor-dyn1"
-                style="
-                    margin-top: 450px;
-                    margin-left: 450px;
-                    height: 100px;
-                    width: 100px;
-                    background: grey;
-                    padding: 12px;
-                "
-            >
-                anchor
-            </div>
-            <fast-anchored-region
-                anchor="anchor-dyn1"
-                viewport="viewport-dyn1"
-                vertical-positioning-mode="dynamic"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="left"
-                horizontal-inset="true"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
-                        height: 100px;
-                        width: 100px;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    Dynamic vertical axis
-                </div>
-            </fast-anchored-region>
-            <fast-anchored-region
-                anchor="anchor-dyn1"
-                viewport="viewport-dyn1"
-                horizontal-positioning-mode="dynamic"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="top"
-                vertical-inset="true"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
-                        height: 100px;
-                        width: 100px;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    Dynamic horizontal axis
-                </div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h2>Viewport lock</h2>
-    <span>
-        When 'viewport lock' is enabled on a particular axis the region will not follow
-        it's anchor out of the viewport. To keep a tooltip in view, for example.
-    </span>
-
-    <div
-        id="viewport-vloc1"
-        style="
-            height: 400px;
-            width: 80%;
-            margin-top: 20px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
-        "
-    >
-        <div style="height: 2000px; width: 2000px; overflow: hidden;">
-            <div
-                id="anchor-vloc1"
-                style="
-                    margin-top: 650px;
-                    margin-left: 650px;
-                    height: 100px;
-                    width: 100px;
-                    background: grey;
-                    padding: 12px;
-                "
-            >
-                anchor
-            </div>
-            <fast-anchored-region
-                anchor="anchor-vloc1"
-                viewport="viewport-vloc1"
-                vertical-positioning-mode="dynamic"
-                horizontal-positioning-mode="dynamic"
-                horizontal-inset="true"
-                auto-update-mode="auto"
-                vertical-viewport-lock="true"
-                horizontal-viewport-lock="true"
-            >
-                <div
-                    style="
-                        height: 100px;
-                        width: 100px;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    Horizontal inset
-                </div>
-            </fast-anchored-region>
-            <fast-anchored-region
-                anchor="anchor-vloc1"
-                viewport="viewport-vloc1"
-                horizontal-positioning-mode="dynamic"
-                vertical-positioning-mode="dynamic"
-                vertical-inset="true"
-                auto-update-mode="auto"
-                vertical-viewport-lock="true"
-                horizontal-viewport-lock="true"
-            >
-                <div
-                    style="
-                        height: 100px;
-                        width: 100px;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    Vertical inset
-                </div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h3>Thresholds</h3>
-    <span>
-        Dynamically place regions can favor one side over the other by setting a default
-        position. Authors can set horizontal and vertical threshold values that will keep
-        the region on the default side until the space available there is less than the
-        threshold value (ie. "display below the button as long as there is at least 200px
-        there."). If no threshold is specified the dimensions of the region are used
-        (except scaling is set to "fill" in which case a value is required).
-    </span>
-
-    <div
-        id="viewport-dyn2"
-        style="
-            height: 400px;
-            width: 80%;
-            margin-top: 20px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
-        "
-    >
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <div
-                id="anchor-dyn2"
-                style="
-                    margin-top: 450px;
-                    margin-left: 450px;
-                    height: 100px;
-                    width: 100px;
-                    background: grey;
-                    padding: 12px;
-                "
-            >
-                anchor
-            </div>
-            <fast-anchored-region
-                anchor="anchor-dyn2"
-                viewport="viewport-dyn2"
-                vertical-positioning-mode="dynamic"
-                vertical-default-position="bottom"
-                vertical-threshold="110"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="left"
-                horizontal-inset="true"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
-                        height: 100px;
-                        width: 100px;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    Defaults to bottom
-                </div>
-            </fast-anchored-region>
-            <fast-anchored-region
-                anchor="anchor-dyn2"
-                viewport="viewport-dyn2"
-                horizontal-positioning-mode="dynamic"
-                horizontal-default-position="right"
-                horizontal-threshold="110"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="top"
-                vertical-inset="true"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
-                        height: 100px;
-                        width: 100px;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    defaults to right
-                </div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h2>Region sizing</h2>
-    <span>
-        The region's size can be determined on each axis by the size of its
-        content(default), the size of the anchor, or the available space between the
-        anchor and the edge of the viewport.
-    </span>
-
-    <div
-        id="viewport-sz1"
-        style="
-            height: 400px;
-            width: 80%;
-            margin-top: 20px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
-        "
-    >
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <div
-                id="anchor-sz1"
-                style="
-                    margin-top: 450px;
-                    margin-left: 450px;
-                    height: 100px;
-                    width: 100px;
-                    background: grey;
-                    padding: 12px;
-                "
-            >
-                anchor
-            </div>
-            <fast-anchored-region
-                anchor="anchor-sz1"
-                viewport="viewport-sz1"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="top"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="left"
-            >
-                <div
-                    style="
-                        height: 60px;
-                        width: 120px;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    Size to content
-                </div>
-            </fast-anchored-region>
-            <fast-anchored-region
-                anchor="anchor-sz1"
-                viewport="viewport-sz1"
-                vertical-scaling="anchor"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="top"
-                horizontal-scaling="anchor"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="right"
-            >
-                <div
-                    style="
-                        box-sizing: border-box;
-                        height: 100%;
-                        width: 100%;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    Size to anchor
-                </div>
-            </fast-anchored-region>
-            <fast-anchored-region
-                anchor="anchor-sz1"
-                viewport="viewport-sz1"
-                vertical-scaling="fill"
-                vertical-positioning-mode="locktodefault"
-                vertical-default-position="bottom"
-                horizontal-scaling="fill"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="right"
-                auto-update-mode="auto"
-            >
-                <div
-                    style="
-                        box-sizing: border-box;
-                        height: 100%;
-                        width: 100%;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    Fill
-                </div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h2>Nesting</h2>
-    <span>
-        Anchored regions can be nested, as is the case with nested menus.
-    </span>
-
-    <fast-menu style="margin: 40px 0 80px 0;">
-        <fast-menu-item>
-            Menu item 1
-            <fast-menu slot="submenu">
-                <fast-menu-item>
-                    Nested Menu item 1.1
-                    <fast-menu>
-                        <fast-menu-item>Nested Menu item 1.1.1</fast-menu-item>
-                        <fast-menu-item>Nested Menu item 1.1.2</fast-menu-item>
-                        <fast-menu-item>Nested Menu item 1.1.3</fast-menu-item>
-                    </fast-menu>
-                </fast-menu-item>
-                <fast-menu-item>
-                    Nested Menu item 1.2
-                    <fast-menu slot="submenu">
-                        <fast-menu-item>Nested Menu item 1.2.1</fast-menu-item>
-                        <fast-menu-item>Nested Menu item 1.2.2</fast-menu-item>
-                        <fast-menu-item>Nested Menu item 1.2.3</fast-menu-item>
-                    </fast-menu>
-                </fast-menu-item>
-            </fast-menu>
-        </fast-menu-item>
-    </fast-menu>
-
-    <h2>Manual updating</h2>
-    <span>
-        Authors can force position updates by calling the component's update() function.
-    </span>
-
-    <div
-        id="viewport-upd1"
-        style="
-            height: 400px;
-            width: 80%;
-            margin-top: 20px;
-            background: lightgray;
-            overflow: scroll;
-            position: relative;
-        "
-    >
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
-            <div
-                id="anchor-upd1"
-                style="
-                    margin-top: 450px;
-                    margin-left: 450px;
-                    height: 100px;
-                    width: 100px;
-                    background: grey;
-                    padding: 12px;
-                "
-            >
-                anchor
-            </div>
-            <fast-anchored-region
-                id="region-upd1"
-                anchor="anchor-upd1"
-                viewport="viewport-upd1"
-                vertical-positioning-mode="dynamic"
-                vertical-scaling="fill"
-                horizontal-positioning-mode="dynamic"
-                horizontal-scaling="fill"
-            >
-                <div
-                    style="
-                        box-sizing: border-box;
-                        height: 100%;
-                        width: 100%;
-                        background: darkblue;
-                        padding: 12px;
-                        border: 2px solid white;
-                    "
-                >
-                    Rescaling on update()
-                </div>
-            </fast-anchored-region>
-        </div>
-    </div>
-
-    <h2>RTL - start and end position</h2>
-    <span>
-        Authors can use start/end instead of left/right to automatically change default
-        based on direction.
-    </span>
-
-    <div
-        id="anchor-rtl1"
-        style="
-            margin-top: 200px;
-            margin-left: 200px;
+            margin: 20px;
+            position: fixed;
             height: 100px;
-            width: 100px;
-            background: grey;
-            padding: 12px;
+            width: calc(100% - 60px);
+            box-sizing: border-box;
+            background: black;
+            border-color: white;
+            border: 2px solid;
+            overflow: hidden;
+            display: grid;
+            grid-template-rows: 1fr;
+            grid-template-columns: 1fr auto auto;
+            z-index: 10;
         "
+        id="fixed-header"
     >
-        anchor
+        <div
+            style="
+                grid-column: 1 / 3;
+                line-height: 60%;
+                height: 50px;
+                padding: 0 8px;
+                white-space: nowrap;
+            "
+        >
+            <h1>
+                Anchored region
+            </h1>
+        </div>
+        <fast-button
+            id="anchor-header-menu-fixed"
+            style="
+                grid-row: 2;
+                margin: 8px 10px;
+                height: 30px;
+                width: 200px;
+                grid-column: 2;
+            "
+        >
+            Fixed size menu
+        </fast-button>
+        <fast-tooltip
+            position="top"
+            anchor="anchor-header-menu-fixed"
+            style="z-index: 1000;"
+        >
+            This menu is of fixed height and avoids the performance cost of resizing
+            itself.
+        </fast-tooltip>
+        <fast-button
+            id="anchor-header-menu-scaling"
+            style="
+                grid-row: 2;
+                margin: 8px 10px;
+                height: 30px;
+                width: 200px;
+                grid-column: 3;
+            "
+        >
+            Scaling menu
+        </fast-button>
+        <fast-tooltip
+            position="top"
+            anchor="anchor-header-menu-scaling"
+            style="z-index: 1000;"
+        >
+            <span style="max-width: 200px;">
+                This menu scales with the parent document and gains scrollbars when it
+                needs to.
+            </span>
+        </fast-tooltip>
+        <fast-anchored-region
+            style="display: none;"
+            id="header-menu-fixed"
+            anchor="anchor-header-menu-fixed"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none; overflow-y: auto;"
+            id="header-menu-scaling"
+            anchor="anchor-header-menu-scaling"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="fill"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>William Hartnell</fast-option>
+                <fast-option>Patrick Troughton</fast-option>
+                <fast-option>Jon Pertwee</fast-option>
+                <fast-option>Tom Baker</fast-option>
+                <fast-option>Peter Davidson</fast-option>
+                <fast-option>Colin Baker</fast-option>
+                <fast-option>Sylvester McCoy</fast-option>
+                <fast-option>Paul McGann</fast-option>
+                <fast-option>Christopher Eccleston</fast-option>
+                <fast-option>David Tenant</fast-option>
+                <fast-option>Matt Smith</fast-option>
+                <fast-option>Peter Capaldi</fast-option>
+                <fast-option>Jodie Whittaker</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
     </div>
-    <fast-anchored-region
-        anchor="anchor-rtl1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="start"
-        auto-update-mode="auto"
-    >
+
+    <div style="overflow: auto; height: 100%; padding: 140px 20px; position: relative;">
+        <h2>
+            About
+        </h2>
+        <span>
+            The "anchored-region" component is a container that can position itself
+            relative to another html element in the same document referred to as the
+            "anchor". Additionally, the component can choose its position based on the
+            available space between the anchor element and the a "viewport" element (the
+            document is used as viewport if not otherwise specified).
+            <p>
+                An anchored-region is primarily intended to be used as the positioning
+                element within other components like tooltips or flyout menus.
+            </p>
+            Note that this page contains way more instances of anchored-region than is
+            expected in a normal scenario. Authors should consider performance impacts of
+            many instances.
+        </span>
+
+        <h2>
+            Header samples
+        </h2>
+        <span>
+            This header element of this page has position:fixed and overflow: hidden. The
+            flyout menus contained within it are wrapped in anchored regions with
+            "fixed-placement" set to "true" which allows the menus render outside the
+            bounds of the parent header when it would otherwise be clipped. Click the
+            buttons to open the menus, resize the browser to see repositioning/resizing.
+        </span>
+
+        <h2>
+            Position updates
+        </h2>
+        <span>
+            The component always calculates its position on screen when it is first placed
+            in the dom, when its properties/attributes are changed, when the anchor
+            element resizes and when the component's update() function is invoked. Authors
+            can use the component's "auto-update-mode" attribute to "auto" which triggers
+            additional positioning checks on window resize, viewport resize and any scroll
+            event in the window.
+            <p>
+                Position checks stive to be efficient but authors should be conscious of
+                possible performance impacts of having many instances running.
+            </p>
+
+            <p>
+                It should be noted that anchored-region's method of checking position uses
+                intersection observer callbacks which avoids some expensive function calls
+                but introduces a frame delay in getting results. This causes an
+                unavoidable 1 frame delay in repositioning when layouts change. Because
+                regions positioned "absolute" vs "fixed" require fewer position
+                corrections this lag is less evident in that case.
+            </p>
+        </span>
+
+        <h2>Positioning options</h2>
+        <span>
+            Authors can specify the default positions of an anchored region relative to
+            its anchor on both the horizontal and vertical axis. A "locktodefault" option
+            forces this position regardless of available space on the other side of the
+            anchor.
+        </span>
+
         <div
+            id="anchor-pos1"
             style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
+                height: 120px;
+                width: 120px;
+                background: grey;
+                margin: 200px;
                 padding: 12px;
-                border: 2px solid white;
             "
         >
-            top/start
+            anchor
         </div>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        anchor="anchor-rtl1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="top"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="end"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
+        <fast-anchored-region
+            anchor="anchor-pos1"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="top"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            auto-update-mode="auto"
         >
-            top/end
-        </div>
-    </fast-anchored-region>
-    <fast-anchored-region
-        anchor="anchor-rtl1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="start"
-        dir="rtl"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            bottom/start/rtl
-        </div>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        anchor="anchor-rtl1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="end"
-        dir="rtl"
-        auto-update-mode="auto"
-    >
-        <div
-            style="
-                height: 100px;
-                width: 100px;
-                background: darkblue;
-                padding: 12px;
-                border: 2px solid white;
-            "
-        >
-            bottom/end/rtl
-        </div>
-    </fast-anchored-region>
-
-    <h2 style="margin-top: 200px;">Toggling attributes</h2>
-    <span>
-        Test changing attributes on the fly
-    </span>
-
-    <div
-        id="viewport-toggles1"
-        style="
-            position: relative;
-            height: 400px;
-            margin-top: 20px;
-            width: 80%;
-            background: lightgray;
-            overflow: scroll;
-        "
-    >
-        <div style="height: 1000px; width: 1000px; overflow: hidden;">
             <div
                 style="
-                    display: grid;
-                    grid-template-columns: 1fr auto 150px auto 1fr;
-                    grid-template-rows: 1fr auto 1fr;
-                    height: 100%;
-                    width: 100%;
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
                 "
             >
-                <fast-button id="toggles1-anchor1" style="grid-column: 2; grid-row: 2;">
-                    Set as anchor
-                </fast-button>
-                <fast-button id="toggles1-anchor2" style="grid-column: 4; grid-row: 2;">
-                    Set as anchor
-                </fast-button>
+                top/left
             </div>
-            <fast-anchored-region
-                id="toggles-region"
-                anchor="toggles1-anchor1"
-                viewport="viewport-toggles1"
-                vertical-positioning-mode="locktodefault"
-                horizontal-positioning-mode="locktodefault"
-                horizontal-default-position="left"
-                vertical-default-position="top"
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            anchor="anchor-pos1"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="top"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="right"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
             >
+                top/right
+            </div>
+        </fast-anchored-region>
+        <fast-anchored-region
+            anchor="anchor-pos1"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                bottom/left
+            </div>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            anchor="anchor-pos1"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="right"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                bottom/right
+            </div>
+        </fast-anchored-region>
+
+        <h2>Inset</h2>
+        <span>
+            Setting "inset on a particular axis changes the anchor point from the outer
+            edge, to the inner edge. The anchored region always grows "away" from the edge
+            it is anchored to (a "top" oriented region would always grow upwards if it
+            were to get taller).
+        </span>
+
+        <div
+            id="anchor-pos2"
+            style="
+                height: 260px;
+                width: 260px;
+                background: grey;
+                margin: 40px 160px;
+                padding: 12px;
+            "
+        >
+            anchor
+        </div>
+        <fast-anchored-region
+            anchor="anchor-pos2"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="top"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-inset="true"
+            vertical-inset="true"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                inset top/
+                <br />
+                inset left
+            </div>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            anchor="anchor-pos2"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="top"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="right"
+            horizontal-inset="true"
+            vertical-inset="true"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                inset top/
+                <br />
+                inset right
+            </div>
+        </fast-anchored-region>
+        <fast-anchored-region
+            anchor="anchor-pos2"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-inset="true"
+            vertical-inset="true"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                inset bottom/
+                <br />
+                inset left
+            </div>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            anchor="anchor-pos2"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="right"
+            horizontal-inset="true"
+            vertical-inset="true"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                inset bottom/
+                <br />
+                inset right
+            </div>
+        </fast-anchored-region>
+
+        <h2>Dynamic positioning</h2>
+        <span>
+            An anchored region can "flip" its position relative to its anchor based on
+            available space when its positioning mode is set to "dynamic".
+        </span>
+
+        <div
+            id="viewport-dyn1"
+            style="
+                height: 400px;
+                width: 80%;
+                margin-top: 20px;
+                background: lightgray;
+                overflow: scroll;
+                position: relative;
+            "
+        >
+            <div style="height: 1000px; width: 1000px; overflow: hidden;">
                 <div
+                    id="anchor-dyn1"
                     style="
+                        margin-top: 450px;
+                        margin-left: 450px;
                         height: 100px;
                         width: 100px;
-                        background: darkblue;
+                        background: grey;
                         padding: 12px;
-                        border: 2px solid white;
-                        box-sizing: border-box;
                     "
-                ></div>
-            </fast-anchored-region>
+                >
+                    anchor
+                </div>
+                <fast-anchored-region
+                    anchor="anchor-dyn1"
+                    viewport="viewport-dyn1"
+                    vertical-positioning-mode="dynamic"
+                    horizontal-positioning-mode="locktodefault"
+                    horizontal-default-position="left"
+                    horizontal-inset="true"
+                    auto-update-mode="auto"
+                >
+                    <div
+                        style="
+                            height: 100px;
+                            width: 100px;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        Dynamic vertical axis
+                    </div>
+                </fast-anchored-region>
+                <fast-anchored-region
+                    anchor="anchor-dyn1"
+                    viewport="viewport-dyn1"
+                    horizontal-positioning-mode="dynamic"
+                    vertical-positioning-mode="locktodefault"
+                    vertical-default-position="top"
+                    vertical-inset="true"
+                    auto-update-mode="auto"
+                >
+                    <div
+                        style="
+                            height: 100px;
+                            width: 100px;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        Dynamic horizontal axis
+                    </div>
+                </fast-anchored-region>
+            </div>
         </div>
+
+        <h2>Viewport lock</h2>
+        <span>
+            When 'viewport lock' is enabled on a particular axis the region will not
+            follow it's anchor out of the viewport. To keep a tooltip in view, for
+            example.
+        </span>
+
+        <div
+            id="viewport-vloc1"
+            style="
+                height: 400px;
+                width: 80%;
+                margin-top: 20px;
+                background: lightgray;
+                overflow: scroll;
+                position: relative;
+            "
+        >
+            <div style="height: 2000px; width: 2000px; overflow: hidden;">
+                <div
+                    id="anchor-vloc1"
+                    style="
+                        margin-top: 650px;
+                        margin-left: 650px;
+                        height: 100px;
+                        width: 100px;
+                        background: grey;
+                        padding: 12px;
+                    "
+                >
+                    anchor
+                </div>
+                <fast-anchored-region
+                    anchor="anchor-vloc1"
+                    viewport="viewport-vloc1"
+                    vertical-positioning-mode="dynamic"
+                    horizontal-positioning-mode="dynamic"
+                    horizontal-inset="true"
+                    auto-update-mode="auto"
+                    vertical-viewport-lock="true"
+                    horizontal-viewport-lock="true"
+                >
+                    <div
+                        style="
+                            height: 100px;
+                            width: 100px;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        Horizontal inset
+                    </div>
+                </fast-anchored-region>
+                <fast-anchored-region
+                    anchor="anchor-vloc1"
+                    viewport="viewport-vloc1"
+                    horizontal-positioning-mode="dynamic"
+                    vertical-positioning-mode="dynamic"
+                    vertical-inset="true"
+                    auto-update-mode="auto"
+                    vertical-viewport-lock="true"
+                    horizontal-viewport-lock="true"
+                >
+                    <div
+                        style="
+                            height: 100px;
+                            width: 100px;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        Vertical inset
+                    </div>
+                </fast-anchored-region>
+            </div>
+        </div>
+
+        <h3>Thresholds</h3>
+        <span>
+            Dynamically place regions can favor one side over the other by setting a
+            default position. Authors can set horizontal and vertical threshold values
+            that will keep the region on the default side until the space available there
+            is less than the threshold value (ie. "display below the button as long as
+            there is at least 200px there."). If no threshold is specified the dimensions
+            of the region are used (except scaling is set to "fill" in which case a value
+            is required).
+        </span>
+
+        <div
+            id="viewport-dyn2"
+            style="
+                height: 400px;
+                width: 80%;
+                margin-top: 20px;
+                background: lightgray;
+                overflow: scroll;
+                position: relative;
+            "
+        >
+            <div style="height: 1000px; width: 1000px; overflow: hidden;">
+                <div
+                    id="anchor-dyn2"
+                    style="
+                        margin-top: 450px;
+                        margin-left: 450px;
+                        height: 100px;
+                        width: 100px;
+                        background: grey;
+                        padding: 12px;
+                    "
+                >
+                    anchor
+                </div>
+                <fast-anchored-region
+                    anchor="anchor-dyn2"
+                    viewport="viewport-dyn2"
+                    vertical-positioning-mode="dynamic"
+                    vertical-default-position="bottom"
+                    vertical-threshold="110"
+                    horizontal-positioning-mode="locktodefault"
+                    horizontal-default-position="left"
+                    horizontal-inset="true"
+                    auto-update-mode="auto"
+                >
+                    <div
+                        style="
+                            height: 100px;
+                            width: 100px;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        Defaults to bottom
+                    </div>
+                </fast-anchored-region>
+                <fast-anchored-region
+                    anchor="anchor-dyn2"
+                    viewport="viewport-dyn2"
+                    horizontal-positioning-mode="dynamic"
+                    horizontal-default-position="right"
+                    horizontal-threshold="110"
+                    vertical-positioning-mode="locktodefault"
+                    vertical-default-position="top"
+                    vertical-inset="true"
+                    auto-update-mode="auto"
+                >
+                    <div
+                        style="
+                            height: 100px;
+                            width: 100px;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        defaults to right
+                    </div>
+                </fast-anchored-region>
+            </div>
+        </div>
+
+        <h2>Region sizing</h2>
+        <span>
+            The region's size can be determined on each axis by the size of its
+            content(default), the size of the anchor, or the available space between the
+            anchor and the edge of the viewport.
+        </span>
+
+        <div
+            id="viewport-sz1"
+            style="
+                height: 400px;
+                width: 80%;
+                margin-top: 20px;
+                background: lightgray;
+                overflow: scroll;
+                position: relative;
+            "
+        >
+            <div style="height: 1000px; width: 1000px; overflow: hidden;">
+                <div
+                    id="anchor-sz1"
+                    style="
+                        margin-top: 450px;
+                        margin-left: 450px;
+                        height: 100px;
+                        width: 100px;
+                        background: grey;
+                        padding: 12px;
+                    "
+                >
+                    anchor
+                </div>
+                <fast-anchored-region
+                    anchor="anchor-sz1"
+                    viewport="viewport-sz1"
+                    vertical-positioning-mode="locktodefault"
+                    vertical-default-position="top"
+                    horizontal-positioning-mode="locktodefault"
+                    horizontal-default-position="left"
+                >
+                    <div
+                        style="
+                            height: 60px;
+                            width: 120px;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        Size to content
+                    </div>
+                </fast-anchored-region>
+                <fast-anchored-region
+                    anchor="anchor-sz1"
+                    viewport="viewport-sz1"
+                    vertical-scaling="anchor"
+                    vertical-positioning-mode="locktodefault"
+                    vertical-default-position="top"
+                    horizontal-scaling="anchor"
+                    horizontal-positioning-mode="locktodefault"
+                    horizontal-default-position="right"
+                >
+                    <div
+                        style="
+                            box-sizing: border-box;
+                            height: 100%;
+                            width: 100%;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        Size to anchor
+                    </div>
+                </fast-anchored-region>
+                <fast-anchored-region
+                    anchor="anchor-sz1"
+                    viewport="viewport-sz1"
+                    vertical-scaling="fill"
+                    vertical-positioning-mode="locktodefault"
+                    vertical-default-position="bottom"
+                    horizontal-scaling="fill"
+                    horizontal-positioning-mode="locktodefault"
+                    horizontal-default-position="right"
+                    auto-update-mode="auto"
+                >
+                    <div
+                        style="
+                            box-sizing: border-box;
+                            height: 100%;
+                            width: 100%;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        Fill
+                    </div>
+                </fast-anchored-region>
+            </div>
+        </div>
+
+        <h2>Nesting</h2>
+        <span>
+            Anchored regions can be nested, as is the case with nested menus.
+        </span>
+
+        <fast-menu style="margin: 40px 0 80px 0;">
+            <fast-menu-item>
+                Menu item 1
+                <fast-menu slot="submenu">
+                    <fast-menu-item>
+                        Nested Menu item 1.1
+                        <fast-menu>
+                            <fast-menu-item>Nested Menu item 1.1.1</fast-menu-item>
+                            <fast-menu-item>Nested Menu item 1.1.2</fast-menu-item>
+                            <fast-menu-item>Nested Menu item 1.1.3</fast-menu-item>
+                        </fast-menu>
+                    </fast-menu-item>
+                    <fast-menu-item>
+                        Nested Menu item 1.2
+                        <fast-menu slot="submenu">
+                            <fast-menu-item>Nested Menu item 1.2.1</fast-menu-item>
+                            <fast-menu-item>Nested Menu item 1.2.2</fast-menu-item>
+                            <fast-menu-item>Nested Menu item 1.2.3</fast-menu-item>
+                        </fast-menu>
+                    </fast-menu-item>
+                </fast-menu>
+            </fast-menu-item>
+        </fast-menu>
+
+        <h2>Manual updating</h2>
+        <span>
+            Authors can force position updates by calling the component's update()
+            function.
+        </span>
+
+        <div
+            id="viewport-upd1"
+            style="
+                height: 400px;
+                width: 80%;
+                margin-top: 20px;
+                background: lightgray;
+                overflow: scroll;
+                position: relative;
+            "
+        >
+            <div style="height: 1000px; width: 1000px; overflow: hidden;">
+                <div
+                    id="anchor-upd1"
+                    style="
+                        margin-top: 450px;
+                        margin-left: 450px;
+                        height: 100px;
+                        width: 100px;
+                        background: grey;
+                        padding: 12px;
+                    "
+                >
+                    anchor
+                </div>
+                <fast-anchored-region
+                    id="region-upd1"
+                    anchor="anchor-upd1"
+                    viewport="viewport-upd1"
+                    vertical-positioning-mode="dynamic"
+                    vertical-scaling="fill"
+                    horizontal-positioning-mode="dynamic"
+                    horizontal-scaling="fill"
+                >
+                    <div
+                        style="
+                            box-sizing: border-box;
+                            height: 100%;
+                            width: 100%;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                        "
+                    >
+                        Rescaling on update()
+                    </div>
+                </fast-anchored-region>
+            </div>
+        </div>
+
+        <h2>RTL - start and end position</h2>
+        <span>
+            Authors can use start/end instead of left/right to automatically change
+            default based on direction.
+        </span>
+
+        <div
+            id="anchor-rtl1"
+            style="
+                margin-top: 200px;
+                margin-left: 200px;
+                height: 100px;
+                width: 100px;
+                background: grey;
+                padding: 12px;
+            "
+        >
+            anchor
+        </div>
+        <fast-anchored-region
+            anchor="anchor-rtl1"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="top"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="start"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                top/start
+            </div>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            anchor="anchor-rtl1"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="top"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="end"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                top/end
+            </div>
+        </fast-anchored-region>
+        <fast-anchored-region
+            anchor="anchor-rtl1"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="start"
+            dir="rtl"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                bottom/start/rtl
+            </div>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            anchor="anchor-rtl1"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="end"
+            dir="rtl"
+            auto-update-mode="auto"
+        >
+            <div
+                style="
+                    height: 100px;
+                    width: 100px;
+                    background: darkblue;
+                    padding: 12px;
+                    border: 2px solid white;
+                "
+            >
+                bottom/end/rtl
+            </div>
+        </fast-anchored-region>
+
+        <h2 style="margin-top: 200px;">Toggling attributes</h2>
+        <span>
+            Test changing attributes on the fly
+        </span>
+
+        <div
+            id="viewport-toggles1"
+            style="
+                position: relative;
+                height: 400px;
+                margin-top: 20px;
+                width: 80%;
+                background: lightgray;
+                overflow: scroll;
+            "
+        >
+            <div style="height: 1000px; width: 1000px; overflow: hidden;">
+                <div
+                    style="
+                        display: grid;
+                        grid-template-columns: 1fr auto 150px auto 1fr;
+                        grid-template-rows: 1fr auto 1fr;
+                        height: 100%;
+                        width: 100%;
+                    "
+                >
+                    <fast-button
+                        id="toggles1-anchor1"
+                        style="grid-column: 2; grid-row: 2;"
+                    >
+                        Set as anchor
+                    </fast-button>
+                    <fast-button
+                        id="toggles1-anchor2"
+                        style="grid-column: 4; grid-row: 2;"
+                    >
+                        Set as anchor
+                    </fast-button>
+                </div>
+                <fast-anchored-region
+                    id="toggles-region"
+                    anchor="toggles1-anchor1"
+                    viewport="viewport-toggles1"
+                    vertical-positioning-mode="locktodefault"
+                    horizontal-positioning-mode="locktodefault"
+                    horizontal-default-position="left"
+                    vertical-default-position="top"
+                >
+                    <div
+                        style="
+                            height: 100px;
+                            width: 100px;
+                            background: darkblue;
+                            padding: 12px;
+                            border: 2px solid white;
+                            box-sizing: border-box;
+                        "
+                    ></div>
+                </fast-anchored-region>
+            </div>
+        </div>
+        <div style="margin-top: 10px; display: flex; flex-direction: row;">
+            <fast-button id="toggle-positions-horizontal" style="margin: 20px;">
+                toggle horizontal position
+            </fast-button>
+            <fast-button id="toggle-positions-vertical" style="margin: 20px;">
+                toggle vertical position
+            </fast-button>
+            <fast-button id="toggle-inset-vertical" style="margin: 20px;">
+                toggle vertical inset
+            </fast-button>
+            <fast-button id="toggle-inset-horizontal" style="margin: 20px;">
+                toggle horizontal inset
+            </fast-button>
+        </div>
+
+        <h2 style="margin-top: 20px;">Many...</h2>
+        <span>
+            Try out multiple open menus and resize/scroll the window.
+            <p>
+                These menus alternate between fixed and absolute positioning. While the
+                fixed menus more easily break out of parent containers to render in the
+                foreground they are also more prone to "jiggling" during resizing (in this
+                case because the text wrapping above resizing the scrolling container as
+                it wraps for different widths).
+            </p>
+        </span>
+
+        <div style="display: flex; flex-wrap: wrap;">
+            <fast-button
+                id="anchor-menu-many1"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many2"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many3"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many4"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many5"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many6"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many7"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many8"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many9"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many10"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many11"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many12"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many13"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many14"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many15"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many16"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many17"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many18"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many19"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many20"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many21"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many22"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many23"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many24"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many25"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many26"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many27"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many28"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many29"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many30"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many31"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Absolute position menu
+            </fast-button>
+
+            <fast-button
+                id="anchor-menu-many32"
+                style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
+            >
+                Fixed position menu
+            </fast-button>
+        </div>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many1"
+            anchor="anchor-menu-many1"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many2"
+            anchor="anchor-menu-many2"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many3"
+            anchor="anchor-menu-many3"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many4"
+            anchor="anchor-menu-many4"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many5"
+            anchor="anchor-menu-many5"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many6"
+            anchor="anchor-menu-many6"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many7"
+            anchor="anchor-menu-many7"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many8"
+            anchor="anchor-menu-many8"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many9"
+            anchor="anchor-menu-many9"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many10"
+            anchor="anchor-menu-many10"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many11"
+            anchor="anchor-menu-many11"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many12"
+            anchor="anchor-menu-many12"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many13"
+            anchor="anchor-menu-many13"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many14"
+            anchor="anchor-menu-many14"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many15"
+            anchor="anchor-menu-many15"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many16"
+            anchor="anchor-menu-many16"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many17"
+            anchor="anchor-menu-many17"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many18"
+            anchor="anchor-menu-many18"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many19"
+            anchor="anchor-menu-many19"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many20"
+            anchor="anchor-menu-many20"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many21"
+            anchor="anchor-menu-many21"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many22"
+            anchor="anchor-menu-many22"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many23"
+            anchor="anchor-menu-many23"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many24"
+            anchor="anchor-menu-many24"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many25"
+            anchor="anchor-menu-many25"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many26"
+            anchor="anchor-menu-many26"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many27"
+            anchor="anchor-menu-many27"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many28"
+            anchor="anchor-menu-many28"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many29"
+            anchor="anchor-menu-many29"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many30"
+            anchor="anchor-menu-many30"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many31"
+            anchor="anchor-menu-many31"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
+
+        <fast-anchored-region
+            style="display: none;"
+            id="menu-many32"
+            anchor="anchor-menu-many32"
+            fixed-placement="true"
+            vertical-positioning-mode="locktodefault"
+            vertical-default-position="bottom"
+            vertical-scaling="content"
+            horizontal-positioning-mode="locktodefault"
+            horizontal-default-position="left"
+            horizontal-scaling="anchor"
+            horizontal-inset="true"
+            auto-update-mode="auto"
+        >
+            <fast-listbox style="width: 100%;">
+                <fast-option>Yes</fast-option>
+                <fast-option>No</fast-option>
+            </fast-listbox>
+        </fast-anchored-region>
     </div>
-    <div style="margin-top: 10px; display: flex; flex-direction: row;">
-        <fast-button id="toggle-positions-horizontal" style="margin: 20px;">
-            toggle horizontal position
-        </fast-button>
-        <fast-button id="toggle-positions-vertical" style="margin: 20px;">
-            toggle vertical position
-        </fast-button>
-        <fast-button id="toggle-inset-vertical" style="margin: 20px;">
-            toggle vertical inset
-        </fast-button>
-        <fast-button id="toggle-inset-horizontal" style="margin: 20px;">
-            toggle horizontal inset
-        </fast-button>
-    </div>
-
-    <h2 style="margin-top: 20px;">Many...</h2>
-    <span>
-        Try out multiple open menus and resize/scroll the window.
-        <p>
-            These menus alternate between fixed and absolute positioning. While the fixed
-            menus more easily break out of parent containers to render in the foreground
-            they are also more prone to "jiggling" during resizing (in this case because
-            the text wrapping above resizing the scrolling container as it wraps for
-            different widths).
-        </p>
-    </span>
-
-    <div style="display: flex; flex-wrap: wrap;">
-        <fast-button
-            id="anchor-menu-many1"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many2"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many3"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many4"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many5"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many6"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many7"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many8"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many9"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many10"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many11"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many12"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many13"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many14"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many15"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many16"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many17"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many18"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many19"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many20"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many21"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many22"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many23"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many24"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many25"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many26"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many27"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many28"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many29"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many30"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many31"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Absolute position menu
-        </fast-button>
-
-        <fast-button
-            id="anchor-menu-many32"
-            style="margin: 20px 20px 100px 0; height: 30px; width: 200px;"
-        >
-            Fixed position menu
-        </fast-button>
-    </div>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many1"
-        anchor="anchor-menu-many1"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many2"
-        anchor="anchor-menu-many2"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many3"
-        anchor="anchor-menu-many3"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many4"
-        anchor="anchor-menu-many4"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many5"
-        anchor="anchor-menu-many5"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many6"
-        anchor="anchor-menu-many6"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many7"
-        anchor="anchor-menu-many7"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many8"
-        anchor="anchor-menu-many8"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many9"
-        anchor="anchor-menu-many9"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many10"
-        anchor="anchor-menu-many10"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many11"
-        anchor="anchor-menu-many11"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many12"
-        anchor="anchor-menu-many12"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many13"
-        anchor="anchor-menu-many13"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many14"
-        anchor="anchor-menu-many14"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many15"
-        anchor="anchor-menu-many15"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many16"
-        anchor="anchor-menu-many16"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many17"
-        anchor="anchor-menu-many17"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many18"
-        anchor="anchor-menu-many18"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many19"
-        anchor="anchor-menu-many19"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many20"
-        anchor="anchor-menu-many20"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many21"
-        anchor="anchor-menu-many21"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many22"
-        anchor="anchor-menu-many22"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many23"
-        anchor="anchor-menu-many23"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many24"
-        anchor="anchor-menu-many24"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many25"
-        anchor="anchor-menu-many25"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many26"
-        anchor="anchor-menu-many26"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many27"
-        anchor="anchor-menu-many27"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many28"
-        anchor="anchor-menu-many28"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many29"
-        anchor="anchor-menu-many29"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many30"
-        anchor="anchor-menu-many30"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many31"
-        anchor="anchor-menu-many31"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
-
-    <fast-anchored-region
-        style="display: none;"
-        id="menu-many32"
-        anchor="anchor-menu-many32"
-        fixed-placement="true"
-        vertical-positioning-mode="locktodefault"
-        vertical-default-position="bottom"
-        vertical-scaling="content"
-        horizontal-positioning-mode="locktodefault"
-        horizontal-default-position="left"
-        horizontal-scaling="anchor"
-        horizontal-inset="true"
-        auto-update-mode="auto"
-    >
-        <fast-listbox style="width: 100%;">
-            <fast-option>Yes</fast-option>
-            <fast-option>No</fast-option>
-        </fast-listbox>
-    </fast-anchored-region>
 </div>

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -399,6 +399,10 @@ export class AnchoredRegion extends FoundationElement {
     private currentDirection: Direction = Direction.ltr;
     private regionVisible: boolean = false;
 
+    // indicates that a layout update should occur even if geometry has not changed
+    // used to ensure some attribute changes are applied
+    private forceUpdate: boolean = false;
+
     // defines how big a difference in pixels there must be between states to
     // justify a layout update that affects the dom (prevents repeated sub-pixel corrections)
     private updateThreshold: number = 0.5;
@@ -472,6 +476,7 @@ export class AnchoredRegion extends FoundationElement {
             (this as FoundationElement).$fastController.isConnected &&
             this.initialLayoutComplete
         ) {
+            this.forceUpdate = true;
             this.update();
         }
     }
@@ -522,6 +527,8 @@ export class AnchoredRegion extends FoundationElement {
 
         this.style.opacity = "0";
         this.style.pointerEvents = "none";
+
+        this.forceUpdate = false;
 
         this.style.position = this.fixedPlacement ? "fixed" : "absolute";
         this.updatePositionClasses();
@@ -658,6 +665,7 @@ export class AnchoredRegion extends FoundationElement {
         // don't update the dom unless there is a significant difference in rect positions
         if (
             !this.regionVisible ||
+            this.forceUpdate ||
             this.regionRect === undefined ||
             this.anchorRect === undefined ||
             this.viewportRect === undefined ||
@@ -681,6 +689,8 @@ export class AnchoredRegion extends FoundationElement {
             }
 
             this.updateRegionOffset();
+
+            this.forceUpdate = false;
 
             return true;
         }


### PR DESCRIPTION
## 📖 Description
In cases where attribute changes don't result in a change in geometry the update could be short circuited which prevented things like updating of classes to happen.  This change adds an internal "forceUpdate" flag to anchored region which ensures that there is a full update after an attribute change even if geometry did not change.

Also updated storybook styles in fast-components so the anchored region samples got the color settings applied.

### 🎫 Issues
https://github.com/microsoft/fast/issues/5213#issuecomment-927921659


## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
