### PR TITLE
ensure bidirectional value updates don't conflict in number field component

### DIFF
--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1588,7 +1588,7 @@ export class NumberField extends FormAssociatedNumberField {
     stepDown(): void;
     stepUp(): void;
     // @internal
-    valueChanged(previous: string, next: string, updateControl?: boolean): void;
+    valueChanged(previous: string, next: string): void;
 }
 
 // @internal

--- a/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
@@ -50,6 +50,7 @@ export const numberFieldTemplate: (
                 min="${x => x.min}"
                 max="${x => x.max}"
                 step="${x => x.step}"
+                :value="${x => x.value}"
                 aria-atomic="${x => x.ariaAtomic}"
                 aria-busy="${x => x.ariaBusy}"
                 aria-controls="${x => x.ariaControls}"

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -200,6 +200,10 @@ export class NumberField extends FormAssociatedNumberField {
             return;
         }
 
+        if (this.control) {
+            this.control.value = this.value;
+        }
+
         super.valueChanged(previous, this.value);
 
         if (previous !== undefined) {
@@ -221,10 +225,10 @@ export class NumberField extends FormAssociatedNumberField {
         if (isNaN(validValue)) {
             this.value = "";
             return;
-        } else {
-            validValue = Math.min(validValue, this.max ?? validValue);
-            validValue = Math.max(validValue, this.min ?? validValue);
         }
+
+        validValue = Math.min(validValue, this.max ?? validValue);
+        validValue = Math.max(validValue, this.min ?? validValue);
 
         this.value = `${validValue}`;
     }
@@ -318,6 +322,7 @@ export class NumberField extends FormAssociatedNumberField {
         switch (key) {
             case keyArrowUp: {
                 if (!this.readOnly) {
+                    this.value = this.control.value;
                     this.stepUp();
                 }
                 return false;
@@ -325,6 +330,7 @@ export class NumberField extends FormAssociatedNumberField {
 
             case keyArrowDown: {
                 if (!this.readOnly) {
+                    this.value = this.control.value;
                     this.stepDown();
                 }
                 return false;

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -112,6 +112,15 @@ export class NumberField extends FormAssociatedNumberField {
     public step: number = 1;
 
     /**
+     * The floating precision of the step attribute.
+     *
+     * @internal
+     */
+    private get stepPrecision(): number {
+        return this.step?.toString().split(".")[1]?.length ?? 12;
+    }
+
+    /**
      * The maximum the value can be
      * @public
      * @remarks
@@ -205,7 +214,9 @@ export class NumberField extends FormAssociatedNumberField {
      * @internal
      */
     private updateValue(): void {
-        let validValue: number = parseFloat(parseFloat(this.value).toPrecision(12));
+        let validValue = parseFloat(
+            parseFloat(this.value).toPrecision(this.stepPrecision)
+        );
 
         if (isNaN(validValue)) {
             this.value = "";

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -267,7 +267,6 @@ export class NumberField extends FormAssociatedNumberField {
 
         this.proxy.setAttribute("type", "number");
         this.validate();
-        this.control.value = this.value;
 
         if (this.autofocus) {
             DOM.queueUpdate(() => {
@@ -282,7 +281,7 @@ export class NumberField extends FormAssociatedNumberField {
      */
     public handleTextInput(): void {
         this.control.value = this.control.value.replace(/[^0-9\-+e.]/g, "");
-        this.valueChanged(this.value, this.control.value, false);
+        this.updateValue();
     }
 
     /**
@@ -334,7 +333,7 @@ export class NumberField extends FormAssociatedNumberField {
      * @internal
      */
     public handleBlur(): void {
-        this.control.value = this.value;
+        this.value = this.control.value;
     }
 }
 

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -133,8 +133,9 @@ export class NumberField extends FormAssociatedNumberField {
         const min = Math.min(this.min, this.max);
         if (this.min !== undefined && this.min !== min) {
             this.min = min;
+            return;
         }
-        this.value = this.getValidValue(this.value);
+        this.updateValue();
     }
 
     /**
@@ -159,8 +160,9 @@ export class NumberField extends FormAssociatedNumberField {
         const max = Math.max(this.min, this.max);
         if (this.max !== undefined && this.max !== max) {
             this.max = max;
+            return;
         }
-        this.value = this.getValidValue(this.value);
+        this.updateValue();
     }
 
     /**
@@ -183,15 +185,10 @@ export class NumberField extends FormAssociatedNumberField {
      * @param updateControl - should the text field be updated with value, defaults to true
      * @internal
      */
-    public valueChanged(
-        previous: string,
-        next: string,
-        updateControl: boolean = true
-    ): void {
-        this.value = this.getValidValue(next);
-
-        if (this.control && updateControl) {
-            this.control.value = this.value;
+    public valueChanged(previous: string, next: string): void {
+        this.updateValue();
+        if (next !== this.value) {
+            return;
         }
 
         super.valueChanged(previous, this.value);
@@ -204,21 +201,21 @@ export class NumberField extends FormAssociatedNumberField {
 
     /**
      * Sets the internal value to a valid number between the min and max properties
-     * @param value - user input
-     * @param updateControl - should the text field update to the valid value
      *
      * @internal
      */
-    private getValidValue(value: string): string {
-        let validValue: number | string = parseFloat(parseFloat(value).toPrecision(12));
+    private updateValue(): void {
+        let validValue: number = parseFloat(parseFloat(this.value).toPrecision(12));
+
         if (isNaN(validValue)) {
-            validValue = "";
+            this.value = "";
+            return;
         } else {
             validValue = Math.min(validValue, this.max ?? validValue);
-            validValue = Math.max(validValue, this.min ?? validValue).toString();
+            validValue = Math.max(validValue, this.min ?? validValue);
         }
 
-        return validValue;
+        this.value = `${validValue}`;
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -5,11 +5,11 @@ import {
     observable,
     SyntheticViewTemplate,
 } from "@microsoft/fast-element";
-import { keyArrowDown, keyArrowUp } from "@microsoft/fast-web-utilities";
-import { StartEnd, StartEndOptions } from "../patterns/index";
-import { applyMixins } from "../utilities/index";
+import { keyArrowDown, keyArrowUp, keyTab } from "@microsoft/fast-web-utilities";
 import type { FoundationElementDefinition } from "../foundation-element";
-import { DelegatesARIATextbox } from "../text-field/index";
+import { StartEnd, StartEndOptions } from "../patterns/start-end";
+import { DelegatesARIATextbox } from "../text-field/text-field";
+import { applyMixins } from "../utilities/apply-mixins";
 import { FormAssociatedNumberField } from "./number-field.form-associated";
 
 /**
@@ -309,16 +309,26 @@ export class NumberField extends FormAssociatedNumberField {
         const key = e.key;
 
         switch (key) {
-            case keyArrowUp:
-                this.stepUp();
+            case keyArrowUp: {
+                if (!this.readOnly) {
+                    this.stepUp();
+                }
                 return false;
+            }
 
-            case keyArrowDown:
-                this.stepDown();
+            case keyArrowDown: {
+                if (!this.readOnly) {
+                    this.stepDown();
+                }
                 return false;
+            }
+
+            case keyTab: {
+                return true;
+            }
         }
 
-        return true;
+        return !this.readOnly;
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

Updates the number field interactions between its internal control value and the component value to prevent bidirectional collisions.

### 🎫 Issues

Merges into #5368.

## 👩‍💻 Reviewer Notes

This PR also fixes a rogue `readonly` bug that allowed a focused number field to be modified via user input.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
