### PR TITLE
docs(badge): describe color

### DIFF
--- a/packages/web-components/fast-foundation/src/badge/badge.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.ts
@@ -17,7 +17,7 @@ export class Badge extends FoundationElement {
     public fill: string;
 
     /**
-     * Indicates the badge should have a filled style.
+     * Indicates the badge's color.
      *
      * @public
      * @remarks


### PR DESCRIPTION
is color a public API? it doesn't appear in the [readme's API](https://github.com/microsoft/fast/blob/b816a09d0cf393567396e3f5a8e06312798dc05e/packages/web-components/fast-foundation/src/badge/badge.spec.md#api)
