### PR TITLE
fix: font-weight to inherit to button control part

### DIFF
--- a/change/@microsoft-fast-components-ad4c2131-3210-4837-819e-c22c0554d1fc.json
+++ b/change/@microsoft-fast-components-ad4c2131-3210-4837-819e-c22c0554d1fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: font-weight to inherit to button control part",
+  "packageName": "@microsoft/fast-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/styles/patterns/button.ts
+++ b/packages/web-components/fast-components/src/styles/patterns/button.ts
@@ -70,6 +70,7 @@ export const BaseButtonStyles = css`
         border-radius: inherit;
         fill: inherit;
         cursor: inherit;
+        font-weight: inherit;
         font-family: inherit;
         font-size: inherit;
         line-height: inherit;
@@ -127,7 +128,7 @@ export const BaseButtonStyles = css`
               color: ${SystemColors.ButtonText};
               fill: currentColor;
             }
-    
+
             :host(:hover) .control {
               forced-color-adjust: none;
               background-color: ${SystemColors.Highlight};


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This was an issue filed awhile ago that only was partially fixed, the `control` `part` in button was not inheriting `font-weight` or `font-size` changes set on the `host` element.

```css
fast-button {
   font-size: 30px;
   font-weight: 900;
}
```

Before fix:
<img width="87" alt="image" src="https://user-images.githubusercontent.com/37851214/152442594-f857c64f-c5fd-4670-b6c6-a038ac87eedb.png">

After fix: 
<img width="148" alt="image" src="https://user-images.githubusercontent.com/37851214/152442728-aa2f8de5-3cff-4a21-8623-7f8ee3b0a685.png">



### 🎫 Issues
Closes: #3578

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->