### PR TITLE
add multiselect functionality to listbox

### DIFF
--- a/change/@microsoft-fast-components-298c2320-eea5-42e0-9ef4-278fb8b7c952.json
+++ b/change/@microsoft-fast-components-298c2320-eea5-42e0-9ef4-278fb8b7c952.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add multiselect functionality to listbox",
+  "packageName": "@microsoft/fast-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-deec4a21-5dbd-4e3d-870c-b1bbc63cfce1.json
+++ b/change/@microsoft-fast-foundation-deec4a21-5dbd-4e3d-870c-b1bbc63cfce1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add multiselect functionality to listbox",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/listbox/README.md
+++ b/packages/web-components/fast-components/src/listbox/README.md
@@ -1,2 +1,3 @@
 # fast-listbox
-An implementation of a [listbox](https://w3c.github.io/aria/#listbox).
+
+An implementation of a [listbox](https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox).

--- a/packages/web-components/fast-components/src/listbox/fixtures/multiselect.html
+++ b/packages/web-components/fast-components/src/listbox/fixtures/multiselect.html
@@ -1,7 +1,7 @@
-<h1>Listbox in single-selection mode</h1>
+<h1>Listbox in multiple-selection mode</h1>
 
 <h2>Default</h2>
-<fast-listbox id="listbox">
+<fast-listbox id="listbox-multiple" multiple>
     <fast-option>William Hartnell</fast-option>
     <fast-option>Patrick Troughton</fast-option>
     <fast-option>Jon Pertwee</fast-option>
@@ -18,35 +18,35 @@
 </fast-listbox>
 
 <h2>Listboxes with size attribute</h2>
-<fast-listbox id="listbox-with-size-1" size="1">
+<fast-listbox id="listbox-with-size-1" size="1" multiple>
     <fast-option>option 1</fast-option>
     <fast-option>option 2</fast-option>
     <fast-option>option 3</fast-option>
     <fast-option>option 4</fast-option>
     <fast-option>option 5</fast-option>
 </fast-listbox>
-<fast-listbox id="listbox-with-size-2" size="2">
+<fast-listbox id="listbox-with-size-2" size="2" multiple>
     <fast-option>option 1</fast-option>
     <fast-option>option 2</fast-option>
     <fast-option>option 3</fast-option>
     <fast-option>option 4</fast-option>
     <fast-option>option 5</fast-option>
 </fast-listbox>
-<fast-listbox id="listbox-with-size-3" size="3">
+<fast-listbox id="listbox-with-size-3" size="3" multiple>
     <fast-option>option 1</fast-option>
     <fast-option>option 2</fast-option>
     <fast-option>option 3</fast-option>
     <fast-option>option 4</fast-option>
     <fast-option>option 5</fast-option>
 </fast-listbox>
-<fast-listbox id="listbox-with-size-4" size="4">
+<fast-listbox id="listbox-with-size-4" size="4" multiple>
     <fast-option>option 1</fast-option>
     <fast-option>option 2</fast-option>
     <fast-option>option 3</fast-option>
     <fast-option>option 4</fast-option>
     <fast-option>option 5</fast-option>
 </fast-listbox>
-<fast-listbox id="listbox-with-size-5" size="5">
+<fast-listbox id="listbox-with-size-5" size="5" multiple>
     <fast-option>option 1</fast-option>
     <fast-option>option 2</fast-option>
     <fast-option>option 3</fast-option>
@@ -55,14 +55,14 @@
 </fast-listbox>
 
 <h2>Listbox with a default selected item</h2>
-<fast-listbox id="listbox-with-default">
+<fast-listbox id="listbox-with-default" multiple>
     <fast-option>John</fast-option>
     <fast-option>Paul</fast-option>
     <fast-option selected>George</fast-option>
     <fast-option>Ringo</fast-option>
 </fast-listbox>
 
-<fast-listbox id="listbox-with-two-default-selected">
+<fast-listbox id="listbox-with-two-default-selected" multiple>
     <fast-option>John</fast-option>
     <fast-option selected>Paul</fast-option>
     <fast-option selected>George</fast-option>
@@ -70,42 +70,42 @@
 </fast-listbox>
 
 <h2>Listbox with disabled items</h2>
-<fast-listbox id="listbox-with-every-other-disabled">
+<fast-listbox id="listbox-with-every-other-disabled" multiple>
     <fast-option>Extra Small</fast-option>
     <fast-option disabled>Small</fast-option>
     <fast-option>Medium</fast-option>
     <fast-option disabled>Large</fast-option>
     <fast-option>Extra Large</fast-option>
 </fast-listbox>
-<fast-listbox id="listbox-with-adjacent-disabled-start">
+<fast-listbox id="listbox-with-adjacent-disabled-start" multiple>
     <fast-option disabled>Extra Small</fast-option>
     <fast-option disabled>Small</fast-option>
     <fast-option>Medium</fast-option>
     <fast-option>Large</fast-option>
     <fast-option>Extra Large</fast-option>
 </fast-listbox>
-<fast-listbox id="listbox-with-adjacent-disabled-middle">
+<fast-listbox id="listbox-with-adjacent-disabled-middle" multiple>
     <fast-option>Extra Small</fast-option>
     <fast-option disabled>Small</fast-option>
     <fast-option disabled>Medium</fast-option>
     <fast-option>Large</fast-option>
     <fast-option>Extra Large</fast-option>
 </fast-listbox>
-<fast-listbox id="listbox-with-adjacent-disabled-end">
+<fast-listbox id="listbox-with-adjacent-disabled-end" multiple>
     <fast-option>Extra Small</fast-option>
     <fast-option>Small</fast-option>
     <fast-option>Medium</fast-option>
     <fast-option disabled>Large</fast-option>
     <fast-option disabled>Extra Large</fast-option>
 </fast-listbox>
-<fast-listbox id="listbox-with-all-but-one-disabled">
+<fast-listbox id="listbox-with-all-but-one-disabled" multiple>
     <fast-option disabled>Extra Small</fast-option>
     <fast-option disabled>Small</fast-option>
     <fast-option disabled>Medium</fast-option>
     <fast-option disabled>Large</fast-option>
     <fast-option>Extra Large</fast-option>
 </fast-listbox>
-<fast-listbox id="listbox-with-all-disabled">
+<fast-listbox id="listbox-with-all-disabled" multiple>
     <fast-option disabled>Extra Small</fast-option>
     <fast-option disabled>Small</fast-option>
     <fast-option disabled>Medium</fast-option>
@@ -114,4 +114,4 @@
 </fast-listbox>
 
 <h2>Empty Listbox</h2>
-<fast-listbox id="listbox-empty"></fast-listbox>
+<fast-listbox id="listbox-empty" multiple></fast-listbox>

--- a/packages/web-components/fast-components/src/listbox/listbox.stories.ts
+++ b/packages/web-components/fast-components/src/listbox/listbox.stories.ts
@@ -1,7 +1,9 @@
 import Base from "./fixtures/base.html";
+import Multiselect from "./fixtures/multiselect.html";
 
 export default {
     title: "Listbox",
 };
 
 export const Listbox = () => Base;
+export const ListboxMultiselect = () => Multiselect;

--- a/packages/web-components/fast-components/src/listbox/listbox.vscode.definition.json
+++ b/packages/web-components/fast-components/src/listbox/listbox.vscode.definition.json
@@ -15,6 +15,14 @@
                     "required": false
                 },
                 {
+                    "name": "multiple",
+                    "title": "Multiple",
+                    "description": "Indicates if the listbox is in multi-selection mode",
+                    "type": "boolean",
+                    "default": false,
+                    "required": false
+                },
+                {
                     "name": "size",
                     "title": "Size",
                     "description": "The maximum number of visible options",

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -808,6 +808,7 @@ export class DelegatesARIAListbox {
     ariaActiveDescendant: string;
     ariaDisabled: "true" | "false";
     ariaExpanded: "true" | "false" | undefined;
+    ariaMultiselectable: "true" | "false" | undefined;
 }
 
 // @internal
@@ -1348,22 +1349,34 @@ export abstract class Listbox extends FoundationElement {
     // @internal
     get firstSelectedOption(): ListboxOption;
     // @internal
-    protected focusAndScrollOptionIntoView(): void;
+    protected focusAndScrollOptionIntoView(optionToFocus?: ListboxOption | null): void;
     // @internal
     focusinHandler(e: FocusEvent): void;
+    // @internal
+    protected getSelectableIndex(prev: number | undefined, next: number): number;
+    // @internal
+    protected getTypeaheadMatches(): ListboxOption[];
+    // @internal
+    handleChange(source: any, propertyName: string): void;
+    // @internal
     handleTypeAhead(key: string): void;
+    // @internal
+    protected get hasSelectableOptions(): boolean;
     // @internal
     keydownHandler(e: KeyboardEvent): boolean | void;
     get length(): number;
     // @internal
     mousedownHandler(e: MouseEvent): boolean | void;
+    multiple: boolean;
+    // @internal
+    multipleChanged(prev: boolean | undefined, next: boolean): void;
     get options(): ListboxOption[];
     set options(value: ListboxOption[]);
     // @internal
     protected _options: ListboxOption[];
     selectedIndex: number;
     // @internal
-    selectedIndexChanged(prev: number, next: number): void;
+    selectedIndexChanged(prev: number | undefined, next: number): void;
     selectedOptions: ListboxOption[];
     // @internal
     protected selectedOptionsChanged(prev: ListboxOption[] | undefined, next: ListboxOption[]): void;
@@ -1383,7 +1396,7 @@ export abstract class Listbox extends FoundationElement {
     // @internal
     slottedOptions: Element[];
     // @internal
-    slottedOptionsChanged(prev: Element[] | unknown, next: Element[]): void;
+    slottedOptionsChanged(prev: Element[] | undefined, next: Element[]): void;
     // @internal
     protected static readonly TYPE_AHEAD_TIMEOUT_MS = 1000;
     // @internal
@@ -1405,11 +1418,57 @@ export interface Listbox extends DelegatesARIAListbox {
 
 // @public
 export class ListboxElement extends Listbox {
+    // @internal
+    protected activeIndex: number;
+    // @internal
+    protected activeIndexChanged(prev: number | undefined, next: number): void;
+    // @internal
+    get activeOption(): ListboxOption | null;
+    // @internal
+    protected checkActiveIndex(): void;
+    // @internal
+    protected get checkedOptions(): ListboxOption[];
+    // @internal
+    protected checkFirstOption(preserveChecked?: boolean): void;
+    // @internal
+    protected checkLastOption(preserveChecked?: boolean): void;
+    // @internal
+    protected checkNextOption(preserveChecked?: boolean): void;
+    // @internal
+    protected checkPreviousOption(preserveChecked?: boolean): void;
+    // @internal @override
+    clickHandler(e: MouseEvent): boolean | void;
+    // @internal @override (undocumented)
+    connectedCallback(): void;
+    // @internal @override (undocumented)
+    disconnectedCallback(): void;
+    // @internal
+    get firstSelectedOptionIndex(): number;
+    // @internal @override (undocumented)
+    protected focusAndScrollOptionIntoView(): void;
+    // @internal @override
+    focusinHandler(e: FocusEvent): boolean | void;
+    // @internal
+    focusoutHandler(e: FocusEvent): void;
+    // @internal @override
+    keydownHandler(e: KeyboardEvent): boolean | void;
     // @internal @override
     mousedownHandler(e: MouseEvent): boolean | void;
+    // @internal @override
+    multipleChanged(prev: boolean | undefined, next: boolean): void;
+    // @internal
+    protected rangeStartIndex: number;
+    // @override
+    protected setSelectedOptions(): void;
     size: number;
     // @internal
     protected sizeChanged(prev: number | unknown, next: number): void;
+    // @internal
+    toggleSelectedForAllCheckedOptions(): void;
+    // @internal @override (undocumented)
+    typeaheadBufferChanged(prev: string, next: string): void;
+    // @internal
+    protected uncheckAllOptions(preserveChecked?: boolean): void;
 }
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -808,7 +808,7 @@ export class DelegatesARIAListbox {
     ariaActiveDescendant: string;
     ariaDisabled: "true" | "false";
     ariaExpanded: "true" | "false" | undefined;
-    ariaMultiselectable: "true" | "false" | undefined;
+    ariaMultiSelectable: "true" | "false" | undefined;
 }
 
 // @internal

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.md
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.md
@@ -2,9 +2,9 @@
 
 ## Overview
 
-The `<fast-option>` component is an option that is intended to be used with `<fast-listbox>` and `<fast-select>`.
+The `<fast-option>` component is an option that is intended to be used with `<fast-listbox>`, `<fast-combobox>`, and `<fast-select>`.
 
-**Note**: To avoid namespace collisions with the [Option() constructor](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement/Option), the component class is `ListboxOption`, and our implementation is defined as `<fast-option>`. This makes the class distinct and keeps the component tag name familiar for authors.
+**Note**: To avoid namespace collisions with the [`Option()` constructor](https://developer.mozilla.org/en-US/docs/Web/API/HTMLOptionElement/Option), the component class is `ListboxOption`, and our implementation is defined as `<fast-option>`. This makes the class distinct and keeps the component tag name familiar for authors.
 
 ### API
 
@@ -59,6 +59,7 @@ The `<fast-option>` component is an option that is intended to be used with `<fa
 
 ### States
 
+- `checked` - The checked state is used when the parent `<fast-listbox>` or `<fast-select>` is in multiple selection mode. To avoid accessibility conflicts, the `checked` state should not be present in single selection mode.
 - `disabled` - when disabled, user interaction has no effect. Disabling the parent `<fast-listbox>` or `<fast-select>` will also prevent user interaction on the `<fast-option>`.
 - `selected` - The selected state is primarily controlled by user interactions on the parent `listbox` component. Changing the `selected` property directly will force the state to change.
 

--- a/packages/web-components/fast-foundation/src/listbox/README.md
+++ b/packages/web-components/fast-foundation/src/listbox/README.md
@@ -5,7 +5,7 @@ sidebar_label: listbox
 custom_edit_url: https://github.com/microsoft/fast/edit/master/packages/web-components/fast-foundation/src/listbox/README.md
 ---
 
-An implementation of a [listbox](https://w3c.github.io/aria-practices/#Listbox). While any DOM content is permissible as a child of the listbox, only [`fast-option`](/docs/components/listbox-option) elements, `option` elements, and slotted items with `role="option"` will be treated as options and receive keyboard support.
+An implementation of a [listbox](https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox). While any DOM content is permissible as a child of the listbox, only [`fast-option`](/docs/components/listbox-option) elements, `option` elements, and slotted items with `role="option"` will be treated as options and receive keyboard support.
 
 The `listbox` component has no internals related to form association. For a form-associated `listbox`, see the [`fast-select` component](/docs/components/select).
 
@@ -59,4 +59,4 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 - [Component explorer examples](https://explore.fast.design/components/fast-listbox)
 - [Component technical specification](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-foundation/src/listbox/listbox.spec.md)
-- [W3C Component Aria Practices](https://w3c.github.io/aria-practices/#Listbox)
+- [W3C Component Aria Practices](https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox)

--- a/packages/web-components/fast-foundation/src/listbox/listbox.element.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.element.ts
@@ -1,4 +1,15 @@
-import { attr, DOM, nullableNumberConverter } from "@microsoft/fast-element";
+import { attr, DOM, nullableNumberConverter, observable } from "@microsoft/fast-element";
+import {
+    inRange,
+    keyArrowDown,
+    keyArrowUp,
+    keyEnd,
+    keyEscape,
+    keyHome,
+    keySpace,
+    keyTab,
+} from "@microsoft/fast-web-utilities";
+import type { ListboxOption } from "../listbox-option/listbox-option";
 import { Listbox } from "./listbox";
 
 /**
@@ -8,6 +19,50 @@ import { Listbox } from "./listbox";
  * @public
  */
 export class ListboxElement extends Listbox {
+    /**
+     * The index of the most recently checked option.
+     *
+     * @internal
+     * @remarks
+     * Multiple-selection mode only.
+     */
+    @observable
+    protected activeIndex: number = -1;
+
+    /**
+     * Returns the last checked option.
+     *
+     * @internal
+     */
+    public get activeOption(): ListboxOption | null {
+        return this.options[this.activeIndex];
+    }
+
+    /**
+     * Returns the list of checked options.
+     *
+     * @internal
+     */
+    protected get checkedOptions(): ListboxOption[] {
+        return this.options?.filter(o => o.checked);
+    }
+
+    /**
+     * Returns the index of the first selected option.
+     *
+     * @internal
+     */
+    public get firstSelectedOptionIndex(): number {
+        return this.options.indexOf(this.firstSelectedOption);
+    }
+
+    /**
+     * The start index when checking a range of options.
+     *
+     * @internal
+     */
+    protected rangeStartIndex: number = -1;
+
     /**
      * The maximum number of options to display.
      *
@@ -20,6 +75,323 @@ export class ListboxElement extends Listbox {
     public size: number;
 
     /**
+     * Updates the `ariaActiveDescendant` property when the active index changes.
+     *
+     * @param prev - the previous active index
+     * @param next - the next active index
+     *
+     * @internal
+     */
+    protected activeIndexChanged(prev: number | undefined, next: number): void {
+        this.ariaActiveDescendant = this.options[next]?.id ?? "";
+        this.focusAndScrollOptionIntoView();
+    }
+
+    /**
+     * Toggles the checked state for the currently active option.
+     *
+     * @remarks
+     * Multiple-selection mode only.
+     *
+     * @internal
+     */
+    protected checkActiveIndex(): void {
+        if (!this.multiple) {
+            return;
+        }
+
+        const activeItem = this.activeOption;
+        if (activeItem) {
+            activeItem.checked = true;
+        }
+    }
+
+    /**
+     * Sets the active index to the first option and marks it as checked.
+     *
+     * @remarks
+     * Multi-selection mode only.
+     *
+     * @param preserveChecked - mark all options unchecked before changing the active index
+     *
+     * @internal
+     */
+    protected checkFirstOption(preserveChecked: boolean = false): void {
+        if (preserveChecked) {
+            if (this.rangeStartIndex === -1) {
+                this.rangeStartIndex = this.activeIndex + 1;
+            }
+
+            this.options.forEach((o, i) => {
+                o.checked = inRange(i, this.rangeStartIndex);
+            });
+        } else {
+            this.uncheckAllOptions();
+        }
+
+        this.activeIndex = 0;
+        this.checkActiveIndex();
+    }
+
+    /**
+     * Decrements the active index and sets the matching option as checked.
+     *
+     * @remarks
+     * Multi-selection mode only.
+     *
+     * @param preserveChecked - mark all options unchecked before changing the active index
+     *
+     * @internal
+     */
+    protected checkLastOption(preserveChecked: boolean = false): void {
+        if (preserveChecked) {
+            if (this.rangeStartIndex === -1) {
+                this.rangeStartIndex = this.activeIndex;
+            }
+
+            this.options.forEach((o, i) => {
+                o.checked = inRange(i, this.rangeStartIndex, this.options.length);
+            });
+        } else {
+            this.uncheckAllOptions();
+        }
+
+        this.activeIndex = this.options.length - 1;
+        this.checkActiveIndex();
+    }
+
+    /**
+     * @override
+     * @internal
+     */
+    public connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener("focusout", this.focusoutHandler);
+    }
+
+    /**
+     * @override
+     * @internal
+     */
+    public disconnectedCallback(): void {
+        this.removeEventListener("focusout", this.focusoutHandler);
+        super.disconnectedCallback();
+    }
+
+    /**
+     * Increments the active index and marks the matching option as checked.
+     *
+     * @remarks
+     * Multiple-selection mode only.
+     *
+     * @param preserveChecked - mark all options unchecked before changing the active index
+     *
+     * @internal
+     */
+    protected checkNextOption(preserveChecked: boolean = false): void {
+        if (preserveChecked) {
+            if (this.rangeStartIndex === -1) {
+                this.rangeStartIndex = this.activeIndex;
+            }
+
+            this.options.forEach((o, i) => {
+                o.checked = inRange(i, this.rangeStartIndex, this.activeIndex + 1);
+            });
+        } else {
+            this.uncheckAllOptions();
+        }
+
+        this.activeIndex += this.activeIndex < this.options.length - 1 ? 1 : 0;
+        this.checkActiveIndex();
+    }
+
+    /**
+     * Decrements the active index and marks the matching option as checked.
+     *
+     * @remarks
+     * Multiple-selection mode only.
+     *
+     * @param preserveChecked - mark all options unchecked before changing the active index
+     *
+     * @internal
+     */
+    protected checkPreviousOption(preserveChecked: boolean = false): void {
+        if (preserveChecked) {
+            if (this.rangeStartIndex === -1) {
+                this.rangeStartIndex = this.activeIndex;
+            }
+
+            if (this.checkedOptions.length === 1) {
+                this.rangeStartIndex += 1;
+            }
+
+            this.options.forEach((o, i) => {
+                o.checked = inRange(i, this.activeIndex, this.rangeStartIndex);
+            });
+        } else {
+            this.uncheckAllOptions();
+        }
+
+        this.activeIndex -= this.activeIndex > 0 ? 1 : 0;
+        this.checkActiveIndex();
+    }
+
+    /**
+     * Handles click events for listbox options.
+     *
+     * @param e - the event object
+     *
+     * @override
+     * @internal
+     */
+    public clickHandler(e: MouseEvent): boolean | void {
+        if (!this.multiple) {
+            return super.clickHandler(e);
+        }
+
+        const captured = (e.target as Element | null)?.closest<ListboxOption>(
+            `[role=option]`
+        );
+
+        if (!captured || captured.disabled) {
+            return;
+        }
+
+        this.uncheckAllOptions();
+        this.activeIndex = this.options.indexOf(captured);
+        this.checkActiveIndex();
+        this.toggleSelectedForAllCheckedOptions();
+
+        return true;
+    }
+
+    /**
+     * @override
+     * @internal
+     */
+    protected focusAndScrollOptionIntoView(): void {
+        super.focusAndScrollOptionIntoView(this.activeOption);
+    }
+
+    /**
+     * In multiple-selection mode:
+     * If any options are selected, the first selected option is checked when
+     * the listbox receives focus. If no options are selected, the first
+     * selectable option is checked.
+     *
+     * @override
+     * @internal
+     */
+    public focusinHandler(e: FocusEvent): boolean | void {
+        if (!this.multiple) {
+            return super.focusinHandler(e);
+        }
+
+        if (!this.shouldSkipFocus && e.target === e.currentTarget) {
+            this.uncheckAllOptions();
+
+            if (this.activeIndex === -1) {
+                this.activeIndex =
+                    this.firstSelectedOptionIndex !== -1
+                        ? this.firstSelectedOptionIndex
+                        : 0;
+            }
+
+            this.checkActiveIndex();
+            this.setSelectedOptions();
+            this.focusAndScrollOptionIntoView();
+        }
+
+        this.shouldSkipFocus = false;
+    }
+
+    /**
+     * Unchecks all options when the listbox loses focus.
+     *
+     * @internal
+     */
+    public focusoutHandler(e: FocusEvent): void {
+        if (this.multiple) {
+            this.uncheckAllOptions();
+        }
+    }
+
+    /**
+     * Handles keydown actions for listbox navigation and typeahead
+     *
+     * @override
+     * @internal
+     */
+    public keydownHandler(e: KeyboardEvent): boolean | void {
+        if (!this.multiple) {
+            return super.keydownHandler(e);
+        }
+
+        if (this.disabled) {
+            return true;
+        }
+
+        const { key, shiftKey } = e;
+
+        this.shouldSkipFocus = false;
+
+        switch (key) {
+            // Select the first available option
+            case keyHome: {
+                this.checkFirstOption(shiftKey);
+                return;
+            }
+
+            // Select the next selectable option
+            case keyArrowDown: {
+                this.checkNextOption(shiftKey);
+                return;
+            }
+
+            // Select the previous selectable option
+            case keyArrowUp: {
+                this.checkPreviousOption(shiftKey);
+                return;
+            }
+
+            // Select the last available option
+            case keyEnd: {
+                this.checkLastOption(shiftKey);
+                return;
+            }
+
+            case keyTab: {
+                this.focusAndScrollOptionIntoView();
+                return true;
+            }
+
+            case keyEscape: {
+                if (this.multiple) {
+                    this.uncheckAllOptions();
+                    this.checkActiveIndex();
+                }
+                return true;
+            }
+
+            case keySpace: {
+                e.preventDefault();
+                if (this.typeAheadExpired) {
+                    this.toggleSelectedForAllCheckedOptions();
+                }
+                return;
+            }
+
+            // Send key to Typeahead handler
+            default: {
+                if (key.length === 1) {
+                    this.handleTypeAhead(`${key}`);
+                }
+                return true;
+            }
+        }
+    }
+
+    /**
      * Prevents `focusin` events from firing before `click` events when the
      * element is unfocused.
      *
@@ -29,6 +401,43 @@ export class ListboxElement extends Listbox {
     public mousedownHandler(e: MouseEvent): boolean | void {
         if (e.offsetX >= 0 && e.offsetX <= this.scrollWidth) {
             return super.mousedownHandler(e);
+        }
+    }
+
+    /**
+     * Switches between single-selection and multi-selection mode.
+     *
+     * @override
+     * @internal
+     */
+    public multipleChanged(prev: boolean | undefined, next: boolean): void {
+        super.multipleChanged(prev, next);
+        this.options?.forEach(o => {
+            o.checked = next ? false : undefined;
+        });
+
+        this.setSelectedOptions();
+
+        if (next && !this.size) {
+            this.size = 0;
+        }
+    }
+
+    /**
+     * Sets an option as selected and gives it focus.
+     *
+     * @override
+     * @public
+     */
+    protected setSelectedOptions() {
+        if (!this.multiple) {
+            super.setSelectedOptions();
+            return;
+        }
+
+        if (this.$fastController.isConnected && this.options) {
+            this.selectedOptions = this.options.filter(o => o.selected);
+            this.focusAndScrollOptionIntoView();
         }
     }
 
@@ -46,6 +455,66 @@ export class ListboxElement extends Listbox {
             DOM.queueUpdate(() => {
                 this.size = size;
             });
+        }
+    }
+
+    /**
+     * Toggles the selected state of the provided options. If any provided items
+     * are in an unselected state, all items are set to selected. If every
+     * provided item is selected, they are all unselected.
+     *
+     * @internal
+     */
+    public toggleSelectedForAllCheckedOptions(): void {
+        const enabledCheckedOptions = this.checkedOptions.filter(o => !o.disabled);
+        const force = !enabledCheckedOptions.every(o => o.selected);
+        enabledCheckedOptions.forEach(o => (o.selected = force));
+        this.selectedIndex = this.options.indexOf(
+            enabledCheckedOptions[enabledCheckedOptions.length - 1]
+        );
+
+        this.setSelectedOptions();
+    }
+
+    /**
+     * @override
+     * @internal
+     */
+    public typeaheadBufferChanged(prev: string, next: string): void {
+        if (!this.multiple) {
+            super.typeaheadBufferChanged(prev, next);
+            return;
+        }
+
+        if (this.$fastController.isConnected) {
+            const typeaheadMatches = this.getTypeaheadMatches();
+            if (typeaheadMatches) {
+                const activeIndex = this.options.indexOf(this.getTypeaheadMatches[0]);
+                if (activeIndex > -1) {
+                    this.activeIndex = activeIndex;
+                    this.uncheckAllOptions();
+                    this.checkActiveIndex();
+                }
+            }
+
+            this.typeAheadExpired = false;
+        }
+    }
+
+    /**
+     * Unchecks all options.
+     *
+     * @remarks
+     * Multiple-selection mode only.
+     *
+     * @param preserveChecked - reset the rangeStartIndex
+     *
+     * @internal
+     */
+    protected uncheckAllOptions(preserveChecked: boolean = false): void {
+        this.options.forEach(o => (o.checked = this.multiple ? false : undefined));
+        if (!preserveChecked) {
+            this.rangeStartIndex = -1;
         }
     }
 }

--- a/packages/web-components/fast-foundation/src/listbox/listbox.spec.md
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.spec.md
@@ -6,17 +6,16 @@ The `listbox` component is a component that provides a navigatable list of optio
 
 ### Background
 
-This component is used as a building block for other components in this library that need a way for users to choose distinct options from a list. The goal for `listbox` is to handle implementation details related to the [`listbox`](https://www.w3.org/TR/wai-aria-practices-1.1/#Listbox) and [`combobox`](https://www.w3.org/TR/wai-aria-practices-1.1/#combobox) aria roles.
+This component is used as a building block for other components in this library that need a way for users to choose distinct options from a list. The goal for `listbox` is to handle implementation details related to the [`listbox`](https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox) and [`combobox`](https://www.w3.org/TR/wai-aria-practices-1.2/#combobox) aria roles.
 
 ### Features
 
-- **Single and multiple selection mode**: Users can choose one or multiple options when the `multiple` attribute is present. *(Note: While our implementation currently only supports single selection mode, multiple selection mode is being tracked in [issue #4190](https://github.com/microsoft/fast/issues/4190).)*
-- **Keyboard navigation and type-ahead**: When the `listbox` is focused, keyboard navigation with the arrow keys will cycle through the available options. Type-ahead is also supported. See [Keyboard Interaction](https://www.w3.org/TR/wai-aria-practices-1.1/#listbox_kbd_interaction) for more details.
-- Users can choose one or multiple options when the `multiple` attribute is present.
+- **Single and multiple selection mode**: Users can choose one or multiple options when the `multiple` attribute is present.
+- **Keyboard navigation and type-ahead**: When the `listbox` is focused, keyboard navigation with the arrow keys will cycle through the available options. Type-ahead is also supported. See [Keyboard Interaction](https://www.w3.org/TR/wai-aria-practices-1.2/#listbox_kbd_interaction) for more details.
 
 ### Prior Art/Examples
 
-- [W3 Example](https://www.w3.org/TR/wai-aria-practices-1.1/examples/listbox/listbox-scrollable.html)
+- [W3 Example](https://www.w3.org/TR/wai-aria-practices-1.2/examples/listbox/listbox-scrollable.html)
 
 ---
 
@@ -29,6 +28,7 @@ This component is used as a building block for other components in this library 
 *Attributes and Properties*:
 
 - `disabled` - Disables the control.
+- `multiple` - Indicates if the listbox is in multi-selection mode.
 - `options` - An array of all options in the `listbox`.
 - `selectedOptions` - A collection of the selected options in the `listbox`.
 - `selectedIndex` - The index of the first selected option, or `-1` if nothing is selected. Setting the `selectedIndex` property will update the `selected` state of the option at the new index. Out of range values will reset the `selectedIndex` to `-1`.
@@ -77,7 +77,7 @@ This component is used as a building block for other components in this library 
 
 ### Accessibility
 
-*Listbox* is RTL compliant and supports the following aria best practices for listbox [W3C aria-practices](https://www.w3.org/TR/wai-aria-practices-1.1/#Listbox).
+*Listbox* is RTL compliant and supports the following aria best practices for listbox [W3C aria-practices](https://www.w3.org/TR/wai-aria-practices-1.2/#Listbox).
 
 ### Test Plan
 

--- a/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
@@ -89,6 +89,26 @@ describe("Listbox", () => {
         await disconnect();
     });
 
+    it("should set the `selectedIndex` to match the selected option after connection", async () => {
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
+
+        await connect();
+
+        expect(element.selectedIndex).to.equal(0);
+
+        option2.setAttribute("selected", "");
+
+        expect(element.selectedIndex).to.equal(1);
+
+        expect(element.selectedOptions).to.not.contain(option1);
+
+        expect(element.selectedOptions).to.contain(option2);
+
+        expect(element.selectedOptions).to.not.contain(option3);
+
+        await disconnect();
+    });
+
     it("should set the `size` property to match the `size` attribute", async () => {
         const { element, connect, disconnect } = await setup();
 
@@ -216,6 +236,26 @@ describe("Listbox", () => {
         await DOM.nextUpdate();
 
         expect(element.getAttribute("aria-activedescendant")).to.equal(option3.id);
+
+        await disconnect();
+    });
+
+    it("should set the `aria-multiselectable` attribute to match the `multiple` attribute", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        element.multiple = true;
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-multiselectable")).to.equal("true");
+
+        element.multiple = false;
+
+        await DOM.nextUpdate();
+
+        expect(element.getAttribute("aria-multiselectable")).to.not.exist;
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
@@ -13,6 +13,7 @@ export const listboxTemplate: FoundationElementTemplate<ViewTemplate<ListboxElem
 ) => html`
     <template
         aria-activedescendant="${x => x.ariaActiveDescendant}"
+        aria-multiselectable="${x => x.ariaMultiselectable}"
         class="listbox"
         role="listbox"
         tabindex="${x => (!x.disabled ? "0" : null)}"

--- a/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
@@ -13,7 +13,7 @@ export const listboxTemplate: FoundationElementTemplate<ViewTemplate<ListboxElem
 ) => html`
     <template
         aria-activedescendant="${x => x.ariaActiveDescendant}"
-        aria-multiselectable="${x => x.ariaMultiselectable}"
+        aria-multiselectable="${x => x.ariaMultiSelectable}"
         class="listbox"
         role="listbox"
         tabindex="${x => (!x.disabled ? "0" : null)}"

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -1,5 +1,6 @@
 import { attr, observable, Observable } from "@microsoft/fast-element";
 import {
+    findLastIndex,
     keyArrowDown,
     keyArrowUp,
     keyEnd,
@@ -39,16 +40,21 @@ export abstract class Listbox extends FoundationElement {
     }
 
     /**
+     * Returns true if there is one or more selectable option.
+     *
+     * @internal
+     */
+    protected get hasSelectableOptions(): boolean {
+        return this.options.length > 0 && !this.options.every(o => o.disabled);
+    }
+
+    /**
      * The number of options.
      *
      * @public
      */
     public get length(): number {
-        if (this.options) {
-            return this.options.length;
-        }
-
-        return 0;
+        return this.options?.length ?? 0;
     }
 
     /**
@@ -89,6 +95,17 @@ export abstract class Listbox extends FoundationElement {
      */
     @attr({ mode: "boolean" })
     public disabled: boolean;
+
+    /**
+     * Indicates if the listbox is in multi-selection mode.
+     *
+     * @remarks
+     * HTML Attribute: `multiple`
+     *
+     * @public
+     */
+    @attr({ mode: "boolean" })
+    public multiple: boolean;
 
     /**
      * The index of the selected option.
@@ -177,16 +194,21 @@ export abstract class Listbox extends FoundationElement {
     }
 
     /**
-     * Focus the first selected option and scroll it into view.
+     * Ensures that the provided option is focused and scrolled into view.
      *
+     * @param optionToFocus - The option to focus
      * @internal
      */
-    protected focusAndScrollOptionIntoView(): void {
-        if (this.contains(document.activeElement) && this.firstSelectedOption) {
-            this.firstSelectedOption.focus();
-            requestAnimationFrame(() => {
-                this.firstSelectedOption.scrollIntoView({ block: "nearest" });
-            });
+    protected focusAndScrollOptionIntoView(
+        optionToFocus: ListboxOption | null = this.firstSelectedOption
+    ): void {
+        if (this.contains(document.activeElement)) {
+            if (optionToFocus) {
+                optionToFocus.focus();
+                requestAnimationFrame(() => {
+                    optionToFocus.scrollIntoView({ block: "nearest" });
+                });
+            }
         }
     }
 
@@ -207,12 +229,93 @@ export abstract class Listbox extends FoundationElement {
     }
 
     /**
+     * Returns the options which match the current typeahead buffer.
+     *
+     * @internal
+     */
+    protected getTypeaheadMatches(): ListboxOption[] {
+        const pattern = this.typeaheadBuffer.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
+        const re = new RegExp(`^${pattern}`, "gi");
+        return this.options.filter((o: ListboxOption) => o.text.trim().match(re));
+    }
+
+    /**
+     * Determines the index of the next option which is selectable, if any.
+     *
+     * @param prev - the previous selected index
+     * @param next - the next index to select
+     *
+     * @internal
+     */
+    protected getSelectableIndex(prev: number = this.selectedIndex, next: number) {
+        const direction = prev > next ? -1 : prev < next ? 1 : 0;
+        const potentialDirection = prev + direction;
+
+        let nextSelectableOption: ListboxOption | null = null;
+
+        switch (direction) {
+            case -1: {
+                nextSelectableOption = this.options.reduceRight(
+                    (nextSelectableOption, thisOption, index) =>
+                        !nextSelectableOption &&
+                        !thisOption.disabled &&
+                        index < potentialDirection
+                            ? thisOption
+                            : nextSelectableOption,
+                    nextSelectableOption
+                );
+                break;
+            }
+
+            case 1: {
+                nextSelectableOption = this.options.reduce(
+                    (nextSelectableOption, thisOption, index) =>
+                        !nextSelectableOption &&
+                        !thisOption.disabled &&
+                        index > potentialDirection
+                            ? thisOption
+                            : nextSelectableOption,
+                    nextSelectableOption
+                );
+                break;
+            }
+
+            default:
+            // impossible!
+        }
+
+        return this.options.indexOf(nextSelectableOption as any);
+    }
+
+    /**
+     * Handles external changes to child options.
+     *
+     * @param source - the source object
+     * @param propertyName - the property
+     *
+     * @internal
+     */
+    public handleChange(source: any, propertyName: string) {
+        switch (propertyName) {
+            case "selected": {
+                if (Listbox.slottedOptionFilter(source)) {
+                    this.selectedIndex = this.options.indexOf(source);
+                }
+                this.setSelectedOptions();
+                break;
+            }
+        }
+    }
+
+    /**
      * Moves focus to an option whose label matches characters typed by the user.
      * Consecutive keystrokes are batched into a buffer of search text used
      * to match against the set of options.  If `TYPE_AHEAD_TIMEOUT_MS` passes
      * between consecutive keystrokes, the search restarts.
      *
      * @param key - the key to be evaluated
+     *
+     * @internal
      */
     public handleTypeAhead(key: string): void {
         if (this.typeaheadTimeout) {
@@ -320,6 +423,18 @@ export abstract class Listbox extends FoundationElement {
     }
 
     /**
+     * Switches between single-selection and multi-selection mode.
+     *
+     * @param prev - the previous value of the `multiple` attribute
+     * @param next - the next value of the `multiple` attribute
+     *
+     * @internal
+     */
+    public multipleChanged(prev: boolean | undefined, next: boolean): void {
+        this.ariaMultiselectable = next ? "true" : undefined;
+    }
+
+    /**
      * Updates the list of selected options when the `selectedIndex` changes.
      *
      * @param prev - the previous selected index value
@@ -327,7 +442,22 @@ export abstract class Listbox extends FoundationElement {
      *
      * @internal
      */
-    public selectedIndexChanged(prev: number, next: number): void {
+    public selectedIndexChanged(prev: number | undefined, next: number): void {
+        if (!this.hasSelectableOptions) {
+            this.selectedIndex = -1;
+            return;
+        }
+
+        if (this.options[this.selectedIndex]?.disabled && typeof prev === "number") {
+            const selectableIndex = this.getSelectableIndex(prev, next);
+            const newNext = selectableIndex > -1 ? selectableIndex : prev;
+            this.selectedIndex = newNext;
+            if (next === newNext) {
+                this.selectedIndexChanged(next, newNext);
+            }
+            return;
+        }
+
         this.setSelectedOptions();
     }
 
@@ -343,11 +473,12 @@ export abstract class Listbox extends FoundationElement {
         prev: ListboxOption[] | undefined,
         next: ListboxOption[]
     ): void {
-        if (this.$fastController.isConnected) {
-            this.options.forEach(o => {
-                o.selected = next.includes(o);
-            });
-        }
+        const filteredNext = next.filter(Listbox.slottedOptionFilter);
+        this.options?.forEach(o => {
+            Observable.getNotifier(o).unsubscribe(this, "selected");
+            o.selected = filteredNext.includes(o);
+            Observable.getNotifier(o).subscribe(this, "selected");
+        });
     }
 
     /**
@@ -357,7 +488,7 @@ export abstract class Listbox extends FoundationElement {
      */
     public selectFirstOption(): void {
         if (!this.disabled) {
-            this.selectedIndex = 0;
+            this.selectedIndex = this.options?.findIndex(o => !o.disabled) ?? -1;
         }
     }
 
@@ -368,7 +499,7 @@ export abstract class Listbox extends FoundationElement {
      */
     public selectLastOption(): void {
         if (!this.disabled) {
-            this.selectedIndex = this.options.length - 1;
+            this.selectedIndex = findLastIndex(this.options, o => !o.disabled);
         }
     }
 
@@ -378,11 +509,7 @@ export abstract class Listbox extends FoundationElement {
      * @internal
      */
     public selectNextOption(): void {
-        if (
-            !this.disabled &&
-            this.options &&
-            this.selectedIndex < this.options.length - 1
-        ) {
+        if (!this.disabled && this.selectedIndex < this.options.length - 1) {
             this.selectedIndex += 1;
         }
     }
@@ -404,8 +531,8 @@ export abstract class Listbox extends FoundationElement {
      * @internal
      */
     protected setDefaultSelectedOption() {
-        if (this.options && this.$fastController.isConnected) {
-            const selectedIndex = this.options.findIndex(
+        if (this.$fastController.isConnected) {
+            const selectedIndex = this.options?.findIndex(
                 el => el.getAttribute("selected") !== null
             );
 
@@ -419,18 +546,13 @@ export abstract class Listbox extends FoundationElement {
     }
 
     /**
-     * Sets the selected option and gives it focus.
+     * Sets an option as selected and gives it focus.
      *
      * @public
      */
     protected setSelectedOptions() {
-        if (this.$fastController.isConnected && this.options) {
-            const selectedOption = this.options[this.selectedIndex] ?? null;
-
-            this.selectedOptions = this.options.filter(el =>
-                el.isSameNode(selectedOption)
-            );
-
+        if (this.options?.length) {
+            this.selectedOptions = [this.options[this.selectedIndex]];
             this.ariaActiveDescendant = this.firstSelectedOption?.id ?? "";
             this.focusAndScrollOptionIntoView();
         }
@@ -444,7 +566,7 @@ export abstract class Listbox extends FoundationElement {
      *
      * @internal
      */
-    public slottedOptionsChanged(prev: Element[] | unknown, next: Element[]) {
+    public slottedOptionsChanged(prev: Element[] | undefined, next: Element[]) {
         this.options = next.reduce<ListboxOption[]>((options, item) => {
             if (isListboxOption(item)) {
                 options.push(item);
@@ -477,15 +599,10 @@ export abstract class Listbox extends FoundationElement {
      */
     public typeaheadBufferChanged(prev: string, next: string): void {
         if (this.$fastController.isConnected) {
-            const pattern = this.typeaheadBuffer.replace(/[.*+\-?^${}()|[\]\\]/g, "\\$&");
-            const re = new RegExp(`^${pattern}`, "gi");
+            const typeaheadMatches = this.getTypeaheadMatches();
 
-            const filteredOptions = this.options.filter((o: ListboxOption) =>
-                o.text.trim().match(re)
-            );
-
-            if (filteredOptions.length) {
-                const selectedIndex = this.options.indexOf(filteredOptions[0]);
+            if (typeaheadMatches.length) {
+                const selectedIndex = this.options.indexOf(typeaheadMatches[0]);
                 if (selectedIndex > -1) {
                     this.selectedIndex = selectedIndex;
                 }
@@ -528,6 +645,15 @@ export class DelegatesARIAListbox {
      */
     @observable
     public ariaExpanded: "true" | "false" | undefined;
+
+    /**
+     * See {@link https://w3c.github.io/aria/#listbox} for more information
+     * @public
+     * @remarks
+     * HTML Attribute: `aria-multiselectable`
+     */
+    @observable
+    public ariaMultiselectable: "true" | "false" | undefined;
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -434,7 +434,7 @@ export abstract class Listbox extends FoundationElement {
      * @internal
      */
     public multipleChanged(prev: boolean | undefined, next: boolean): void {
-        this.ariaMultiselectable = next ? "true" : undefined;
+        this.ariaMultiSelectable = next ? "true" : undefined;
     }
 
     /**
@@ -656,7 +656,7 @@ export class DelegatesARIAListbox {
      * HTML Attribute: `aria-multiselectable`
      */
     @observable
-    public ariaMultiselectable: "true" | "false" | undefined;
+    public ariaMultiSelectable: "true" | "false" | undefined;
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -202,13 +202,16 @@ export abstract class Listbox extends FoundationElement {
     protected focusAndScrollOptionIntoView(
         optionToFocus: ListboxOption | null = this.firstSelectedOption
     ): void {
-        if (this.contains(document.activeElement)) {
-            if (optionToFocus) {
-                optionToFocus.focus();
-                requestAnimationFrame(() => {
-                    optionToFocus.scrollIntoView({ block: "nearest" });
-                });
-            }
+        // To ensure that the browser handles both `focus()` and `scrollIntoView()`, the
+        // timing here needs to guarantee that they happen on different frames. Since this
+        // function is typically called from the `openChanged` observer, `DOM.queueUpdate`
+        // causes the calls to be grouped into the same frame. To prevent this,
+        // `requestAnimationFrame` is used instead of `DOM.queueUpdate`.
+        if (this.contains(document.activeElement) && optionToFocus !== null) {
+            optionToFocus.focus();
+            requestAnimationFrame(() => {
+                optionToFocus.scrollIntoView({ block: "nearest" });
+            });
         }
     }
 

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -282,9 +282,6 @@ export abstract class Listbox extends FoundationElement {
                 );
                 break;
             }
-
-            default:
-            // impossible!
         }
 
         return this.options.indexOf(nextSelectableOption as any);

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -475,9 +475,10 @@ export abstract class Listbox extends FoundationElement {
     ): void {
         const filteredNext = next.filter(Listbox.slottedOptionFilter);
         this.options?.forEach(o => {
-            Observable.getNotifier(o).unsubscribe(this, "selected");
+            const notifier = Observable.getNotifier(o);
+            notifier.unsubscribe(this, "selected");
             o.selected = filteredNext.includes(o);
-            Observable.getNotifier(o).subscribe(this, "selected");
+            notifier.subscribe(this, "selected");
         });
     }
 

--- a/sites/site-utilities/statics/assets/components/fast-listbox.schema.json
+++ b/sites/site-utilities/statics/assets/components/fast-listbox.schema.json
@@ -14,6 +14,12 @@
       "mapsToAttribute": "disabled",
       "type": "boolean"
     },
+    "multiple": {
+      "title": "Multiple",
+      "description": "Indicates if the listbox is in multi-selection mode",
+      "mapsToAttribute": "multiple",
+      "type": "boolean"
+    },
     "size": {
       "title": "Size",
       "description": "The maximum number of visible options",


### PR DESCRIPTION
# Pull Request

## 📖 Description
Adds the `multiple` attribute to `<fast-listbox>`.

### 🎫 Issues

* #4190 

## 👩‍💻 Reviewer Notes

This PR supersedes the earlier #4974 PR.

## 📑 Test Plan

The `<fast-listbox>` element should accept the `multiple` boolean attribute, which will put the component into a mode where more than one option can be selected by a user.

_For the purposes of this implementation, "focus" is the `checked` state of the listbox's options. While interacting with a listbox, focus should remain on the listbox and shouldn't be placed on the options. [See this note for more information](https://www.w3.org/TR/wai-aria-practices-1.2/#h-note-16)._

* The `ArrowDown` key should move focus to the next selectable option.
  * Holding `Shift` while pressing `ArrowDown` should toggle focus for the next selectable option.
* The `ArrowUp` key should move focus to the previous selectable option
  * Holding `Shift` while pressing `ArrowUp` should toggle focus for the previous selectable option.
* The `Home` key should move focus to the first selectable option.
  * Holding `Shift` while pressing `Home` should toggle focus for all options starting from the currently focused option to the first selectable option.
* The `End` key should move focus to the last selectable option
  * Holding `Shift` while pressing `End` should toggle focus for all options starting from the currently focused option to the last selectable option.
* The ` ` (Space) key should select all currently focused options.
  * If any focused options are unselected, all focused options will be selected.
  * If all focused options are selected, all focused options will be unselected.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [x] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

This PR is part of a series, split from #4974 to unblock improvements made independently of multiple selection mode.