### PR TITLE
DRAFT fix: rework tree view events

### DIFF
--- a/change/@microsoft-fast-foundation-96d671a6-621c-4790-8217-b319bdc883d3.json
+++ b/change/@microsoft-fast-foundation-96d671a6-621c-4790-8217-b319bdc883d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "tree view events",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2487,26 +2487,25 @@ export function transient<T extends Constructable>(target: T & Partial<RegisterS
 //
 // @public
 export class TreeItem extends FoundationElement {
-    // (undocumented)
+    // @internal
     childItemLength(): number;
-    // (undocumented)
+    // @internal (undocumented)
     childItems: HTMLElement[];
     disabled: boolean;
     // @internal
     expandCollapseButton: HTMLDivElement;
     expanded: boolean;
-    // (undocumented)
+    // @internal
     focusable: boolean;
     static focusItem(el: HTMLElement): void;
-    // (undocumented)
+    // @internal
     handleExpandCollapseButtonClick: (e: MouseEvent) => void;
-    // (undocumented)
     readonly isNestedItem: () => boolean;
-    // (undocumented)
+    // @internal
     items: HTMLElement[];
-    // @internal (undocumented)
+    // @internal
     nested: boolean;
-    // (undocumented)
+    // @internal (undocumented)
     renderCollapsedChildren: boolean;
     selected: boolean;
     }
@@ -2530,6 +2529,8 @@ export class TreeView extends FoundationElement {
     // @internal
     currentFocused: HTMLElement | TreeItem | null;
     currentSelected: HTMLElement | TreeItem | null;
+    // @internal
+    handleBlur: (e: FocusEvent) => void;
     // @internal
     handleClick(e: Event): boolean | void;
     // @internal

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2499,8 +2499,6 @@ export class TreeItem extends FoundationElement {
     focusable: boolean;
     static focusItem(el: HTMLElement): void;
     // (undocumented)
-    handleClick: (e: MouseEvent) => void | boolean;
-    // (undocumented)
     handleExpandCollapseButtonClick: (e: MouseEvent) => void;
     // (undocumented)
     readonly isNestedItem: () => boolean;
@@ -2535,6 +2533,8 @@ export class TreeView extends FoundationElement {
     currentSelected: HTMLElement | TreeItem | null;
     // (undocumented)
     handleBlur: (e: FocusEvent) => void;
+    // (undocumented)
+    handleClick(e: Event): boolean;
     // (undocumented)
     handleFocus: (e: FocusEvent) => void;
     // (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2492,7 +2492,7 @@ export class TreeItem extends FoundationElement {
     // (undocumented)
     childItems: HTMLElement[];
     disabled: boolean;
-    // (undocumented)
+    // @internal
     expandCollapseButton: HTMLDivElement;
     expanded: boolean;
     // (undocumented)
@@ -2527,23 +2527,21 @@ export const treeItemTemplate: (context: ElementDefinitionContext, definition: T
 export class TreeView extends FoundationElement {
     // (undocumented)
     connectedCallback(): void;
-    // (undocumented)
+    // @internal
     currentFocused: HTMLElement | TreeItem | null;
-    // (undocumented)
     currentSelected: HTMLElement | TreeItem | null;
-    // (undocumented)
-    handleBlur: (e: FocusEvent) => void;
-    // (undocumented)
-    handleClick(e: Event): boolean;
-    // (undocumented)
+    // @internal
+    handleClick(e: Event): boolean | void;
+    // @internal
     handleFocus: (e: FocusEvent) => void;
-    // (undocumented)
-    handleKeyDown: (e: KeyboardEvent) => void | boolean;
-    // (undocumented)
+    // @internal
+    handleKeyDown: (e: KeyboardEvent) => boolean | void;
+    // @internal
+    handleSelectedChange: (e: Event) => boolean | void;
     renderCollapsedNodes: boolean;
-    // (undocumented)
+    // @internal
     slottedTreeItems: HTMLElement[];
-    // (undocumented)
+    // @internal
     treeView: HTMLElement;
 }
 

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.spec.ts
@@ -179,15 +179,13 @@ describe("TreeItem", () => {
         await disconnect();
     });
 
-    it("should set a tabindex when `focusable` is true", async () => {
+    it("should set a tabindex of -1", async () => {
         const { element, connect, disconnect } = await setup();
-
-        element.focusable = true;
 
         await connect();
 
         expect(element.hasAttribute("tabindex")).to.equal(true);
-        expect(element.getAttribute("tabindex")).to.equal("0");
+        expect(element.getAttribute("tabindex")).to.equal("-1");
 
         await disconnect();
     });
@@ -315,25 +313,20 @@ describe("TreeItem", () => {
             const nestedItem = document.createElement("fast-tree-item");
             element.appendChild(nestedItem);
 
-            let wasClicked = false;
+            let wasSelected = false;
 
             element.addEventListener("selected-change", e => {
                 e.preventDefault();
 
-                wasClicked = true;
+                wasSelected = true;
             });
 
             await connect();
+
+            element.setAttribute("selected", "true");
             await DOM.nextUpdate();
 
-            let container = element.shadowRoot?.querySelector(
-                ".positioning-region"
-            ) as any;
-            container?.click();
-
-            await DOM.nextUpdate();
-
-            expect(wasClicked).to.equal(true);
+            expect(wasSelected).to.equal(true);
 
             await disconnect();
         });

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -26,7 +26,6 @@ export const treeItemTemplate: (
             x.childItems && x.childItemLength() > 0 ? x.expanded : void 0}"
         aria-selected="${x => x.selected}"
         aria-disabled="${x => x.disabled}"
-        @click="${(x, c) => x.handleClick(c.event as MouseEvent)}"
         ${children({
             property: "childItems",
             filter: elements(),

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -18,7 +18,7 @@ export const treeItemTemplate: (
     <template
         role="treeitem"
         slot="${x => (x.isNestedItem() ? "item" : void 0)}"
-        tabindex="${x => (!x.focusable ? -1 : 0)}"
+        tabindex="-1"
         class="${x => (x.expanded ? "expanded" : "")} ${x =>
             x.selected ? "selected" : ""} ${x => (x.nested ? "nested" : "")}
             ${x => (x.disabled ? "disabled" : "")}"

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -73,12 +73,27 @@ export class TreeItem extends FoundationElement {
      */
     public expandCollapseButton: HTMLDivElement;
 
+    /**
+     * Whether the item is focusable
+     *
+     * @internal
+     */
     @observable
     public focusable: boolean = false;
 
+    /**
+     *
+     *
+     * @internal
+     */
     @observable
     public childItems: HTMLElement[];
 
+    /**
+     * The slotted child tree items
+     *
+     * @internal
+     */
     @observable
     public items: HTMLElement[];
     private itemsChanged(oldValue, newValue): void {
@@ -93,16 +108,25 @@ export class TreeItem extends FoundationElement {
     }
 
     /**
+     * Indicates if the tree item is nested
+     *
      * @internal
      */
     @observable
     public nested: boolean;
 
+    /**
+     *
+     *
+     * @internal
+     */
     @observable
     public renderCollapsedChildren: boolean;
 
     /**
      * Places document focus on a tree item
+     *
+     * @public
      * @param el - the element to focus
      */
     public static focusItem(el: HTMLElement) {
@@ -110,12 +134,31 @@ export class TreeItem extends FoundationElement {
         el.focus();
     }
 
+    /**
+     * Whether the tree is nested
+     *
+     * @public
+     */
+    public readonly isNestedItem = (): boolean => {
+        return isTreeItemElement(this.parentElement as Element);
+    };
+
+    /**
+     * Handle expand button click
+     *
+     * @internal
+     */
     public handleExpandCollapseButtonClick = (e: MouseEvent): void => {
         if (!this.disabled && !e.defaultPrevented) {
             this.expanded = !this.expanded;
         }
     };
 
+    /**
+     * Gets number of children
+     *
+     * @internal
+     */
     public childItemLength(): number {
         const treeChildren: HTMLElement[] = this.childItems.filter(
             (item: HTMLElement) => {
@@ -124,10 +167,6 @@ export class TreeItem extends FoundationElement {
         );
         return treeChildren ? treeChildren.length : 0;
     }
-
-    public readonly isNestedItem = (): boolean => {
-        return isTreeItemElement(this.parentElement as Element);
-    };
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -66,6 +66,11 @@ export class TreeItem extends FoundationElement {
     @attr({ mode: "boolean" })
     public disabled: boolean;
 
+    /**
+     *  Reference to the expand/collapse button
+     *
+     * @internal
+     */
     public expandCollapseButton: HTMLDivElement;
 
     @observable

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -37,6 +37,11 @@ export class TreeItem extends FoundationElement {
      */
     @attr({ mode: "boolean" })
     public expanded: boolean = false;
+    private expandedChanged(): void {
+        if (this.$fastController.isConnected) {
+            this.$emit("expanded-change", this);
+        }
+    }
 
     /**
      * When true, the control will appear selected by user interaction.
@@ -46,6 +51,11 @@ export class TreeItem extends FoundationElement {
      */
     @attr({ mode: "boolean" })
     public selected: boolean;
+    private selectedChanged(): void {
+        if (this.$fastController.isConnected) {
+            this.$emit("selected-change", this);
+        }
+    }
 
     /**
      * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/disabled | disabled HTML attribute} for more information.
@@ -96,23 +106,8 @@ export class TreeItem extends FoundationElement {
     }
 
     public handleExpandCollapseButtonClick = (e: MouseEvent): void => {
-        if (!this.disabled) {
-            e.preventDefault();
-            this.setExpanded(!this.expanded);
-        }
-    };
-
-    public handleClick = (e: MouseEvent): void | boolean => {
-        if (!e.defaultPrevented) {
-            const target = e.composedPath();
-            const clickedTreeItem = target.find(
-                (t: EventTarget) => t instanceof HTMLElement && isTreeItemElement(t)
-            );
-            if ((clickedTreeItem as any) === this) {
-                this.handleSelected();
-            }
-            // do not prevent default as it completely eats the click
-            return true;
+        if (!this.disabled && !e.defaultPrevented) {
+            this.expanded = !this.expanded;
         }
     };
 
@@ -128,15 +123,6 @@ export class TreeItem extends FoundationElement {
     public readonly isNestedItem = (): boolean => {
         return isTreeItemElement(this.parentElement as Element);
     };
-
-    private handleSelected(e?: Event): void {
-        this.$emit("selected-change", e);
-    }
-
-    private setExpanded(expanded: boolean): void {
-        this.expanded = expanded;
-        this.$emit("expanded-change", this);
-    }
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
@@ -20,6 +20,7 @@ export const treeViewTemplate: (
         ${ref("treeView")}
         @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
         @focusin="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
+        @focusout="${(x, c) => x.handleBlur(c.event as FocusEvent)}"
         @click="${(x, c) => x.handleClick(c.event as MouseEvent)}"
         @selected-change="${(x, c) => x.handleSelectedChange(c.event)}"
     >

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
@@ -21,6 +21,7 @@ export const treeViewTemplate: (
         @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
         @focusout="${(x, c) => x.handleBlur(c.event as FocusEvent)}"
         @focusin="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
+        @click="${(x, c) => x.handleClick(c.event as MouseEvent)}"
     >
         <slot ${slotted("slottedTreeItems")}></slot>
     </template>

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
@@ -19,9 +19,9 @@ export const treeViewTemplate: (
         role="tree"
         ${ref("treeView")}
         @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
-        @focusout="${(x, c) => x.handleBlur(c.event as FocusEvent)}"
         @focusin="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
         @click="${(x, c) => x.handleClick(c.event as MouseEvent)}"
+        @selected-change="${(x, c) => x.handleSelectedChange(c.event)}"
     >
         <slot ${slotted("slottedTreeItems")}></slot>
     </template>

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -21,11 +21,12 @@ import { FoundationElement } from "../foundation-element";
  */
 export class TreeView extends FoundationElement {
     /**
-     * When true, the control will be appear expanded by user interaction.
-     * @public
-     * @remarks
-     * HTML Attribute: render-collapsed-nodes
-     */
+   /**
+    * When true, the control will be appear expanded by user interaction.
+    * @public
+    * @remarks
+    * HTML Attribute: render-collapsed-nodes
+    */
     @attr({ attribute: "render-collapsed-nodes" })
     public renderCollapsedNodes: boolean;
 
@@ -34,17 +35,12 @@ export class TreeView extends FoundationElement {
      * @public
      */
     @observable
-    public currentSelected: HTMLElement | TreeItem | null;
+    public currentSelected: HTMLElement | TreeItem | null = null;
     private currentSelectedChanged(oldValue, newValue): void {
         if (this.$fastController.isConnected) {
-            // enforce single select
-            this.treeItems.forEach((item: HTMLElement) => {
-                if (item instanceof TreeItem) {
-                    if (item !== newValue) {
-                        (item as TreeItem).selected = false;
-                    }
-                }
-            });
+            if (isTreeItemElement(oldValue)) {
+                (oldValue as TreeItem).selected = false;
+            }
         }
     }
 
@@ -57,74 +53,58 @@ export class TreeView extends FoundationElement {
     private slottedTreeItemsChanged(): void {
         if (this.$fastController.isConnected) {
             // update for slotted children change
-            this.treeItems = this.getVisibleNodes();
             this.setItems();
         }
     }
 
     /**
      * The tree item that is designated to be in the tab queue.
-     * If there is no currentFocused element the tree itself is in
-     * the tab queue (ie. tabindex = 0)
      *
      * @internal
      */
     @observable
     public currentFocused: HTMLElement | TreeItem | null = null;
-    private currentFocusedChanged(oldFocusItem, newFocusItemj): void {
-        if (this.$fastController.isConnected) {
-            this.treeItems.forEach((item: HTMLElement) => {
-                if (item instanceof TreeItem) {
-                    if (item !== newFocusItemj) {
-                        item.setAttribute("tabindex", "-1");
-                    }
-                }
-            });
-            if (isTreeItemElement(newFocusItemj)) {
-                (newFocusItemj as HTMLElement).setAttribute("tabindex", "0");
-                this.setAttribute("tabindex", "-1");
-            } else {
-                // make the tree focusable
-                this.setAttribute("tabindex", "0");
-            }
-        }
-    }
 
     /**
-     * Handle a bubbled focus event
+     * Handle focus events
      *
      * @internal
      */
     public handleFocus = (e: FocusEvent): void => {
-        if (e.target === this) {
-            // if the tree view gets focus shift it to a valid tree item if possible
-
-            // if we have a currentFocus element
-            // focus on that
-            if (this.currentFocused !== null) {
-                this.currentFocused.focus();
-                return;
-            }
-
-            // otherwise use the first one we find
-            const newFocusItem:
-                | null
-                | HTMLElement
-                | TreeItem = this.getValidFocusableItem();
-            if (newFocusItem !== null) {
-                newFocusItem.focus();
-            }
+        if (this.slottedTreeItems.length < 1) {
+            // no child items, nothing to do
             return;
         }
 
-        if (
-            this.contains(e.target as Element) &&
-            this.isFocusableElement(e.target as Element)
-        ) {
-            // focus event is from a valid tree item child
-            //  it becomes currentFocused
-            this.currentFocused = e.target as HTMLElement;
+        if (e.target === this) {
+            if (this.currentFocused === null) {
+                this.currentFocused = this.getValidFocusableItem();
+            }
+
+            if (this.currentFocused !== null) {
+                TreeItem.focusItem(this.currentFocused);
+            }
+
             return;
+        }
+
+        if (this.contains(e.target as Node)) {
+            this.setAttribute("tabindex", "-1");
+            this.currentFocused = e.target as HTMLElement;
+        }
+    };
+
+    /**
+     * Handle blur events
+     *
+     * @internal
+     */
+    public handleBlur = (e: FocusEvent): void => {
+        if (
+            e.target instanceof HTMLElement &&
+            (e.relatedTarget === null || !this.contains(e.relatedTarget as Node))
+        ) {
+            this.setAttribute("tabindex", "0");
         }
     };
 
@@ -135,13 +115,14 @@ export class TreeView extends FoundationElement {
      */
     public treeView: HTMLElement;
 
-    private treeItems: HTMLElement[];
     private nested: boolean;
 
     public connectedCallback(): void {
         super.connectedCallback();
         this.setAttribute("tabindex", "0");
-        this.setItems();
+        DOM.queueUpdate(() => {
+            this.setItems();
+        });
     }
 
     /**
@@ -154,19 +135,21 @@ export class TreeView extends FoundationElement {
             return;
         }
 
-        if (!this.treeItems) {
+        if (this.slottedTreeItems.length < 1) {
             return true;
         }
 
+        const treeItems: HTMLElement[] | void = this.getVisibleNodes();
+
         switch (e.key) {
             case keyHome:
-                if (this.treeItems && this.treeItems.length) {
-                    TreeItem.focusItem(this.treeItems[0]);
+                if (treeItems.length) {
+                    TreeItem.focusItem(treeItems[0]);
                 }
                 return;
             case keyEnd:
-                if (this.treeItems && this.treeItems.length) {
-                    TreeItem.focusItem(this.treeItems[this.treeItems.length - 1]);
+                if (treeItems.length) {
+                    TreeItem.focusItem(treeItems[treeItems.length - 1]);
                 }
                 return;
             case keyArrowLeft:
@@ -278,8 +261,6 @@ export class TreeView extends FoundationElement {
      * Updates the tree view when slottedTreeItems changes
      */
     private setItems = (): void => {
-        this.treeItems = this.getVisibleNodes();
-
         // force single selection
         // defaults to first one found
         const selectedItem: HTMLElement | null = this.treeView.querySelector(
@@ -292,9 +273,11 @@ export class TreeView extends FoundationElement {
             this.currentFocused = this.getValidFocusableItem();
         }
 
-        // toggle the nested attribute on child elements
+        // toggle properties on child elements
         this.nested = this.checkForNestedItems();
-        this.slottedTreeItems.forEach(node => {
+
+        const treeItems: HTMLElement[] | void = this.getVisibleNodes();
+        treeItems.forEach(node => {
             if (isTreeItemElement(node)) {
                 (node as TreeItem).nested = this.nested;
             }
@@ -305,14 +288,15 @@ export class TreeView extends FoundationElement {
      * checks if there are any nested tree items
      */
     private getValidFocusableItem(): null | HTMLElement | TreeItem {
+        const treeItems: HTMLElement[] | void = this.getVisibleNodes();
         // default to selected element if there is one
-        let focusIndex = this.treeItems.findIndex(this.isSelectedElement);
+        let focusIndex = treeItems.findIndex(this.isSelectedElement);
         if (focusIndex === -1) {
             // otherwise first focusable tree item
-            focusIndex = this.treeItems.findIndex(this.isFocusableElement);
+            focusIndex = treeItems.findIndex(this.isFocusableElement);
         }
         if (focusIndex !== -1) {
-            return this.treeItems[focusIndex];
+            return treeItems[focusIndex];
         }
 
         return null;

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -269,7 +269,7 @@ export class TreeView extends FoundationElement {
         this.currentSelected = selectedItem;
 
         // invalidate the current focused item if it is no longer valid
-        if (this.currentFocused !== null && !this.contains(this.currentFocused)) {
+        if (this.currentFocused === null || !this.contains(this.currentFocused)) {
             this.currentFocused = this.getValidFocusableItem();
         }
 

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -20,90 +20,138 @@ import { FoundationElement } from "../foundation-element";
  * @public
  */
 export class TreeView extends FoundationElement {
-    public treeView: HTMLElement;
-
+    /**
+     * When true, the control will be appear expanded by user interaction.
+     * @public
+     * @remarks
+     * HTML Attribute: render-collapsed-nodes
+     */
     @attr({ attribute: "render-collapsed-nodes" })
     public renderCollapsedNodes: boolean;
 
+    /**
+     * The currently selected tree item
+     * @public
+     */
     @observable
     public currentSelected: HTMLElement | TreeItem | null;
-
-    @observable
-    private nested: boolean;
-
-    @observable slottedTreeItems: HTMLElement[];
-    private slottedTreeItemsChanged(oldValue, newValue): void {
+    private currentSelectedChanged(oldValue, newValue): void {
         if (this.$fastController.isConnected) {
-            // filter the tree items until that's done for us in the framework
+            // enforce single select
+            this.treeItems.forEach((item: HTMLElement) => {
+                if (item instanceof TreeItem) {
+                    if (item !== newValue) {
+                        (item as TreeItem).selected = false;
+                    }
+                }
+            });
+        }
+    }
+
+    /**
+     *  Slotted children
+     *
+     * @internal
+     */
+    @observable slottedTreeItems: HTMLElement[];
+    private slottedTreeItemsChanged(): void {
+        if (this.$fastController.isConnected) {
+            // update for slotted children change
             this.treeItems = this.getVisibleNodes();
             this.setItems();
+        }
+    }
 
-            // check if any tree items have nested items
-            // if they do, apply the nested attribute
-            if (this.checkForNestedItems()) {
-                this.slottedTreeItems.forEach(node => {
-                    if (isTreeItemElement(node)) {
-                        (node as TreeItem).nested = true;
+    /**
+     * The tree item that is designated to be in the tab queue.
+     * If there is no currentFocused element the tree itself is in
+     * the tab queue (ie. tabindex = 0)
+     *
+     * @internal
+     */
+    @observable
+    public currentFocused: HTMLElement | TreeItem | null = null;
+    private currentFocusedChanged(oldFocusItem, newFocusItemj): void {
+        if (this.$fastController.isConnected) {
+            this.treeItems.forEach((item: HTMLElement) => {
+                if (item instanceof TreeItem) {
+                    if (item !== newFocusItemj) {
+                        item.setAttribute("tabindex", "-1");
                     }
-                });
+                }
+            });
+            if (isTreeItemElement(newFocusItemj)) {
+                (newFocusItemj as HTMLElement).setAttribute("tabindex", "0");
+                this.setAttribute("tabindex", "-1");
+            } else {
+                // make the tree focusable
+                this.setAttribute("tabindex", "0");
             }
         }
     }
 
-    private checkForNestedItems(): boolean {
-        return this.slottedTreeItems.some((node: HTMLElement) => {
-            return isTreeItemElement(node) && node.querySelector("[role='treeitem']");
-        });
-    }
+    /**
+     * Handle a bubbled focus event
+     *
+     * @internal
+     */
+    public handleFocus = (e: FocusEvent): void => {
+        if (e.target === this) {
+            // if the tree view gets focus shift it to a valid tree item if possible
 
-    public currentFocused: HTMLElement | TreeItem | null;
+            // if we have a currentFocus element
+            // focus on that
+            if (this.currentFocused !== null) {
+                this.currentFocused.focus();
+                return;
+            }
+
+            // otherwise use the first one we find
+            const newFocusItem:
+                | null
+                | HTMLElement
+                | TreeItem = this.getValidFocusableItem();
+            if (newFocusItem !== null) {
+                newFocusItem.focus();
+            }
+            return;
+        }
+
+        if (
+            this.contains(e.target as Element) &&
+            this.isFocusableElement(e.target as Element)
+        ) {
+            // focus event is from a valid tree item child
+            //  it becomes currentFocused
+            this.currentFocused = e.target as HTMLElement;
+            return;
+        }
+    };
+
+    /**
+     * ref to the tree item
+     *
+     * @internal
+     */
+    public treeView: HTMLElement;
 
     private treeItems: HTMLElement[];
-
-    public handleBlur = (e: FocusEvent): void => {
-        const { relatedTarget, target } = e;
-        if (
-            target instanceof HTMLElement &&
-            (relatedTarget === null || !this.contains(relatedTarget as Node))
-        ) {
-            this.setAttribute("tabindex", "0");
-        }
-    };
-
-    public handleFocus = (e: FocusEvent): void => {
-        const { relatedTarget, target } = e;
-
-        if (
-            target instanceof HTMLElement &&
-            (relatedTarget === null || !this.contains(relatedTarget as Node))
-        ) {
-            const treeView = this as HTMLElement;
-            if (target === this && this.currentFocused instanceof TreeItem) {
-                TreeItem.focusItem(this.currentFocused);
-                this.currentFocused.setAttribute("tabindex", "0");
-            }
-            treeView.setAttribute("tabindex", "-1");
-        }
-    };
+    private nested: boolean;
 
     public connectedCallback(): void {
         super.connectedCallback();
-        this.treeItems = this.getVisibleNodes();
-
-        DOM.queueUpdate(() => {
-            //only supporting single select
-            const node: HTMLElement | null = this.treeView.querySelector(
-                "[aria-selected='true']"
-            );
-            if (node) {
-                this.currentSelected = node;
-            }
-        });
+        this.setAttribute("tabindex", "0");
+        this.setItems();
     }
 
-    public handleKeyDown = (e: KeyboardEvent): void | boolean => {
+    /**
+     * KeyDown handler
+     *
+     *  @internal
+     */
+    public handleKeyDown = (e: KeyboardEvent): boolean | void => {
         if (e.defaultPrevented) {
-            return false;
+            return;
         }
 
         if (!this.treeItems) {
@@ -114,18 +162,13 @@ export class TreeView extends FoundationElement {
             case keyHome:
                 if (this.treeItems && this.treeItems.length) {
                     TreeItem.focusItem(this.treeItems[0]);
-                    this.treeItems[0].setAttribute("tabindex", "0");
                 }
-                break;
+                return;
             case keyEnd:
                 if (this.treeItems && this.treeItems.length) {
                     TreeItem.focusItem(this.treeItems[this.treeItems.length - 1]);
-                    this.treeItems[this.treeItems.length - 1].setAttribute(
-                        "tabindex",
-                        "0"
-                    );
                 }
-                break;
+                return;
             case keyArrowLeft:
                 if (e.target && this.isFocusableElement(e.target as HTMLElement)) {
                     const item = e.target as HTMLElement;
@@ -133,7 +176,7 @@ export class TreeView extends FoundationElement {
                         item.expanded = false;
                     }
                 }
-                break;
+                return false;
             case keyArrowRight:
                 if (e.target && this.isFocusableElement(e.target as HTMLElement)) {
                     const item = e.target as HTMLElement;
@@ -141,96 +184,147 @@ export class TreeView extends FoundationElement {
                         item.expanded = true;
                     }
                 }
-                break;
+                return;
             case keyArrowDown:
                 if (e.target && this.isFocusableElement(e.target as HTMLElement)) {
                     this.focusNextNode(1, e.target as TreeItem);
                 }
-                break;
+                return;
             case keyArrowUp:
                 if (e.target && this.isFocusableElement(e.target as HTMLElement)) {
                     this.focusNextNode(-1, e.target as TreeItem);
                 }
-                break;
+                return;
             case keyEnter:
                 // In single-select trees where selection does not follow focus (see note below),
                 // the default action is typically to select the focused node.
                 this.handleClick(e as Event);
-                break;
-            default:
-                return true;
+                return;
         }
+
+        // don't prevent default if we took no action
+        return true;
     };
 
+    /**
+     * Handles click events bubbling up
+     *
+     *  @internal
+     */
+    public handleClick(e: Event): boolean | void {
+        if (e.defaultPrevented) {
+            // handled, do nothing
+            return;
+        }
+
+        if (!(e.target instanceof Element) || !isTreeItemElement(e.target as Element)) {
+            // not a tree item, ignore
+            return true;
+        }
+
+        const item: TreeItem = e.target as TreeItem;
+
+        if (!item.disabled) {
+            item.selected = !item.selected;
+        }
+
+        return;
+    }
+
+    /**
+     * Handles the selected-changed events bubbling up
+     * from child tree items
+     *
+     *  @internal
+     */
+    public handleSelectedChange = (e: Event): boolean | void => {
+        if (e.defaultPrevented) {
+            return;
+        }
+
+        if (!(e.target instanceof Element) || !isTreeItemElement(e.target as Element)) {
+            return true;
+        }
+
+        const item: TreeItem = e.target as TreeItem;
+
+        if (item.selected && this.currentSelected !== item) {
+            // new selected item
+            this.currentSelected = item;
+        } else if (!item.selected && this.currentSelected === item) {
+            // selected item deselected
+            this.currentSelected = null;
+        }
+
+        return;
+    };
+
+    /**
+     * Move focus to a tree item based on its offset from the provided item
+     */
     private focusNextNode(delta: number, item: TreeItem): void {
         const visibleNodes: HTMLElement[] | void = this.getVisibleNodes();
         if (!visibleNodes) {
             return;
         }
 
-        const index = visibleNodes.indexOf(item);
-        const lastItem = visibleNodes[index];
-        if (delta < 0 && index > 0) {
-            lastItem.setAttribute("tabindex", "-1");
-        } else if (delta > 0 && index < visibleNodes.length - 1) {
-            lastItem.setAttribute("tabindex", "-1");
-        }
         const focusItem = visibleNodes[visibleNodes.indexOf(item) + delta];
         if (isHTMLElement(focusItem)) {
             TreeItem.focusItem(focusItem);
-            focusItem.setAttribute("tabindex", "0");
-            this.currentFocused = focusItem;
         }
     }
 
+    /**
+     * Updates the tree view when slottedTreeItems changes
+     */
     private setItems = (): void => {
-        let focusIndex = this.treeItems.findIndex(this.isSelectedElement);
-        if (focusIndex === -1) {
-            focusIndex = this.treeItems.findIndex(this.isFocusableElement);
+        this.treeItems = this.getVisibleNodes();
+
+        // force single selection
+        // defaults to first one found
+        const selectedItem: HTMLElement | null = this.treeView.querySelector(
+            "[aria-selected='true']"
+        );
+        this.currentSelected = selectedItem;
+
+        // invalidate the current focused item if it is no longer valid
+        if (this.currentFocused !== null && !this.contains(this.currentFocused)) {
+            this.currentFocused = this.getValidFocusableItem();
         }
 
-        for (let item: number = 0; item < this.treeItems.length; item++) {
-            if (item === focusIndex) {
-                this.treeItems[item].setAttribute("tabindex", "0");
-                this.currentFocused = this.treeItems[item];
+        // toggle the nested attribute on child elements
+        this.nested = this.checkForNestedItems();
+        this.slottedTreeItems.forEach(node => {
+            if (isTreeItemElement(node)) {
+                (node as TreeItem).nested = this.nested;
             }
-        }
+        });
     };
 
-    public handleClick(e: Event): boolean {
-        if (
-            e.defaultPrevented ||
-            !(e.target instanceof HTMLElement) ||
-            !isTreeItemElement(e.target as HTMLElement)
-        ) {
-            return true;
+    /**
+     * checks if there are any nested tree items
+     */
+    private getValidFocusableItem(): null | HTMLElement | TreeItem {
+        // default to selected element if there is one
+        let focusIndex = this.treeItems.findIndex(this.isSelectedElement);
+        if (focusIndex === -1) {
+            // otherwise first focusable tree item
+            focusIndex = this.treeItems.findIndex(this.isFocusableElement);
+        }
+        if (focusIndex !== -1) {
+            return this.treeItems[focusIndex];
         }
 
-        const item: TreeItem = e.target as TreeItem;
+        return null;
+    }
 
-        if (this.currentSelected !== item) {
-            item.setAttribute("tabindex", "0");
-            if (this.currentSelected instanceof TreeItem && this.currentFocused) {
-                if (!item.disabled) {
-                    this.currentSelected.selected = false;
-                }
-                this.currentFocused.setAttribute("tabindex", "-1");
-            }
-            if (!this.currentSelected) {
-                this.slottedTreeItems.forEach((item: HTMLElement) => {
-                    if (item instanceof TreeItem) {
-                        item.setAttribute("tabindex", "-1");
-                    }
-                });
-            }
-            if (!item.disabled) {
-                item.selected = true;
-                this.currentSelected = item;
-            }
-            this.currentFocused = item;
-        }
-
-        return false;
+    /**
+     * checks if there are any nested tree items
+     */
+    private checkForNestedItems(): boolean {
+        return this.slottedTreeItems.some((node: HTMLElement) => {
+            return isTreeItemElement(node) && node.querySelector("[role='treeitem']");
+        });
     }
 
     /**


### PR DESCRIPTION
## 📖 Description

The current tree view event model results in a tree item emitting a selection event prior to its selection state actually changing, which is not what a developer would expect.  With this change tree view listens for click events in order to determine when an item is selected, and items only emit a selected event when their selected state actually changes.  Worth noting this approach should enable the tree to respond to developer's setting the selected state of an item directly.

Additionally, tree view no longer sets the tabindex on tree items as the tree itself was already adding itself to the tab queue so setting it on the items was redundant.

Also added comments/labels to a number of functions.

### 🎫 Issues


## 👩‍💻 Reviewer Notes

This is a breaking change because any change to the timing of events and state changes could break some custom implementations as did the previous change that changed the order of setting prop and emitting change event.

## 📑 Test Plan
Need to add tests around events.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
