### PR TITLE
feat: use tabbable shadow dom support

### DIFF
--- a/change/@microsoft-fast-foundation-680ad93b-949d-43f0-8211-46d8089a97fe.json
+++ b/change/@microsoft-fast-foundation-680ad93b-949d-43f0-8211-46d8089a97fe.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "use tabbable for shadow dom",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/dialog/dialog.stories.ts
+++ b/packages/web-components/fast-components/src/dialog/dialog.stories.ts
@@ -26,7 +26,7 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
             "dialog2"
         ) as FoundationDialog;
 
-        const shadowButton1: HTMLButtonElement = document.createElement("button");
+        const shadowButton1: HTMLElement = document.createElement("fast-button");
         shadowButton1.textContent = "Shadow Button 1";
         dialog2.dialog.prepend(shadowButton1);
 

--- a/packages/web-components/fast-components/src/dialog/dialog.stories.ts
+++ b/packages/web-components/fast-components/src/dialog/dialog.stories.ts
@@ -28,6 +28,7 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
 
         const shadowButton1: HTMLElement = document.createElement("fast-button");
         shadowButton1.textContent = "Shadow Button 1";
+        shadowButton1.setAttribute("tabindex", "0");
         dialog2.dialog.prepend(shadowButton1);
 
         const shadowNumberField: HTMLElement = document.createElement(

--- a/packages/web-components/fast-components/src/dialog/dialog.stories.ts
+++ b/packages/web-components/fast-components/src/dialog/dialog.stories.ts
@@ -30,6 +30,11 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
         shadowButton1.textContent = "Shadow Button 1";
         dialog2.dialog.prepend(shadowButton1);
 
+        const shadowNumberField: HTMLElement = document.createElement(
+            "fast-number-field"
+        );
+        dialog2.dialog.prepend(shadowNumberField);
+
         const shadowButton2: HTMLButtonElement = document.createElement("button");
         shadowButton2.textContent = "Shadow Button 2";
         dialog2.dialog.appendChild(shadowButton2);

--- a/packages/web-components/fast-components/src/dialog/dialog.stories.ts
+++ b/packages/web-components/fast-components/src/dialog/dialog.stories.ts
@@ -1,12 +1,15 @@
 import { STORY_RENDERED } from "@storybook/core-events";
 import addons from "@storybook/addons";
+import { Dialog as FoundationDialog } from "@microsoft/fast-foundation";
 import DialogTemplate from "./fixtures/dialog.html";
 import "./index.js";
 
 addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
     if (name.toLowerCase().startsWith("dialog")) {
         const button1 = document.getElementById("button1");
-        const dialog1 = document.getElementById("dialog1");
+        const dialog1: FoundationDialog = document.getElementById(
+            "dialog1"
+        ) as FoundationDialog;
 
         if (button1 && dialog1) {
             button1.addEventListener("click", (e: MouseEvent) => {
@@ -15,6 +18,29 @@ addons.getChannel().addListener(STORY_RENDERED, (name: string) => {
 
             dialog1.addEventListener("dismiss", (e: Event) => {
                 dialog1.hidden = true;
+            });
+        }
+
+        const button2 = document.getElementById("button2");
+        const dialog2: FoundationDialog = document.getElementById(
+            "dialog2"
+        ) as FoundationDialog;
+
+        const shadowButton1: HTMLButtonElement = document.createElement("button");
+        shadowButton1.textContent = "Shadow Button 1";
+        dialog2.dialog.prepend(shadowButton1);
+
+        const shadowButton2: HTMLButtonElement = document.createElement("button");
+        shadowButton2.textContent = "Shadow Button 2";
+        dialog2.dialog.appendChild(shadowButton2);
+
+        if (button2 && dialog2) {
+            button2.addEventListener("click", (e: MouseEvent) => {
+                dialog2.hidden = false;
+            });
+
+            dialog2.addEventListener("dismiss", (e: Event) => {
+                dialog2.hidden = true;
             });
         }
     }

--- a/packages/web-components/fast-components/src/dialog/fixtures/dialog.html
+++ b/packages/web-components/fast-components/src/dialog/fixtures/dialog.html
@@ -38,7 +38,7 @@
     hidden="true"
 >
     <h2>With shadow dom elements</h2>
-    <fast-button>Button A</fast-button>
+    <fast-button tabindex="0">Button A</fast-button>
     <p></p>
     <button>Button B</button>
     <p></p>

--- a/packages/web-components/fast-components/src/dialog/fixtures/dialog.html
+++ b/packages/web-components/fast-components/src/dialog/fixtures/dialog.html
@@ -1,9 +1,7 @@
 <fast-button id="button1">
-    Show dialog
+    Basic Dialog
 </fast-button>
 <p></p>
-
-tab queue detected automatically
 
 <fast-dialog
     id="dialog1"
@@ -25,4 +23,32 @@ tab queue detected automatically
     </fast-toolbar>
     <p></p>
     (esc to close)
+</fast-dialog>
+
+<fast-button id="button2">
+    With shadow dom elements
+</fast-button>
+<p></p>
+
+<fast-dialog
+    id="dialog2"
+    aria-label="Simple dialog"
+    modal="true"
+    trap-focus="true"
+    hidden="true"
+>
+    <h2>With shadow dom elements</h2>
+    <fast-button>Button A</fast-button>
+    <p></p>
+    <button>Button B</button>
+    <p></p>
+    <fast-checkbox>A checkbox</fast-checkbox>
+    <p></p>
+    <fast-toolbar>
+        <fast-button>One</fast-button>
+        <fast-button>Three</fast-button>
+    </fast-toolbar>
+    <p></p>
+    (esc to close)
+    <p></p>
 </fast-dialog>

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -97,7 +97,7 @@
   "dependencies": {
     "@microsoft/fast-element": "^1.10.1",
     "@microsoft/fast-web-utilities": "^5.4.1",
-    "tabbable": "^5.2.0",
+    "tabbable": "^5.3.1",
     "tslib": "^1.13.0"
   },
   "customElements": "dist/custom-elements.json"

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -162,7 +162,7 @@ export class Button extends FormAssociatedButton {
         super.connectedCallback();
 
         this.proxy.setAttribute("type", this.type);
-        this.handleUnsupportedDelegatesFocus();
+        // this.handleUnsupportedDelegatesFocus();
 
         const elements = Array.from(this.control?.children) as HTMLSpanElement[];
         if (elements) {
@@ -235,18 +235,18 @@ export class Button extends FormAssociatedButton {
      * This check works for Chrome, Edge Chromium, FireFox, and Safari
      * Relevant PR on the Firefox browser: https://phabricator.services.mozilla.com/D123858
      */
-    private handleUnsupportedDelegatesFocus = () => {
-        // Check to see if delegatesFocus is supported
-        if (
-            window.ShadowRoot &&
-            !window.ShadowRoot.prototype.hasOwnProperty("delegatesFocus") &&
-            this.$fastController.definition.shadowOptions?.delegatesFocus
-        ) {
-            this.focus = () => {
-                this.control.focus();
-            };
-        }
-    };
+    // private handleUnsupportedDelegatesFocus = () => {
+    //     // Check to see if delegatesFocus is supported
+    //     if (
+    //         window.ShadowRoot &&
+    //         !window.ShadowRoot.prototype.hasOwnProperty("delegatesFocus") &&
+    //         this.$fastController.definition.shadowOptions?.delegatesFocus
+    //     ) {
+    //         this.focus = () => {
+    //             this.control.focus();
+    //         };
+    //     }
+    // };
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -162,7 +162,6 @@ export class Button extends FormAssociatedButton {
         super.connectedCallback();
 
         this.proxy.setAttribute("type", this.type);
-        // this.handleUnsupportedDelegatesFocus();
 
         const elements = Array.from(this.control?.children) as HTMLSpanElement[];
         if (elements) {
@@ -229,24 +228,6 @@ export class Button extends FormAssociatedButton {
     };
 
     public control: HTMLButtonElement;
-
-    /**
-     * Overrides the focus call for where delegatesFocus is unsupported.
-     * This check works for Chrome, Edge Chromium, FireFox, and Safari
-     * Relevant PR on the Firefox browser: https://phabricator.services.mozilla.com/D123858
-     */
-    // private handleUnsupportedDelegatesFocus = () => {
-    //     // Check to see if delegatesFocus is supported
-    //     if (
-    //         window.ShadowRoot &&
-    //         !window.ShadowRoot.prototype.hasOwnProperty("delegatesFocus") &&
-    //         this.$fastController.definition.shadowOptions?.delegatesFocus
-    //     ) {
-    //         this.focus = () => {
-    //             this.control.focus();
-    //         };
-    //     }
-    // };
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/dialog/README.md
+++ b/packages/web-components/fast-foundation/src/dialog/README.md
@@ -57,9 +57,9 @@ export const myDialog = Dialog.compose({
 
 #### Superclass
 
-| Name                | Module                                        | Package |
-| ------------------- | --------------------------------------------- | ------- |
-| `FoundationElement` | /src/foundation-element/foundation-element.js |         |
+| Name                | Module                  | Package |
+| ------------------- | ----------------------- | ------- |
+| `FoundationElement` | /src/foundation-element |         |
 
 #### Fields
 

--- a/packages/web-components/fast-foundation/src/dialog/README.md
+++ b/packages/web-components/fast-foundation/src/dialog/README.md
@@ -57,9 +57,9 @@ export const myDialog = Dialog.compose({
 
 #### Superclass
 
-| Name                | Module                  | Package |
-| ------------------- | ----------------------- | ------- |
-| `FoundationElement` | /src/foundation-element |         |
+| Name                | Module                           | Package |
+| ------------------- | -------------------------------- | ------- |
+| `FoundationElement` | /src/foundation-element/index.js |         |
 
 #### Fields
 

--- a/packages/web-components/fast-foundation/src/dialog/dialog.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.ts
@@ -1,7 +1,7 @@
 import { attr, DOM, Notifier, Observable } from "@microsoft/fast-element";
 import { keyEscape, keyTab } from "@microsoft/fast-web-utilities";
-import { FocusableElement, isTabbable, tabbable } from "tabbable";
-import { FoundationElement } from "../foundation-element";
+import { FocusableElement, tabbable } from "tabbable";
+import { FoundationElement } from "../foundation-element/index.js";
 
 /**
  * A Switch Custom HTML Element.
@@ -194,7 +194,7 @@ export class Dialog extends FoundationElement {
             return;
         }
 
-        const bounds: (HTMLElement | SVGElement)[] = this.getTabQueueBounds();
+        const bounds: FocusableElement[] = this.getTabQueueBounds();
 
         if (bounds.length === 0) {
             return;

--- a/packages/web-components/fast-foundation/src/dialog/dialog.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.ts
@@ -1,7 +1,7 @@
 import { attr, DOM, Notifier, Observable } from "@microsoft/fast-element";
 import { keyEscape, keyTab } from "@microsoft/fast-web-utilities";
-import { isTabbable } from "tabbable";
-import { FoundationElement } from "../foundation-element/foundation-element.js";
+import { isTabbable, tabbable } from "tabbable";
+import { FoundationElement } from "../foundation-element";
 
 /**
  * A Switch Custom HTML Element.
@@ -219,9 +219,9 @@ export class Dialog extends FoundationElement {
     };
 
     private getTabQueueBounds = (): (HTMLElement | SVGElement)[] => {
-        const bounds: HTMLElement[] = [];
+        // const bounds: HTMLElement[] = [];
 
-        return Dialog.reduceTabbableItems(bounds, this);
+        return tabbable(this);
     };
 
     /**

--- a/packages/web-components/fast-foundation/src/dialog/dialog.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.ts
@@ -222,9 +222,7 @@ export class Dialog extends FoundationElement {
 
     private getTabQueueBounds = (): FocusableElement[] => {
         return tabbable(this, {
-            getShadowRoot: () => {
-                return undefined;
-            },
+            getShadowRoot: true,
         });
     };
 

--- a/packages/web-components/fast-foundation/src/toolbar/README.md
+++ b/packages/web-components/fast-foundation/src/toolbar/README.md
@@ -87,9 +87,9 @@ export const myToolbar = Toolbar.compose({
 
 #### Superclass
 
-| Name                | Module                  | Package |
-| ------------------- | ----------------------- | ------- |
-| `FoundationElement` | /src/foundation-element |         |
+| Name                | Module                                        | Package |
+| ------------------- | --------------------------------------------- | ------- |
+| `FoundationElement` | /src/foundation-element/foundation-element.js |         |
 
 #### Fields
 

--- a/packages/web-components/fast-foundation/src/toolbar/README.md
+++ b/packages/web-components/fast-foundation/src/toolbar/README.md
@@ -87,9 +87,9 @@ export const myToolbar = Toolbar.compose({
 
 #### Superclass
 
-| Name                | Module                                        | Package |
-| ------------------- | --------------------------------------------- | ------- |
-| `FoundationElement` | /src/foundation-element/foundation-element.js |         |
+| Name                | Module                  | Package |
+| ------------------- | ----------------------- | ------- |
+| `FoundationElement` | /src/foundation-element |         |
 
 #### Fields
 

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
@@ -1,11 +1,14 @@
-import { attr, FASTElement, observable, Observable } from "@microsoft/fast-element";
+import { attr, observable, Observable } from "@microsoft/fast-element";
 import { ArrowKeys, Direction, limit, Orientation } from "@microsoft/fast-web-utilities";
-import { FocusableElement, isFocusable, tabbable } from "tabbable";
-import { FoundationElement, FoundationElementDefinition } from "../foundation-element";
-import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global";
-import { StartEnd, StartEndOptions } from "../patterns/start-end";
-import { applyMixins } from "../utilities/apply-mixins";
-import { getDirection } from "../utilities/direction";
+import { focusable, FocusableElement } from "tabbable";
+import {
+    FoundationElement,
+    FoundationElementDefinition,
+} from "../foundation-element/foundation-element.js";
+import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global.js";
+import { StartEnd, StartEndOptions } from "../patterns/start-end.js";
+import { applyMixins } from "../utilities/apply-mixins.js";
+import { getDirection } from "../utilities/direction.js";
 
 /**
  * Toolbar configuration options
@@ -230,54 +233,10 @@ export class Toolbar extends FoundationElement {
      * @internal
      */
     protected reduceFocusableElements(): void {
-        this.focusableElements = this.allSlottedItems.reduce(
-            Toolbar.reduceFocusableItems,
-            []
-        );
-        // this.focusableElements = tabbable(this, {
-        //     getShadowRoot: () => {
-        //         return undefined;
-        //     },
-        // });
+        this.focusableElements = focusable(this, {
+            getShadowRoot: true,
+        });
         this.setFocusableElements();
-    }
-
-    /**
-     * Reduce a collection to only its focusable elements.
-     *
-     * @param elements - Collection of elements to reduce
-     * @param element - The current element
-     *
-     * @internal
-     */
-    private static reduceFocusableItems(
-        elements: HTMLElement[],
-        element: FASTElement & HTMLElement
-    ): HTMLElement[] {
-        const isRoleRadio = element.getAttribute("role") === "radio";
-        const isFocusableFastElement =
-            element.$fastController?.definition.shadowOptions?.delegatesFocus;
-        const hasFocusableShadow = Array.from(
-            element.shadowRoot?.querySelectorAll("*") ?? []
-        ).some(x => isFocusable(x));
-
-        if (
-            isFocusable(element) ||
-            isRoleRadio ||
-            isFocusableFastElement ||
-            hasFocusableShadow
-        ) {
-            elements.push(element);
-            return elements;
-        }
-
-        if (element.childElementCount) {
-            return elements.concat(
-                Array.from(element.children).reduce(Toolbar.reduceFocusableItems, [])
-            );
-        }
-
-        return elements;
     }
 
     /**

--- a/yarn.lock
+++ b/yarn.lock
@@ -23170,11 +23170,6 @@ tabbable@^4.0.0:
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
   integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
 
-tabbable@^5.2.0:
-  version "5.2.1"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.2.1.tgz#e3fda7367ddbb172dcda9f871c0fdb36d1c4cd9c"
-  integrity sha512-40pEZ2mhjaZzK0BnI+QGNjJO8UYx9pP5v7BGe17SORTO0OEuuaAwQTkAp8whcZvqon44wKFOikD+Al11K3JICQ==
-
 table@^5.2.3:
   version "5.4.6"
   resolved "https://registry.yarnpkg.com/table/-/table-5.4.6.tgz#1292d19500ce3f86053b05f0e8e7e4a3bb21079e"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23160,15 +23160,15 @@ symbol.prototype.description@^1.0.0:
     has-symbols "^1.0.2"
     object.getownpropertydescriptors "^2.1.2"
 
-tabbable@5.3.0-beta.0:
-  version "5.3.0-beta.0"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.0-beta.0.tgz#2840539883f236f2887312431fbfe07dc305bce5"
-  integrity sha512-zNNUKn79Qve4JNB3/tP38EdS8eA4Phjh6go1TQ1/o2QcQDoTBVbS4hDYwj6jF4242fCMseo1fLBfaeAQqVgOcA==
-
 tabbable@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"
   integrity sha512-H1XoH1URcBOa/rZZWxLxHCtOdVUEev+9vo5YdYhC9tCY4wnybX+VQrCYuy9ubkg69fCBxCONJOSLGfw0DWMffQ==
+
+tabbable@^5.3.1:
+  version "5.3.1"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.1.tgz#059f2a19b829efce2a0ec05785a47dd3bcd0a25b"
+  integrity sha512-NtO7I7eoAHR+JwwcNsi/PipamtAEebYDnur/k9wM6n238HHy/+1O4+7Zx7e/JaDAbKJPlIFYsfsV/6tPqTOQvg==
 
 table@^5.2.3:
   version "5.4.6"

--- a/yarn.lock
+++ b/yarn.lock
@@ -23160,6 +23160,11 @@ symbol.prototype.description@^1.0.0:
     has-symbols "^1.0.2"
     object.getownpropertydescriptors "^2.1.2"
 
+tabbable@5.3.0-beta.0:
+  version "5.3.0-beta.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-5.3.0-beta.0.tgz#2840539883f236f2887312431fbfe07dc305bce5"
+  integrity sha512-zNNUKn79Qve4JNB3/tP38EdS8eA4Phjh6go1TQ1/o2QcQDoTBVbS4hDYwj6jF4242fCMseo1fLBfaeAQqVgOcA==
+
 tabbable@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-4.0.0.tgz#5bff1d1135df1482cf0f0206434f15eadbeb9261"


### PR DESCRIPTION
## 📖 Description
This pr updates the dialog and toolbar elements to use [tabbable's](https://github.com/focus-trap/tabbable?msclkid=bb1d0c7fcd5b11ec81a99b1d2d3a9767) new shadom dom support.

### 🎫 Issues
Removes some local code.

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

- todo: add some shadow dom tests for dialog/toolbar, ideally in play wright.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)