### PR TITLE
fix: number-field increment and decrement don't update display text

### DIFF
--- a/change/@microsoft-fast-foundation-d4d8112a-4f61-4ecd-ad14-39f354c9e2bd.json
+++ b/change/@microsoft-fast-foundation-d4d8112a-4f61-4ecd-ad14-39f354c9e2bd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: number-field increment and decrement not working",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "robarb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1414,6 +1414,7 @@ export class NumberField extends FormAssociatedNumberField {
     // @internal (undocumented)
     defaultSlottedNodes: Node[];
     displayText: string;
+    handleBlur(): void;
     // @internal
     handleChange(): void;
     // @internal

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -540,7 +540,7 @@ describe("NumberField", () => {
             expect(wasInput).to.equal(true);
 
             await disconnect();
-        })
+        });
     });
 
     describe("when the owning form's reset() method is invoked", () => {
@@ -718,7 +718,9 @@ describe("NumberField", () => {
 
             await disconnect();
         });
+    });
 
+    describe("step and increment/decrement", () => {
         it("should set step to a default of 1", async () => {
             const { element, connect, disconnect } = await setup();
             const step = 1;
@@ -751,10 +753,12 @@ describe("NumberField", () => {
 
             element.step = step;
             element.value = `${value}`;
+            await connect();
+
             element.stepUp();
 
-            await connect();
             expect(element.value).to.equal(`${value + step}`);
+            expect(element.value).to.equal(element.displayText);
 
             await disconnect();
         });
@@ -766,10 +770,12 @@ describe("NumberField", () => {
 
             element.step = step;
             element.value = `${value}`;
+            await connect();
+
             element.stepDown();
 
-            await connect();
             expect(element.value).to.equal(`${value - step}`);
+            expect(element.value).to.equal(element.displayText);
 
             await disconnect();
         });
@@ -778,10 +784,12 @@ describe("NumberField", () => {
             const { element, connect, disconnect } = await setup();
             const step = 2;
             element.step = step;
+            await connect();
+
             element.stepUp();
 
-            await connect();
             expect(element.value).to.equal(`${step}`);
+            expect(element.value).to.equal(element.displayText);
 
             await disconnect();
         });
@@ -790,10 +798,13 @@ describe("NumberField", () => {
             const { element, connect, disconnect } = await setup();
             const step = 2;
             element.step = step;
-            element.stepDown();
-
             await connect();
+
+            element.stepDown();
+            await DOM.nextUpdate();
+
             expect(element.value).to.equal(`${0 - step}`);
+            expect(element.value).to.equal(element.displayText);
 
             await disconnect();
         });
@@ -805,11 +816,13 @@ describe("NumberField", () => {
 
             element.step = step;
             element.value = `${value}`;
+            await connect();
+
             element.stepUp();
 
-            await connect();
             expect(element.value).to.equal(`${value + step}`);
             expect(element.proxy.value).to.equal(`${value + step}`);
+            expect(element.value).to.equal(element.displayText);
 
             await disconnect();
         });
@@ -821,11 +834,13 @@ describe("NumberField", () => {
 
             element.step = step;
             element.value = `${value}`;
+            await connect();
+
             element.stepDown();
 
-            await connect();
             expect(element.value).to.equal(`${value - step}`);
             expect(element.proxy.value).to.equal(`${value - step}`);
+            expect(element.value).to.equal(element.displayText);
 
             await disconnect();
         });

--- a/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
@@ -35,6 +35,7 @@ export const numberFieldTemplate: (
                 @input="${x => x.handleTextInput()}"
                 @change="${x => x.handleChange()}"
                 @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
+                @blur="${(x, c) => x.handleBlur()}"
                 ?autofocus="${x => x.autofocus}"
                 ?disabled="${x => x.disabled}"
                 list="${x => x.list}"

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -181,6 +181,7 @@ export class NumberField extends FormAssociatedNumberField {
         super.valueChanged(previousValue, nextValue);
 
         this.updateValue(nextValue);
+        this.displayText = this.value;
     }
 
     /**
@@ -291,6 +292,15 @@ export class NumberField extends FormAssociatedNumberField {
         }
 
         return true;
+    }
+
+    /**
+     * Handles populating the input field with a validated value when
+     *  leaving the input field.
+     * @public
+     */
+    public handleBlur(): void {
+        this.control.value = this.value;
     }
 }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

When using the increment and decrement arrows to change the value, the displayed value does not update. Also, changing the value through script does not update the displayed value.


### 🎫 Issues

https://github.com/microsoft/fast/issues/5246

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->