### PR TITLE
fix: tooltip doesn't get clipped by viewport

### DIFF
--- a/change/@microsoft-fast-components-8cbe62f9-3275-4866-ad93-d062424af767.json
+++ b/change/@microsoft-fast-components-8cbe62f9-3275-4866-ad93-d062424af767.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "tooltip uses \"center\"",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-29f3478c-20e9-4088-8f0b-a1adf770691e.json
+++ b/change/@microsoft-fast-foundation-29f3478c-20e9-4088-8f0b-a1adf770691e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "tooltip uses \"center\"",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/tooltip/fixtures/base.html
+++ b/packages/web-components/fast-components/src/tooltip/fixtures/base.html
@@ -12,7 +12,7 @@
 
 <h2>Show/Hide with auto updating and lock to viewport</h2>
 
-<div style="height: 400px; width: 600px; background: lightgray; overflow: scroll;">
+<div style="height: 400px; width: 100%; background: lightgray; overflow: scroll;">
     <fast-tooltip
         id="tooltip-show-1"
         anchor="anchor-show"
@@ -53,7 +53,7 @@
     >
         Helpful text is helpful
     </fast-tooltip>
-    <fast-button id="anchor-show" style="margin: 200px 300px 200px 300px;">
+    <fast-button id="anchor-show" style="margin: 600px 600px 600px 600px;">
         Toggle tooltips
     </fast-button>
 </div>

--- a/packages/web-components/fast-components/src/tooltip/fixtures/base.html
+++ b/packages/web-components/fast-components/src/tooltip/fixtures/base.html
@@ -11,49 +11,52 @@
 </div>
 
 <h2>Show/Hide with auto updating and lock to viewport</h2>
-<fast-tooltip
-    id="tooltip-show-1"
-    anchor="anchor-show"
-    position="top"
-    auto-update-mode="auto"
-    vertical-viewport-lock="true"
-    horizontal-viewport-lock="true"
->
-    Helpful text is helpful
-</fast-tooltip>
-<fast-tooltip
-    id="tooltip-show-2"
-    anchor="anchor-show"
-    position="right"
-    auto-update-mode="auto"
-    vertical-viewport-lock="true"
-    horizontal-viewport-lock="true"
->
-    Helpful text is helpful
-</fast-tooltip>
-<fast-tooltip
-    id="tooltip-show-3"
-    anchor="anchor-show"
-    position="bottom"
-    auto-update-mode="auto"
-    vertical-viewport-lock="true"
-    horizontal-viewport-lock="true"
->
-    Helpful text is helpful
-</fast-tooltip>
-<fast-tooltip
-    id="tooltip-show-4"
-    anchor="anchor-show"
-    position="left"
-    auto-update-mode="auto"
-    vertical-viewport-lock="true"
-    horizontal-viewport-lock="true"
->
-    Helpful text is helpful
-</fast-tooltip>
-<fast-button id="anchor-show" style="margin: 100px 200px 100px 200px;">
-    Toggle tooltips
-</fast-button>
+
+<div style="height: 400px; width: 600px; background: lightgray; overflow: scroll;">
+    <fast-tooltip
+        id="tooltip-show-1"
+        anchor="anchor-show"
+        position="top"
+        auto-update-mode="auto"
+        vertical-viewport-lock="true"
+        horizontal-viewport-lock="true"
+    >
+        Helpful text is helpful
+    </fast-tooltip>
+    <fast-tooltip
+        id="tooltip-show-2"
+        anchor="anchor-show"
+        position="right"
+        auto-update-mode="auto"
+        vertical-viewport-lock="true"
+        horizontal-viewport-lock="true"
+    >
+        Helpful text is helpful
+    </fast-tooltip>
+    <fast-tooltip
+        id="tooltip-show-3"
+        anchor="anchor-show"
+        position="bottom"
+        auto-update-mode="auto"
+        vertical-viewport-lock="true"
+        horizontal-viewport-lock="true"
+    >
+        Helpful text is helpful
+    </fast-tooltip>
+    <fast-tooltip
+        id="tooltip-show-4"
+        anchor="anchor-show"
+        position="left"
+        auto-update-mode="auto"
+        vertical-viewport-lock="true"
+        horizontal-viewport-lock="true"
+    >
+        Helpful text is helpful
+    </fast-tooltip>
+    <fast-button id="anchor-show" style="margin: 200px 300px 200px 300px;">
+        Toggle tooltips
+    </fast-button>
+</div>
 
 <h2>Fixed positions</h2>
 <div style="height: 400px; width: 400px; background: lightgray; overflow: scroll;">

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
@@ -4,6 +4,7 @@ import { fixture } from "../test-utilities/fixture";
 import { tooltipTemplate as template, Tooltip } from "./index";
 import { TooltipPosition } from "./tooltip";
 import { AnchoredRegion, anchoredRegionTemplate } from '../anchored-region';
