### PR TITLE
`focusStrokeWidth` not applied on text-field and number-field

### DIFF
--- a/change/@microsoft-fast-components-81388374-b10c-4574-94fc-b77db302786a.json
+++ b/change/@microsoft-fast-components-81388374-b10c-4574-94fc-b77db302786a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "`focusStrokeWidth` not applied on text-field and number-field Fixes #5565",
+  "packageName": "@microsoft/fast-components",
+  "email": "fcollonval@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/number-field/number-field.styles.ts
+++ b/packages/web-components/fast-components/src/number-field/number-field.styles.ts
@@ -17,6 +17,7 @@ import {
     designUnit,
     disabledOpacity,
     focusStrokeOuter,
+    focusStrokeWidth,
     neutralFillHover,
     neutralFillInputHover,
     neutralFillInputRest,
@@ -151,7 +152,7 @@ export const numberFieldStyles: FoundationElementTemplate<
 
     :host(:focus-within:not([disabled])) .root {
         border-color: ${focusStrokeOuter};
-        box-shadow: 0 0 0 1px ${focusStrokeOuter} inset;
+        box-shadow: 0 0 0 calc(${focusStrokeWidth} * 1px) ${focusStrokeOuter} inset;
     }
 
     :host(:hover:not([disabled])) .controls,

--- a/packages/web-components/fast-components/src/text-field/text-field.styles.ts
+++ b/packages/web-components/fast-components/src/text-field/text-field.styles.ts
@@ -2,7 +2,6 @@ import { css, ElementStyles } from "@microsoft/fast-element";
 import {
     disabledCursor,
     display,
-    ElementDefinitionContext,
     focusVisible,
     forcedColorsStylesheetBehavior,
     FoundationElementTemplate,
@@ -18,6 +17,7 @@ import {
     designUnit,
     disabledOpacity,
     focusStrokeOuter,
+    focusStrokeWidth,
     neutralFillHover,
     neutralFillInputHover,
     neutralFillInputRest,
@@ -127,7 +127,7 @@ export const textFieldStyles: FoundationElementTemplate<
 
     :host(:focus-within:not([disabled])) .root {
         border-color: ${focusStrokeOuter};
-        box-shadow: 0 0 0 1px ${focusStrokeOuter} inset;
+        box-shadow: 0 0 0 calc(${focusStrokeWidth} * 1px) ${focusStrokeOuter} inset;
     }
 
     :host([appearance="filled"]) .root {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
Focus style on text and number fields does not use `focusStrokeWidth` (as e.g. do select).

Question: there is also a variation the text and number fields are using `inset` box-shadow when select is not. Does this need to be changed too? If so which one is the correct style to apply?

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Fixes #5565

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->