### PR TITLE
Draft: Add `abbr` as a new component

### DIFF
--- a/change/@microsoft-fast-components-1114fbc9-e41b-4e7a-ad45-d006d399c748.json
+++ b/change/@microsoft-fast-components-1114fbc9-e41b-4e7a-ad45-d006d399c748.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add abbr as a new component",
+  "packageName": "@microsoft/fast-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-b5cccbbf-7e66-4ce3-b31f-5bd36eb093be.json
+++ b/change/@microsoft-fast-foundation-b5cccbbf-7e66-4ce3-b31f-5bd36eb093be.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add abbr as a new component",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { Abbr } from '@microsoft/fast-foundation';
 import { Accordion } from '@microsoft/fast-foundation';
 import { AccordionItem } from '@microsoft/fast-foundation';
 import { AccordionItemOptions } from '@microsoft/fast-foundation';
@@ -147,6 +148,7 @@ export const accordionStyles: (context: import("@microsoft/fast-foundation").Ele
 
 // @public
 export const allComponents: {
+    fastAbbr: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof import("@microsoft/fast-foundation").Abbr>;
     fastAccordion: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof import("@microsoft/fast-foundation").Accordion>;
     fastAccordionItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").AccordionItemOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").AccordionItemOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
     fastAnchor: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof Anchor>;
@@ -441,6 +443,9 @@ export { Divider }
 
 // @public
 export const dividerStyles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").FoundationElementDefinition) => import("@microsoft/fast-element").ElementStyles;
+
+// @public
+export const fastAbbr: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof Abbr>;
 
 // @public
 export const fastAccordion: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof Accordion>;
@@ -1188,14 +1193,14 @@ export const typeRampPlus6LineHeight: import("@microsoft/fast-foundation").CSSDe
 //
 // dist/dts/color/palette.d.ts:48:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
 // dist/dts/color/palette.d.ts:49:5 - (ae-forgotten-export) The symbol "from" needs to be exported by the entry point index.d.ts
-// dist/dts/custom-elements.d.ts:71:5 - (ae-incompatible-release-tags) The symbol "fastButton" is marked as @public, but its signature references "Button" which is marked as @internal
-// dist/dts/custom-elements.d.ts:72:5 - (ae-incompatible-release-tags) The symbol "fastCard" is marked as @public, but its signature references "Card" which is marked as @internal
-// dist/dts/custom-elements.d.ts:78:5 - (ae-incompatible-release-tags) The symbol "fastDesignSystemProvider" is marked as @public, but its signature references "DesignSystemProvider" which is marked as @internal
-// dist/dts/custom-elements.d.ts:80:5 - (ae-incompatible-release-tags) The symbol "fastDisclosure" is marked as @public, but its signature references "Disclosure" which is marked as @internal
-// dist/dts/custom-elements.d.ts:101:5 - (ae-incompatible-release-tags) The symbol "fastSliderLabel" is marked as @public, but its signature references "SliderLabel" which is marked as @internal
-// dist/dts/custom-elements.d.ts:106:5 - (ae-incompatible-release-tags) The symbol "fastTextArea" is marked as @public, but its signature references "TextArea" which is marked as @internal
-// dist/dts/custom-elements.d.ts:107:5 - (ae-incompatible-release-tags) The symbol "fastTextField" is marked as @public, but its signature references "TextField" which is marked as @internal
-// dist/dts/custom-elements.d.ts:109:5 - (ae-incompatible-release-tags) The symbol "fastToolbar" is marked as @public, but its signature references "Toolbar" which is marked as @internal
+// dist/dts/custom-elements.d.ts:73:5 - (ae-incompatible-release-tags) The symbol "fastButton" is marked as @public, but its signature references "Button" which is marked as @internal
+// dist/dts/custom-elements.d.ts:74:5 - (ae-incompatible-release-tags) The symbol "fastCard" is marked as @public, but its signature references "Card" which is marked as @internal
+// dist/dts/custom-elements.d.ts:80:5 - (ae-incompatible-release-tags) The symbol "fastDesignSystemProvider" is marked as @public, but its signature references "DesignSystemProvider" which is marked as @internal
+// dist/dts/custom-elements.d.ts:82:5 - (ae-incompatible-release-tags) The symbol "fastDisclosure" is marked as @public, but its signature references "Disclosure" which is marked as @internal
+// dist/dts/custom-elements.d.ts:103:5 - (ae-incompatible-release-tags) The symbol "fastSliderLabel" is marked as @public, but its signature references "SliderLabel" which is marked as @internal
+// dist/dts/custom-elements.d.ts:108:5 - (ae-incompatible-release-tags) The symbol "fastTextArea" is marked as @public, but its signature references "TextArea" which is marked as @internal
+// dist/dts/custom-elements.d.ts:109:5 - (ae-incompatible-release-tags) The symbol "fastTextField" is marked as @public, but its signature references "TextField" which is marked as @internal
+// dist/dts/custom-elements.d.ts:111:5 - (ae-incompatible-release-tags) The symbol "fastToolbar" is marked as @public, but its signature references "Toolbar" which is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-components/src/abbr/abbr.open-ui.definition.json
+++ b/packages/web-components/fast-components/src/abbr/abbr.open-ui.definition.json
@@ -1,0 +1,4 @@
+{
+    "name": "Abbr",
+    "url": "https://fast.design/docs/components/abbr"
+}

--- a/packages/web-components/fast-components/src/abbr/abbr.stories.ts
+++ b/packages/web-components/fast-components/src/abbr/abbr.stories.ts
@@ -1,0 +1,8 @@
+import AbbrTemplate from "./fixtures/abbr.html";
+import "./index";
+
+export default {
+    title: "Abbr",
+};
+
+export const Abbr = () => AbbrTemplate;

--- a/packages/web-components/fast-components/src/abbr/abbr.styles.ts
+++ b/packages/web-components/fast-components/src/abbr/abbr.styles.ts
@@ -1,0 +1,26 @@
+import { css } from "@microsoft/fast-element";
+import {
+    display,
+    ElementDefinitionContext,
+    FoundationElementDefinition,
+} from "@microsoft/fast-foundation";
+import {
+    accentForegroundRest,
+    bodyFont,
+    neutralForegroundRest,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+} from "../design-tokens";
+
+export const abbrStyles = (
+    context: ElementDefinitionContext,
+    definition: FoundationElementDefinition
+) => css`
+    ${display("inline")} :host {
+        font-family: ${bodyFont};
+        font-size: ${typeRampBaseFontSize};
+        line-height: ${typeRampBaseLineHeight};
+        color: ${neutralForegroundRest};
+        border-bottom: 1px dashed ${accentForegroundRest};
+    }
+`;

--- a/packages/web-components/fast-components/src/abbr/abbr.vscode.definition.json
+++ b/packages/web-components/fast-components/src/abbr/abbr.vscode.definition.json
@@ -1,0 +1,51 @@
+{
+    "version": 1.1,
+    "tags": [
+        {
+            "name": "fast-abbr",
+            "title": "Abbr",
+            "description": "The FAST abbr element",
+            "attributes": [
+                {
+                    "name": "text",
+                    "title": "Text",
+                    "description": "The full text of the abbreviation",
+                    "type": "string",
+                    "required": false
+                },
+                {
+                    "name": "delay",
+                    "title": "Delay",
+                    "description":
+                        "The delay in milliseconds before a tooltip is shown after a hover event",
+                    "type": "number",
+                    "default": 300,
+                    "required": false
+                },
+                {
+                    "name": "position",
+                    "title": "Position",
+                    "description":
+                        "Controls the placement of the tooltip relative to the configured 'Anchor ID'",
+                    "values": [
+                        { "name": "top" },
+                        { "name": "right" },
+                        { "name": "bottom" },
+                        { "name": "left" },
+                        { "name": "start" },
+                        { "name": "end" }
+                    ],
+                    "type": "string",
+                    "required,": false
+                }
+            ],
+            "slots": [
+                {
+                    "name": "",
+                    "title": "Default slot",
+                    "description": "The abbreviation text"
+                }
+            ]
+        }
+    ]
+}

--- a/packages/web-components/fast-components/src/abbr/fixtures/abbr.html
+++ b/packages/web-components/fast-components/src/abbr/fixtures/abbr.html
@@ -1,0 +1,55 @@
+<h1>Abbr</h1>
+
+<h2>Default</h2>
+<fast-abbr text="Abbreviation">abbr</fast-abbr>
+
+<h2>Position</h2>
+<h3>Delay</h3>
+<p>
+    Web Components allow us to use
+    <fast-abbr delay="10000" text="HyperText Markup Language">HTML</fast-abbr>
+    without needing additional frameworks.
+</p>
+
+<h2>Position</h2>
+<h3>Top</h3>
+<p>
+    Web Components allow us to use
+    <fast-abbr position="top" text="HyperText Markup Language">HTML</fast-abbr>
+    without needing additional frameworks.
+</p>
+
+<h3>Bottom</h3>
+<p>
+    Web Components allow us to use
+    <fast-abbr position="bottom" text="HyperText Markup Language">HTML</fast-abbr>
+    without needing additional frameworks.
+</p>
+
+<h3>Left</h3>
+<p>
+    Web Components allow us to use
+    <fast-abbr position="left" text="HyperText Markup Language">HTML</fast-abbr>
+    without needing additional frameworks.
+</p>
+
+<h3>Right</h3>
+<p>
+    Web Components allow us to use
+    <fast-abbr position="right" text="HyperText Markup Language">HTML</fast-abbr>
+    without needing additional frameworks.
+</p>
+
+<h3>Start</h3>
+<p>
+    Web Components allow us to use
+    <fast-abbr position="start" text="HyperText Markup Language">HTML</fast-abbr>
+    without needing additional frameworks.
+</p>
+
+<h3>End</h3>
+<p>
+    Web Components allow us to use
+    <fast-abbr position="end" text="HyperText Markup Language">HTML</fast-abbr>
+    without needing additional frameworks.
+</p>

--- a/packages/web-components/fast-components/src/abbr/index.ts
+++ b/packages/web-components/fast-components/src/abbr/index.ts
@@ -1,0 +1,17 @@
+import { Abbr, abbrTemplate as template } from "@microsoft/fast-foundation";
+import { abbrStyles as styles } from "./abbr.styles";
+
+/**
+ * A function that returns a {@link @microsoft/fast-foundation#Abbr} registration for configuring the component with a DesignSystem.
+ * Implements {@link @microsoft/fast-foundation#abbrTemplate} and {@link @microsoft/fast-foundation#Abbr:class}.
+ *
+ *
+ * @public
+ * @remarks
+ * Generates the HTML Element: \<fast-abbr\>
+ */
+export const fastAbbr = Abbr.compose({
+    baseName: "abbr",
+    template,
+    styles,
+});

--- a/packages/web-components/fast-components/src/abbr/index.ts
+++ b/packages/web-components/fast-components/src/abbr/index.ts
@@ -3,7 +3,7 @@ import { abbrStyles as styles } from "./abbr.styles";
 
 /**
  * A function that returns a {@link @microsoft/fast-foundation#Abbr} registration for configuring the component with a DesignSystem.
- * Implements {@link @microsoft/fast-foundation#abbrTemplate} and {@link @microsoft/fast-foundation#Abbr:class}.
+ * Implements {@link @microsoft/fast-foundation#abbrTemplate} and {@link @microsoft/fast-foundation#(Abbr:class)}.
  *
  *
  * @public

--- a/packages/web-components/fast-components/src/custom-elements.ts
+++ b/packages/web-components/fast-components/src/custom-elements.ts
@@ -2,6 +2,7 @@
  * Export all custom element definitions
  */
 import type { Container } from "@microsoft/fast-foundation";
+import { fastAbbr } from "./abbr/index";
 import { fastAccordion, fastAccordionItem } from "./accordion/index";
 import { fastAnchor } from "./anchor/index";
 import { fastAnchoredRegion } from "./anchored-region/index";
@@ -70,6 +71,7 @@ import type { Toolbar } from "./toolbar/index";
 // throws for `export * as` expressions. https://github.com/microsoft/rushstack/pull/1796S
 
 export {
+    fastAbbr,
     fastAccordion,
     fastAccordionItem,
     fastAnchor,
@@ -129,6 +131,7 @@ export {
  * statically link and register all available components.
  */
 export const allComponents = {
+    fastAbbr,
     fastAccordion,
     fastAccordionItem,
     fastAnchor,

--- a/packages/web-components/fast-components/src/index.ts
+++ b/packages/web-components/fast-components/src/index.ts
@@ -3,6 +3,7 @@
  */
 export * from "./custom-elements";
 export * from "./fast-design-system";
+export * from "./abbr/index";
 export * from "./accordion/index";
 export * from "./anchor/index";
 export * from "./anchored-region/index";

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -19,6 +19,31 @@ import { SyntheticViewTemplate } from '@microsoft/fast-element';
 import { ViewTemplate } from '@microsoft/fast-element';
 
 // @public
+export class Abbr extends FoundationElement {
+    // (undocumented)
+    connectedCallback(): void;
+    // (undocumented)
+    delay: number;
+    // @internal (undocumented)
+    handleMouseOut: (e: MouseEvent) => void;
+    // @internal (undocumented)
+    handleMouseOver: (e: MouseEvent) => void;
+    // (undocumented)
+    position: TooltipPosition;
+    // @internal (undocumented)
+    root: HTMLElement;
+    // @internal (undocumented)
+    showTooltip: boolean;
+    // (undocumented)
+    text: string;
+    // @internal (undocumented)
+    tooltip: Tooltip;
+}
+
+// @public
+export const abbrTemplate: (context: ElementDefinitionContext, definition: FoundationElementDefinition) => ViewTemplate<Abbr>;
+
+// @public
 export class Accordion extends FoundationElement {
     // @internal (undocumented)
     accordionItems: HTMLElement[];

--- a/packages/web-components/fast-foundation/src/abbr/abbr.template.ts
+++ b/packages/web-components/fast-foundation/src/abbr/abbr.template.ts
@@ -1,0 +1,33 @@
+import { html, ref, ViewTemplate } from "@microsoft/fast-element";
+import { Tooltip } from "../tooltip";
+import type { ElementDefinitionContext } from "../design-system";
+import type { FoundationElementDefinition } from "../foundation-element";
+import type { Abbr } from "./abbr";
+
+/**
+ * The template for the {@link @microsoft/fast-foundation#Abbr} component.
+ * @public
+ */
+export const abbrTemplate: (
+    context: ElementDefinitionContext,
+    definition: FoundationElementDefinition
+) => ViewTemplate<Abbr> = (
+    context: ElementDefinitionContext,
+    definition: FoundationElementDefinition
+) => html<Abbr>`
+    <template
+      @mouseover=${(x, c) => x.handleMouseOver(c.event as MouseEvent)}
+      @mouseout=${(x, c) => x.handleMouseOut(c.event as MouseEvent)}
+      ${ref("root")}
+    >
+        <slot></slot>
+        <${context.tagFor(Tooltip)}
+          part="tooltip"
+          class="tooltip"
+          position=${x => x.position}
+          visible=${x => x.showTooltip}
+          delay=${x => x.delay}
+          ${ref("tooltip")}
+        >${x => x.text}</${context.tagFor(Tooltip)}>
+    </template>
+`;

--- a/packages/web-components/fast-foundation/src/abbr/abbr.ts
+++ b/packages/web-components/fast-foundation/src/abbr/abbr.ts
@@ -1,0 +1,69 @@
+import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
+import { FoundationElement } from "../foundation-element";
+import type { Tooltip, TooltipPosition } from "../tooltip";
+
+/**
+ * An Abbr Custom HTML Element
+ * Implements {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/abbr | HTML abbr}.
+ * @public
+ *
+ * @remarks
+ * Designed to be used with {@link @microsoft/fast-foundation#abbrTemplate}.
+ */
+export class Abbr extends FoundationElement {
+    /**
+     * @public
+     */
+    @attr
+    public text: string;
+
+    /**
+     * @public
+     */
+    @attr
+    public position: TooltipPosition;
+
+    /**
+     * @public
+     */
+    @attr({ converter: nullableNumberConverter })
+    public delay: number;
+
+    /**
+     * @internal
+     */
+    @observable
+    public showTooltip: boolean = false;
+
+    /**
+     * @internal
+     */
+    public tooltip: Tooltip;
+
+    /**
+     * @internal
+     */
+    public root: HTMLElement;
+
+    public connectedCallback() {
+        super.connectedCallback();
+
+        this.tooltip.anchorElement = this.root;
+        this.tooltip.horizontalViewportLock = true;
+        this.tooltip.verticalViewportLock = true;
+    }
+
+    /**
+     * @internal
+     */
+    public handleMouseOver = (e: MouseEvent): void => {
+        this.showTooltip = true;
+    };
+
+    /**
+     * @internal
+     */
+    public handleMouseOut = (e: MouseEvent): void => {
+        this.showTooltip = false;
+    };
+}

--- a/packages/web-components/fast-foundation/src/abbr/index.ts
+++ b/packages/web-components/fast-foundation/src/abbr/index.ts
@@ -1,0 +1,2 @@
+export * from "./abbr";
+export * from "./abbr.template";

--- a/packages/web-components/fast-foundation/src/index.ts
+++ b/packages/web-components/fast-foundation/src/index.ts
@@ -1,3 +1,4 @@
+export * from "./abbr/index";
 export * from "./accordion-item/index";
 export * from "./accordion/index";
 export * from "./anchor/index";

--- a/yarn.lock
+++ b/yarn.lock
@@ -18236,7 +18236,7 @@ react-dnd@^9.0.0:
     hoist-non-react-statics "^3.3.0"
     shallowequal "^1.1.0"
 
-react-dom@16.14.0, react-dom@^16.12.0, react-dom@^16.3.0, react-dom@^16.6.3:
+react-dom@16.14.0, react-dom@^16.12.0, react-dom@^16.3.0, react-dom@^16.6.3, react-dom@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.14.0.tgz#7ad838ec29a777fb3c75c3a190f661cf92ab8b89"
   integrity sha512-1gCeQXDLoIqMgqD3IO2Ah9bnf0w9kzhwN5q4FGnHZ67hBm9yePzB5JJAIQCc8x3pFnNlwFq4RidZggNAAkzWWw==
@@ -18499,7 +18499,7 @@ react-window@^1.8.1:
     "@babel/runtime" "^7.0.0"
     memoize-one ">=3.1.1 <6"
 
-react@16.14.0, react@^16.12.0, react@^16.3.0, react@^16.6.3, react@^16.8.0:
+react@16.14.0, react@^16.12.0, react@^16.3.0, react@^16.6.3, react@^16.8.0, react@^16.9.0:
   version "16.14.0"
   resolved "https://registry.yarnpkg.com/react/-/react-16.14.0.tgz#94d776ddd0aaa37da3eda8fc5b6b18a4c9a3114d"
   integrity sha512-0X2CImDkJGApiAlcf0ODKIneSwBPhqJawOa5wCtKbu7ZECrmS26NvtSILynQ66cgkT/RJ4LidJOc3bUESwmU8g==


### PR DESCRIPTION
# Pull Request

## 📖 Description
Adds `abbr` as a new component - this PR implements #5258.

### 🎫 Issues
- `title` attribute is unable to be overridden - should we suppress this behavior if a user tries to *add* a title attribute (duplicates tooltip)?

// TODO:
- [ ] - Delay doesn't seem to be working for tooltip as expected. Need to investigate.
- [ ] - Unit tests
- [ ] - Documentation

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [x] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->