### PR TITLE
feat: enable synchronous dom updates for SSR

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -1,5 +1,5 @@
 module.exports = {
-    disallowedChangeTypes: ["major"],
+    branch: "origin/features/fast-element-2",
     ignorePatterns: [
         ".ignore",
         ".github/",

--- a/change/@microsoft-fast-element-ecbe6511-b19c-4312-91f2-1c354ebd5245.json
+++ b/change/@microsoft-fast-element-ecbe6511-b19c-4312-91f2-1c354ebd5245.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enable synchronous dom updates for SSR",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-router-08a4dedc-a404-44ca-ac6a-fe3b4b22a2a1.json
+++ b/change/@microsoft-fast-router-08a4dedc-a404-44ca-ac6a-fe3b4b22a2a1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update router to work with new template primitives",
+  "packageName": "@microsoft/fast-router",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
   "scripts": {
     "bump": "beachball bump",
     "change": "beachball change",
-    "checkchange": "beachball check  --scope \"!sites/*\" --changehint \"Run 'yarn change' to generate a change file\" -b origin/features/fast-element-2",
+    "checkchange": "beachball check  --scope \"!sites/*\" --changehint \"Run 'yarn change' to generate a change file\"",
     "check": "beachball check ",
     "publish": "beachball publish",
     "publish-ci": "beachball publish -y --access public",

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -209,6 +209,7 @@ export const DOM: Readonly<{
     createInterpolationPlaceholder(index: number): string;
     createCustomAttributePlaceholder(index: number): string;
     createBlockPlaceholder(index: number): string;
+    setUpdateMode(isAsync: boolean): void;
     queueUpdate(callable: Callable): void;
     nextUpdate(): Promise<void>;
     processUpdates(): void;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds a feature that enables switching the rendering engine into a fully synchronous mode. Ordering of DOM updates is still preserved, such that nested tasks do not execute until after the parent task.

### 🎫 Issues

Closes #5592 

## 👩‍💻 Reviewer Notes

I added a method called `DOM.setUpdateMode()` to turn on/off async updates. Internally, work is still added to a queue so that ordering is preserved in nested tasks. However, once work is added, if the queue only has one item (it's not being currently drained synchronously) then we begin synchronously draining the queue. Similar updates were made to how exceptions are handled. An interesting detail is that once an exception is thrown the queue needs to be emptied in synchronous mode.

## 📑 Test Plan

Relevant tests from the async test suite were replicated and modified to ensure synchronous scenarios operate correctly.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

None at this time.