### PR TITLE
Updated calculateOverlayColor to automatically determine the overlay color

### DIFF
--- a/change/@microsoft-fast-colors-647d4127-6f05-471a-9b55-37bea72a2a57.json
+++ b/change/@microsoft-fast-colors-647d4127-6f05-471a-9b55-37bea72a2a57.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Updated calculateOverlayColor to automatically determine the overlay color",
+  "packageName": "@microsoft/fast-colors",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/fast-colors/docs/api-report.md
+++ b/packages/utilities/fast-colors/docs/api-report.md
@@ -53,7 +53,7 @@ export function blendScreen(bottom: ColorRGBA64, top: ColorRGBA64): ColorRGBA64;
 export function blendScreenChannel(bottom: number, top: number): number;
 
 // @public
-export function calculateOverlayColor(rgbMatch: ColorRGBA64, rgbBackground: ColorRGBA64, rgbOverlay: ColorRGBA64): ColorRGBA64;
+export function calculateOverlayColor(rgbMatch: ColorRGBA64, rgbBackground: ColorRGBA64, rgbOverlay?: ColorRGBA64): ColorRGBA64;
 
 // @public
 export function centeredRescale(input: ColorRGBA64[], config?: CenteredRescaleConfig): ColorRGBA64[];

--- a/packages/utilities/fast-colors/src/color-converters.spec.ts
+++ b/packages/utilities/fast-colors/src/color-converters.spec.ts
@@ -1,4 +1,5 @@
 import {
+    calculateOverlayColor,
     ColorHSL,
     ColorHSV,
     ColorLAB,
@@ -62,6 +63,31 @@ describe("Color converter functions", () => {
             expect(contrastRatio(bottom, top)).toBeCloseTo(data.contrast, testPrecision);
         }
         for (const data of testData.colorPairs) {
+            testPair(data);
+        }
+    });
+
+    test("calculateOverlayColor", () => {
+        function testPair(data: any): void {
+            const match: ColorRGBA64 = new ColorRGBA64(
+                data.match.r,
+                data.match.g,
+                data.match.b,
+                1
+            );
+            const background: ColorRGBA64 = new ColorRGBA64(
+                data.background.r,
+                data.background.g,
+                data.background.b,
+                1
+            );
+            const rgb: ColorRGBA64 = calculateOverlayColor(match, background);
+            expect(rgb.r).toBeCloseTo(data.overlayColorResult.r, testPrecision);
+            expect(rgb.g).toBeCloseTo(data.overlayColorResult.g, testPrecision);
+            expect(rgb.b).toBeCloseTo(data.overlayColorResult.b, testPrecision);
+            expect(rgb.a).toBeCloseTo(data.overlayColorResult.a, testPrecision);
+        }
+        for (const data of testData.overlayPairs) {
             testPair(data);
         }
     });

--- a/packages/utilities/fast-colors/src/color-converters.ts
+++ b/packages/utilities/fast-colors/src/color-converters.ts
@@ -87,9 +87,21 @@ function calcRgbOverlay(
     rgbBackground: ColorRGBA64,
     rgbOverlay: ColorRGBA64
 ): number {
-    const rChannel: number = calcChannelOverlay(rgbMatch.r, rgbBackground.r, rgbOverlay.r);
-    const gChannel: number = calcChannelOverlay(rgbMatch.g, rgbBackground.g, rgbOverlay.g);
-    const bChannel: number = calcChannelOverlay(rgbMatch.b, rgbBackground.b, rgbOverlay.b);
+    const rChannel: number = calcChannelOverlay(
+        rgbMatch.r,
+        rgbBackground.r,
+        rgbOverlay.r
+    );
+    const gChannel: number = calcChannelOverlay(
+        rgbMatch.g,
+        rgbBackground.g,
+        rgbOverlay.g
+    );
+    const bChannel: number = calcChannelOverlay(
+        rgbMatch.b,
+        rgbBackground.b,
+        rgbOverlay.b
+    );
     return (rChannel + gChannel + bChannel) / 3;
 }
 

--- a/packages/utilities/fast-colors/src/color-converters.ts
+++ b/packages/utilities/fast-colors/src/color-converters.ts
@@ -74,8 +74,27 @@ export function contrastRatio(a: ColorRGBA64, b: ColorRGBA64): number {
         : calculateContrastRatio(luminanceB, luminanceA);
 }
 
