### PR TITLE
feat: Emit scrollend in horizontal-scroll

### DIFF
--- a/change/@microsoft-fast-foundation-548d1ba5-8823-4a2a-9639-55ec835cd841.json
+++ b/change/@microsoft-fast-foundation-548d1ba5-8823-4a2a-9639-55ec835cd841.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Emit scrollend in horizontal-scroll",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "beschmal@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -406,7 +406,7 @@ export class HorizontalScroll extends FoundationElement {
 
         if (this.speed < 1) {
             this.scrollContainer.scrollLeft = newPosition;
-            this.$emit("scrollend", newPosition);
+            this.$emit("scrollend");
             return;
         }
 
@@ -420,7 +420,7 @@ export class HorizontalScroll extends FoundationElement {
 
         if (stepCount < 1) {
             this.scrolling = false;
-            this.$emit("scrollend", newPosition);
+            this.$emit("scrollend");
             return;
         }
 
@@ -434,7 +434,6 @@ export class HorizontalScroll extends FoundationElement {
         steps.push(newPosition);
 
         this.move(steps, this.frameTime);
-        this.$emit("scrollend", newPosition);
     }
 
     /**
@@ -453,6 +452,7 @@ export class HorizontalScroll extends FoundationElement {
         if (!steps || steps.length <= 0) {
             this.setFlippers();
             this.scrolling = false;
+            this.$emit("scrollend");
             return;
         }
 

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -406,7 +406,7 @@ export class HorizontalScroll extends FoundationElement {
 
         if (this.speed < 1) {
             this.scrollContainer.scrollLeft = newPosition;
-            this.$emit('scrollend', newPosition);
+            this.$emit("scrollend", newPosition);
             return;
         }
 
@@ -420,7 +420,7 @@ export class HorizontalScroll extends FoundationElement {
 
         if (stepCount < 1) {
             this.scrolling = false;
-            this.$emit('scrollend', newPosition);
+            this.$emit("scrollend", newPosition);
             return;
         }
 
@@ -434,7 +434,7 @@ export class HorizontalScroll extends FoundationElement {
         steps.push(newPosition);
 
         this.move(steps, this.frameTime);
-        this.$emit('scrollend', newPosition);
+        this.$emit("scrollend", newPosition);
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -406,6 +406,7 @@ export class HorizontalScroll extends FoundationElement {
 
         if (this.speed < 1) {
             this.scrollContainer.scrollLeft = newPosition;
+            this.$emit('scrollend', newPosition);
             return;
         }
 
@@ -419,6 +420,7 @@ export class HorizontalScroll extends FoundationElement {
 
         if (stepCount < 1) {
             this.scrolling = false;
+            this.$emit('scrollend', newPosition);
             return;
         }
 
@@ -432,6 +434,7 @@ export class HorizontalScroll extends FoundationElement {
         steps.push(newPosition);
 
         this.move(steps, this.frameTime);
+        this.$emit('scrollend', newPosition);
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

Emit scrollend events when horizontal-scroll is done scrolling. This feature is needed, so I can track the visibility of ads in carousel.

### 🎫 Issues


## 📑 Test Plan


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->