### PR TITLE
feat: add 'recycle' option to repeat directives

### DIFF
--- a/change/@microsoft-fast-element-388fae35-a3bd-4880-93de-c69f1dee7166.json
+++ b/change/@microsoft-fast-element-388fae35-a3bd-4880-93de-c69f1dee7166.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add recyle option to repeat directive",
+  "packageName": "@microsoft/fast-element",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -461,7 +461,8 @@ export class RepeatDirective<TSource = any> extends HTMLDirective {
 
 // @public
 export interface RepeatOptions {
-    positioning: boolean;
+    positioning?: boolean;
+    recycle?: boolean;
 }
 
 // Warning: (ae-internal-missing-underscore) The name "setCurrentEvent" should be prefixed with an underscore because the declaration is marked as @internal

--- a/packages/web-components/fast-element/docs/guide/using-directives.md
+++ b/packages/web-components/fast-element/docs/guide/using-directives.md
@@ -140,6 +140,19 @@ Some context properties are opt-in because they are more costly to update. So, f
 </ul>
 ```
 
+Whether or not a repeat directive re-uses item views can be controlled with the `recycle` option setting. When `recycle: true`, which is the default value, the repeat directive may reuse views rather than create new ones from the template.  When `recycle: false` 
+previously used views are always discarded and each item will always be assigned a new view. Recyling previously used views may improve performance in some situations but may also be "dirty" from the previously displayed item.
+
+**Example: List Rendering without view recycling**
+
+```html
+<ul>
+  ${repeat(x => x.friends, html<string>`
+    <li>${(x, c) => c.index} ${x => x}</li>
+  `, { recycle: false })}
+</ul>
+```
+
 In addition to providing a template to render the items with, you can also provide an expression that evaluates to a template. This enables you to dynamically change what you are using to render the items. Each item will still be rendered with the same template, but you can use techniques from "Composing Templates" below to render a different template depending on the item itself.
 
 ### Composing templates

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -22,11 +22,17 @@ export interface RepeatOptions {
     /**
      * Enables index, length, and dependent positioning updates in item templates.
      */
-    positioning: boolean;
+    positioning?: boolean;
+
+    /**
+     * Enables view recycling
+     */
+    recycle?: boolean;
 }
 
 const defaultRepeatOptions: RepeatOptions = Object.freeze({
     positioning: false,
+    recycle: true,
 });
 
 function bindWithoutPositioning(
@@ -206,7 +212,9 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
                 const neighbor = views[addIndex];
                 const location = neighbor ? neighbor.firstChild : this.location;
                 const view =
-                    totalRemoved.length > 0 ? totalRemoved.shift()! : template.create();
+                    this.options.recycle && totalRemoved.length > 0
+                        ? totalRemoved.shift()!
+                        : template.create();
 
                 views.splice(addIndex, 0, view);
                 bindView(view, items, addIndex, childContext);


### PR DESCRIPTION
## 📖 Description

Proposing this as I am encountering situations where the repeat directive reuses "dirty" views which may have artifacts left over from the previous item it displayed.  This change adds a `recycle` option to the repeat directive which forces the creation of a new view from the template each time a new item is displayed.  The default value of `true` maintains the current behavior.

### 🎫 Issues
Saw flickering of past states like images with old content during list manipulation.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
