### PR TITLE
feat: add valueAsNumber property to number field and slider

### DIFF
--- a/change/@microsoft-fast-foundation-4ee40a31-ef0d-49e1-bf01-ca13520e74d9.json
+++ b/change/@microsoft-fast-foundation-4ee40a31-ef0d-49e1-bf01-ca13520e74d9.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add valueAsNumber to number field and slider",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "5454342+brianehenry@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1621,6 +1621,8 @@ export class NumberField extends FormAssociatedNumberField {
     step: number;
     stepDown(): void;
     stepUp(): void;
+    get valueAsNumber(): number;
+    set valueAsNumber(next: number);
     // @internal
     valueChanged(previous: string, next: string): void;
 }
@@ -2162,6 +2164,8 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     trackMinWidth: number;
     // @internal (undocumented)
     trackWidth: number;
+    get valueAsNumber(): number;
+    set valueAsNumber(next: number);
     // @internal (undocumented)
     valueChanged(previous: any, next: any): void;
     valueTextFormatter: (value: string) => string | null;

--- a/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.spec.ts
@@ -883,4 +883,26 @@ describe("NumberField", () => {
             await disconnect();
         });
     });
+
+    describe("valueAsNumber", () => {
+        it("should allow setting value with number", async () => {
+            const { element, disconnect } = await setup();
+
+            element.valueAsNumber = 18;
+
+            expect(element.value).to.equal("18");
+
+            await disconnect();
+        });
+
+        it("should allow reading value as number", async () => {
+            const { element, disconnect } = await setup();
+
+            element.value = "18";
+
+            expect(element.valueAsNumber).to.equal(18);
+
+            await disconnect();
+        });
+    });
 });

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -183,6 +183,19 @@ export class NumberField extends FormAssociatedNumberField {
     private isUserInput: boolean = false;
 
     /**
+     * The value property, typed as a number.
+     *
+     * @public
+     */
+    public get valueAsNumber(): number {
+        return parseFloat(super.value);
+    }
+
+    public set valueAsNumber(next: number) {
+        this.value = next.toString();
+    }
+
+    /**
      * Validates that the value is a number between the min and max
      * @param previous - previous stored value
      * @param next - value being updated
@@ -213,7 +226,6 @@ export class NumberField extends FormAssociatedNumberField {
     /**
      * Sets the internal value to a valid number between the min and max properties
      * @param value - user input
-     * @param updateControl - should the text field update to the valid value
      *
      * @internal
      */

--- a/packages/web-components/fast-foundation/src/slider/slider.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.spec.ts
@@ -444,4 +444,26 @@ describe("Slider", () => {
             await disconnect();
         });
     });
+
+    describe("valueAsNumber", () => {
+        it("should allow setting value with number", async () => {
+            const { element, disconnect } = await setup();
+
+            element.valueAsNumber = 18;
+
+            expect(element.value).to.equal("18");
+
+            await disconnect();
+        });
+
+        it("should allow reading value as number", async () => {
+            const { element, disconnect } = await setup();
+
+            element.value = "18";
+
+            expect(element.valueAsNumber).to.equal(18);
+
+            await disconnect();
+        });
+    });
 });

--- a/packages/web-components/fast-foundation/src/slider/slider.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.ts
@@ -133,6 +133,19 @@ export class Slider extends FormAssociatedSlider implements SliderConfiguration 
     public trackMinHeight: number = 0;
 
     /**
+     * The value property, typed as a number.
+     *
+     * @public
+     */
+    public get valueAsNumber(): number {
+        return parseFloat(super.value);
+    }
+
+    public set valueAsNumber(next: number) {
+        this.value = next.toString();
+    }
+
+    /**
      * Custom function that generates a string for the component's "aria-valuetext" attribute based on the current value.
      *
      * @public


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds `valueAsNumber` property to number field and slider. See linked issue for background.

### 🎫 Issues

Fixes #5506 

## 👩‍💻 Reviewer Notes

Not sure if there needs to be documentation added for this property, let me know if so.

## 📑 Test Plan

Added unit tests for getting/setting `valueAsNumber` property.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

None