### PR TITLE
fix: listbox-option, listbox, select, and combobox accessibility

### DIFF
--- a/change/@microsoft-fast-components-f3bbcdfe-0cb8-4a25-bf26-4c4593449db7.json
+++ b/change/@microsoft-fast-components-f3bbcdfe-0cb8-4a25-bf26-4c4593449db7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "remove configurable role attribute from listbox, select, and combobox",
+  "packageName": "@microsoft/fast-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-9ae2c02f-3412-4ca0-b766-fba6dad2e98d.json
+++ b/change/@microsoft-fast-foundation-9ae2c02f-3412-4ca0-b766-fba6dad2e98d.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "fix accessibility for listbox, select, and combobox",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -200,7 +200,15 @@ export const allComponents: {
         template: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition>) => import("@microsoft/fast-element").ViewTemplate<import("@microsoft/fast-foundation").ListboxElement, any>;
         styles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition>) => import("@microsoft/fast-element").ElementStyles;
     }, typeof Listbox>;
-    fastOption: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof import("@microsoft/fast-foundation").ListboxOption>;
+    fastOption: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+        baseName: string;
+        template: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").AnchorOptions>) => import("@microsoft/fast-element").ViewTemplate<import("@microsoft/fast-foundation").ListboxOption, any>;
+        styles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").AnchorOptions>) => import("@microsoft/fast-element").ElementStyles;
+    }> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+        baseName: string;
+        template: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").AnchorOptions>) => import("@microsoft/fast-element").ViewTemplate<import("@microsoft/fast-foundation").ListboxOption, any>;
+        styles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").AnchorOptions>) => import("@microsoft/fast-element").ElementStyles;
+    }, typeof import("@microsoft/fast-foundation").ListboxOption>;
     fastMenu: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof import("@microsoft/fast-foundation").Menu>;
     fastMenuItem: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").MenuItemOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").MenuItemOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
     fastNumberField: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").NumberFieldOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").NumberFieldOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
