### PR TITLE
fix: changing tooltip anchor attribute should take effect

### DIFF
--- a/change/@microsoft-fast-components-e8145ce8-2bce-4cb7-8776-807efd872c7e.json
+++ b/change/@microsoft-fast-components-e8145ce8-2bce-4cb7-8776-807efd872c7e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "tooltip anchor attribute updates work",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-b3093cad-95fb-4a13-8018-99d9429ea39c.json
+++ b/change/@microsoft-fast-foundation-b3093cad-95fb-4a13-8018-99d9429ea39c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "tooltip anchor attribute updates work",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/tooltip/fixtures/base.html
+++ b/packages/web-components/fast-components/src/tooltip/fixtures/base.html
@@ -120,35 +120,35 @@
         Helpful text is helpful
     </fast-tooltip>
 
-    <fast-button id="anchor-anchor-switch-1" style="margin: 40px;">
+    <fast-button id="anchor-anchor-switch-prop-1" style="margin: 40px;">
         anchor
     </fast-button>
 
-    <fast-button id="anchor-anchor-switch-2" style="margin: 40px;">
+    <fast-button id="anchor-anchor-switch-prop-2" style="margin: 40px;">
         anchor
     </fast-button>
 
-    <fast-button id="anchor-anchor-switch-3" style="margin: 40px;">
+    <fast-button id="anchor-anchor-switch-prop-3" style="margin: 40px;">
         anchor
     </fast-button>
 
-    <fast-button id="anchor-anchor-switch-4" style="margin: 40px;">
+    <fast-button id="anchor-anchor-switch-prop-4" style="margin: 40px;">
         anchor
     </fast-button>
 
-    <fast-button id="anchor-anchor-switch-5" style="margin: 40px;">
+    <fast-button id="anchor-anchor-switch-attribute-5" style="margin: 40px;">
         anchor
     </fast-button>
 
-    <fast-button id="anchor-anchor-switch-6" style="margin: 40px;">
+    <fast-button id="anchor-anchor-switch-attribute-6" style="margin: 40px;">
         anchor
     </fast-button>
 
-    <fast-button id="anchor-anchor-switch-7" style="margin: 40px;">
+    <fast-button id="anchor-anchor-switch-attribute-7" style="margin: 40px;">
         anchor
     </fast-button>
 
-    <fast-button id="anchor-anchor-switch-8" style="margin: 40px;">
+    <fast-button id="anchor-anchor-switch-attribute-8" style="margin: 40px;">
         anchor
     </fast-button>
 </div>

--- a/packages/web-components/fast-components/src/tooltip/tooltip.stories.ts
+++ b/packages/web-components/fast-components/src/tooltip/tooltip.stories.ts
@@ -14,7 +14,8 @@ function onShowClick(): void {
     }
 }
 
-function onAnchorMouseEnter(e: MouseEvent): void {
+//check changing anchor by changing anchorElement
+function onAnchorMouseEnterProp(e: MouseEvent): void {
     if (!e.target) {
         return;
     }
@@ -25,12 +26,30 @@ function onAnchorMouseEnter(e: MouseEvent): void {
     tooltipInstance.anchorElement = e.target as HTMLElement;
 }
 
+//check changing anchor by setting attribute
+function onAnchorMouseEnterAttribute(e: MouseEvent): void {
+    if (!e.target) {
+        return;
+    }
+
+    const tooltipInstance = document.getElementById(
+        "tooltip-anchor-switch"
+    ) as FoundationTooltip;
+    tooltipInstance.setAttribute("anchor", (e.target as HTMLElement).id);
+}
+
 addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
     if (name.toLowerCase().startsWith("tooltip")) {
         document
-            .querySelectorAll("fast-button[id^=anchor-anchor-switch]")
+            .querySelectorAll("fast-button[id^=anchor-anchor-switch-prop]")
             .forEach((el: HTMLElement) => {
-                el.addEventListener("mouseenter", onAnchorMouseEnter);
+                el.addEventListener("mouseenter", onAnchorMouseEnterProp);
+            });
+
+        document
+            .querySelectorAll("fast-button[id^=anchor-anchor-switch-attribute]")
+            .forEach((el: HTMLElement) => {
+                el.addEventListener("mouseenter", onAnchorMouseEnterAttribute);
             });
 
         const showButton = document.getElementById("anchor-show") as HTMLElement;

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.spec.ts
@@ -22,7 +22,11 @@ async function setup() {
     const button = document.createElement("button");
     button.id = "anchor";
 
+    const button2 = document.createElement("button");
+    button2.id = "anchor2";
+
     parent.insertBefore(button, element);
+    parent.insertBefore(button2, element);
 
     element.setAttribute("anchor", "anchor");
     element.id = "tooltip";
@@ -313,4 +317,19 @@ describe("Tooltip", () => {
 
         await disconnect();
     });
+
+    it("should change anchor element when the anchor attribute changes", async () => {
+        const { element, connect, disconnect } = await setup();
+        const tooltip: Tooltip = element;
+
+        await connect();
+
+        expect(tooltip.anchorElement?.id).to.equal("anchor");
+        tooltip.setAttribute("anchor", "anchor2")
+        expect(tooltip.anchorElement?.id).to.equal("anchor2");
+
+        await disconnect();
+    });
+
+
 });

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -46,7 +46,7 @@ export class Tooltip extends FoundationElement {
     public anchor: string = "";
     private anchorChanged(): void {
         if ((this as FASTElement).$fastController.isConnected) {
-            this.updateLayout();
+            this.anchorElement = this.getAnchor();
         }
     }
 
@@ -264,8 +264,6 @@ export class Tooltip extends FoundationElement {
     public connectedCallback(): void {
         super.connectedCallback();
         this.anchorElement = this.getAnchor();
-
-        this.updateLayout();
         this.updateTooltipVisibility();
     }
 


### PR DESCRIPTION
## 📖 Description
dynamically changing tooltip anchorElement worked, but changing the anchor attribute after the component was created did not.  This change enables anchor attribute changes to take effect.

### 🎫 Issues
fixes https://github.com/microsoft/fast/issues/5327

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