+function calcChannelOverlay(match: number, background: number, overlay: number): number {
+    if (overlay - background === 0) {
+        return 0;
+    } else {
+        return (match - background) / (overlay - background);
+    }
+}
+
+function calcRgbOverlay(
+    rgbMatch: ColorRGBA64,
+    rgbBackground: ColorRGBA64,
+    rgbOverlay: ColorRGBA64
+): number {
+    const rChannel: number = calcChannelOverlay(rgbMatch.r, rgbBackground.r, rgbOverlay.r);
+    const gChannel: number = calcChannelOverlay(rgbMatch.g, rgbBackground.g, rgbOverlay.g);
+    const bChannel: number = calcChannelOverlay(rgbMatch.b, rgbBackground.b, rgbOverlay.b);
+    return (rChannel + gChannel + bChannel) / 3;
+}
+
 /**
- * Calculate an overlay color that uses rgba (rgb + alpha) that matches the appareance of a given solid color when placed on the same background
+ * Calculate an overlay color that uses rgba (rgb + alpha) that matches the appearance of a given solid color when placed on the same background
  * @param rgbMatch - The solid color the overlay should match in appearance when placed over the rgbBackground
  * @param rgbBackground - The background on which the overlay rests
  * @param rgbOverlay - The rgb color of the overlay. Typically this is either pure white or pure black and when not provided will be determined automatically. This color will be used in the returned output
@@ -88,36 +107,17 @@ export function calculateOverlayColor(
     rgbBackground: ColorRGBA64,
     rgbOverlay: ColorRGBA64 = null
 ): ColorRGBA64 {
-    function calcChannel(match: number, background: number, overlay: number): number {
-        if (overlay - background === 0) {
-            return 0;
-        } else {
-            return (match - background) / (overlay - background);
-        }
-    }
-
-    function calcRgb(
-        rgbMatch: ColorRGBA64,
-        rgbBackground: ColorRGBA64,
-        rgbOverlay: ColorRGBA64
-    ): number {
-        const rChannel: number = calcChannel(rgbMatch.r, rgbBackground.r, rgbOverlay.r);
-        const gChannel: number = calcChannel(rgbMatch.g, rgbBackground.g, rgbOverlay.g);
-        const bChannel: number = calcChannel(rgbMatch.b, rgbBackground.b, rgbOverlay.b);
-        return (rChannel + gChannel + bChannel) / 3;
-    }
-
     let alpha: number = 0;
     let overlay: ColorRGBA64 = rgbOverlay;
 
     if (overlay !== null) {
-        alpha = calcRgb(rgbMatch, rgbBackground, overlay);
+        alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
     } else {
         overlay = new ColorRGBA64(0, 0, 0, 1);
-        alpha = calcRgb(rgbMatch, rgbBackground, overlay);
+        alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
         if (alpha <= 0) {
             overlay = new ColorRGBA64(1, 1, 1, 1);
-            alpha = calcRgb(rgbMatch, rgbBackground, overlay);
+            alpha = calcRgbOverlay(rgbMatch, rgbBackground, overlay);
         }
     }
     alpha = Math.round(alpha * 1000) / 1000;
@@ -318,7 +318,7 @@ export function lchToLAB(lch: ColorLCH): ColorLAB {
  */
 export function labToLCH(lab: ColorLAB): ColorLCH {
     let h: number = 0;
-    // Because of the discontuity at 0 if a number is very close to 0 - often due to floating point errors - then
+    // Because of the discontinuity at 0 if a number is very close to 0 - often due to floating point errors - then
     // it gives unexpected results. EG: 0.000000000001 gives a different result than 0. So just avoid any number
     // that has both a and b very close to zero and lump it in with the h = 0 case.
     if (Math.abs(lab.b) > 0.001 || Math.abs(lab.a) > 0.001) {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Calculating an overlay color is the base of the support for opacity in the color algorithms. This is from some of the proof of concept work and automatically determines if the overlay color should be white or black rather than requiring a color to be passed in.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

One fewer change in the way of adding support for opacity in the color system!