+import { contentRect } from "../utilities/resize-observer";
 
 const FASTTooltip = Tooltip.compose({
     baseName: "tooltip",
@@ -17,7 +18,7 @@ const FASTAnchoredRegion = AnchoredRegion.compose({
 
 async function setup() {
     const { element, connect, disconnect, parent } = await fixture([FASTTooltip(), FASTAnchoredRegion()]);
-    
+
     const button = document.createElement("button");
     button.id = "anchor";
 
@@ -101,33 +102,33 @@ describe("Tooltip", () => {
         await disconnect();
     });
 
-    it("should not set a default position by default", async () => {
+    it("should set horizontal position to 'center' and vertical position to 'undefined' by default", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 
         await connect();
 
         expect(tooltip.verticalDefaultPosition).to.equal(undefined);
-        expect(tooltip.horizontalDefaultPosition).to.equal(undefined);
+        expect(tooltip.horizontalDefaultPosition).to.equal("center");
 
         await disconnect();
     });
 
-    it("should set horizontal scaling to match anchor and vertical scaling to match content by default", async () => {
+    it("should set horizontal scaling and vertical scaling to match content by default", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 
         await connect();
 
         expect(tooltip.verticalScaling).to.equal("content");
-        expect(tooltip.horizontalScaling).to.equal("anchor");
+        expect(tooltip.horizontalScaling).to.equal("content");
 
         await disconnect();
     });
 
     // top position settings
 
-    it("should set vertical positioning mode to locked and horizontal to dynamic when position is set to top", async () => {
+    it("should set vertical and horizontal positioning mode to locktodefault when position is set to top", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 
@@ -136,7 +137,7 @@ describe("Tooltip", () => {
         await connect();
 
         expect(tooltip.verticalPositioningMode).to.equal("locktodefault");
-        expect(tooltip.horizontalPositioningMode).to.equal("dynamic");
+        expect(tooltip.horizontalPositioningMode).to.equal("locktodefault");
 
         await disconnect();
     });
@@ -150,12 +151,12 @@ describe("Tooltip", () => {
         await connect();
 
         expect(tooltip.verticalDefaultPosition).to.equal("top");
-        expect(tooltip.horizontalDefaultPosition).to.equal(undefined);
+        expect(tooltip.horizontalDefaultPosition).to.equal("center");
 
         await disconnect();
     });
 
-    it("should set horizontal scaling to match anchor and vertical scaling to match content when position is set to top", async () => {
+    it("should set scaling to match content when position is set to top", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 
@@ -164,14 +165,14 @@ describe("Tooltip", () => {
         await connect();
 
         expect(tooltip.verticalScaling).to.equal("content");
-        expect(tooltip.horizontalScaling).to.equal("anchor");
+        expect(tooltip.horizontalScaling).to.equal("content");
 
         await disconnect();
     });
 
     // bottom position settings
 
-    it("should set vertical positioning mode to locked and horizontal to dynamic when position is set to bottom", async () => {
+    it("should set vertical positioning mode to locked when position is set to bottom", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 
@@ -180,7 +181,7 @@ describe("Tooltip", () => {
         await connect();
 
         expect(tooltip.verticalPositioningMode).to.equal("locktodefault");
-        expect(tooltip.horizontalPositioningMode).to.equal("dynamic");
+        expect(tooltip.horizontalPositioningMode).to.equal("locktodefault");
 
         await disconnect();
     });
@@ -194,7 +195,7 @@ describe("Tooltip", () => {
         await connect();
 
         expect(tooltip.verticalDefaultPosition).to.equal("bottom");
-        expect(tooltip.horizontalDefaultPosition).to.equal(undefined);
+        expect(tooltip.horizontalDefaultPosition).to.equal("center");
 
         await disconnect();
     });
@@ -208,14 +209,14 @@ describe("Tooltip", () => {
         await connect();
 
         expect(tooltip.verticalScaling).to.equal("content");
-        expect(tooltip.horizontalScaling).to.equal("anchor");
+        expect(tooltip.horizontalScaling).to.equal("content");
 
         await disconnect();
     });
 
     // left position settings
 
-    it("should set horizontal positioning mode to locked and vertical to dynamic when position is set to left", async () => {
+    it("should set positioning mode to locked when position is set to left", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 
@@ -223,7 +224,7 @@ describe("Tooltip", () => {
 
         await connect();
 
-        expect(tooltip.verticalPositioningMode).to.equal("dynamic");
+        expect(tooltip.verticalPositioningMode).to.equal("locktodefault");
         expect(tooltip.horizontalPositioningMode).to.equal("locktodefault");
 
         await disconnect();
@@ -237,13 +238,13 @@ describe("Tooltip", () => {
 
         await connect();
 
-        expect(tooltip.verticalDefaultPosition).to.equal(undefined);
+        expect(tooltip.verticalDefaultPosition).to.equal("center");
         expect(tooltip.horizontalDefaultPosition).to.equal("left");
 
         await disconnect();
     });
 
-    it("should set vertical scaling to match anchor and horizontal scaling to match content when position is set to bottom", async () => {
+    it("should set vertical scaling to match content when position is set to bottom", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 
@@ -251,7 +252,7 @@ describe("Tooltip", () => {
 
         await connect();
 
-        expect(tooltip.verticalScaling).to.equal("anchor");
+        expect(tooltip.verticalScaling).to.equal("content");
         expect(tooltip.horizontalScaling).to.equal("content");
 
         await disconnect();
@@ -259,7 +260,7 @@ describe("Tooltip", () => {
 
     // right position settings
 
-    it("should set horizontal positioning mode to locked and vertical to dynamic when position is set to right", async () => {
+    it("should set positioning mode to locked when position is set to right", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 
@@ -267,7 +268,7 @@ describe("Tooltip", () => {
 
         await connect();
 
-        expect(tooltip.verticalPositioningMode).to.equal("dynamic");
+        expect(tooltip.verticalPositioningMode).to.equal("locktodefault");
         expect(tooltip.horizontalPositioningMode).to.equal("locktodefault");
 
         await disconnect();
@@ -281,13 +282,13 @@ describe("Tooltip", () => {
 
         await connect();
 
-        expect(tooltip.verticalDefaultPosition).to.equal(undefined);
+        expect(tooltip.verticalDefaultPosition).to.equal("center");
         expect(tooltip.horizontalDefaultPosition).to.equal("right");
 
         await disconnect();
     });
 
-    it("should set vertical scaling to match anchor and horizontal scaling to match content when position is set to rig", async () => {
+    it("should set scaling to match content when position is set to right", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 
@@ -295,7 +296,7 @@ describe("Tooltip", () => {
 
         await connect();
 
-        expect(tooltip.verticalScaling).to.equal("anchor");
+        expect(tooltip.verticalScaling).to.equal("content");
         expect(tooltip.horizontalScaling).to.equal("content");
 
         await disconnect();

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
@@ -186,7 +186,7 @@ describe("Tooltip", () => {
         await disconnect();
     });
 
-    it("should set default vertical position to top when position is set to top", async () => {
+    it("should set default vertical position to bottom when position is set to bottom", async () => {
         const { element, connect, disconnect } = await setup();
         const tooltip: Tooltip = element;
 

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -197,7 +197,7 @@ export class Tooltip extends FoundationElement {
      * @internal
      */
     @observable
-    public horizontalInset: string = "true";
+    public horizontalInset: string = "false";
 
     /**
      * @internal
@@ -209,7 +209,7 @@ export class Tooltip extends FoundationElement {
      * @internal
      */
     @observable
-    public horizontalScaling: AxisScalingMode = "anchor";
+    public horizontalScaling: AxisScalingMode = "content";
 
     /**
      * @internal
@@ -288,6 +288,10 @@ export class Tooltip extends FoundationElement {
             "inset-bottom",
             this.region.verticalPosition === "insetEnd"
         );
+        this.classList.toggle(
+            "center-vertical",
+            this.region.verticalPosition === "center"
+        );
 
         this.classList.toggle("left", this.region.horizontalPosition === "start");
         this.classList.toggle("right", this.region.horizontalPosition === "end");
@@ -298,6 +302,10 @@ export class Tooltip extends FoundationElement {
         this.classList.toggle(
             "inset-right",
             this.region.horizontalPosition === "insetEnd"
+        );
+        this.classList.toggle(
+            "center-horizontal",
+            this.region.horizontalPosition === "center"
         );
     };
 
@@ -372,38 +380,26 @@ export class Tooltip extends FoundationElement {
             case TooltipPosition.top:
             case TooltipPosition.bottom:
                 this.verticalPositioningMode = "locktodefault";
-                this.horizontalPositioningMode = "dynamic";
+                this.horizontalPositioningMode = "locktodefault";
                 this.verticalDefaultPosition = this.position;
-                this.horizontalDefaultPosition = undefined;
-                this.horizontalInset = "true";
-                this.verticalInset = "false";
-                this.horizontalScaling = "anchor";
-                this.verticalScaling = "content";
+                this.horizontalDefaultPosition = "center";
                 break;
 
             case TooltipPosition.right:
             case TooltipPosition.left:
             case TooltipPosition.start:
             case TooltipPosition.end:
-                this.verticalPositioningMode = "dynamic";
+                this.verticalPositioningMode = "locktodefault";
                 this.horizontalPositioningMode = "locktodefault";
-                this.verticalDefaultPosition = undefined;
+                this.verticalDefaultPosition = "center";
                 this.horizontalDefaultPosition = this.position;
-                this.horizontalInset = "false";
-                this.verticalInset = "true";
-                this.horizontalScaling = "content";
-                this.verticalScaling = "anchor";
                 break;
 
             default:
                 this.verticalPositioningMode = "dynamic";
                 this.horizontalPositioningMode = "dynamic";
-                this.verticalDefaultPosition = undefined;
-                this.horizontalDefaultPosition = undefined;
-                this.horizontalInset = "true";
-                this.verticalInset = "false";
-                this.horizontalScaling = "anchor";
-                this.verticalScaling = "content";
+                this.verticalDefaultPosition = void 0;
+                this.horizontalDefaultPosition = "center";
                 break;
         }
     }


### PR DESCRIPTION
## 📖 Description

This pr hooks up the new anchored region "center" position option so that "locktoviewport" works with tooltip.  The previous method of using css tricks to get the tooltip look centered was getting clipped in some cases.

### 🎫 Issues


## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
