### PR TITLE
fix: NumberField increment/decrement buttons no longer update display value

### DIFF
--- a/change/@microsoft-fast-foundation-eab39a41-affe-455e-8298-279c09489ebc.json
+++ b/change/@microsoft-fast-foundation-eab39a41-affe-455e-8298-279c09489ebc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix inc/dec not updating displayText",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "26874831+atmgrifter00@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-react-wrapper-a959ca07-d92b-4cb9-a857-97447e6390a9.json
+++ b/change/@microsoft-fast-react-wrapper-a959ca07-d92b-4cb9-a857-97447e6390a9.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: add fast-react-wrapper package",
-  "packageName": "@microsoft/fast-react-wrapper",
-  "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -540,7 +540,7 @@ describe("NumberField", () => {
             expect(wasInput).to.equal(true);
 
             await disconnect();
-        })
+        });
     });
 
     describe("when the owning form's reset() method is invoked", () => {
@@ -718,7 +718,9 @@ describe("NumberField", () => {
 
             await disconnect();
         });
+    });
 
+    describe("step and increment/decrement", () => {
         it("should set step to a default of 1", async () => {
             const { element, connect, disconnect } = await setup();
             const step = 1;
@@ -826,6 +828,34 @@ describe("NumberField", () => {
             await connect();
             expect(element.value).to.equal(`${value - step}`);
             expect(element.proxy.value).to.equal(`${value - step}`);
+
+            await disconnect();
+        });
+
+        it("should update displayText when incrementing", async () => {
+            const { element, connect, disconnect } = await setup();
+            const value = 0;
+            element.value = `${value}`;
+
+            await connect();
+
+            element.stepUp();
+
+            expect(element.displayText).to.equal(1);
+
+            await disconnect();
+        });
+
+        it("should update displayText when decrementing", async () => {
+            const { element, connect, disconnect } = await setup();
+            const value = 0;
+            element.value = `${value}`;
+
+            await connect();
+
+            element.stepDown();
+
+            expect(element.displayText).to.equal(-1);
 
             await disconnect();
         });

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -209,6 +209,7 @@ export class NumberField extends FormAssociatedNumberField {
         }
 
         if (value != this.value) {
+            this.displayText = value;
             this.value = value.toString();
             this.$emit("input");
             this.$emit("change");


### PR DESCRIPTION
# Pull Request

## 📖 Description

A [recent change](https://github.com/microsoft/fast/pull/5205) to the NumberField inadvertently broke the increment/decrement buttons from changing the displayed value when pressed. More broadly, any programmatic change of the value will not update the displayed value appropriately.

### 🎫 Issues

#5246 

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

I've added a couple of unit tests that focus on the `stepUp` and `stepDown` methods updating the displayText as expected. While the issue is technically broader than this, this seems like a reasonable set of tests.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->