### PR TITLE
add `abbr` specification

### DIFF
--- a/specs/README.md
+++ b/specs/README.md
@@ -7,6 +7,7 @@ Here you'll find specifications for custom elements and other library features.
 ## Web Component Specifications
 | Name | Spec | Component |
 | :--------- | :---------: | ---------: |
+| [Abbr](./abbr.spec.md) | :white_check_mark: | -- |
 | [Accordion](../packages/web-components/fast-foundation/src/accordion/accordion-spec.md) | :white_check_mark: | :white_check_mark: |
 | Alert | -- | -- |
 | [Anchored region](../packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md) | :white_check_mark: | :white_check_mark: |

--- a/specs/abbr.spec.md
+++ b/specs/abbr.spec.md
@@ -1,0 +1,77 @@
+# Abbr (abbreviation)
+
+## Overview
+
+From [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr), the `<abbr>` HTML element represents an abbreviation or acronym. Much of this specification borrows heavily from the details provided by MDN. The primary *need* for this element is that it relies on the native browser tooltip which cannot be styled. Design systems and web authors looking for consistency across experiences may find a `<fast-attr>` element beneficial as it would enable comparable support with customizable UI.
+
+### Use Cases
+
+- When an abbreviation is used and you want to provide an expansion or definition outside the flow of the document's content, use `<fast-abbr>` with a tooltip for full text.
+- To define an abbreviation which may be unfamiliar to the reader, present the term using `<fast-abbr>` and either the corresponding attribute for full text or inline text providing the definition.
+- When an abbreviation's presence in the text needs to be clearly noted, the `<fast-abbr>` element is useful. This can be used, in turn, for styling or scripting purposes.
+
+
+### Non-goals
+
+- Abbr includes no implicit role and does not receive focus. Accordingly, the tooltip of `<fast-abbr>` will only show on hover.
+- Full parity with the `<abbr>` API is a non-goal as it relies on the native tooltip tied to the `title` attribute. As this behavior cannot be suppressed we will need to use a different attribute namespace.
+
+### Prior Art/Examples
+
+-   [MDN](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr)
+
+---
+
+### API
+
+_Component name:_
+
+-   `fast-abbr`
+
+_Attributes:_
+
+-   `text` - The full text content of the abbreviation.
+-   `delay` - time in milliseconds to wait before showing and hiding the tooltip. Defaults to 300.
+-   `position` - where the tooltip should appear relative to its target. 'start' and 'end' are like 'left' and 'right' but are inverted when the direction is 'rtl' When the position is undefined the tooltip is placed above or below the anchor based on available space.
+    -   top
+    -   bottom
+    -   left
+    -   right
+    -   start
+    -   end
+
+_Slots:_
+
+-   `default` - typically used for the abbreviation text
+
+### Anatomy and Appearance
+
+_Template:_
+
+```
+<template>
+    <slot></slot>
+    <fast-tooltip
+        position=${x => x.position}
+        visible=${x => x.showTooltip}
+        delay=${x => x.delay}
+        ${ref("tooltip")}
+    >
+        ${x => x.text}
+    </fast-tooltip>
+</template>
+```
+
+## Implementation
+
+```
+<p>This <fast-abbr text="Specification">spec</fast-abbr> makes the case for abbr.</p>
+```
+
+### Accessibility
+
+There is no implicit role on the component. Any role is allowed.
+
+### Dependencies
+
+This component depends on [Tooltip](../tooltip/tooltip.spec.md) which likewise depends on [anchored region](../anchored-region/anchored-region.spec.md).


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR submits a new spec for review: `abbr` (abbreviation). While `<abbr>` is a standard element, there are limitations to styling which make customization for users prohibitive and a custom element a welcome addition.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->