### PR TITLE
do not prevent default on tree item click handler

### DIFF
--- a/change/@microsoft-fast-components-1aa787ec-5c72-48a8-9733-1aa7a27c9b18.json
+++ b/change/@microsoft-fast-components-1aa787ec-5c72-48a8-9733-1aa7a27c9b18.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "do not prevent default on tree item click",
+  "packageName": "@microsoft/fast-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-83e650ae-505d-4c26-8b4e-b3b2ab75d3ae.json
+++ b/change/@microsoft-fast-foundation-83e650ae-505d-4c26-8b4e-b3b2ab75d3ae.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "do not prevent default on tree item click",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/tree-item/fixtures/tree-item.html
+++ b/packages/web-components/fast-components/src/tree-item/fixtures/tree-item.html
@@ -14,6 +14,14 @@
 <h2>Selected</h2>
 <fast-tree-item selected>Tree item</fast-tree-item>
 
+<h2>Anchor as child</h2>
+<fast-tree-item><a href="https://bing.com" target="_blank">Bing</a></fast-tree-item>
+
+<h2>FAST Anchor as child</h2>
+<fast-tree-item>
+    <fast-anchor href="https://bing.com" target="_blank">Bing</fast-anchor>
+</fast-tree-item>
+
 <h2>Before content</h2>
 <fast-tree-item>
     <svg slot="start">

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2346,7 +2346,9 @@ export class TreeItem extends FoundationElement {
     focusable: boolean;
     static focusItem(el: HTMLElement): void;
     // (undocumented)
-    handleClick: (e: MouseEvent) => void;
+    handleChange(source: any, propertyName: string): void;
+    // (undocumented)
+    handleClick: (e: MouseEvent) => void | boolean;
     // (undocumented)
     handleExpandCollapseButtonClick: (e: MouseEvent) => void;
     // (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2346,8 +2346,6 @@ export class TreeItem extends FoundationElement {
     focusable: boolean;
     static focusItem(el: HTMLElement): void;
     // (undocumented)
-    handleChange(source: any, propertyName: string): void;
-    // (undocumented)
     handleClick: (e: MouseEvent) => void | boolean;
     // (undocumented)
     handleExpandCollapseButtonClick: (e: MouseEvent) => void;

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -103,9 +103,9 @@ export class TreeItem extends FoundationElement {
     };
 
     public handleClick = (e: MouseEvent): void | boolean => {
-        if (!e.defaultPrevented && !this.disabled) {
+        if (!e.defaultPrevented) {
             this.handleSelected(e);
-            // should we be prevented default when handling click here? It's completely eating the click
+            // do not prevent default as it completely eats the click
             return true;
         }
     };

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -102,9 +102,11 @@ export class TreeItem extends FoundationElement {
         }
     };
 
-    public handleClick = (e: MouseEvent): void => {
-        if (!e.defaultPrevented) {
+    public handleClick = (e: MouseEvent): void | boolean => {
+        if (!e.defaultPrevented && !this.disabled) {
             this.handleSelected(e);
+            // should we be prevented default when handling click here? It's completely eating the click
+            return true;
         }
     };
 


### PR DESCRIPTION
# Pull Request

## 📖 Description
This issue updates the click handler for tree item to *not* prevent default in order to enable valid scenarios such as anchors within the control.

### 🎫 Issues
closes #5159

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->