### PR TITLE
refactor DesignToken to not emit to document.body

### DIFF
--- a/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
+++ b/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
@@ -6,7 +6,10 @@ import {
     FASTElement,
     observable,
     Observable,
+    TargetedHTMLDirective,
 } from "@microsoft/fast-element";
+
+export const defaultElement = document.createElement("div");
 
 function isFastElement(element: HTMLElement | FASTElement): element is FASTElement {
     return element instanceof FASTElement;
@@ -17,16 +20,8 @@ interface PropertyTarget {
     removeProperty(name: string);
 }
 
-/**
- * Handles setting properties for a FASTElement using Constructable Stylesheets
- */
-class ConstructableStyleSheetTarget implements PropertyTarget {
-    private target: PropertyTarget;
-    constructor(source: HTMLElement & FASTElement) {
-        const sheet = new CSSStyleSheet();
-        this.target = (sheet.cssRules[sheet.insertRule(":host{}")] as CSSStyleRule).style;
-        source.$fastController.addStyles(ElementStyles.create([sheet]));
-    }
+abstract class QueuedStyleSheetTarget implements PropertyTarget {
+    protected abstract target: PropertyTarget;
 
     public setProperty(name: string, value: string) {
         DOM.queueUpdate(() => this.target.setProperty(name, value));
@@ -35,7 +30,54 @@ class ConstructableStyleSheetTarget implements PropertyTarget {
         DOM.queueUpdate(() => this.target.removeProperty(name));
     }
 }
+/**
+ * Handles setting properties for a FASTElement using Constructable Stylesheets
+ */
+class ConstructableStyleSheetTarget extends QueuedStyleSheetTarget {
+    protected target: PropertyTarget;
+    constructor(source: HTMLElement & FASTElement) {
+        super();
 
+        const sheet = new CSSStyleSheet();
+        this.target = (sheet.cssRules[sheet.insertRule(":host{}")] as CSSStyleRule).style;
+        source.$fastController.addStyles(ElementStyles.create([sheet]));
+    }
+}
+
+class DocumentStyleSheetTarget extends QueuedStyleSheetTarget {
+    protected target: PropertyTarget;
+    constructor() {
+        super();
+
+        const sheet = new CSSStyleSheet();
+        this.target = (sheet.cssRules[sheet.insertRule(":root{}")] as CSSStyleRule).style;
+        (document as any).adoptedStyleSheets = [
+            ...(document as any).adoptedStyleSheets,
+            sheet,
+        ];
+    }
+}
+
+class HeadStyleElementStyleSheetTarget extends QueuedStyleSheetTarget {
+    protected target: PropertyTarget;
+    private readonly style: HTMLStyleElement;
+
+    constructor() {
+        super();
+
+        this.style = document.createElement("style") as HTMLStyleElement;
+        document.head.appendChild(this.style);
+        const { sheet } = this.style;
+
+        if (sheet) {
+            const index = sheet.insertRule(":root{}");
+            this.target = (sheet.rules[index] as CSSStyleRule).style;
+        } else {
+            throw new Error("This should never get thrown");
+        }
+    }
+}
+// How can StyleElementStyleSheetTarget be made to work with HTMLHeadElement types?
 /**
  * Handles setting properties for a FASTElement using an HTMLStyleElement
  */
@@ -138,9 +180,18 @@ export const PropertyTargetManager = Object.freeze({
             return propertyTargetCache.get(source)!;
         }
 
-        const target = isFastElement(source)
-            ? new propertyTargetCtor(source)
-            : new ElementStyleSheetTarget(source);
+        let target: PropertyTarget;
+
+        if (source === defaultElement) {
+            target = DOM.supportsAdoptedStyleSheets
+                ? new DocumentStyleSheetTarget()
+                : new HeadStyleElementStyleSheetTarget();
+        } else if (isFastElement(source)) {
+            target = new propertyTargetCtor(source);
+        } else {
+            target = new ElementStyleSheetTarget(source);
+        }
+
         propertyTargetCache.set(source, target);
 
         return target;

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -18,8 +18,7 @@ import type {
     DesignTokenValue,
     StaticDesignTokenValue,
 } from "./interfaces";
-
-const defaultElement = document.body;
+import { defaultElement } from "./custom-property-manager";
 
 /**
  * Describes a DesignToken instance.
@@ -737,8 +736,6 @@ class DesignTokenNode implements Behavior, Subscriber {
                 token,
                 this.target
             );
-
-            DesignTokenNode.cssCustomPropertyReflector;
         }
     }
 


### PR DESCRIPTION
…'t emitted to the body

<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR refactors how `DesignToken.withDefault()` emits CSS custom properties. Prior to this change, token values set with `.withDefault()` would be emitted to `document.body` using the `HTMLElement.style.setProperty()` API. That approach is problematic because:
1. document.body is not defined tokens are set via a script executing prior to the document being fully parsed, as can be  the case if the script is loaded in the `document.head`
2. It emits a lot of inline styles to the document.body, which clutters that element (this isn't a problem per-se, but more of a nuisance). 

With this change, default DesignToken values will be emitted to CSS custom properties in one of two ways.
1. When constructable styles are supported, a `CSSStyleSheet` will be created and added to the `document.adoptedStyleSheets` array.
2. When constructable styles are *not* supported, a `HTMLStyleElement` will be created and added to the `document.head`.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
fixes https://github.com/microsoft/fast/issues/5125
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
There is a discussion point I've added below to discuss one of the implementation details. I'll leave this PR in draft-state until that point has been discussed / resolved.
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->