### PR TITLE
fix: change style Attribute to style tag(to add CSP support)

### DIFF
--- a/packages/utilities/fast-web-utilities/src/dom.ts
+++ b/packages/utilities/fast-web-utilities/src/dom.ts
@@ -38,7 +38,7 @@ export function getKeyCode(event: KeyboardEvent | null): number | null {
  *
  * Based on https://github.com/cssinjs/jss/blob/master/packages/jss/src/DomRenderer.js
  */
-function getNonce(): string | null {
+export function getNonce(): string | null {
     const node = document.querySelector('meta[property="csp-nonce"]');
     if (node) {
         return node.getAttribute("content");

--- a/packages/web-components/fast-element/src/templating/view.ts
+++ b/packages/web-components/fast-element/src/templating/view.ts
@@ -1,3 +1,4 @@
+import { getNonce } from "@microsoft/fast-web-utilities";
 import type { Behavior } from "../observation/behavior";
 import type { ExecutionContext } from "../observation/observable";
 
@@ -124,10 +125,23 @@ export class HTMLView implements ElementView, SyntheticView {
     }
 
     /**
+     * If nonces are present on the page, set it when creating the style elements.
+     */
+    trySetNonce(): void {
+        const nonce = getNonce();
+        if (nonce) {
+            this.fragment.querySelectorAll("style").forEach(element => {
+                element.nonce = nonce;
+            });
+        }
+    }
+
+    /**
      * Appends the view's DOM nodes to the referenced node.
      * @param node - The parent node to append the view's DOM nodes to.
      */
     public appendTo(node: Node): void {
+        this.trySetNonce();
         node.appendChild(this.fragment);
     }
 
@@ -136,6 +150,7 @@ export class HTMLView implements ElementView, SyntheticView {
      * @param node - The node to insert the view's DOM before.
      */
     public insertBefore(node: Node): void {
+        this.trySetNonce();
         if (this.fragment.hasChildNodes()) {
             node.parentNode!.insertBefore(this.fragment, node);
         } else {

--- a/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
@@ -14,11 +14,17 @@ export const avatarTemplate: (
     context: ElementDefinitionContext,
     definition: AvatarOptions
 ) => html`
+    <style>
+        div.backplate {
+            ${x => (x.fill ? `background-color: var(--avatar-fill-${x.fill});` : void 0)}
+        }
+        a.link {
+            ${x => (x.color ? `color: var(--avatar-color-${x.color});` : void 0)}
+        }
+    </style>
     <div
         class="backplate ${x => x.shape}"
         part="backplate"
-        style="${x =>
-            x.fill ? `background-color: var(--avatar-fill-${x.fill});` : void 0}"
     >
         <a
             class="link"

--- a/packages/web-components/fast-foundation/src/badge/badge.spec.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.spec.ts
@@ -17,6 +17,8 @@ let expectedFill = (fill?: string) => `background-color: var(--badge-fill-${fill
 
 let expectedColor = (color?: string) => `color: var(--badge-color-${color});`;
 
+let expectCssText = (cssText?: string) => `div.control { ${cssText ? `${cssText} ` : '' }}`
+
 describe("Badge", () => {
     it("should set both the background-color and fill on the control as an inline style when `fill` and `color` are provided", async () => {
         const { element, connect, disconnect } = await setup();
@@ -29,8 +31,8 @@ describe("Badge", () => {
         await connect();
 
         expect(
-            element.shadowRoot?.querySelector(".control")?.getAttribute("style")
-        ).to.equal(`${expectedColor(color)} ${expectedFill(fill)}`);
+            element.shadowRoot?.styleSheets[0].cssRules[0].cssText
+        ).to.equal(expectCssText(`${expectedColor(color)} ${expectedFill(fill)}`));
 
         await disconnect();
     });
@@ -44,8 +46,8 @@ describe("Badge", () => {
         await connect();
 
         expect(
-            element.shadowRoot?.querySelector(".control")?.getAttribute("style")
-        ).to.equal(expectedFill(fill));
+            element.shadowRoot?.styleSheets[0].cssRules[0].cssText
+        ).to.equal(expectCssText(expectedFill(fill)));
 
         await disconnect();
     });
@@ -56,8 +58,8 @@ describe("Badge", () => {
         await connect();
 
         expect(
-            element.shadowRoot?.querySelector(".control")?.getAttribute("style")
-        ).to.equal(null);
+            element.shadowRoot?.styleSheets[0].cssRules[0].cssText
+        ).to.equal(expectCssText());
 
         await disconnect();
     });
@@ -71,8 +73,8 @@ describe("Badge", () => {
         await connect();
 
         expect(
-            element.shadowRoot?.querySelector(".control")?.getAttribute("style")
-        ).to.equal(expectedColor(color));
+            element.shadowRoot?.styleSheets[0].cssRules[0].cssText
+        ).to.equal(expectCssText(expectedColor(color)));
 
         await disconnect();
     });
@@ -83,8 +85,8 @@ describe("Badge", () => {
         await connect();
 
         expect(
-            element.shadowRoot?.querySelector(".control")?.getAttribute("style")
-        ).to.equal(null);
+            element.shadowRoot?.styleSheets[0].cssRules[0].cssText
+        ).to.equal(expectCssText());
 
         await disconnect();
     });
@@ -95,8 +97,8 @@ describe("Badge", () => {
         await connect();
 
         expect(
-            element.shadowRoot?.querySelector(".control")?.getAttribute("style")
-        ).to.equal(null);
+            element.shadowRoot?.styleSheets[0].cssRules[0].cssText
+        ).to.equal(expectCssText());
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/badge/badge.template.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.template.ts
@@ -16,7 +16,12 @@ export const badgeTemplate: (
     definition: FoundationElementDefinition
 ) => html`
     <template class="${x => (x.circular ? "circular" : "")}">
-        <div class="control" part="control" style="${x => x.generateBadgeStyle()}">
+        <style>
+            ${x => (x.circular ? ":host([circular])" : "")} div.control {
+                ${x => x.generateBadgeStyle()}
+            }
+        </style>
+        <div class="control" part="control">
             <slot></slot>
         </div>
     </template>

--- a/packages/web-components/fast-foundation/src/progress-ring/progress-ring.template.ts
+++ b/packages/web-components/fast-foundation/src/progress-ring/progress-ring.template.ts
@@ -26,6 +26,13 @@ export const progressRingTemplate: (
         ${when(
             x => typeof x.value === "number",
             html<BaseProgress>`
+                <style>
+                    circle.determinate {
+                        stroke-dasharray: ${x =>
+                                (progressSegments * x.percentComplete) / 100}px
+                            ${progressSegments}px;
+                    }
+                </style>
                 <svg
                     class="progress"
                     part="progress"
@@ -42,9 +49,6 @@ export const progressRingTemplate: (
                     <circle
                         class="determinate"
                         part="determinate"
-                        style="stroke-dasharray: ${x =>
-                            (progressSegments * x.percentComplete) /
-                            100}px ${progressSegments}px"
                         cx="8px"
                         cy="8px"
                         r="7px"

--- a/packages/web-components/fast-foundation/src/progress/progress.template.ts
+++ b/packages/web-components/fast-foundation/src/progress/progress.template.ts
@@ -24,12 +24,13 @@ export const progressTemplate: (
         ${when(
             x => typeof x.value === "number",
             html<BaseProgress>`
+                <style>
+                    div.determinate {
+                        width: ${x => x.percentComplete}%;
+                    }
+                </style>
                 <div class="progress" part="progress" slot="determinate">
-                    <div
-                        class="determinate"
-                        part="determinate"
-                        style="width: ${x => x.percentComplete}%"
-                    ></div>
+                    <div class="determinate" part="determinate"></div>
                 </div>
             `
         )}

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
@@ -21,7 +21,10 @@ export const sliderLabelTemplate: (
         class="${x => x.sliderOrientation || Orientation.horizontal}
             ${x => (x.disabled ? "disabled" : "")}"
     >
-        <div ${ref("root")} part="root" class="root" style="${x => x.positionStyle}">
+        <style>
+            div.root{${x => x.positionStyle}}
+        </style>
+        <div ${ref("root")} part="root" class="root">
             <div class="container">
                 ${when(
                     x => !x.hideMark,

--- a/packages/web-components/fast-foundation/src/slider/slider.template.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.template.ts
@@ -29,17 +29,20 @@ export const sliderTemplate: (
         aria-orientation="${x => x.orientation}"
         class="${x => x.orientation}"
     >
+        <style>
+            ${x =>
+                `:host([orientation="${
+                    x.orientation || Orientation.horizontal
+                }"])`} div.thumb-container {
+                ${x => x.position}
+            }
+        </style>
         <div part="positioning-region" class="positioning-region">
             <div ${ref("track")} part="track-container" class="track">
                 <slot name="track"></slot>
             </div>
             <slot></slot>
-            <div
-                ${ref("thumb")}
-                part="thumb-container"
-                class="thumb-container"
-                style="${x => x.position}"
-            >
+            <div ${ref("thumb")} part="thumb-container" class="thumb-container">
                 <slot name="thumb">${definition.thumb || ""}</slot>
             </div>
         </div>


### PR DESCRIPTION
<!---
プルリクエストの提出、ありがとうございます😄 ! 提出する前に、以下の内容をお読みください。

投稿する前に、オープン/クローズドの課題を検索してください。誰かが同じことをしたかもしれません。

上のタイトル欄に変更点の概要を記入してください。
-->

# Pull Request

## 📖 Description

This PR is to make it possible to set nonce for fast-element.
This solved the problem I encountered, but I couldn't decide if this policy is OK, so I made a Draft.
I hope this helps with #5444.

### Background

This all started when I realized that it was hard to resolve a csp violation in my repository.

https://github.com/SilkyFowl/fable-vscode-extension-samples/pull/17

The [@vscode/webview-ui-toolkit](https://github.com/microsoft/vscode-webview-ui-toolkit) used in this repository depends on fast.
By the way, vscode extension [recommends the use of Content security policy when using WebView.](https://code.visualstudio.com/api/extension-guides/webview#content-security-policy)
A sample implementation can be found here.
https://github.com/microsoft/vscode-extension-samples/blob/e958fb7d45abda8177f413062318447ce59c780f/webview-sample/src/extension.ts#L196

Currently, if using Vscode's webview-ui-toolkit, it will violate Vscode's recommendations.
To resolve the inconsistency of webview-ui-toolkit, we need to resolving #5444.

<!---
いくつかの背景と作品の説明を提供する。
この変更はどのような問題を解決しますか？
この変更は、破壊的な変更ですか、雑用ですか、修正ですか、機能ですか、など。
-->

### 🎫 Issues

#5444 <- #4510

This PR was created using #5444 as a hint.

<!---
* 関連する問題をここにリストアップしてリンクします。
-->

## 👩‍💻 Reviewer Notes

<!---
レビューアが的を射たフィードバックやテストを行えるように、いくつかのメモを提供する。

このPRにスモークテストを推奨しますか？どのようなステップを踏むべきですか？
レビュアーが注目すべきコードの特定の領域はありますか？
-->

## 📑 Test Plan

<!---
今回の作業で影響を受けたテストの概要と、機能/修正のテストで採用した独自の戦略を教えてください。
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
このPRに関連するフォローアップ作業がある場合は、既存の問題点を挙げたり、次に何をしたいかを簡単に説明してください。
-->