### PR TITLE
fix: disabled listbox missing styles & allows click

### DIFF
--- a/change/@microsoft-fast-components-31def213-6e59-4866-973f-61494c9ce492.json
+++ b/change/@microsoft-fast-components-31def213-6e59-4866-973f-61494c9ce492.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: diabled listbox missing styles & allows click",
+  "packageName": "@microsoft/fast-components",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-4b675f50-9184-4758-8f84-366ba154ae1e.json
+++ b/change/@microsoft-fast-foundation-4b675f50-9184-4758-8f84-366ba154ae1e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: diabled listbox missing styles & allows click",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "jes@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/listbox/fixtures/base.html
+++ b/packages/web-components/fast-components/src/listbox/fixtures/base.html
@@ -17,6 +17,15 @@
     <fast-option>Jodie Whittaker</fast-option>
 </fast-listbox>
 
+<h2>Disabled</h2>
+<fast-listbox disabled>
+    <fast-option>option 1</fast-option>
+    <fast-option>option 2</fast-option>
+    <fast-option>option 3</fast-option>
+    <fast-option>option 4</fast-option>
+    <fast-option>option 5</fast-option>
+</fast-listbox>
+
 <h2>Listboxes with size attribute</h2>
 <fast-listbox id="listbox-with-size-1" size="1">
     <fast-option>option 1</fast-option>

--- a/packages/web-components/fast-components/src/listbox/listbox.styles.ts
+++ b/packages/web-components/fast-components/src/listbox/listbox.styles.ts
@@ -7,9 +7,11 @@ import {
 } from "@microsoft/fast-foundation";
 import type { FoundationElementTemplate } from "@microsoft/fast-foundation";
 import { SystemColors } from "@microsoft/fast-web-utilities";
+import { disabledCursor } from "@microsoft/fast-foundation";
 import {
     controlCornerRadius,
     designUnit,
+    disabledOpacity,
     focusStrokeOuter,
     focusStrokeWidth,
     neutralLayerFloating,
@@ -40,6 +42,12 @@ export const listboxStyles: FoundationElementTemplate<ElementStyles> = (
             border-color: ${focusStrokeOuter};
             box-shadow: 0 0 0 calc((${focusStrokeWidth} - ${strokeWidth}) * 1px)
                 ${focusStrokeOuter} inset;
+        }
+
+        :host([disabled]) ::slotted(*) {
+            opacity: ${disabledOpacity};
+            cursor: ${disabledCursor};
+            pointer-events: none;
         }
 
         :host([size]) {

--- a/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.spec.ts
@@ -73,6 +73,18 @@ describe("Listbox", () => {
         await disconnect();
     });
 
+    it("should not select the first option when listbox is `disabled`", async () => {
+        const { element, connect, disconnect, option1, option2, option3 } = await setup();
+        element.disabled = true;
+        await connect();
+        //await DOM.nextUpdate();
+        expect(element.selectedOptions).to.not.contain(option1);
+        expect(element.selectedOptions).to.not.contain(option2);
+        expect(element.selectedOptions).to.not.contain(option3);
+
+        await disconnect();
+    });
+
     it("should select the option with a `selected` attribute", async () => {
         const { element, connect, disconnect, option1, option2, option3 } = await setup();
 

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -552,7 +552,7 @@ export abstract class Listbox extends FoundationElement {
      * @public
      */
     protected setSelectedOptions() {
-        if (this.options?.length) {
+        if (this.options?.length && !this.disabled) {
             this.selectedOptions = [this.options[this.selectedIndex]];
             this.ariaActiveDescendant = this.firstSelectedOption?.id ?? "";
             this.focusAndScrollOptionIntoView();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This change adds styling too for a `disabled` `listbox`. This also prevents setting the initial `listbox-item` to `selected` if `listbox` is `disabled`. However, it's important to note that if an item is set to `selected` or the `listbox` is set to `disabled` after initial load the `listbox-item` would remain selected even if the `listbox` is `disabled`. This matches the native behavior of `select` and `option`

Disabled
<img width="245" alt="Screen Shot 2022-02-03 at 4 00 54 PM" src="https://user-images.githubusercontent.com/37851214/152581567-bab67558-0cfc-4036-b944-cd7348cdf18d.png">

Disabled but an item is set to selected
<img width="290" alt="Screen Shot 2022-02-03 at 3 34 11 PM" src="https://user-images.githubusercontent.com/37851214/152581623-09765e16-f6ed-4777-96b6-d533c224913a.png">

### 🎫 Issues
Closes: #4137

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->