@@ -590,7 +598,15 @@ export const fastMenuItem: (overrideDefinition?: import("@microsoft/fast-foundat
 export const fastNumberField: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<NumberFieldOptions> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<NumberFieldOptions, import("@microsoft/fast-element").Constructable<import("@microsoft/fast-foundation").FoundationElement>>;
 
 // @public
-export const fastOption: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof ListboxOption>;
+export const fastOption: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<{
+    baseName: string;
+    template: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").AnchorOptions>) => import("@microsoft/fast-element").ViewTemplate<ListboxOption, any>;
+    styles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").AnchorOptions>) => import("@microsoft/fast-element").ElementStyles;
+}> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<{
+    baseName: string;
+    template: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").AnchorOptions>) => import("@microsoft/fast-element").ViewTemplate<ListboxOption, any>;
+    styles: (context: import("@microsoft/fast-foundation").ElementDefinitionContext, definition: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").AnchorOptions>) => import("@microsoft/fast-element").ElementStyles;
+}, typeof ListboxOption>;
 
 // @alpha
 export const fastPicker: (overrideDefinition?: import("@microsoft/fast-foundation").OverrideFoundationElementDefinition<import("@microsoft/fast-foundation").FoundationElementDefinition> | undefined) => import("@microsoft/fast-foundation").FoundationElementRegistry<import("@microsoft/fast-foundation").FoundationElementDefinition, typeof Picker>;
@@ -1285,11 +1301,11 @@ export const verticalSliderLabelStyles: ElementStyles;
 // dist/dts/custom-elements.d.ts:87:5 - (ae-incompatible-release-tags) The symbol "fastCard" is marked as @public, but its signature references "Card" which is marked as @internal
 // dist/dts/custom-elements.d.ts:93:5 - (ae-incompatible-release-tags) The symbol "fastDesignSystemProvider" is marked as @public, but its signature references "DesignSystemProvider" which is marked as @internal
 // dist/dts/custom-elements.d.ts:95:5 - (ae-incompatible-release-tags) The symbol "fastDisclosure" is marked as @public, but its signature references "Disclosure" which is marked as @internal
-// dist/dts/custom-elements.d.ts:121:5 - (ae-incompatible-release-tags) The symbol "fastSearch" is marked as @public, but its signature references "Search" which is marked as @internal
-// dist/dts/custom-elements.d.ts:125:5 - (ae-incompatible-release-tags) The symbol "fastSliderLabel" is marked as @public, but its signature references "SliderLabel" which is marked as @internal
-// dist/dts/custom-elements.d.ts:130:5 - (ae-incompatible-release-tags) The symbol "fastTextArea" is marked as @public, but its signature references "TextArea" which is marked as @internal
-// dist/dts/custom-elements.d.ts:131:5 - (ae-incompatible-release-tags) The symbol "fastTextField" is marked as @public, but its signature references "TextField" which is marked as @internal
-// dist/dts/custom-elements.d.ts:133:5 - (ae-incompatible-release-tags) The symbol "fastToolbar" is marked as @public, but its signature references "Toolbar" which is marked as @internal
+// dist/dts/custom-elements.d.ts:129:5 - (ae-incompatible-release-tags) The symbol "fastSearch" is marked as @public, but its signature references "Search" which is marked as @internal
+// dist/dts/custom-elements.d.ts:133:5 - (ae-incompatible-release-tags) The symbol "fastSliderLabel" is marked as @public, but its signature references "SliderLabel" which is marked as @internal
+// dist/dts/custom-elements.d.ts:138:5 - (ae-incompatible-release-tags) The symbol "fastTextArea" is marked as @public, but its signature references "TextArea" which is marked as @internal
+// dist/dts/custom-elements.d.ts:139:5 - (ae-incompatible-release-tags) The symbol "fastTextField" is marked as @public, but its signature references "TextField" which is marked as @internal
+// dist/dts/custom-elements.d.ts:141:5 - (ae-incompatible-release-tags) The symbol "fastToolbar" is marked as @public, but its signature references "Toolbar" which is marked as @internal
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-components/docs/api-report.md
+++ b/packages/web-components/fast-components/docs/api-report.md
@@ -1079,7 +1079,7 @@ export const searchStyles: (context: import("@microsoft/fast-foundation").Elemen
 export { Select }
 
 // @public
-export const selectStyles: (context: ElementDefinitionContext, definition: SelectOptions) => ElementStyles;
+export const selectStyles: FoundationElementTemplate<ElementStyles, SelectOptions>;
 
 export { Skeleton }
 

--- a/packages/web-components/fast-components/src/listbox/listbox.vscode.definition.json
+++ b/packages/web-components/fast-components/src/listbox/listbox.vscode.definition.json
@@ -7,19 +7,6 @@
             "description": "The FAST listbox element",
             "attributes": [
                 {
-                    "name": "role",
-                    "title": "Role",
-                    "description": "The ARIA role for the listbox",
-                    "type": "string",
-                    "default": "listbox",
-                    "required": true,
-                    "values": [
-                        {
-                            "name": "listbox"
-                        }
-                    ]
-                },
-                {
                     "name": "disabled",
                     "title": "Disabled",
                     "description": "Sets the disabled state of the listbox",

--- a/packages/web-components/fast-components/src/select/select.styles.ts
+++ b/packages/web-components/fast-components/src/select/select.styles.ts
@@ -1,10 +1,13 @@
-import { css, ElementStyles } from "@microsoft/fast-element";
+import { css } from "@microsoft/fast-element";
+import type { ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
-    ElementDefinitionContext,
     focusVisible,
     forcedColorsStylesheetBehavior,
+} from "@microsoft/fast-foundation";
+import type {
+    FoundationElementTemplate,
     SelectOptions,
 } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
@@ -39,10 +42,10 @@ import { heightNumber } from "../styles/size";
  * Styles for Select
  * @public
  */
-export const selectStyles: (
-    context: ElementDefinitionContext,
-    definition: SelectOptions
-) => ElementStyles = (context: ElementDefinitionContext, definition: SelectOptions) =>
+export const selectStyles: FoundationElementTemplate<ElementStyles, SelectOptions> = (
+    context,
+    definition
+) =>
     css`
     ${display("inline-flex")} :host {
         --elevation: 14;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -495,7 +495,7 @@ export type ComboboxOptions = FoundationElementDefinition & StartEndOptions & {
 };
 
 // @public
-export const comboboxTemplate: (context: ElementDefinitionContext, definition: ComboboxOptions) => ViewTemplate<Combobox>;
+export const comboboxTemplate: FoundationElementTemplate<ViewTemplate<Combobox>, ComboboxOptions>;
 
 // @public
 export interface ComponentPresentation {
@@ -2080,7 +2080,7 @@ export enum SelectRole {
 }
 
 // @public
-export const selectTemplate: (context: ElementDefinitionContext, definition: SelectOptions) => ViewTemplate<Select>;
+export const selectTemplate: FoundationElementTemplate<ViewTemplate<Select>, SelectOptions>;
 
 // @public
 export interface ServiceLocator {

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -780,11 +780,12 @@ export interface DelegatesARIAButton extends ARIAGlobalStatesAndProperties {
 //
 // @public
 export class DelegatesARIACombobox {
-    ariaAutocomplete: "inline" | "list" | "both" | "none" | undefined;
+    ariaAutoComplete: "inline" | "list" | "both" | "none" | undefined;
+    ariaControls: string;
 }
 
 // @internal
-export interface DelegatesARIACombobox extends ARIAGlobalStatesAndProperties {
+export interface DelegatesARIACombobox extends DelegatesARIAListbox {
 }
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -814,6 +814,20 @@ export interface DelegatesARIAListbox extends ARIAGlobalStatesAndProperties {
 }
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
+// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "DelegatesARIAListboxOption" because one of its declarations is marked as @internal
+//
+// @public
+export class DelegatesARIAListboxOption {
+    ariaPosInSet: string;
+    ariaSelected: "true" | "false" | undefined;
+    ariaSetSize: string;
+}
+
+// @internal (undocumented)
+export interface DelegatesARIAListboxOption extends ARIAGlobalStatesAndProperties {
+}
+
+// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "DelegatesARIASearch" because one of its declarations is marked as @internal
 //
 // @public
@@ -1432,14 +1446,14 @@ export class ListboxOption extends FoundationElement {
     }
 
 // @internal (undocumented)
-export interface ListboxOption extends StartEnd {
+export interface ListboxOption extends StartEnd, DelegatesARIAListboxOption {
 }
 
 // @public
 export type ListboxOptionOptions = FoundationElementDefinition & StartEndOptions;
 
 // @public
-export const listboxOptionTemplate: (context: ElementDefinitionContext, definition: ListboxOptionOptions) => ViewTemplate<ListboxOption>;
+export const listboxOptionTemplate: FoundationElementTemplate<ViewTemplate<ListboxOption>, ListboxOptionOptions>;
 
 // @public
 export const listboxTemplate: FoundationElementTemplate<ViewTemplate<ListboxElement>>;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -843,12 +843,11 @@ export interface DelegatesARIASearch extends ARIAGlobalStatesAndProperties {
 //
 // @public
 export class DelegatesARIASelect {
-    ariaExpanded: "true" | "false" | undefined;
-    ariaPressed: "true" | "false" | "mixed" | undefined;
+    ariaControls: string;
 }
 
 // @internal
-export interface DelegatesARIASelect extends ARIAGlobalStatesAndProperties {
+export interface DelegatesARIASelect extends DelegatesARIAListbox {
 }
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -457,7 +457,6 @@ export class Combobox extends FormAssociatedCombobox {
     protected placeholderChanged(): void;
     position: SelectPosition;
     positionAttribute: SelectPosition;
-    role: SelectRole;
     // @internal
     selectedIndexChanged(prev: number, next: number): void;
     // @internal
@@ -1346,7 +1345,6 @@ export abstract class Listbox extends FoundationElement {
     set options(value: ListboxOption[]);
     // @internal
     protected _options: ListboxOption[];
-    role: string;
     selectedIndex: number;
     // @internal
     selectedIndexChanged(prev: number, next: number): void;
@@ -1442,12 +1440,6 @@ export type ListboxOptionOptions = FoundationElementDefinition & StartEndOptions
 
 // @public
 export const listboxOptionTemplate: (context: ElementDefinitionContext, definition: ListboxOptionOptions) => ViewTemplate<ListboxOption>;
-
-// @public
-export enum ListboxRole {
-    // (undocumented)
-    listbox = "listbox"
-}
 
 // @public
 export const listboxTemplate: FoundationElementTemplate<ViewTemplate<ListboxElement>>;
@@ -2046,7 +2038,6 @@ export class Select extends FormAssociatedSelect {
     protected openChanged(): void;
     position: SelectPosition;
     positionAttribute: SelectPosition;
-    role: SelectRole;
     // @internal
     selectedIndexChanged(prev: any, next: any): void;
     setPositioning(): void;
@@ -2071,12 +2062,6 @@ export enum SelectPosition {
     above = "above",
     // (undocumented)
     below = "below"
-}
-
-// @public
-export enum SelectRole {
-    // (undocumented)
-    combobox = "combobox"
 }
 
 // @public

--- a/packages/web-components/fast-foundation/src/combobox/combobox.spec.md
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.spec.md
@@ -52,7 +52,6 @@ Extends [`listbox`](../listbox/listbox.spec.md) and [form associated custom elem
 
 - `options` - An array of all options.
 - `placeholder` - Sets the placeholder of the element, generally used to provide a hint to the user.
-- `role` - The role of the element.
 - `value` - Reflects the value of the first selected option. Setting the `value` property will update the `selected` state of the first option that matches the value, if any.
 
 *Events*:

--- a/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
@@ -1,6 +1,6 @@
 import { DOM } from "@microsoft/fast-element";
 import { keyArrowDown, keyArrowUp } from "@microsoft/fast-web-utilities";
-import { assert, expect } from "chai";
+import { expect } from "chai";
 import { ListboxOption, listboxOptionTemplate } from "../listbox-option";
 import { fixture } from "../test-utilities/fixture";
 import { Combobox, comboboxTemplate as template } from "./index";
@@ -40,16 +40,6 @@ async function setup() {
 
 // TODO: Need to add tests for keyboard handling & focus management
 describe("Combobox", () => {
-    it("should include a control with a role of `combobox`", async () => {
-        const { element, connect, disconnect } = await setup();
-
-        await connect();
-
-        assert.strictEqual(element.control.getAttribute("role"), "combobox");
-
-        await disconnect();
-    });
-
     it("should set the `aria-disabled` attribute equal to the `disabled` value", async () => {
         const { element, connect, disconnect } = await setup();
 

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -29,7 +29,7 @@ export const comboboxTemplate: FoundationElementTemplate<
                     class="selected-value"
                     part="selected-value"
                     placeholder="${x => x.placeholder}"
-                    role="${x => x.role}"
+                    role="combobox"
                     type="text"
                     aria-activedescendant="${x =>
                         x.open ? x.ariaActiveDescendant : null}"

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -14,32 +14,34 @@ export const comboboxTemplate: FoundationElementTemplate<
     ComboboxOptions
 > = (context, definition) => html`
     <template
-        autocomplete="${x => x.autocomplete}"
-        class="${x => (x.disabled ? "disabled" : "")} ${x => x.position}"
-        tabindex="${x => (!x.disabled ? "0" : null)}"
         aria-disabled="${x => x.ariaDisabled}"
-        aria-autocomplete="${x => x.autocomplete}"
+        autocomplete="${x => x.autocomplete}"
+        class="${x => (x.open ? "open" : "")} ${x =>
+            x.disabled ? "disabled" : ""} ${x => x.position}"
+        tabindex="${x => (!x.disabled ? "0" : null)}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
         @focusout="${(x, c) => x.focusoutHandler(c.event as FocusEvent)}"
+        @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     >
         <div class="control" part="control">
             ${startSlotTemplate(context, definition)}
             <slot name="control">
                 <input
+                    aria-activedescendant="${x =>
+                        x.open ? x.ariaActiveDescendant : null}"
+                    aria-autocomplete="${x => x.ariaAutoComplete}"
+                    aria-controls="${x => x.ariaControls}"
+                    aria-disabled="${x => x.ariaDisabled}"
+                    aria-expanded="${x => x.ariaExpanded}"
+                    aria-haspopup="listbox"
                     class="selected-value"
                     part="selected-value"
                     placeholder="${x => x.placeholder}"
                     role="combobox"
                     type="text"
-                    aria-activedescendant="${x =>
-                        x.open ? x.ariaActiveDescendant : null}"
-                    aria-controls="${x => x.listboxId}"
-                    aria-expanded="${x => x.ariaExpanded}"
-                    aria-haspopup="listbox"
                     ?disabled="${x => x.disabled}"
                     :value="${x => x.value}"
                     @input="${(x, c) => x.inputHandler(c.event as InputEvent)}"
-                    @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
                     @keyup="${(x, c) => x.keyupHandler(c.event as KeyboardEvent)}"
                     ${ref("control")}
                 />
@@ -52,9 +54,7 @@ export const comboboxTemplate: FoundationElementTemplate<
             ${endSlotTemplate(context, definition)}
         </div>
         <div
-            aria-disabled="${x => x.disabled}"
             class="listbox"
-            id="${x => x.listboxId}"
             part="listbox"
             role="listbox"
             ?disabled="${x => x.disabled}"

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -1,21 +1,18 @@
 import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
+import type { FoundationElementTemplate } from "../foundation-element";
 import { Listbox } from "../listbox/listbox";
 import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
-import type { ElementDefinitionContext } from "../design-system";
 import type { Combobox, ComboboxOptions } from "./combobox";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Combobox:class)} component.
  * @public
  */
-export const comboboxTemplate: (
-    context: ElementDefinitionContext,
-    definition: ComboboxOptions
-) => ViewTemplate<Combobox> = (
-    context: ElementDefinitionContext,
-    definition: ComboboxOptions
-) => html`
+export const comboboxTemplate: FoundationElementTemplate<
+    ViewTemplate<Combobox>,
+    ComboboxOptions
+> = (context, definition) => html`
     <template
         autocomplete="${x => x.autocomplete}"
         class="${x => (x.disabled ? "disabled" : "")} ${x => x.position}"

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -1,14 +1,11 @@
-import {
-    attr,
-    Observable,
-    observable,
-    SyntheticViewTemplate,
-} from "@microsoft/fast-element";
+import { attr, Observable, observable } from "@microsoft/fast-element";
+import type { SyntheticViewTemplate } from "@microsoft/fast-element";
 import { limit, uniqueId } from "@microsoft/fast-web-utilities";
 import type { FoundationElementDefinition } from "../foundation-element";
 import type { ListboxOption } from "../listbox-option/listbox-option";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
-import { StartEnd, StartEndOptions } from "../patterns/start-end";
+import { StartEnd } from "../patterns/start-end";
+import type { StartEndOptions } from "../patterns/start-end";
 import { SelectPosition, SelectRole } from "../select/select.options";
 import { applyMixins } from "../utilities/apply-mixins";
 import { FormAssociatedCombobox } from "./combobox.form-associated";

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -6,7 +6,7 @@ import type { ListboxOption } from "../listbox-option/listbox-option";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
 import { StartEnd } from "../patterns/start-end";
 import type { StartEndOptions } from "../patterns/start-end";
-import { SelectPosition, SelectRole } from "../select/select.options";
+import { SelectPosition } from "../select/select.options";
 import { applyMixins } from "../utilities/apply-mixins";
 import { FormAssociatedCombobox } from "./combobox.form-associated";
 import { ComboboxAutocomplete } from "./combobox.options";
@@ -193,15 +193,6 @@ export class Combobox extends FormAssociatedCombobox {
      */
     @observable
     public position: SelectPosition = SelectPosition.below;
-
-    /**
-     * The role of the element.
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: role
-     */
-    public role: SelectRole = SelectRole.combobox;
 
     /**
      * The value property.

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -2,8 +2,8 @@ import { attr, Observable, observable } from "@microsoft/fast-element";
 import type { SyntheticViewTemplate } from "@microsoft/fast-element";
 import { limit, uniqueId } from "@microsoft/fast-web-utilities";
 import type { FoundationElementDefinition } from "../foundation-element";
+import { DelegatesARIAListbox } from "../listbox";
 import type { ListboxOption } from "../listbox-option/listbox-option";
-import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
 import { StartEnd } from "../patterns/start-end";
 import type { StartEndOptions } from "../patterns/start-end";
 import { SelectPosition } from "../select/select.options";
@@ -134,11 +134,17 @@ export class Combobox extends FormAssociatedCombobox {
     @attr({ attribute: "open", mode: "boolean" })
     public open: boolean = false;
     protected openChanged() {
-        this.ariaExpanded = this.open ? "true" : "false";
         if (this.open) {
+            this.ariaControls = this.listbox.id;
+            this.ariaExpanded = "true";
+
             this.setPositioning();
             this.focusAndScrollOptionIntoView();
+            return;
         }
+
+        this.ariaControls = "";
+        this.ariaExpanded = "false";
     }
 
     /**
@@ -269,6 +275,10 @@ export class Combobox extends FormAssociatedCombobox {
         this.forcedPosition = !!this.positionAttribute;
         if (this.value) {
             this.initialValue = this.value;
+        }
+
+        if (!this.listbox.id) {
+            this.listbox.id = uniqueId("listbox-");
         }
     }
 
@@ -636,13 +646,24 @@ export class Combobox extends FormAssociatedCombobox {
  */
 export class DelegatesARIACombobox {
     /**
-     * See {@link https://w3c.github.io/aria/#aria-autocomplete} for more information
+     * See {@link https://www.w3.org/TR/wai-aria-1.2/#aria-autocomplete} for more information.
+     *
      * @public
      * @remarks
-     * HTML Attribute: aria-autocomplete
+     * HTML Attribute: `aria-autocomplete`
      */
-    @attr({ attribute: "aria-autocomplete", mode: "fromView" })
-    public ariaAutocomplete: "inline" | "list" | "both" | "none" | undefined;
+    @observable
+    public ariaAutoComplete: "inline" | "list" | "both" | "none" | undefined;
+
+    /**
+     * See {@link https://www.w3.org/TR/wai-aria-1.2/#aria-controls} for more information.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: `aria-controls`
+     */
+    @observable
+    public ariaControls: string;
 }
 
 /**
@@ -651,8 +672,8 @@ export class DelegatesARIACombobox {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface DelegatesARIACombobox extends ARIAGlobalStatesAndProperties {}
-applyMixins(DelegatesARIACombobox, ARIAGlobalStatesAndProperties);
+export interface DelegatesARIACombobox extends DelegatesARIAListbox {}
+applyMixins(DelegatesARIACombobox, DelegatesARIAListbox);
 
 /**
  * Mark internal because exporting class and interface of the same name

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
@@ -1,20 +1,30 @@
-import { expect } from "chai";
-import { fixture } from "../test-utilities/fixture";
 import { DOM } from "@microsoft/fast-element";
-import { ListboxOption } from "./listbox-option";
+import { expect } from "chai";
 import { listboxOptionTemplate } from "../listbox-option/listbox-option.template";
-
-const FASTOption = ListboxOption.compose({
-    baseName: "option",
-    template: listboxOptionTemplate,
-})
+import { fixture } from "../test-utilities/fixture";
+import { ListboxOption } from "./listbox-option";
 
 describe("ListboxOption", () => {
+    const FASTOption = ListboxOption.compose({
+        baseName: "option",
+        template: listboxOptionTemplate,
+    });
+
     async function setup() {
         const { element, connect, disconnect } = await fixture(FASTOption());
 
         return { element, connect, disconnect };
     }
+
+    it("should have a role of `option`", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        expect(element.getAttribute("role")).to.equal("option");
+
+        await disconnect();
+    });
 
     it("should set the `aria-selected` attribute equal to the `selected` value", async () => {
         const { element, connect, disconnect } = await setup();
@@ -30,6 +40,24 @@ describe("ListboxOption", () => {
         await DOM.nextUpdate();
 
         expect(element.getAttribute("aria-selected")).to.equal("false");
+
+        await disconnect();
+    });
+
+    it("should set the `aria-disabled` attribute equal to the `disabled` value", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        element.disabled = true;
+
+        await connect();
+
+        expect(element.getAttribute("aria-disabled")).to.equal("true");
+
+        element.disabled = false;
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-disabled")).to.equal("false");
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
@@ -1,24 +1,26 @@
 import { html } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
+import type { FoundationElementTemplate } from "../foundation-element";
 import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
-import type { ElementDefinitionContext } from "../design-system";
 import type { ListboxOption, ListboxOptionOptions } from "./listbox-option";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(ListboxOption:class)} component.
  * @public
  */
-export const listboxOptionTemplate: (
-    context: ElementDefinitionContext,
-    definition: ListboxOptionOptions
-) => ViewTemplate<ListboxOption> = (
-    context: ElementDefinitionContext,
-    definition: ListboxOptionOptions
-) => html`
+export const listboxOptionTemplate: FoundationElementTemplate<
+    ViewTemplate<ListboxOption>,
+    ListboxOptionOptions
+> = (context, definition) => html`
     <template
-        aria-selected="${x => x.selected}"
-        class="${x => (x.selected ? "selected" : "")} ${x =>
-            x.disabled ? "disabled" : ""}"
+        aria-disabled="${x => x.ariaDisabled}"
+        aria-posinset="${x => x.ariaPosInSet}"
+        aria-selected="${x => x.ariaSelected}"
+        aria-setsize="${x => x.ariaSetSize}"
+        class="${x =>
+            [x.selected && "selected", x.disabled && "disabled"]
+                .filter(Boolean)
+                .join(" ")}"
         role="option"
     >
         ${startSlotTemplate(context, definition)}

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
@@ -1,8 +1,11 @@
 import { attr, observable, Observable } from "@microsoft/fast-element";
 import { isHTMLElement } from "@microsoft/fast-web-utilities";
