### PR TITLE
Figma plugin: Add support for text recipes

### DIFF
--- a/packages/tooling/fast-figma-plugin-msft/src/core/ui/components/generic-recipe/index.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/core/ui/components/generic-recipe/index.ts
@@ -1,0 +1,80 @@
+import { attr, css, customElement, FASTElement, html } from "@microsoft/fast-element";
+import { neutralFillStealthHover, neutralForegroundHint } from "@fluentui/web-components";
+
+const template = html<GenericRecipe>`
+    <template
+        class="${x => x.orientation} ${x => (x.interactive ? "interactive" : "")} ${x =>
+            x.selected ? "selected" : ""}"
+        tabindex="${x => (x.interactive ? "interactive" : null)}"
+        aria-selected="${x => x.selected}"
+    >
+        <div class="icon">${x => x.icon || ""}</div>
+        <slot></slot>
+    </template>
+`;
+
+const styles = css`
+    :host {
+        box-sizing: border-box;
+        display: inline-flex;
+        align-items: center;
+        text-align: center;
+        color: ${neutralForegroundHint};
+    }
+
+    .icon {
+        width: 28px;
+        height: 28px;
+        position: relative;
+        overflow: hidden;
+    }
+
+    :host(.vertical) {
+        flex-direction: column;
+        padding: 8px;
+    }
+
+    :host(.vertical) .indicator {
+        margin-bottom: 8px;
+    }
+
+    :host(.horizontal) .indicator {
+        margin-inline-end: 12px;
+    }
+
+    :host(.interactive) {
+        outline: none;
+    }
+
+    :host(.interactive:hover) {
+        cursor: pointer;
+        background: ${neutralFillStealthHover};
+    }
+
+    :host(.selected),
+    :host(.selected:hover) {
+        background: #daebf7;
+    }
+`;
+
+@customElement({
+    name: "td-generic-recipe",
+    template,
+    styles,
+})
+export class GenericRecipe extends FASTElement {
+    @attr
+    public value: string = "";
+
+    @attr
+    public icon?: string;
+
+    @attr
+    public orientation: "vertical" | "horizontal" = "vertical";
+
+    @attr({ mode: "boolean" })
+    public interactive: boolean = false;
+
+    @attr({ mode: "boolean" })
+    public selected: boolean = false;
+}

--- a/packages/tooling/fast-figma-plugin-msft/src/core/ui/components/index.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/core/ui/components/index.ts
@@ -1,4 +1,5 @@
 export * from "./drawer";
 export * from "./stealth-button";
+export * from "./generic-recipe";
 export * from "./swatch";
 export * from "./corner-radius";

--- a/packages/tooling/fast-figma-plugin-msft/src/core/ui/declarations.d.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/core/ui/declarations.d.ts
@@ -59,6 +59,16 @@ declare global {
                 interactive?: boolean;
                 selected?: boolean;
             };
+            "td-generic-recipe": {
+                key?: string;
+                value: string;
+                icon?: string;
+                children?: React.ReactNode;
+                orientation?: "horizontal" | "vertical";
+                onClick?: any;
+                interactive?: boolean;
+                selected?: boolean;
+            };
         }
     }
 }

--- a/packages/tooling/fast-figma-plugin-msft/src/core/ui/design-token-registry.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/core/ui/design-token-registry.ts
@@ -7,6 +7,9 @@ export enum DesignTokenType {
     foregroundFill = "foregroundFill",
     strokeFill = "strokeFill",
     cornerRadius = "cornerRadius",
+    fontName = "fontName",
+    fontSize = "fontSize",
+    lineHeight = "lineHeight",
 }
 
 /**
@@ -43,11 +46,6 @@ export interface DesignTokenDefinition<T extends {} = any> {
      * The underlying DesignToken for the plugin definition
      */
     token: DesignToken<T>;
