### PR TITLE
fix: menu should update child items on connect

### DIFF
--- a/change/@microsoft-fast-foundation-2addeddd-ae48-4d72-b6bc-7ad7415f6a71.json
+++ b/change/@microsoft-fast-foundation-2addeddd-ae48-4d72-b6bc-7ad7415f6a71.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "ensure menu items update",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/menu/menu.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.spec.ts
@@ -104,6 +104,8 @@ describe("Menu", () => {
 
         await connect();
 
+        await DOM.nextUpdate();
+
         expect(document.getElementById("id1")?.getAttribute("tabindex")).to.equal("0");
 
         await disconnect();
@@ -130,6 +132,7 @@ describe("Menu", () => {
         (menuItem1 as MenuItem).disabled = true;
 
         await connect();
+        await DOM.nextUpdate();
 
         expect(document.getElementById("id1")?.getAttribute("tabindex")).to.equal("0");
 
@@ -157,6 +160,8 @@ describe("Menu", () => {
         element.appendChild(menuItem3);
 
         await connect();
+
+        await DOM.nextUpdate();
 
         expect(
             element.querySelector("[role='menuitem']")?.getAttribute("tabindex")

--- a/packages/web-components/fast-foundation/src/menu/menu.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.spec.ts
@@ -121,6 +121,8 @@ describe("Menu", () => {
 
         await connect();
 
+        await DOM.nextUpdate();
+
         expect(document.getElementById("not-an-item")?.hasAttribute("tabindex")).to.equal(false);
 
         await disconnect();

--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -27,7 +27,9 @@ export class Menu extends FoundationElement {
     @observable
     public items: HTMLSlotElement;
     private itemsChanged(oldValue, newValue): void {
-        this.setItems();
+        if (this.$fastController.isConnected) {
+            this.setItems();
+        }
     }
 
     private menuItems: Element[];
@@ -196,18 +198,7 @@ export class Menu extends FoundationElement {
     };
 
     private setItems = (): void => {
-        if (!this.$fastController.isConnected) {
-            return;
-        }
-
         const newItems: Element[] = this.domChildren();
-        if (
-            this.menuItems !== undefined &&
-            newItems.length === this.menuItems.length &&
-            newItems.every((value, index) => value === this.menuItems[index])
-        ) {
-            return;
-        }
 
         this.removeItemListeners();
         this.menuItems = newItems;

--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -27,11 +27,13 @@ export class Menu extends FoundationElement {
     @observable
     public items: HTMLSlotElement;
     private itemsChanged(oldValue, newValue): void {
-        if (this.$fastController.isConnected) {
-            this.menuItems = this.domChildren();
-            this.resetItems(oldValue);
-            this.setItems();
+        if (oldValue) {
+            oldValue.forEach((item: HTMLElement) => {
+                item.removeEventListener("expanded-change", this.handleExpandedChanged);
+                item.removeEventListener("focus", this.handleItemFocus);
+            });
         }
+        this.setItems();
     }
 
     private menuItems: Element[];
@@ -51,7 +53,7 @@ export class Menu extends FoundationElement {
      */
     public connectedCallback(): void {
         super.connectedCallback();
-        this.menuItems = this.domChildren();
+        this.setItems();
 
         this.addEventListener("change", this.changeHandler);
     }
@@ -190,6 +192,11 @@ export class Menu extends FoundationElement {
     };
 
     private setItems = (): void => {
+        if (!this.$fastController.isConnected) {
+            return;
+        }
+
+        this.menuItems = this.domChildren();
         const menuItems = this.menuItems.filter(this.isMenuItemElement);
 
         // if our focus index is not -1 we have items
@@ -235,13 +242,6 @@ export class Menu extends FoundationElement {
             if (item instanceof MenuItem) {
                 item.startColumnCount = indent;
             }
-        });
-    };
-
-    private resetItems = (oldValue: HTMLElement[]): void => {
-        oldValue.forEach((item: HTMLElement) => {
-            item.removeEventListener("expanded-change", this.handleExpandedChanged);
-            item.removeEventListener("focus", this.handleItemFocus);
         });
     };
 

--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -27,12 +27,6 @@ export class Menu extends FoundationElement {
     @observable
     public items: HTMLSlotElement;
     private itemsChanged(oldValue, newValue): void {
-        if (oldValue) {
-            oldValue.forEach((item: HTMLElement) => {
-                item.removeEventListener("expanded-change", this.handleExpandedChanged);
-                item.removeEventListener("focus", this.handleItemFocus);
-            });
-        }
         this.setItems();
     }
 
@@ -63,6 +57,7 @@ export class Menu extends FoundationElement {
      */
     public disconnectedCallback(): void {
         super.disconnectedCallback();
+        this.removeItemListeners();
         this.menuItems = [];
         this.removeEventListener("change", this.changeHandler);
     }
@@ -191,12 +186,32 @@ export class Menu extends FoundationElement {
         }
     };
 
+    private removeItemListeners = (): void => {
+        if (this.menuItems) {
+            this.menuItems.forEach((item: HTMLElement) => {
+                item.removeEventListener("expanded-change", this.handleExpandedChanged);
+                item.removeEventListener("focus", this.handleItemFocus);
+            });
+        }
+    };
+
     private setItems = (): void => {
         if (!this.$fastController.isConnected) {
             return;
         }
 
-        this.menuItems = this.domChildren();
+        const newItems: Element[] = this.domChildren();
+        if (
+            this.menuItems !== undefined &&
+            newItems.length === this.menuItems.length &&
+            newItems.every((value, index) => value === this.menuItems[index])
+        ) {
+            return;
+        }
+
+        this.removeItemListeners();
+        this.menuItems = newItems;
+
         const menuItems = this.menuItems.filter(this.isMenuItemElement);
 
         // if our focus index is not -1 we have items


### PR DESCRIPTION
## 📖 Description

A user encountered an issue where the menu was not reliably updating the properties on child menu items on subsequent connect events for the same menu.  This change specifically updates child menu items when the component connects as well as when the slotted children change.

### 🎫 Issues

user reported

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