-import { StartEnd, StartEndOptions } from "../patterns/start-end";
+import { FoundationElement } from "../foundation-element";
+import type { FoundationElementDefinition } from "../foundation-element";
+import { ARIAGlobalStatesAndProperties } from "../patterns";
+import { StartEnd } from "../patterns/start-end";
+import type { StartEndOptions } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
-import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
 
 /**
  * Listbox option configuration options
@@ -72,6 +75,8 @@ export class ListboxOption extends FoundationElement {
     @attr({ mode: "boolean" })
     public disabled: boolean;
     protected disabledChanged(prev, next): void {
+        this.ariaDisabled = this.disabled ? "true" : "false";
+
         if (this.proxy instanceof HTMLOptionElement) {
             this.proxy.disabled = this.disabled;
         }
@@ -102,14 +107,14 @@ export class ListboxOption extends FoundationElement {
     @observable
     public selected: boolean = this.defaultSelected;
     protected selectedChanged(): void {
-        if (this.$fastController.isConnected) {
-            if (!this.dirtySelected) {
-                this.dirtySelected = true;
-            }
+        this.ariaSelected = this.selected ? "true" : "false";
 
-            if (this.proxy instanceof HTMLOptionElement) {
-                this.proxy.selected = this.selected;
-            }
+        if (!this.dirtySelected) {
+            this.dirtySelected = true;
+        }
+
+        if (this.proxy instanceof HTMLOptionElement) {
+            this.proxy.selected = this.selected;
         }
     }
 
@@ -201,7 +206,55 @@ export class ListboxOption extends FoundationElement {
 }
 
 /**
- * @internal
+ * States and properties relating to the ARIA `option` role.
+ *
+ * @public
  */
