### PR TITLE
fix: clicking on disabled fast-button events should behave like native button (#4884)

### DIFF
--- a/change/@microsoft-fast-components-0589cbfe-cc68-48de-a2f6-4c70135397c5.json
+++ b/change/@microsoft-fast-components-0589cbfe-cc68-48de-a2f6-4c70135397c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: clicking on disabled fast-button events should behave like native button (#4884)",
+  "packageName": "@microsoft/fast-components",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -92,6 +92,15 @@ export const BaseButtonStyles = css`
         border: 0;
     }
 
+    .control:disabled span
+    {
+        pointer-events: none;
+    }
+
+    ::slotted(*) {
+        pointer-events: auto;
+    }
+
     .start,
     .end {
         display: flex;
@@ -127,7 +136,7 @@ export const BaseButtonStyles = css`
               color: ${SystemColors.ButtonText};
               fill: currentColor;
             }
-    
+
             :host(:hover) .control {
               forced-color-adjust: none;
               background-color: ${SystemColors.Highlight};


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This change makes sure that the click events from fast-button in its disabled state behaves the same way as a native html button. 
Specifically, if text is not wrapped around addition html element, clicking on the button should not propagate events to the container div.
```
<div id="container">
   <fast-button disabled>Button</fast-button>
</div>
```

If in the following example, there is a span wrapped around text, then clicking on the span would propagate to the container as a span within a native button would behave.
```
<div id="container">
   <fast-button disabled><span>Button</span></fast-button>
</div>
```

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
fixes #4884 
## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->