### PR TITLE
fix: inline tags in tsdoc blocks use escaped characters

### DIFF
--- a/change/@microsoft-fast-components-da5a25fb-a4db-492e-9b37-4347e66913fb.json
+++ b/change/@microsoft-fast-components-da5a25fb-a4db-492e-9b37-4347e66913fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: Inline tags in tsdoc blocks use escaped characters",
+  "packageName": "@microsoft/fast-components",
+  "email": "srdsecond@gmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-components/src/accordion-item/index.ts
+++ b/packages/web-components/fast-components/src/accordion-item/index.ts
@@ -12,7 +12,7 @@ import { accordionItemStyles as styles } from "./accordion-item.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-accordion-item\>
+ * Generates HTML Element: `<fast-accordion-item>`
  */
 export const fastAccordionItem = AccordionItem.compose<AccordionItemOptions>({
     baseName: "accordion-item",

--- a/packages/web-components/fast-components/src/accordion/index.ts
+++ b/packages/web-components/fast-components/src/accordion/index.ts
@@ -10,7 +10,7 @@ export * from "../accordion-item/index";
  *
  * @public
  * @remarks
- * Generates the HTML Element: \<fast-accordion\>
+ * Generates HTML Element: `<fast-accordion>`
  */
 export const fastAccordion = Accordion.compose({
     baseName: "accordion",

--- a/packages/web-components/fast-components/src/anchor/index.ts
+++ b/packages/web-components/fast-components/src/anchor/index.ts
@@ -69,7 +69,7 @@ export class Anchor extends FoundationAnchor {
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-anchor\>
+ * Generates HTML Element: `<fast-anchor>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/anchored-region/index.ts
+++ b/packages/web-components/fast-components/src/anchored-region/index.ts
@@ -11,7 +11,7 @@ import { anchoredRegionStyles as styles } from "./anchored-region.styles";
  *
  * @beta
  * @remarks
- * Generates HTML Element: \<fast-anchored-region\>
+ * Generates HTML Element: `<fast-anchored-region>`
  */
 export const fastAnchoredRegion = AnchoredRegion.compose({
     baseName: "anchored-region",

--- a/packages/web-components/fast-components/src/avatar/index.ts
+++ b/packages/web-components/fast-components/src/avatar/index.ts
@@ -59,7 +59,7 @@ export const imgTemplate = html<Avatar>`
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-avatar\>
+ * Generates HTML Element: `<fast-avatar>`
  */
 export const fastAvatar = Avatar.compose<AvatarOptions>({
     baseName: "avatar",

--- a/packages/web-components/fast-components/src/badge/index.ts
+++ b/packages/web-components/fast-components/src/badge/index.ts
@@ -8,7 +8,7 @@ import { badgeStyles as styles } from "./badge.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-badge\>
+ * Generates HTML Element: `<fast-badge>`
  */
 export const fastBadge = Badge.compose({
     baseName: "badge",

--- a/packages/web-components/fast-components/src/breadcrumb-item/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb-item/index.ts
@@ -12,7 +12,7 @@ import { breadcrumbItemStyles as styles } from "./breadcrumb-item.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-breadcrumb-item\>
+ * Generates HTML Element: `<fast-breadcrumb-item>`
  */
 export const fastBreadcrumbItem = BreadcrumbItem.compose<BreadcrumbItemOptions>({
     baseName: "breadcrumb-item",

--- a/packages/web-components/fast-components/src/breadcrumb/index.ts
+++ b/packages/web-components/fast-components/src/breadcrumb/index.ts
@@ -8,7 +8,7 @@ import { breadcrumbStyles as styles } from "./breadcrumb.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-breadcrumb\>
+ * Generates HTML Element: `<fast-breadcrumb>`
  */
 export const fastBreadcrumb = Breadcrumb.compose({
     baseName: "breadcrumb",

--- a/packages/web-components/fast-components/src/button/index.ts
+++ b/packages/web-components/fast-components/src/button/index.ts
@@ -62,7 +62,7 @@ export class Button extends FoundationButton {
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-button\>
+ * Generates HTML Element: `<fast-button>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/calendar/index.ts
+++ b/packages/web-components/fast-components/src/calendar/index.ts
@@ -12,7 +12,7 @@ import { CalendarStyles as styles } from "./calendar.styles";
  *
  * @public
  * @remarks
- * HTML Element: \<fast-calendar\>
+ * HTML Element: `<fast-calendar>`
  */
 export const fastCalendar = Calendar.compose({
     baseName: "calendar",

--- a/packages/web-components/fast-components/src/card/index.ts
+++ b/packages/web-components/fast-components/src/card/index.ts
@@ -35,7 +35,7 @@ export class Card extends FoundationCard {
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-card\>
+ * Generates HTML Element: `<fast-card>`
  */
 export const fastCard = Card.compose({
     baseName: "card",

--- a/packages/web-components/fast-components/src/checkbox/index.ts
+++ b/packages/web-components/fast-components/src/checkbox/index.ts
@@ -12,7 +12,7 @@ import { checkboxStyles as styles } from "./checkbox.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-checkbox\>
+ * Generates HTML Element: `<fast-checkbox>`
  */
 export const fastCheckbox = Checkbox.compose<CheckboxOptions>({
     baseName: "checkbox",

--- a/packages/web-components/fast-components/src/combobox/index.ts
+++ b/packages/web-components/fast-components/src/combobox/index.ts
@@ -11,7 +11,7 @@ import { comboboxStyles as styles } from "./combobox.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-combobox\>
+ * Generates HTML Element: `<fast-combobox>`
  *
  */
 export const fastCombobox = Combobox.compose<ComboboxOptions>({

--- a/packages/web-components/fast-components/src/data-grid/index.ts
+++ b/packages/web-components/fast-components/src/data-grid/index.ts
@@ -15,7 +15,7 @@ import { dataGridCellStyles } from "./data-grid-cell.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-data-grid-cell\>
+ * Generates HTML Element: `<fast-data-grid-cell>`
  */
 export const fastDataGridCell = DataGridCell.compose({
     baseName: "data-grid-cell",
@@ -28,7 +28,7 @@ export const fastDataGridCell = DataGridCell.compose({
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-data-grid-row\>
+ * Generates HTML Element: `<fast-data-grid-row>`
  */
 export const fastDataGridRow = DataGridRow.compose({
     baseName: "data-grid-row",
@@ -41,7 +41,7 @@ export const fastDataGridRow = DataGridRow.compose({
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-data-grid\>
+ * Generates HTML Element: `<fast-data-grid>`
  */
 export const fastDataGrid = DataGrid.compose({
     baseName: "data-grid",

--- a/packages/web-components/fast-components/src/design-system-provider/index.ts
+++ b/packages/web-components/fast-components/src/design-system-provider/index.ts
@@ -1077,7 +1077,7 @@ export const designSystemProviderStyles = (
  * A function that returns a {@link DesignSystemProvider} registration for configuring the component with a DesignSystem.
  * @public
  * @remarks
- * Generates HTML Element: \<fast-design-system-provider\>
+ * Generates HTML Element: `<fast-design-system-provider>`
  */
 export const fastDesignSystemProvider = DesignSystemProvider.compose({
     baseName: "design-system-provider",

--- a/packages/web-components/fast-components/src/dialog/index.ts
+++ b/packages/web-components/fast-components/src/dialog/index.ts
@@ -8,7 +8,7 @@ import { dialogStyles as styles } from "./dialog.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-dialog\>
+ * Generates HTML Element: `<fast-dialog>`
  */
 export const fastDialog = Dialog.compose({
     baseName: "dialog",

--- a/packages/web-components/fast-components/src/disclosure/index.ts
+++ b/packages/web-components/fast-components/src/disclosure/index.ts
@@ -84,7 +84,7 @@ export class Disclosure extends FoundationDisclosure {
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-Disclosure\>
+ * Generates HTML Element: `<fast-Disclosure>`
  *
  */
 export const fastDisclosure = Disclosure.compose({

--- a/packages/web-components/fast-components/src/divider/index.ts
+++ b/packages/web-components/fast-components/src/divider/index.ts
@@ -8,7 +8,7 @@ import { dividerStyles as styles } from "./divider.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-divider\>
+ * Generates HTML Element: `<fast-divider>`
  */
 export const fastDivider = Divider.compose({
     baseName: "divider",

--- a/packages/web-components/fast-components/src/flipper/index.ts
+++ b/packages/web-components/fast-components/src/flipper/index.ts
@@ -12,7 +12,7 @@ import { flipperStyles as styles } from "./flipper.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-flipper\>
+ * Generates HTML Element: `<fast-flipper>`
  */
 export const fastFlipper = Flipper.compose<FlipperOptions>({
     baseName: "flipper",

--- a/packages/web-components/fast-components/src/horizontal-scroll/index.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/index.ts
@@ -33,7 +33,7 @@ export class HorizontalScroll extends FoundationHorizontalScroll {
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-horizontal-scroll\>
+ * Generates HTML Element: `<fast-horizontal-scroll>`
  */
 export const fastHorizontalScroll = HorizontalScroll.compose<HorizontalScrollOptions>({
     baseName: "horizontal-scroll",

--- a/packages/web-components/fast-components/src/listbox-option/index.ts
+++ b/packages/web-components/fast-components/src/listbox-option/index.ts
@@ -11,7 +11,7 @@ import { optionStyles as styles } from "./listbox-option.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-option\>
+ * Generates HTML Element: `<fast-option>`
  *
  */
 export const fastOption = ListboxOption.compose({

--- a/packages/web-components/fast-components/src/listbox/index.ts
+++ b/packages/web-components/fast-components/src/listbox/index.ts
@@ -8,7 +8,7 @@ import { listboxStyles as styles } from "./listbox.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-listbox\>
+ * Generates HTML Element: `<fast-listbox>`
  *
  */
 export const fastListbox = Listbox.compose({

--- a/packages/web-components/fast-components/src/menu-item/index.ts
+++ b/packages/web-components/fast-components/src/menu-item/index.ts
@@ -12,7 +12,7 @@ import { menuItemStyles as styles } from "./menu-item.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-menu-item\>
+ * Generates HTML Element: `<fast-menu-item>`
  */
 export const fastMenuItem = MenuItem.compose<MenuItemOptions>({
     baseName: "menu-item",

--- a/packages/web-components/fast-components/src/menu/index.ts
+++ b/packages/web-components/fast-components/src/menu/index.ts
@@ -8,7 +8,7 @@ import { menuStyles as styles } from "./menu.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-menu\>
+ * Generates HTML Element: `<fast-menu>`
  */
 export const fastMenu = Menu.compose({
     baseName: "menu",

--- a/packages/web-components/fast-components/src/number-field/index.ts
+++ b/packages/web-components/fast-components/src/number-field/index.ts
@@ -45,7 +45,7 @@ export class NumberField extends FoundationNumberField {
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-number-field\>
+ * Generates HTML Element: `<fast-number-field>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/picker/index.ts
+++ b/packages/web-components/fast-components/src/picker/index.ts
@@ -23,7 +23,7 @@ import { pickerListItemStyles } from "./picker-list-item.styles";
  *
  * @alpha
  * @remarks
- * * Generates HTML Element: \<fast-picker\>
+ * * Generates HTML Element: `<fast-picker>`
  */
 export const fastPicker = Picker.compose({
     baseName: "picker",

--- a/packages/web-components/fast-components/src/progress-ring/index.ts
+++ b/packages/web-components/fast-components/src/progress-ring/index.ts
@@ -12,7 +12,7 @@ import { progressRingStyles as styles } from "./progress-ring.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-progress-ring\>
+ * Generates HTML Element: `<fast-progress-ring>`
  */
 export const fastProgressRing = ProgressRing.compose<ProgressRingOptions>({
     baseName: "progress-ring",

--- a/packages/web-components/fast-components/src/progress/index.ts
+++ b/packages/web-components/fast-components/src/progress/index.ts
@@ -12,7 +12,7 @@ import { progressStyles as styles } from "./progress.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-progress\>
+ * Generates HTML Element: `<fast-progress>`
  */
 export const fastProgress = Progress.compose<ProgressOptions>({
     baseName: "progress",

--- a/packages/web-components/fast-components/src/radio-group/index.ts
+++ b/packages/web-components/fast-components/src/radio-group/index.ts
@@ -8,7 +8,7 @@ import { radioGroupStyles as styles } from "./radio-group.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-radio-group\>
+ * Generates HTML Element: `<fast-radio-group>`
  */
 export const fastRadioGroup = RadioGroup.compose({
     baseName: "radio-group",

--- a/packages/web-components/fast-components/src/radio/index.ts
+++ b/packages/web-components/fast-components/src/radio/index.ts
@@ -12,7 +12,7 @@ import { radioStyles as styles } from "./radio.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-radio\>
+ * Generates HTML Element: `<fast-radio>`
  */
 export const fastRadio = Radio.compose<RadioOptions>({
     baseName: "radio",

--- a/packages/web-components/fast-components/src/select/index.ts
+++ b/packages/web-components/fast-components/src/select/index.ts
@@ -12,7 +12,7 @@ import { selectStyles as styles } from "./select.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-select\>
+ * Generates HTML Element: `<fast-select>`
  *
  */
 export const fastSelect = Select.compose<SelectOptions>({

--- a/packages/web-components/fast-components/src/skeleton/index.ts
+++ b/packages/web-components/fast-components/src/skeleton/index.ts
@@ -8,7 +8,7 @@ import { skeletonStyles as styles } from "./skeleton.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-skeleton\>
+ * Generates HTML Element: `<fast-skeleton>`
  */
 export const fastSkeleton = Skeleton.compose({
     baseName: "skeleton",

--- a/packages/web-components/fast-components/src/slider-label/index.ts
+++ b/packages/web-components/fast-components/src/slider-label/index.ts
@@ -31,7 +31,7 @@ export class SliderLabel extends FoundationSliderLabel {
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-slider-label\>
+ * Generates HTML Element: `<fast-slider-label>`
  */
 
 export const fastSliderLabel = SliderLabel.compose({

--- a/packages/web-components/fast-components/src/slider/index.ts
+++ b/packages/web-components/fast-components/src/slider/index.ts
@@ -12,7 +12,7 @@ import { sliderStyles as styles } from "./slider.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-slider\>
+ * Generates HTML Element: `<fast-slider>`
  */
 export const fastSlider = Slider.compose<SliderOptions>({
     baseName: "slider",

--- a/packages/web-components/fast-components/src/switch/index.ts
+++ b/packages/web-components/fast-components/src/switch/index.ts
@@ -12,7 +12,7 @@ import { switchStyles as styles } from "./switch.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-switch\>
+ * Generates HTML Element: `<fast-switch>`
  */
 export const fastSwitch = Switch.compose<SwitchOptions>({
     baseName: "switch",

--- a/packages/web-components/fast-components/src/tab-panel/index.ts
+++ b/packages/web-components/fast-components/src/tab-panel/index.ts
@@ -8,7 +8,7 @@ import { tabPanelStyles as styles } from "./tab-panel.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-tab-panel\>
+ * Generates HTML Element: `<fast-tab-panel>`
  */
 export const fastTabPanel = TabPanel.compose({
     baseName: "tab-panel",

--- a/packages/web-components/fast-components/src/tab/index.ts
+++ b/packages/web-components/fast-components/src/tab/index.ts
@@ -8,7 +8,7 @@ import { tabStyles as styles } from "./tab.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-tab\>
+ * Generates HTML Element: `<fast-tab>`
  */
 export const fastTab = Tab.compose({
     baseName: "tab",

--- a/packages/web-components/fast-components/src/tabs/index.ts
+++ b/packages/web-components/fast-components/src/tabs/index.ts
@@ -8,7 +8,7 @@ import { tabsStyles as styles } from "./tabs.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-tabs\>
+ * Generates HTML Element: `<fast-tabs>`
  */
 export const fastTabs = Tabs.compose({
     baseName: "tabs",

--- a/packages/web-components/fast-components/src/text-area/index.ts
+++ b/packages/web-components/fast-components/src/text-area/index.ts
@@ -44,7 +44,7 @@ export class TextArea extends FoundationTextArea {
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-text-area\>
+ * Generates HTML Element: `<fast-text-area>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/text-field/index.ts
+++ b/packages/web-components/fast-components/src/text-field/index.ts
@@ -44,7 +44,7 @@ export class TextField extends FoundationTextField {
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-text-field\>
+ * Generates HTML Element: `<fast-text-field>`
  *
  * {@link https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot/delegatesFocus | delegatesFocus}
  */

--- a/packages/web-components/fast-components/src/toolbar/index.ts
+++ b/packages/web-components/fast-components/src/toolbar/index.ts
@@ -35,7 +35,7 @@ export class Toolbar extends FoundationToolbar {
  * @public
  * @remarks
  *
- * Generates HTML Element: \<fast-toolbar\>
+ * Generates HTML Element: `<fast-toolbar>`
  *
  */
 export const fastToolbar = Toolbar.compose({

--- a/packages/web-components/fast-components/src/tooltip/index.ts
+++ b/packages/web-components/fast-components/src/tooltip/index.ts
@@ -8,7 +8,7 @@ import { tooltipStyles as styles } from "./tooltip.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-tooltip\>
+ * Generates HTML Element: `<fast-tooltip>`
  */
 export const fastTooltip = Tooltip.compose({
     baseName: "tooltip",

--- a/packages/web-components/fast-components/src/tree-item/index.ts
+++ b/packages/web-components/fast-components/src/tree-item/index.ts
@@ -12,7 +12,7 @@ import { treeItemStyles as styles } from "./tree-item.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-tree-item\>
+ * Generates HTML Element: `<fast-tree-item>`
  *
  */
 export const fastTreeItem = TreeItem.compose<TreeItemOptions>({

--- a/packages/web-components/fast-components/src/tree-view/index.ts
+++ b/packages/web-components/fast-components/src/tree-view/index.ts
@@ -8,7 +8,7 @@ import { treeViewStyles as styles } from "./tree-view.styles";
  *
  * @public
  * @remarks
- * Generates HTML Element: \<fast-tree-view\>
+ * Generates HTML Element: `<fast-tree-view>`
  *
  */
 export const fastTreeView = TreeView.compose({


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

The TSDoc blocks for components are transformed to markdown for API Reference.

Remarks section of the components documents the defined tag name, such as:

Generates HTML Element: \<fast-accordion\>

Tag names should be escaped by backtick instead of backslash, so the generated markdown puts them in the inline `<code>` elements. Above example should be rendered like:

Generates HTML Element: `<fast-accordion>`

### 🎫 Issues

fixes #5351

## 👩‍💻 Reviewer Notes

None

## 📑 Test Plan

None

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

None