-export interface ListboxOption extends StartEnd {}
-applyMixins(ListboxOption, StartEnd);
+export class DelegatesARIAListboxOption {
+    /**
+     * See {@link https://www.w3.org/TR/wai-aria-1.2/#option} for more information.
+     * @public
+     * @remarks
+     * HTML Attribute: `aria-posinset`
+     */
+    @observable
+    ariaPosInSet: string;
+
+    /**
+     * See {@link https://www.w3.org/TR/wai-aria-1.2/#option} for more information.
+     * @public
+     * @remarks
+     * HTML Attribute: `aria-selected`
+     */
+    @observable
+    ariaSelected: "true" | "false" | undefined;
+
+    /**
+     * See {@link https://www.w3.org/TR/wai-aria-1.2/#option} for more information.
+     * @public
+     * @remarks
+     * HTML Attribute: `aria-setsize`
+     */
+    @observable
+    ariaSetSize: string;
+}
+
+/**
+ * @internal
+ * @privateRemarks
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ */
+export interface DelegatesARIAListboxOption extends ARIAGlobalStatesAndProperties {}
+applyMixins(DelegatesARIAListboxOption, ARIAGlobalStatesAndProperties);
+
+/**
+ * @internal
+ * @privateRemarks
+ * Mark internal because exporting class and interface of the same name
+ * confuses API documenter.
+ * TODO: https://github.com/microsoft/fast/issues/3317
+ */
+export interface ListboxOption extends StartEnd, DelegatesARIAListboxOption {}
+applyMixins(ListboxOption, StartEnd, DelegatesARIAListboxOption);

