### PR TITLE
allow pr deploy steps to continue on errors

### DIFF
--- a/.github/workflows/cd-deploy-color-staging.yml
+++ b/.github/workflows/cd-deploy-color-staging.yml
@@ -85,9 +85,10 @@ jobs:
         name: ${{ env.ARTIFACT_NAME }}
         path: ${{ env.AZURE_WEBAPP_DIST_PATH }}
 
-    - name: Deploy Component Explorer
+    - name: Deploy Color Explorer
       id: deploypr
       uses: Azure/static-web-apps-deploy@v0.0.1-preview
+      continue-on-error: ${{ (github.event_name == 'pull_request' && github.event.action != 'closed') }}
       with:
         azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APP_COLOR_PR_TOKEN }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-deploy-explore-staging.yml
+++ b/.github/workflows/cd-deploy-explore-staging.yml
@@ -88,6 +88,7 @@ jobs:
     - name: Deploy Component Explorer
       id: deploypr
       uses: Azure/static-web-apps-deploy@v0.0.1-preview
+      continue-on-error: ${{ (github.event_name == 'pull_request' && github.event.action != 'closed') }}
       with:
         azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APP_EXPLORE_PR_TOKEN }}
         repo_token: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/cd-deploy-www-staging.yml
+++ b/.github/workflows/cd-deploy-www-staging.yml
@@ -88,6 +88,7 @@ jobs:
       - name: Deploy Documentation
         id: deploypr
         uses: Azure/static-web-apps-deploy@v0.0.1-preview
+        continue-on-error: ${{ (github.event_name == 'pull_request' && github.event.action != 'closed') }}
         with:
           azure_static_web_apps_api_token: ${{ secrets.AZURE_STATIC_WEB_APP_WWW_PR_TOKEN }}
           repo_token: ${{ secrets.GITHUB_TOKEN }}


### PR DESCRIPTION
# Pull Request

## 📖 Description

Allows the PR site deployment steps to continue when encountering errors.

## 👩‍💻 Reviewer Notes

This should make site deployments for PRs succeed with a failure message, rather than display as an action failure.

## 📑 Test Plan

PR deployment steps for both the Color Explorer and Component Explorer may still fail, but they'll no longer cause every PR to appear as if it has completely failed.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

The deploy steps should be modified to either be triggered manually, or made to delete the oldest deployment if there are no more available staging environments.