### PR TITLE
allow empty string values for listbox-option value attribute

### DIFF
--- a/change/@microsoft-fast-foundation-c37ba884-df53-40b6-988c-6eff22ae40a3.json
+++ b/change/@microsoft-fast-foundation-c37ba884-df53-40b6-988c-6eff22ae40a3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "allow empty string values for listbox-option value attribute",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
@@ -65,7 +65,6 @@ describe("ListboxOption", () => {
     it("should set the `aria-checked` attribute to match the `checked` property", async () => {
         const { element, connect, disconnect } = await setup();
 
-
         await connect();
 
         expect(element.hasAttribute("aria-checked")).to.be.false;
@@ -87,6 +86,35 @@ describe("ListboxOption", () => {
         await DOM.nextUpdate();
 
         expect(element.hasAttribute("aria-checked")).to.be.false;
+
+        await disconnect();
+    });
+
+    it("should have an empty string `value` when the `value` attribute exists", async () => {
+        const { connect, element, disconnect } = await setup();
+
+        await connect();
+
+        element.setAttribute("value", "");
+        element.innerText = "hello";
+
+        expect(element.text).to.equal("hello");
+
+        expect(element.value).to.equal("");
+
+        await disconnect();
+    });
+
+    it("should return the text content when the `value` attribute does not exist", async () => {
+        const { connect, element, disconnect } = await setup();
+
+        await connect();
+
+        element.innerText = "hello";
+
+        expect(element.text).to.equal("hello");
+
+        expect(element.value).to.equal("hello");
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
@@ -90,7 +90,7 @@ describe("ListboxOption", () => {
         await disconnect();
     });
 
-    it("should have an empty string `value` when the `value` attribute exists", async () => {
+    it("should have an empty string `value` when the `value` attribute exists and is empty", async () => {
         const { connect, element, disconnect } = await setup();
 
         await connect();

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
@@ -169,7 +169,7 @@ export class ListboxOption extends FoundationElement {
     }
 
     public get label() {
-        return this.value ? this.value : this.textContent ? this.textContent : "";
+        return this.value ?? this.textContent ?? "";
     }
 
     public get text(): string {
@@ -190,7 +190,7 @@ export class ListboxOption extends FoundationElement {
 
     public get value(): string {
         Observable.track(this, "value");
-        return this._value ? this._value : this.text;
+        return this._value ?? this.textContent ?? "";
     }
 
     public get form(): HTMLFormElement | null {
@@ -204,7 +204,6 @@ export class ListboxOption extends FoundationElement {
         selected?: boolean
     ) {
         super();
-        this.initialValue = this.initialValue || "";
 
         if (text) {
             this.textContent = text;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Sets the `<fast-option>` value property to always match the `value` attribute if present.

### 🎫 Issues

Closes #5569

## 📑 Test Plan

Two tests added to check value and text content collisions.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