--- a/packages/web-components/fast-foundation/src/listbox/index.ts
+++ b/packages/web-components/fast-foundation/src/listbox/index.ts
@@ -1,4 +1,3 @@
 export * from "./listbox";
 export * from "./listbox.element";
-export * from "./listbox.options";
 export * from "./listbox.template";

--- a/packages/web-components/fast-foundation/src/listbox/listbox.options.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.options.ts
@@ -1,7 +1,0 @@
-/**
- * Listbox role.
- * @public
- */
-export enum ListboxRole {
-    listbox = "listbox",
-}

--- a/packages/web-components/fast-foundation/src/listbox/listbox.spec.md
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.spec.md
@@ -30,7 +30,6 @@ This component is used as a building block for other components in this library 
 
 - `disabled` - Disables the control.
 - `options` - An array of all options in the `listbox`.
-- `role` - The role of the element, defaults to "listbox".
 - `selectedOptions` - A collection of the selected options in the `listbox`.
 - `selectedIndex` - The index of the first selected option, or `-1` if nothing is selected. Setting the `selectedIndex` property will update the `selected` state of the option at the new index. Out of range values will reset the `selectedIndex` to `-1`.
 - `size` - The maximum number of options that should be visible in the `listbox` scroll area.

--- a/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
@@ -36,16 +36,6 @@ describe("Listbox", () => {
         return { element, connect, disconnect, option1, option2, option3 };
     }
 
-    it("should have a role of `listbox`", async () => {
-        const { element, connect, disconnect } = await setup();
-
-        await connect();
-
-        expect(element.getAttribute("role")).to.equal("listbox");
-
-        await disconnect();
-    });
-
     it("should have a tabindex of 0 when `disabled` is not defined", async () => {
         const { element, connect, disconnect } = await setup();
 

--- a/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
@@ -5,17 +5,16 @@ import { listboxOptionTemplate as itemTemplate } from "../listbox-option/listbox
 import { fixture } from "../test-utilities/fixture";
 import { ListboxElement, listboxTemplate as template } from "./index";
 
-const FASTListbox = ListboxElement.compose({
-    baseName: "listbox",
-    template
-})
-
-// TODO: Need to add tests for keyboard handling & focus management
 describe("Listbox", () => {
+    const FASTListbox = ListboxElement.compose({
+        baseName: "listbox",
+        template
+    });
+
     const FASTOption = ListboxOption.compose({
         baseName: "option",
         template: itemTemplate
-    })
+    });
 
     async function setup() {
         const { element, connect, disconnect } = await fixture([FASTListbox(), FASTOption()]);
@@ -175,6 +174,48 @@ describe("Listbox", () => {
 
         expect(option3.getAttribute("aria-posinset")).to.equal("3");
         expect(option3.getAttribute("aria-setsize")).to.equal("3");
+
+        await disconnect();
+    });
+
+    it("should set a unique ID for each slotted option without an ID", async () => {
+        const { connect, disconnect, option1, option2, option3 } = await setup();
+
+        option2.id = "unique-id";
+
+        await connect();
+
+        await DOM.nextUpdate();
+
+        expect(option1.id).to.match(/option-\d+/);
+
+        expect(option2.id).to.equal("unique-id");
+
+        expect(option3.id).to.match(/option-\d+/);
+
+        await disconnect();
+    });
+
+    it("should set the `aria-activedescendant` property to the ID of the currently selected option", async () => {
+        const { connect, disconnect, element, option1, option2, option3 } = await setup();
+
+        await connect();
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-activedescendant")).to.exist.and.equal(option1.id);
+
+        element.selectNextOption();
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-activedescendant")).to.equal(option2.id);
+
+        element.selectNextOption();
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-activedescendant")).to.equal(option3.id);
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
@@ -159,4 +159,23 @@ describe("Listbox", () => {
             await disconnect();
         });
     });
+
+    it("should set the `aria-setsize` and `aria-posinset` properties on slotted options", async () => {
+        const { connect, disconnect, option1, option2, option3 } = await setup();
+
+        await connect();
+
+        await DOM.nextUpdate();
+
+        expect(option1.getAttribute("aria-posinset")).to.equal("1");
+        expect(option1.getAttribute("aria-setsize")).to.equal("3");
+
+        expect(option2.getAttribute("aria-posinset")).to.equal("2");
+        expect(option2.getAttribute("aria-setsize")).to.equal("3");
+
+        expect(option3.getAttribute("aria-posinset")).to.equal("3");
+        expect(option3.getAttribute("aria-setsize")).to.equal("3");
+
+        await disconnect();
+    });
 });

--- a/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
@@ -14,7 +14,7 @@ export const listboxTemplate: FoundationElementTemplate<ViewTemplate<ListboxElem
     <template
         aria-activedescendant="${x => x.ariaActiveDescendant}"
         class="listbox"
-        role="${x => x.role}"
+        role="listbox"
         tabindex="${x => (!x.disabled ? "0" : null)}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
         @focusin="${(x, c) => x.focusinHandler(c.event as FocusEvent)}"

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -14,7 +14,6 @@ import { FoundationElement } from "../foundation-element";
 import { isListboxOption, ListboxOption } from "../listbox-option/listbox-option";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
 import { applyMixins } from "../utilities/apply-mixins";
-import { ListboxRole } from "./listbox.options";
 
 /**
  * A Listbox Custom HTML Element.
@@ -90,16 +89,6 @@ export abstract class Listbox extends FoundationElement {
      */
     @attr({ mode: "boolean" })
     public disabled: boolean;
-
-    /**
-     * The role of the element.
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: `role`
-     */
-    @attr
-    public role: string = ListboxRole.listbox;
 
     /**
      * The index of the selected option.

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -503,28 +503,28 @@ export abstract class Listbox extends FoundationElement {
  */
 export class DelegatesARIAListbox {
     /**
-     * See {@link https://www.w3.org/WAI/PF/aria/roles#listbox} for more information
+     * See {@link https://www.w3.org/TR/wai-aria-1.2/#listbox} for more information
      * @public
      * @remarks
-     * HTML Attribute: aria-activedescendant
+     * HTML Attribute: `aria-activedescendant`
      */
     @observable
-    public ariaActiveDescendant: string = "";
+    public ariaActiveDescendant: string;
 
     /**
-     * See {@link https://www.w3.org/WAI/PF/aria/roles#listbox} for more information
+     * See {@link https://www.w3.org/TR/wai-aria-1.2/#listbox} for more information
      * @public
      * @remarks
-     * HTML Attribute: aria-disabled
+     * HTML Attribute: `aria-disabled`
      */
     @observable
     public ariaDisabled: "true" | "false";
 
     /**
-     * See {@link https://www.w3.org/WAI/PF/aria/roles#listbox} for more information
+     * See {@link https://www.w3.org/TR/wai-aria-1.2/#listbox} for more information
      * @public
      * @remarks
-     * HTML Attribute: aria-expanded
+     * HTML Attribute: `aria-expanded`
      */
     @observable
     public ariaExpanded: "true" | "false" | undefined;

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -445,18 +445,23 @@ export abstract class Listbox extends FoundationElement {
      * @internal
      */
     public slottedOptionsChanged(prev: Element[] | unknown, next: Element[]) {
+        this.options = next.reduce<ListboxOption[]>((options, item) => {
+            if (isListboxOption(item)) {
+                options.push(item);
+            }
+            return options;
+        }, []);
+
+        const setSize = `${this.options.length}`;
+        this.options.forEach((option, index) => {
+            if (!option.id) {
+                option.id = uniqueId("option-");
+            }
+            option.ariaPosInSet = `${index + 1}`;
+            option.ariaSetSize = setSize;
+        });
+
         if (this.$fastController.isConnected) {
-            this.options = next.reduce((options, item) => {
-                if (isListboxOption(item)) {
-                    options.push(item);
-                }
-                return options;
-            }, [] as ListboxOption[]);
-
-            this.options.forEach(o => {
-                o.id = o.id || uniqueId("option-");
-            });
-
             this.setSelectedOptions();
             this.setDefaultSelectedOption();
         }

--- a/packages/web-components/fast-foundation/src/select/select.options.ts
+++ b/packages/web-components/fast-foundation/src/select/select.options.ts
@@ -6,11 +6,3 @@ export enum SelectPosition {
     above = "above",
     below = "below",
 }
-
-/**
- * Select role.
- * @public
- */
-export enum SelectRole {
-    combobox = "combobox",
-}

--- a/packages/web-components/fast-foundation/src/select/select.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.spec.ts
@@ -1,8 +1,8 @@
-import { assert, expect } from "chai";
 import { DOM } from "@microsoft/fast-element";
 import { keyArrowDown, keyArrowUp, keyEnd, keyHome } from "@microsoft/fast-web-utilities";
-import { fixture } from "../test-utilities/fixture";
+import { expect } from "chai";
 import { ListboxOption, listboxOptionTemplate } from "../listbox-option";
+import { fixture } from "../test-utilities/fixture";
 import { timeout } from "../test-utilities/timeout";
 import { Select, selectTemplate as template } from "./index";
 
@@ -37,16 +37,6 @@ async function setup() {
 
 // TODO: Need to add tests for keyboard handling & focus management
 describe("Select", () => {
-    it("should include a role of `combobox`", async () => {
-        const { element, connect, disconnect } = await setup();
-
-        await connect();
-
-        assert.strictEqual(element.getAttribute("role"), "combobox");
-
-        await disconnect();
-    });
-
     it("should set the `aria-disabled` attribute equal to the `disabled` value", async () => {
         const { element, connect, disconnect } = await setup();
 

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -16,7 +16,7 @@ export const selectTemplate: FoundationElementTemplate<
     <template
         class="${x => (x.open ? "open" : "")} ${x =>
             x.disabled ? "disabled" : ""} ${x => x.position}"
-        role="${x => x.role}"
+        role="combobox"
         tabindex="${x => (!x.disabled ? "0" : null)}"
         aria-disabled="${x => x.ariaDisabled}"
         aria-expanded="${x => x.ariaExpanded}"
@@ -27,7 +27,6 @@ export const selectTemplate: FoundationElementTemplate<
         <div
             aria-activedescendant="${x => (x.open ? x.ariaActiveDescendant : null)}"
             aria-controls="listbox"
-            aria-expanded="${x => x.ariaExpanded}"
             aria-haspopup="listbox"
             class="control"
             part="control"

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -1,21 +1,18 @@
 import { html, ref, slotted } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
+import type { FoundationElementTemplate } from "../foundation-element";
 import { Listbox } from "../listbox/listbox";
 import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end";
-import type { ElementDefinitionContext } from "../design-system";
 import type { Select, SelectOptions } from "./select";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(Select:class)} component.
  * @public
  */
-export const selectTemplate: (
-    context: ElementDefinitionContext,
-    definition: SelectOptions
-) => ViewTemplate<Select> = (
-    context: ElementDefinitionContext,
-    definition: SelectOptions
-) => html`
+export const selectTemplate: FoundationElementTemplate<
+    ViewTemplate<Select>,
+    SelectOptions
+> = (context, definition) => html`
     <template
         class="${x => (x.open ? "open" : "")} ${x =>
             x.disabled ? "disabled" : ""} ${x => x.position}"

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -16,29 +16,24 @@ export const selectTemplate: FoundationElementTemplate<
     <template
         class="${x => (x.open ? "open" : "")} ${x =>
             x.disabled ? "disabled" : ""} ${x => x.position}"
-        role="combobox"
-        tabindex="${x => (!x.disabled ? "0" : null)}"
+        aria-activedescendant="${x => x.ariaActiveDescendant}"
+        aria-controls="${x => x.ariaControls}"
         aria-disabled="${x => x.ariaDisabled}"
         aria-expanded="${x => x.ariaExpanded}"
+        aria-haspopup="listbox"
+        role="combobox"
+        tabindex="${x => (!x.disabled ? "0" : null)}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
         @focusout="${(x, c) => x.focusoutHandler(c.event as FocusEvent)}"
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
     >
-        <div
-            aria-activedescendant="${x => (x.open ? x.ariaActiveDescendant : null)}"
-            aria-controls="listbox"
-            aria-haspopup="listbox"
-            class="control"
-            part="control"
-            role="button"
-            ?disabled="${x => x.disabled}"
-        >
+        <div class="control" part="control" ?disabled="${x => x.disabled}">
             ${startSlotTemplate(context, definition)}
             <slot name="button-container">
                 <div class="selected-value" part="selected-value">
                     <slot name="selected-value">${x => x.displayValue}</slot>
                 </div>
-                <div class="indicator" part="indicator">
+                <div aria-hidden="true" class="indicator" part="indicator">
                     <slot name="indicator">
                         ${definition.indicator || ""}
                     </slot>
@@ -47,9 +42,7 @@ export const selectTemplate: FoundationElementTemplate<
             ${endSlotTemplate(context, definition)}
         </div>
         <div
-            aria-disabled="${x => x.disabled}"
             class="listbox"
-            id="listbox"
             part="listbox"
             role="listbox"
             ?disabled="${x => x.disabled}"

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -1,13 +1,10 @@
-import {
-    attr,
-    Observable,
-    observable,
-    SyntheticViewTemplate,
-} from "@microsoft/fast-element";
+import { attr, Observable, observable } from "@microsoft/fast-element";
+import type { SyntheticViewTemplate } from "@microsoft/fast-element";
 import type { FoundationElementDefinition } from "../foundation-element";
 import type { ListboxOption } from "../listbox-option/listbox-option";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
-import { StartEnd, StartEndOptions } from "../patterns/start-end";
+import { StartEnd } from "../patterns/start-end";
+import type { StartEndOptions } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 import { FormAssociatedSelect } from "./select.form-associated";
 import { SelectPosition, SelectRole } from "./select.options";

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -7,7 +7,7 @@ import { StartEnd } from "../patterns/start-end";
 import type { StartEndOptions } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
 import { FormAssociatedSelect } from "./select.form-associated";
-import { SelectPosition, SelectRole } from "./select.options";
+import { SelectPosition } from "./select.options";
 
 /**
  * Select configuration options
@@ -138,15 +138,6 @@ export class Select extends FormAssociatedSelect {
      * @internal
      */
     private forcedPosition: boolean = false;
-
-    /**
-     * The role of the element.
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: role
-     */
-    public role: SelectRole = SelectRole.combobox;
 
     /**
      * Holds the current state for the calculated position of the listbox.

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -1,8 +1,9 @@
 import { attr, Observable, observable } from "@microsoft/fast-element";
 import type { SyntheticViewTemplate } from "@microsoft/fast-element";
+import { uniqueId } from "@microsoft/fast-web-utilities";
 import type { FoundationElementDefinition } from "../foundation-element";
+import { DelegatesARIAListbox } from "../listbox";
 import type { ListboxOption } from "../listbox-option/listbox-option";
-import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
 import { StartEnd } from "../patterns/start-end";
 import type { StartEndOptions } from "../patterns/start-end";
 import { applyMixins } from "../utilities/apply-mixins";
@@ -33,12 +34,18 @@ export class Select extends FormAssociatedSelect {
     @attr({ attribute: "open", mode: "boolean" })
     public open: boolean = false;
     protected openChanged() {
-        this.ariaExpanded = this.open ? "true" : "false";
         if (this.open) {
+            this.ariaControls = this.listbox.id;
+            this.ariaExpanded = "true";
+
             this.setPositioning();
             this.focusAndScrollOptionIntoView();
             this.indexWhenOpened = this.selectedIndex;
+            return;
         }
+
+        this.ariaControls = "";
+        this.ariaExpanded = "false";
     }
 
     private indexWhenOpened: number;
@@ -372,6 +379,10 @@ export class Select extends FormAssociatedSelect {
     public connectedCallback() {
         super.connectedCallback();
         this.forcedPosition = !!this.positionAttribute;
+
+        if (!this.listbox.id) {
+            this.listbox.id = uniqueId("listbox-");
+        }
     }
 }
 
@@ -382,22 +393,13 @@ export class Select extends FormAssociatedSelect {
  */
 export class DelegatesARIASelect {
     /**
-     * See {@link https://www.w3.org/WAI/PF/aria/roles#button} for more information
+     * See {@link https://www.w3.org/TR/wai-aria-1.2/#combobox} for more information
      * @public
      * @remarks
-     * HTML Attribute: aria-expanded
+     * HTML Attribute: `aria-controls`
      */
     @observable
-    public ariaExpanded: "true" | "false" | undefined;
-
-    /**
-     * See {@link https://www.w3.org/WAI/PF/aria/roles#button} for more information
-     * @public
-     * @remarks
-     * HTML Attribute: aria-pressed
-     */
-    @attr({ attribute: "aria-pressed", mode: "fromView" })
-    public ariaPressed: "true" | "false" | "mixed" | undefined;
+    public ariaControls: string;
 }
 
 /**
@@ -406,8 +408,8 @@ export class DelegatesARIASelect {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface DelegatesARIASelect extends ARIAGlobalStatesAndProperties {}
-applyMixins(DelegatesARIASelect, ARIAGlobalStatesAndProperties);
+export interface DelegatesARIASelect extends DelegatesARIAListbox {}
+applyMixins(DelegatesARIASelect, DelegatesARIAListbox);
 
 /**
  * @internal

--- a/sites/site-utilities/statics/assets/components/fast-listbox.schema.json
+++ b/sites/site-utilities/statics/assets/components/fast-listbox.schema.json
@@ -8,16 +8,6 @@
   "version": 1.1,
   "mapsToTagName": "fast-listbox",
   "properties": {
-    "role": {
-      "enum": [
-        "listbox"
-      ],
-      "default": "listbox",
-      "title": "Role",
-      "description": "The ARIA role for the listbox",
-      "mapsToAttribute": "role",
-      "type": "string"
-    },
     "disabled": {
       "title": "Disabled",
       "description": "Sets the disabled state of the listbox",


### PR DESCRIPTION
# Pull Request

## 📖 Description

Improves the ARIA states and property handling for the `<fast-option>`, `<fast-listbox>`, `<fast-select>`, and `<fast-combobox>` components.

* Adds `aria-posinset` and `aria-setsize` attributes to `<fast-option>`
* Moves ARIA properties from the `<template>` to the internal `<input>` in `<fast-combobox>`
* Sets the `aria-controls` to match the internal `listbox` element in `<fast-select>` and `<fast-combobox>`

### 🎫 Issues

Fixes #5243 and #4824.

## 👩‍💻 Reviewer Notes

Screen reader results can vary drastically based on configuration and browser environment, so I compared the output to these examples:

* [Scrollable Listbox](https://w3c.github.io/aria-practices/examples/listbox/listbox-scrollable.html)
* [Select-Only Combobox](https://w3c.github.io/aria-practices/examples/combobox/combobox-select-only.html)
* [Editable Combobox With Both List and Inline Autocomplete](https://w3c.github.io/aria-practices/examples/combobox/combobox-autocomplete-both.html)

## 📑 Test Plan

Tested with Edge 96 in Windows 11 with Narrator.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

This PR is part of a series, split from #4974 to unblock improvements made independently of multiple selection mode.