-
-    /**
-     * Evaluates a design token
-     */
-    evaluate: (element: HTMLElement) => T;
 }
 
 export class DesignTokenRegistry {

--- a/packages/tooling/fast-figma-plugin-msft/src/core/ui/index.tsx
+++ b/packages/tooling/fast-figma-plugin-msft/src/core/ui/index.tsx
@@ -3,13 +3,19 @@ import { ColorRGBA64, parseColorHexRGB } from "@microsoft/fast-colors";
 import { StandardLuminance, Swatch, SwatchRGB } from "@fluentui/web-components";
 // import DetachIcon from "./assets/detach.svg";
 // import RevertIcon from "./assets/revert.svg";
-import { CornerRadius, Drawer, Swatch as SwatchComponent } from "./components";
+import {
+    CornerRadius,
+    Drawer,
+    GenericRecipe,
+    Swatch as SwatchComponent,
+} from "./components";
 import { DesignTokenType } from "./design-token-registry";
 import { PluginUINodeData, UIController } from "./ui-controller";
 
 /* tslint:disable:no-unused-expression */
 CornerRadius;
 Drawer;
+GenericRecipe;
 SwatchComponent;
 /* tslint:enable:no-unused-expression */
 
@@ -95,6 +101,11 @@ export class PluginUI extends React.Component<PluginUIProps> {
         const cornerRadiusRecipes = this.controller.appliedRecipes(
             DesignTokenType.cornerRadius
         );
+        const textRecipes = [
+            ...this.controller.appliedRecipes(DesignTokenType.fontName),
+            ...this.controller.appliedRecipes(DesignTokenType.fontSize),
+            ...this.controller.appliedRecipes(DesignTokenType.lineHeight),
+        ];
         const supportsDesignSystem = this.props.selectedNodes.some(node =>
             node.supports.includes(DesignTokenType.designToken)
         );
@@ -492,6 +503,83 @@ export class PluginUI extends React.Component<PluginUIProps> {
                                         >
                                             {recipe.name}
                                         </td-corner-radius>
+                                        <div>
+                                            <span>
+                                                {this.controller.getDefaultDesignTokenValue(
+                                                    recipe.token
+                                                )}
+                                            </span>
+                                            <plugin-button
+                                                appearance="stealth"
+                                                aria-label="Detach"
+                                                onClick={this.controller.removeRecipe.bind(
+                                                    this.controller,
+                                                    recipe
+                                                )}
+                                            >
+                                                Detach
+                                            </plugin-button>
+                                        </div>
+                                    </p>
+                                ))}
+                            </div>
+                        ) : null}
+                    </td-drawer>
+                    <td-drawer name="Text">
+                        {this.props.selectedNodes.some(node =>
+                            node.supports.includes(DesignTokenType.fontName)
+                        ) ? (
+                            <div className="swatch-grid" style={{ marginTop: 8 }}>
+                                {[
+                                    ...this.controller.recipeOptionsByType(
+                                        DesignTokenType.fontName
+                                    ),
+                                    ...this.controller.recipeOptionsByType(
+                                        DesignTokenType.fontSize
+                                    ),
+                                    ...this.controller.recipeOptionsByType(
+                                        DesignTokenType.lineHeight
+                                    ),
+                                ].map(recipe => {
+                                    return (
+                                        <td-generic-recipe
+                                            key={recipe.id}
+                                            value={this.controller.getDefaultDesignTokenValue(
+                                                recipe.token
+                                            )}
+                                            interactive
+                                            selected={
+                                                !!this.controller.recipeIsAssigned(
+                                                    recipe.id
+                                                ).length
+                                            }
+                                            onClick={this.controller.assignRecipe.bind(
+                                                this.controller,
+                                                recipe
+                                            )}
+                                        >
+                                            {recipe.name}
+                                        </td-generic-recipe>
+                                    );
+                                })}
+                            </div>
+                        ) : null}
+                        {textRecipes.length ? (
+                            <div slot="collapsed-content">
+                                {textRecipes.map(recipe => (
+                                    <p className="applied-recipe" key={recipe.id}>
+                                        <td-generic-recipe
+                                            value={this.controller.getDefaultDesignTokenValue(
+                                                recipe.token
+                                            )}
+                                            orientation="horizontal"
+                                            onClick={this.controller.assignRecipe.bind(
+                                                this.controller,
+                                                recipe
+                                            )}
+                                        >
+                                            {recipe.name}
+                                        </td-generic-recipe>
                                         <div>
                                             <span>
                                                 {this.controller.getDefaultDesignTokenValue(

--- a/packages/tooling/fast-figma-plugin-msft/src/core/ui/recipes.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/core/ui/recipes.ts
@@ -4,6 +4,7 @@ import {
     accentFillRest,
     accentForegroundRest,
     baseLayerLuminance,
+    bodyFont,
     controlCornerRadius,
     fillColor,
     focusStrokeInner,
@@ -32,6 +33,24 @@ import {
     neutralStrokeRest,
     neutralStrokeStrongRest,
     Swatch,
+    typeRampBaseFontSize,
+    typeRampBaseLineHeight,
+    typeRampMinus1FontSize,
+    typeRampMinus1LineHeight,
+    typeRampMinus2FontSize,
+    typeRampMinus2LineHeight,
+    typeRampPlus1FontSize,
+    typeRampPlus1LineHeight,
+    typeRampPlus2FontSize,
+    typeRampPlus2LineHeight,
+    typeRampPlus3FontSize,
+    typeRampPlus3LineHeight,
+    typeRampPlus4FontSize,
+    typeRampPlus4LineHeight,
+    typeRampPlus5FontSize,
+    typeRampPlus5LineHeight,
+    typeRampPlus6FontSize,
+    typeRampPlus6LineHeight,
 } from "@fluentui/web-components";
 import {
     DesignTokenDefinition,
@@ -41,6 +60,7 @@ import {
 
 interface DesignTokenStore<T> {
     [key: string]: {
+        type?: DesignTokenType;
         token: DesignToken<T>;
         name: string;
     };
@@ -110,8 +130,102 @@ const cornerRadiusRecipes: DesignTokenStore<number> = {
     layerCornerRadius: { token: layerCornerRadius, name: "Layer" },
 };
 
+const textRecipes: DesignTokenStore<any> = {
+    bodyFont: { type: DesignTokenType.fontName, token: bodyFont, name: "Font" },
+    typeRampPlus6FontSize: {
+        type: DesignTokenType.fontSize,
+        token: typeRampPlus6FontSize,
+        name: "Plus 6 font size",
+    },
+    typeRampPlus6LineHeight: {
+        type: DesignTokenType.lineHeight,
+        token: typeRampPlus6LineHeight,
+        name: "Plus 6 line height",
+    },
+    typeRampPlus5FontSize: {
+        type: DesignTokenType.fontSize,
+        token: typeRampPlus5FontSize,
+        name: "Plus 5 font size",
+    },
+    typeRampPlus5LineHeight: {
+        type: DesignTokenType.lineHeight,
+        token: typeRampPlus5LineHeight,
+        name: "Plus 5 line height",
+    },
+    typeRampPlus4FontSize: {
+        type: DesignTokenType.fontSize,
+        token: typeRampPlus4FontSize,
+        name: "Plus 4 font size",
+    },
+    typeRampPlus4LineHeight: {
+        type: DesignTokenType.lineHeight,
+        token: typeRampPlus4LineHeight,
+        name: "Plus 4 line height",
+    },
+    typeRampPlus3FontSize: {
+        type: DesignTokenType.fontSize,
+        token: typeRampPlus3FontSize,
+        name: "Plus 3 font size",
+    },
+    typeRampPlus3LineHeight: {
+        type: DesignTokenType.lineHeight,
+        token: typeRampPlus3LineHeight,
+        name: "Plus 3 line height",
+    },
+    typeRampPlus2FontSize: {
+        type: DesignTokenType.fontSize,
+        token: typeRampPlus2FontSize,
+        name: "Plus 2 font size",
+    },
+    typeRampPlus2LineHeight: {
+        type: DesignTokenType.lineHeight,
+        token: typeRampPlus2LineHeight,
+        name: "Plus 2 line height",
+    },
+    typeRampPlus1FontSize: {
+        type: DesignTokenType.fontSize,
+        token: typeRampPlus1FontSize,
+        name: "Plus 1 font size",
+    },
+    typeRampPlus1LineHeight: {
+        type: DesignTokenType.lineHeight,
+        token: typeRampPlus1LineHeight,
+        name: "Plus 1 line height",
+    },
+    typeRampBaseFontSize: {
+        type: DesignTokenType.fontSize,
+        token: typeRampBaseFontSize,
+        name: "Base font size",
+    },
+    typeRampBaseLineHeight: {
+        type: DesignTokenType.lineHeight,
+        token: typeRampBaseLineHeight,
+        name: "Base line height",
+    },
+    typeRampMinus1FontSize: {
+        type: DesignTokenType.fontSize,
+        token: typeRampMinus1FontSize,
+        name: "Minus 1 font size",
+    },
+    typeRampMinus1LineHeight: {
+        type: DesignTokenType.lineHeight,
+        token: typeRampMinus1LineHeight,
+        name: "Minus 1 line height",
+    },
+    typeRampMinus2FontSize: {
+        type: DesignTokenType.fontSize,
+        token: typeRampMinus2FontSize,
+        name: "Minus 2 font size",
+    },
+    typeRampMinus2LineHeight: {
+        type: DesignTokenType.lineHeight,
+        token: typeRampMinus2LineHeight,
+        name: "Minus 2 line height",
+    },
+};
+
 function registerStore<T>(
-    type: DesignTokenType,
+    type: DesignTokenType | null,
     store: DesignTokenStore<T>,
     title: string,
     registry: DesignTokenRegistry
@@ -119,19 +233,18 @@ function registerStore<T>(
     Object.keys(store).forEach((key: string) => {
         const entry = store[key];
 
+        const thisType = type || entry.type;
+        if (thisType === null) {
+            throw `DesignTokenType not specified for ${key}`;
+        }
+
         const definition: DesignTokenDefinition = {
             id: key,
             name: entry.name,
             groupTitle: title,
-            type,
+            // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+            type: thisType!,
             token: entry.token,
-            evaluate: (element: HTMLElement) => {
-                let val = entry.token.getValueFor(element);
-                if (typeof (val as any).toColorString === "function") {
-                    val = (val as any).toColorString();
-                }
-                return val;
-            },
         };
 
         registry.register(definition);
@@ -158,4 +271,5 @@ export const registerRecipes = (registry: DesignTokenRegistry) => {
         "Corner radius",
         registry
     );
+    registerStore(null, textRecipes, "Text", registry);
 };

--- a/packages/tooling/fast-figma-plugin-msft/src/figma/node.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/figma/node.ts
@@ -140,6 +140,10 @@ export class FigmaPluginNode extends PluginNode {
                     ].some((test: (node: BaseNode) => boolean) => test(this.node));
                 case DesignTokenType.foregroundFill:
                     return isTextNode(this.node);
+                case DesignTokenType.fontName:
+                case DesignTokenType.fontSize:
+                case DesignTokenType.lineHeight:
+                    return isTextNode(this.node);
                 default:
                     return false;
             }
@@ -156,6 +160,35 @@ export class FigmaPluginNode extends PluginNode {
                 break;
             case DesignTokenType.cornerRadius:
                 this.paintCornerRadius(data);
+                break;
+            case DesignTokenType.fontName:
+                {
+                    // TODO Handle font list better and font weight
+                    const families = data.value.split(",");
+                    const fontName = { family: families[0], style: "Regular" };
+                    figma.loadFontAsync(fontName).then(x => {
+                        (this.node as TextNode).fontName = fontName;
+                    });
+                }
+                break;
+            case DesignTokenType.fontSize:
+                {
+                    const textNode = this.node as TextNode;
+                    figma.loadFontAsync(textNode.fontName as FontName).then(x => {
+                        textNode.fontSize = Number.parseFloat(data.value);
+                    });
+                }
+                break;
+            case DesignTokenType.lineHeight:
+                {
+                    const textNode = this.node as TextNode;
+                    figma.loadFontAsync(textNode.fontName as FontName).then(x => {
+                        textNode.lineHeight = {
+                            value: Number.parseFloat(data.value),
+                            unit: "PIXELS",
+                        };
+                    });
+                }
                 break;
             default:
                 throw new Error(`Recipe could not be painted ${JSON.stringify(data)}`);
@@ -210,7 +243,7 @@ export class FigmaPluginNode extends PluginNode {
 
         if (isInstanceNode(this.node)) {
             // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
-            const mainNode = (this.node as InstanceNode).mainComponent!;
+            // const mainNode = (this.node as InstanceNode).mainComponent!;
             // console.log("    getPluginData", mainNode.id, mainNode.type, key, mainNode.getPluginData(key));
         }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Added support for applying text design tokens to text layers in Figma.

### 🎫 Issues

## 👩‍💻 Reviewer Notes

The plugin is still very much in-progress, but this is hopefully a nice, contained change.

## 📑 Test Plan

The test page has been updated to have text recipes applied to all text layers. https://www.figma.com/file/YCFM1UHB0pphAUd8llTGez/Plug-in-Test-Components?node-id=0%3A1

![image](https://user-images.githubusercontent.com/47367562/154115841-3e6cb935-4634-4d39-8658-d5ae1ba08a90.png)

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
