### PR TITLE
fix: Disabling scroll easing for speed=0

### DIFF
--- a/change/@microsoft-fast-foundation-b999493b-a98c-4569-9ae5-27b1215ff0a6.json
+++ b/change/@microsoft-fast-foundation-b999493b-a98c-4569-9ae5-27b1215ff0a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Disabling scroll easing for speed=0",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "robarb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -66,9 +66,9 @@ async function setup() {
         } = await fixture(FASTHorizontalScroll());
 
     // Removing animated scroll so that tests don't have to wait on DOM updates
-    element.speed = 0;
+    element.speed = -1;
 
-    element.setAttribute("style", `width: ${horizontalScrollWidth}px}`);
+    element.setAttribute("style", `width: ${horizontalScrollWidth}px; scroll-behavior: auto;`);
     element.innerHTML = getCards(8);
 
     await connect();
@@ -151,6 +151,7 @@ describe("HorinzontalScroll", () => {
             element.scrollToNext();
             await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToPrevious();
             await DOM.nextUpdate();
 

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -66,7 +66,7 @@ async function setup() {
         } = await fixture(FASTHorizontalScroll());
 
     // Removing animated scroll so that tests don't have to wait on DOM updates
-    element.speed = -1;
+    element.speed = 0;
 
     element.setAttribute("style", `width: ${horizontalScrollWidth}px; scroll-behavior: auto;`);
     element.innerHTML = getCards(8);
@@ -131,9 +131,7 @@ describe("HorinzontalScroll", () => {
             const { element, disconnect } = await setup();
 
             element.scrollToNext();
-            await DOM.nextUpdate();
             element.scrollToNext();
-            await DOM.nextUpdate();
             element.scrollToNext();
             await DOM.nextUpdate();
 
@@ -145,13 +143,9 @@ describe("HorinzontalScroll", () => {
             const { element, disconnect } = await setup();
 
             element.scrollToNext();
-            await DOM.nextUpdate();
             element.scrollToNext();
-            await DOM.nextUpdate();
             element.scrollToNext();
-            await DOM.nextUpdate();
             element.scrollToNext();
-            await DOM.nextUpdate();
             element.scrollToPrevious();
             await DOM.nextUpdate();
 

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -131,7 +131,9 @@ describe("HorinzontalScroll", () => {
             const { element, disconnect } = await setup();
 
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
             await DOM.nextUpdate();
 
@@ -143,8 +145,11 @@ describe("HorinzontalScroll", () => {
             const { element, disconnect } = await setup();
 
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
             element.scrollToPrevious();
             await DOM.nextUpdate();

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -138,6 +138,9 @@ describe("HorinzontalScroll", () => {
 
             element.scrollToNext();
             await DOM.nextUpdate();
+
+            element.scrollToNext();
+            await DOM.nextUpdate();
             await DOM.nextUpdate();
 
             expect(element.shadowRoot?.querySelector(".scroll-next")?.classList.contains("disabled")).to.equal(true);
@@ -146,6 +149,9 @@ describe("HorinzontalScroll", () => {
 
         it("should re-enable the next flipper when its scrolled back from the end", async () => {
             const { element, disconnect } = await setup();
+
+            element.scrollToNext();
+            await DOM.nextUpdate();
 
             element.scrollToNext();
             await DOM.nextUpdate();

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -111,6 +111,7 @@ describe("HorinzontalScroll", () => {
 
             element.scrollToNext();
             await DOM.nextUpdate();
+            await DOM.nextUpdate();
 
             expect(element.shadowRoot?.querySelector(".scroll-prev")?.classList.contains("disabled")).to.equal(false);
             await disconnect();
@@ -120,7 +121,10 @@ describe("HorinzontalScroll", () => {
             const { element, disconnect } = await setup();
 
             element.scrollToNext();
+            await DOM.nextUpdate();
+
             element.scrollToPrevious();
+            await DOM.nextUpdate();
             await DOM.nextUpdate();
 
             expect(element.shadowRoot?.querySelector(".scroll-prev")?.classList.contains("disabled")).to.equal(true);

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -132,10 +132,10 @@ describe("HorinzontalScroll", () => {
 
             element.scrollToNext();
             await DOM.nextUpdate();
+
             element.scrollToNext();
             await DOM.nextUpdate();
-            element.scrollToNext();
-            await DOM.nextUpdate();
+
             element.scrollToNext();
             await DOM.nextUpdate();
             await DOM.nextUpdate();
@@ -149,12 +149,13 @@ describe("HorinzontalScroll", () => {
 
             element.scrollToNext();
             await DOM.nextUpdate();
+
             element.scrollToNext();
             await DOM.nextUpdate();
+
             element.scrollToNext();
             await DOM.nextUpdate();
-            element.scrollToNext();
-            await DOM.nextUpdate();
+
             element.scrollToPrevious();
             await DOM.nextUpdate();
             await DOM.nextUpdate();

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -68,7 +68,7 @@ async function setup() {
     // Removing animated scroll so that tests don't have to wait on DOM updates
     element.speed = 0;
 
-    element.setAttribute("style", `width: ${horizontalScrollWidth}px; scroll-behavior: auto;`);
+    element.setAttribute("style", `width: ${horizontalScrollWidth}px;`);
     element.innerHTML = getCards(8);
 
     await connect();
@@ -130,6 +130,7 @@ describe("HorinzontalScroll", () => {
         it("should disable the next flipper when it reaches the end of the content", async () => {
             const { element, disconnect } = await setup();
 
+            element.scrollToNext();
             element.scrollToNext();
             element.scrollToNext();
             element.scrollToNext();

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -144,10 +144,15 @@ describe("HorinzontalScroll", () => {
             const { element, disconnect } = await setup();
 
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToPrevious();
+            await DOM.nextUpdate();
             await DOM.nextUpdate();
 
             expect(element.shadowRoot?.querySelector(".scroll-next")?.classList.contains("disabled")).to.equal(false);

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -131,9 +131,13 @@ describe("HorinzontalScroll", () => {
             const { element, disconnect } = await setup();
 
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             element.scrollToNext();
+            await DOM.nextUpdate();
             await DOM.nextUpdate();
 
             expect(element.shadowRoot?.querySelector(".scroll-next")?.classList.contains("disabled")).to.equal(true);

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -405,6 +405,7 @@ export class HorizontalScroll extends FoundationElement {
         }
 
         if (this.speed < 1) {
+            this.scrollContainer.style.scrollBehavior = "auto";
             this.scrollContainer.scrollLeft = newPosition;
             return;
         }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Horizontal scroll tests are failing for Mac. This disables the smooth scrolling when the speed is set to 0.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->