### PR TITLE
fix: focus on combobox input when clicking an associated label

### DIFF
--- a/change/@microsoft-fast-foundation-a940dbfa-2032-470a-a328-cc925747cf44.json
+++ b/change/@microsoft-fast-foundation-a940dbfa-2032-470a-a328-cc925747cf44.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "focus on combobox control when clicking an associated label",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -428,6 +428,8 @@ export class Combobox extends FormAssociatedCombobox {
     filteredOptions: ListboxOption[];
     filterOptions(): void;
     // @internal
+    protected focusAndScrollOptionIntoView(): void;
+    // @internal
     focusoutHandler(e: FocusEvent): boolean | void;
     // @internal
     formResetCallback(): void;

--- a/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
@@ -1,9 +1,9 @@
-import { assert, expect } from "chai";
 import { DOM } from "@microsoft/fast-element";
-import { listboxOptionTemplate, ListboxOption } from "../listbox-option";
+import { keyArrowDown, keyArrowUp } from "@microsoft/fast-web-utilities";
+import { assert, expect } from "chai";
+import { ListboxOption, listboxOptionTemplate } from "../listbox-option";
 import { fixture } from "../test-utilities/fixture";
 import { Combobox, comboboxTemplate as template } from "./index";
-import { keyArrowDown, keyArrowUp } from "@microsoft/fast-web-utilities";
 
 const FASTCombobox = Combobox.compose({
     baseName: "combobox",
@@ -19,6 +19,8 @@ async function setup() {
     const { element, connect, disconnect, parent } = await fixture(
         [FASTCombobox(), FASTOption()]
     );
+
+    element.id = "combobox";
 
     const option1 = document.createElement("fast-option") as ListboxOption;
     option1.textContent = "one";
@@ -288,5 +290,24 @@ describe("Combobox", () => {
 
             await disconnect();
         });
+    });
+
+    it("should focus the control when an associated label is clicked", async () => {
+        const { element, connect, disconnect, parent } = await setup();
+
+        const label = document.createElement("label");
+        label.setAttribute("for", element.id);
+
+        parent.insertBefore(label, element);
+
+        await connect();
+
+        expect(element.labels).to.contain(label);
+
+        label.click();
+
+        expect(document.activeElement).to.equal(element);
+
+        await disconnect();
     });
 });

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -5,12 +5,12 @@ import {
     SyntheticViewTemplate,
 } from "@microsoft/fast-element";
 import { limit, uniqueId } from "@microsoft/fast-web-utilities";
+import type { FoundationElementDefinition } from "../foundation-element";
 import type { ListboxOption } from "../listbox-option/listbox-option";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
 import { StartEnd, StartEndOptions } from "../patterns/start-end";
 import { SelectPosition, SelectRole } from "../select/select.options";
 import { applyMixins } from "../utilities/apply-mixins";
-import type { FoundationElementDefinition } from "../foundation-element";
 import { FormAssociatedCombobox } from "./combobox.form-associated";
 import { ComboboxAutocomplete } from "./combobox.options";
 
@@ -264,12 +264,13 @@ export class Combobox extends FormAssociatedCombobox {
 
             this.selectedOptions = [captured];
             this.control.value = captured.text;
+            this.updateValue(true);
         }
 
         this.open = !this.open;
 
-        if (!this.open) {
-            this.updateValue(true);
+        if (this.open) {
+            this.control.focus();
         }
 
         return true;
@@ -322,6 +323,24 @@ export class Combobox extends FormAssociatedCombobox {
             this._options.forEach(o => {
                 o.hidden = !this.filteredOptions.includes(o);
             });
+        }
+    }
+
+    /**
+     * Focus the control and scroll the first selected option into view.
+     *
+     * @internal
+     * @remarks
+     * Overrides: `Listbox.focusAndScrollOptionIntoView`
+     */
+    protected focusAndScrollOptionIntoView(): void {
+        if (this.contains(document.activeElement)) {
+            this.control.focus();
+            if (this.firstSelectedOption) {
+                requestAnimationFrame(() => {
+                    this.firstSelectedOption.scrollIntoView({ block: "nearest" });
+                });
+            }
         }
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Clicking on a label for a `<fast-combobox>` should move focus to the text input control.

## 👩‍💻 Reviewer Notes

This bug was discovered while updating the fixtures for combobox.

## 📑 Test Plan

Clicking on label which is associated with a combobox should move focus to the text input in the combobox. Clicking away should close the combobox.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
