### PR TITLE
fix: incorrect z-index in fast-menu slot='submenu'

### DIFF
--- a/change/@microsoft-fast-components-7253ee5c-f527-43d3-a800-4e3bee4d3030.json
+++ b/change/@microsoft-fast-components-7253ee5c-f527-43d3-a800-4e3bee4d3030.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: incorrect z-index in fast-menu slot=\"submenu\"",
+  "packageName": "@microsoft/fast-components",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -58,6 +58,9 @@ export const menuItemStyles: (
         line-height: ${typeRampBaseLineHeight};
         border-radius: calc(${controlCornerRadius} * 1px);
         border: calc(${focusStrokeWidth} * 1px) solid transparent;
+    }
+
+    :host(:hover) {
         position: relative;
         z-index: 1;
     }

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -220,6 +220,7 @@ export const menuItemStyles: (
         display: flex;
         align-items: center;
         justify-content: center;
+        position: relative;
         width: 20px;
         height: 20px;
         box-sizing: border-box;
@@ -270,6 +271,7 @@ export const menuItemStyles: (
     }
 
     :host([aria-checked="true"]) .radio-indicator {
+        position: absolute;
         top: 4px;
         left: 4px;
         right: 4px;

--- a/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
+++ b/packages/web-components/fast-components/src/menu-item/menu-item.styles.ts
@@ -58,6 +58,8 @@ export const menuItemStyles: (
         line-height: ${typeRampBaseLineHeight};
         border-radius: calc(${controlCornerRadius} * 1px);
         border: calc(${focusStrokeWidth} * 1px) solid transparent;
+        position: relative;
+        z-index: 1;
     }
 
     :host(.indent-0) {
@@ -215,7 +217,6 @@ export const menuItemStyles: (
         display: flex;
         align-items: center;
         justify-content: center;
-        position: relative;
         width: 20px;
         height: 20px;
         box-sizing: border-box;
@@ -266,7 +267,6 @@ export const menuItemStyles: (
     }
 
     :host([aria-checked="true"]) .radio-indicator {
-        position: absolute;
         top: 4px;
         left: 4px;
         right: 4px;

--- a/packages/web-components/fast-components/src/menu/fixtures/menu.html
+++ b/packages/web-components/fast-components/src/menu/fixtures/menu.html
@@ -308,3 +308,56 @@
         </svg>
     </fast-menu-item>
 </fast-menu>
+
+<h4>Z-index handling</h4>
+<div style="display: inline-block; width: 100%;">
+    <fast-menu style="float: left; width: 370px;">
+        <fast-menu-item>Menu item 1</fast-menu-item>
+        <fast-menu-item>Menu item 2</fast-menu-item>
+        <fast-menu-item disabled="true">Menu item 3</fast-menu-item>
+        <fast-menu-item>
+            Menu item 4
+            <div slot="end">
+                Shortcut text
+            </div>
+        </fast-menu-item>
+        <fast-menu-item>
+            Menu item 5
+            <fast-menu>
+                <fast-menu-item>Nested Menu item 1.1</fast-menu-item>
+                <fast-menu-item>Nested Menu item 1.2</fast-menu-item>
+                <fast-menu-item>Nested Menu item 1.3</fast-menu-item>
+            </fast-menu>
+        </fast-menu-item>
+        <fast-menu-item>
+            Menu item 6
+            <div slot="end">
+                Shortcut text
+            </div>
+            <fast-menu>
+                <fast-menu-item>Nested Menu item 1.1</fast-menu-item>
+                <fast-menu-item>Nested Menu item 1.2</fast-menu-item>
+                <fast-menu-item>Nested Menu item 1.3</fast-menu-item>
+            </fast-menu>
+        </fast-menu-item>
+    </fast-menu>
+
+    <div
+        style="
+            padding: 20px;
+            margin: 0 0 0 380px;
+            width: 200px;
+            height: 210px;
+            background: var(--neutral-layer-floating);
+            color: var(--neutral-foreground-rest);
+            font-size: small;
+            line-height: 1.5em;
+            position: absolute;
+            font-family: sans-serif;
+        "
+    >
+        Div with absolute position next to a menu. No z-index is declared on this block.
+        Flyout menus will go over elements with position set to relative or absolute so
+        long as they don't have a z-index set or if z-index is less than 1.
+    </div>
+</div>

--- a/packages/web-components/fast-components/src/menu/fixtures/menu.html
+++ b/packages/web-components/fast-components/src/menu/fixtures/menu.html
@@ -310,8 +310,38 @@
 </fast-menu>
 
 <h4>Z-index handling</h4>
-<div style="display: inline-block; width: 100%;">
-    <fast-menu style="float: left; width: 370px;">
+<style>
+    .flex-menus {
+        display: flex;
+    }
+
+    .flex-menus > fast-menu {
+        width: 370px;
+    }
+
+    .flex-menus fast-menu-item {
+        z-index: 3;
+    }
+
+    .flex-menus > * + * {
+        margin: 0 0 0 10px;
+    }
+
+    .flex-menus > div {
+        width: 250px;
+        height: 250px;
+        padding: 20px;
+        box-sizing: border-box;
+        background: var(--neutral-layer-floating);
+        color: var(--neutral-foreground-rest);
+        font-family: var(--body-font);
+        font-size: small;
+        position: relative;
+        z-index: 2;
+    }
+</style>
+<div style="display: flex;" class="flex-menus">
+    <fast-menu>
         <fast-menu-item>Menu item 1</fast-menu-item>
         <fast-menu-item>Menu item 2</fast-menu-item>
         <fast-menu-item disabled="true">Menu item 3</fast-menu-item>
@@ -341,23 +371,35 @@
             </fast-menu>
         </fast-menu-item>
     </fast-menu>
-
-    <div
-        style="
-            padding: 20px;
-            margin: 0 0 0 380px;
-            width: 200px;
-            height: 210px;
-            background: var(--neutral-layer-floating);
-            color: var(--neutral-foreground-rest);
-            font-size: small;
-            line-height: 1.5em;
-            position: absolute;
-            font-family: sans-serif;
-        "
-    >
-        Div with absolute position next to a menu. No z-index is declared on this block.
-        Flyout menus will go over elements with position set to relative or absolute so
-        long as they don't have a z-index set or if z-index is less than 1.
-    </div>
+    <fast-menu style="margin: 0 0 0 10px;">
+        <fast-menu-item>Menu item 1</fast-menu-item>
+        <fast-menu-item>Menu item 2</fast-menu-item>
+        <fast-menu-item disabled="true">Menu item 3</fast-menu-item>
+        <fast-menu-item>
+            Menu item 4
+            <div slot="end">
+                Shortcut text
+            </div>
+        </fast-menu-item>
+        <fast-menu-item>
+            Menu item 5
+            <fast-menu>
+                <fast-menu-item>Nested Menu item 1.1</fast-menu-item>
+                <fast-menu-item>Nested Menu item 1.2</fast-menu-item>
+                <fast-menu-item>Nested Menu item 1.3</fast-menu-item>
+            </fast-menu>
+        </fast-menu-item>
+        <fast-menu-item>
+            Menu item 6
+            <div slot="end">
+                Shortcut text
+            </div>
+            <fast-menu>
+                <fast-menu-item>Nested Menu item 1.1</fast-menu-item>
+                <fast-menu-item>Nested Menu item 1.2</fast-menu-item>
+                <fast-menu-item>Nested Menu item 1.3</fast-menu-item>
+            </fast-menu>
+        </fast-menu-item>
+    </fast-menu>
+    <div>Test div</div>
 </div>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
When using a menu next to another menu, submenus will appear under menu items of the next menu.

### 🎫 Issues

https://github.com/microsoft/fast/issues/5417

## 👩‍💻 Reviewer Notes

This is the least obtrusive way to get flyout menus to go over other elements. This will fix both the issue of a menu next to another menu as well as submenus going under an element next to it that has `position: relative` or `position: absolute`. Even if that element doesn't have a z-index property. Developers can still manage z-index on the fast-menu-item as in the example that I added to the fixture. They could also add z-index to the fast-menu but that becomes trickier if they are using menus side-by-side.

## 📑 Test Plan

Not really testable in Jest. Added a working example in the fixtures.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->