### PR TITLE
feat: enable pluggable style handling strategies

### DIFF
--- a/change/@microsoft-fast-element-58e983d2-9c67-4292-b678-88bc265b1fe8.json
+++ b/change/@microsoft-fast-element-58e983d2-9c67-4292-b678-88bc265b1fe8.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat: enable pluggable style handling strategies",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -226,7 +226,7 @@ export type ElementsFilter = (value: Node, index: number, array: Node[]) => bool
 // @public
 export class ElementStyles {
     constructor(
-    styles: ReadonlyArray<ComposableStyles>, strategy?: StyleStrategy | null);
+    styles: ReadonlyArray<ComposableStyles>);
     // @internal (undocumented)
     addStylesTo(target: StyleTarget): void;
     // @internal (undocumented)
@@ -235,11 +235,11 @@ export class ElementStyles {
     isAttachedTo(target: StyleTarget): boolean;
     // @internal (undocumented)
     removeStylesFrom(target: StyleTarget): void;
-    // (undocumented)
     static setStrategyFactory(factory: StyleStrategyFactory): void;
     // @internal (undocumented)
     readonly styles: ReadonlyArray<ComposableStyles>;
     withBehaviors(...behaviors: Behavior<HTMLElement>[]): this;
+    withStrategy(strategy: StyleStrategy): this;
 }
 
 // @public
@@ -498,13 +498,9 @@ export class Splice {
     removed: any[];
 }
 
-// @public (undocumented)
+// @public
 export interface StyleStrategy {
-    // (undocumented)
     addStylesTo(target: StyleTarget): void;
-    // (undocumented)
-    normalizeTarget(target: StyleTarget): StyleTarget;
-    // (undocumented)
     removeStylesFrom(target: StyleTarget): void;
 }
 
@@ -515,8 +511,6 @@ export type StyleStrategyFactory = (styles: (string | CSSStyleSheet)[]) => Style
 export interface StyleTarget {
     adoptedStyleSheets?: CSSStyleSheet[];
     append(styles: HTMLStyleElement): void;
-    // @deprecated
-    prepend(styles: HTMLStyleElement): void;
     querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
     removeChild(styles: HTMLStyleElement): void;
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -151,6 +151,11 @@ export type Constructable<T = {}> = {
 };
 
 // @public
+export type ConstructibleStyleStrategy = {
+    new (styles: (string | CSSStyleSheet)[]): StyleStrategy;
+};
+
+// @public
 export class Controller extends PropertyChangeNotifier {
     // @internal
     constructor(element: HTMLElement, definition: FASTElementDefinition);
@@ -235,11 +240,12 @@ export class ElementStyles {
     isAttachedTo(target: StyleTarget): boolean;
     // @internal (undocumented)
     removeStylesFrom(target: StyleTarget): void;
-    static setStrategyFactory(factory: StyleStrategyFactory): void;
+    static setDefaultStrategy(Strategy: ConstructibleStyleStrategy): void;
+    get strategy(): StyleStrategy;
     // @internal (undocumented)
     readonly styles: ReadonlyArray<ComposableStyles>;
     withBehaviors(...behaviors: Behavior<HTMLElement>[]): this;
-    withStrategy(strategy: StyleStrategy): this;
+    withStrategy(Strategy: ConstructibleStyleStrategy): this;
 }
 
 // @public
@@ -503,9 +509,6 @@ export interface StyleStrategy {
     addStylesTo(target: StyleTarget): void;
     removeStylesFrom(target: StyleTarget): void;
 }
-
-// @public
-export type StyleStrategyFactory = (styles: (string | CSSStyleSheet)[]) => StyleStrategy;
 
 // @public
 export interface StyleTarget {

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -226,7 +226,7 @@ export type ElementsFilter = (value: Node, index: number, array: Node[]) => bool
 // @public
 export class ElementStyles {
     constructor(
-    styles: ReadonlyArray<ComposableStyles>);
+    styles: ReadonlyArray<ComposableStyles>, strategy?: StyleStrategy | null);
     // @internal (undocumented)
     addStylesTo(target: StyleTarget): void;
     // @internal (undocumented)
@@ -509,7 +509,7 @@ export interface StyleStrategy {
 }
 
 // @public
-export type StyleStrategyFactory = (styles: ReadonlyArray<ComposableStyles>) => StyleStrategy;
+export type StyleStrategyFactory = (styles: (string | CSSStyleSheet)[]) => StyleStrategy;
 
 // @public
 export interface StyleTarget {

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -224,22 +224,19 @@ export const elements: (selector?: string | undefined) => ElementsFilter;
 export type ElementsFilter = (value: Node, index: number, array: Node[]) => boolean;
 
 // @public
-export type ElementStyleFactory = (styles: ReadonlyArray<ComposableStyles>) => ElementStyles;
-
-// @public
-export abstract class ElementStyles {
+export class ElementStyles {
     constructor(
-    styles: ReadonlyArray<ComposableStyles>,
-    behaviors: ReadonlyArray<Behavior<HTMLElement>> | null);
+    styles: ReadonlyArray<ComposableStyles>);
     // @internal (undocumented)
     addStylesTo(target: StyleTarget): void;
     // @internal (undocumented)
     readonly behaviors: ReadonlyArray<Behavior<HTMLElement>> | null;
-    static readonly create: ElementStyleFactory;
     // @internal (undocumented)
     isAttachedTo(target: StyleTarget): boolean;
     // @internal (undocumented)
     removeStylesFrom(target: StyleTarget): void;
+    // (undocumented)
+    static setStrategyFactory(factory: StyleStrategyFactory): void;
     // @internal (undocumented)
     readonly styles: ReadonlyArray<ComposableStyles>;
     withBehaviors(...behaviors: Behavior<HTMLElement>[]): this;
@@ -500,6 +497,19 @@ export class Splice {
     static normalize(previous: unknown[] | undefined, current: unknown[], changes: Splice[] | undefined): Splice[] | undefined;
     removed: any[];
 }
+
+// @public (undocumented)
+export interface StyleStrategy {
+    // (undocumented)
+    addStylesTo(target: StyleTarget): void;
+    // (undocumented)
+    normalizeTarget(target: StyleTarget): StyleTarget;
+    // (undocumented)
+    removeStylesFrom(target: StyleTarget): void;
+}
+
+// @public
+export type StyleStrategyFactory = (styles: ReadonlyArray<ComposableStyles>) => StyleStrategy;
 
 // @public
 export interface StyleTarget {

--- a/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
@@ -33,7 +33,7 @@ describe("FASTElementDefinition", () => {
 
         it("can accept ElementStyles", () => {
             const css = ".class { color: red; }";
-            const styles = ElementStyles.create([css]);
+            const styles = new ElementStyles([css]);
             const options = {
                 name: "test-element",
                 styles,
@@ -45,8 +45,8 @@ describe("FASTElementDefinition", () => {
         it("can accept multiple ElementStyles", () => {
             const css1 = ".class { color: red; }";
             const css2 = ".class2 { color: red; }";
-            const existingStyles1 = ElementStyles.create([css1]);
-            const existingStyles2 = ElementStyles.create([css2]);
+            const existingStyles1 = new ElementStyles([css1]);
+            const existingStyles2 = new ElementStyles([css2]);
             const options = {
                 name: "test-element",
                 styles: [existingStyles1, existingStyles2],
@@ -60,7 +60,7 @@ describe("FASTElementDefinition", () => {
         it("can accept mixed strings and ElementStyles", () => {
             const css1 = ".class { color: red; }";
             const css2 = ".class2 { color: red; }";
-            const existingStyles2 = ElementStyles.create([css2]);
+            const existingStyles2 = new ElementStyles([css2]);
             const options = {
                 name: "test-element",
                 styles: [css1, existingStyles2],
@@ -98,7 +98,7 @@ describe("FASTElementDefinition", () => {
             it("can accept mixed strings, ElementStyles, and CSSStyleSheets", () => {
                 const css1 = ".class { color: red; }";
                 const css2 = ".class2 { color: red; }";
-                const existingStyles2 = ElementStyles.create([css2]);
+                const existingStyles2 = new ElementStyles([css2]);
                 const styleSheet3 = new CSSStyleSheet();
                 const options = {
                     name: "test-element",

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -152,10 +152,10 @@ export class FASTElementDefinition<TType extends Function = Function> {
             nameOrConfig.styles === void 0
                 ? void 0
                 : Array.isArray(nameOrConfig.styles)
-                ? ElementStyles.create(nameOrConfig.styles)
+                ? new ElementStyles(nameOrConfig.styles)
                 : nameOrConfig.styles instanceof ElementStyles
                 ? nameOrConfig.styles
-                : ElementStyles.create([nameOrConfig.styles]);
+                : new ElementStyles([nameOrConfig.styles]);
     }
 
     /**

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -11,8 +11,8 @@ export type { Callable, Constructable, Mutable } from "./interfaces.js";
 export * from "./templating/compiler.js";
 export {
     ElementStyles,
-    StyleStrategyFactory,
     StyleStrategy,
+    ConstructibleStyleStrategy,
     ComposableStyles,
     StyleTarget,
 } from "./styles/element-styles.js";

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -11,7 +11,8 @@ export type { Callable, Constructable, Mutable } from "./interfaces.js";
 export * from "./templating/compiler.js";
 export {
     ElementStyles,
-    ElementStyleFactory,
+    StyleStrategyFactory,
+    StyleStrategy,
     ComposableStyles,
     StyleTarget,
 } from "./styles/element-styles.js";

--- a/packages/web-components/fast-element/src/styles/css.ts
+++ b/packages/web-components/fast-element/src/styles/css.ts
@@ -62,7 +62,7 @@ export function css(
     ...values: (ComposableStyles | CSSDirective)[]
 ): ElementStyles {
     const { styles, behaviors } = collectStyles(strings, values);
-    const elementStyles = ElementStyles.create(styles);
+    const elementStyles = new ElementStyles(styles);
     return behaviors.length ? elementStyles.withBehaviors(...behaviors) : elementStyles;
 }
 
@@ -91,7 +91,7 @@ class CSSPartial extends CSSDirective implements Behavior<HTMLElement> {
         );
 
         if (stylesheets.length) {
-            this.styles = ElementStyles.create(stylesheets);
+            this.styles = new ElementStyles(stylesheets);
         }
     }
 

--- a/packages/web-components/fast-element/src/styles/element-styles.ts
+++ b/packages/web-components/fast-element/src/styles/element-styles.ts
@@ -92,7 +92,27 @@ export class ElementStyles {
         /** @internal */
         public readonly styles: ReadonlyArray<ComposableStyles>
     ) {
-        this.behaviors = reduceBehaviors(styles);
+        this.behaviors = styles
+            .map((x: ComposableStyles) =>
+                x instanceof ElementStyles ? x.behaviors : null
+            )
+            .reduce(
+                (
+                    prev: Behavior<HTMLElement>[] | null,
+                    curr: Behavior<HTMLElement>[] | null
+                ) => {
+                    if (curr === null) {
+                        return prev;
+                    }
+
+                    if (prev === null) {
+                        prev = [];
+                    }
+
+                    return prev.concat(curr);
+                },
+                null as Behavior<HTMLElement>[] | null
+            );
     }
 
     /** @internal */
@@ -138,30 +158,6 @@ function reduceStyles(
             x instanceof ElementStyles ? reduceStyles(x.styles) : [x]
         )
         .reduce((prev: string[], curr: string[]) => prev.concat(curr), []);
-}
-
-function reduceBehaviors(
-    styles: ReadonlyArray<ComposableStyles>
-): ReadonlyArray<Behavior<HTMLElement>> | null {
-    return styles
-        .map((x: ComposableStyles) => (x instanceof ElementStyles ? x.behaviors : null))
-        .reduce(
-            (
-                prev: Behavior<HTMLElement>[] | null,
-                curr: Behavior<HTMLElement>[] | null
-            ) => {
-                if (curr === null) {
-                    return prev;
-                }
-
-                if (prev === null) {
-                    prev = [];
-                }
-
-                return prev.concat(curr);
-            },
-            null as Behavior<HTMLElement>[] | null
-        );
 }
 
 /**

--- a/packages/web-components/fast-element/src/styles/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles/styles.spec.ts
@@ -16,8 +16,7 @@ if (DOM.supportsAdoptedStyleSheets) {
     describe("AdoptedStyleSheetsStrategy", () => {
         context("when removing styles", () => {
             it("should remove an associated stylesheet", () => {
-                const cache = new Map();
-                const strategy = new AdoptedStyleSheetsStrategy([``], cache);
+                const strategy = new AdoptedStyleSheetsStrategy([``]);
                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
                     adoptedStyleSheets: [],
                 };
@@ -30,8 +29,7 @@ if (DOM.supportsAdoptedStyleSheets) {
             });
 
             it("should not remove unassociated styles", () => {
-                const cache = new Map();
-                const strategy = new AdoptedStyleSheetsStrategy(["test"], cache);
+                const strategy = new AdoptedStyleSheetsStrategy(["test"]);
                 const style = new CSSStyleSheet();
                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
                     adoptedStyleSheets: [style],
@@ -39,12 +37,12 @@ if (DOM.supportsAdoptedStyleSheets) {
                 strategy.addStylesTo(target as StyleTarget);
 
                 expect(target.adoptedStyleSheets!.length).to.equal(2);
-                expect(target.adoptedStyleSheets).to.contain(cache.get("test"));
+                expect(target.adoptedStyleSheets).to.contain(strategy.sheets[0]);
 
                 strategy.removeStylesFrom(target as StyleTarget);
 
                 expect(target.adoptedStyleSheets!.length).to.equal(1);
-                expect(target.adoptedStyleSheets).not.to.contain(cache.get("test"));
+                expect(target.adoptedStyleSheets).not.to.contain(strategy.sheets[0]);
             });
 
             it("should track when added and removed from a target", () => {
@@ -64,9 +62,8 @@ if (DOM.supportsAdoptedStyleSheets) {
             });
 
             it("should order HTMLStyleElement order by addStyleTo() call order", () => {
-                const cache = new Map();
-                const red = new AdoptedStyleSheetsStrategy(['r'], cache);
-                const green = new AdoptedStyleSheetsStrategy(['g'], cache);
+                const red = new AdoptedStyleSheetsStrategy(['r']);
+                const green = new AdoptedStyleSheetsStrategy(['g']);
                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
                     adoptedStyleSheets: [],
                 };
@@ -74,20 +71,19 @@ if (DOM.supportsAdoptedStyleSheets) {
                 red.addStylesTo(target as StyleTarget);
                 green.addStylesTo(target as StyleTarget);
 
-                expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
-                expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
+                expect((target.adoptedStyleSheets![0])).to.equal(red.sheets[0]);
+                expect((target.adoptedStyleSheets![1])).to.equal(green.sheets[0]);
             });
             it("should order HTMLStyleElements in array order of provided sheets", () => {
-                const cache = new Map();
-                const red = new AdoptedStyleSheetsStrategy(['r', 'g'], cache);
+                const red = new AdoptedStyleSheetsStrategy(['r', 'g']);
                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
                     adoptedStyleSheets: [],
                 };
 
                 red.addStylesTo(target as StyleTarget);
 
-                expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
-                expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
+                expect((target.adoptedStyleSheets![0])).to.equal(red.sheets[0]);
+                expect((target.adoptedStyleSheets![1])).to.equal(red.sheets[1]);
             });
         });
     });
@@ -97,7 +93,7 @@ describe("StyleElementStrategy", () => {
     it("can add and remove from the document directly", () => {
         const styles = [``];
         const elementStyles = new ElementStyles(styles)
-            .withStrategy(new StyleElementStrategy(styles));
+            .withStrategy(StyleElementStrategy);
         document.body.innerHTML = "";
 
         elementStyles.addStylesTo(document);

--- a/packages/web-components/fast-element/src/styles/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles/styles.spec.ts
@@ -1,362 +1,362 @@
-import { expect } from "chai";
-import {
-    AdoptedStyleSheetsStyles,
-    StyleElementStyles,
-    StyleTarget,
-    ElementStyles,
-} from "./element-styles";
-import { DOM } from "../dom";
-import { CSSDirective } from "./css-directive";
-import { css, cssPartial } from "./css";
-import type { Behavior } from "../observation/behavior";
-import { defaultExecutionContext } from "../observation/observable";
-import type { FASTElement } from "..";
-
-if (DOM.supportsAdoptedStyleSheets) {
-    describe("AdoptedStyleSheetsStyles", () => {
-        context("when removing styles", () => {
-            it("should remove an associated stylesheet", () => {
-                const cache = new Map();
-                const sheet = new AdoptedStyleSheetsStyles([``], cache);
-                const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
-                    adoptedStyleSheets: [],
-                };
-
-                sheet.addStylesTo(target as StyleTarget);
-                expect(target.adoptedStyleSheets!.length).to.equal(1);
-
-                sheet.removeStylesFrom(target as StyleTarget);
-                expect(target.adoptedStyleSheets!.length).to.equal(0);
-            });
-
-            it("should not remove unassociated styles", () => {
-                const cache = new Map();
-                const sheet = new AdoptedStyleSheetsStyles(["test"], cache);
-                const style = new CSSStyleSheet();
-                const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
-                    adoptedStyleSheets: [style],
-                };
-                sheet.addStylesTo(target as StyleTarget);
-
-                expect(target.adoptedStyleSheets!.length).to.equal(2);
-                expect(target.adoptedStyleSheets).to.contain(cache.get("test"));
-
-                sheet.removeStylesFrom(target as StyleTarget);
-
-                expect(target.adoptedStyleSheets!.length).to.equal(1);
-                expect(target.adoptedStyleSheets).not.to.contain(cache.get("test"));
-            });
-
-            it("should track when added and removed from a target", () => {
-                const cache = new Map();
-                const styles = ``;
-                const elementStyles = new AdoptedStyleSheetsStyles([styles], cache);
-                const target = {
-                    adoptedStyleSheets: [],
-                } as unknown as StyleTarget;
-
-                expect(elementStyles.isAttachedTo(target as StyleTarget)).to.equal(false)
-
-                elementStyles.addStylesTo(target);
-                expect(elementStyles.isAttachedTo(target)).to.equal(true)
-
-                elementStyles.removeStylesFrom(target);
-                expect(elementStyles.isAttachedTo(target)).to.equal(false)
-            });
-
-            it("should order HTMLStyleElement order by addStyleTo() call order", () => {
-                const cache = new Map();
-                const red = new AdoptedStyleSheetsStyles(['r'], cache);
-                const green = new AdoptedStyleSheetsStyles(['g'], cache);
-                const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
-                    adoptedStyleSheets: [],
-                };
-
-                red.addStylesTo(target as StyleTarget);
-                green.addStylesTo(target as StyleTarget);
-
-                expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
-                expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
-            });
-            it("should order HTMLStyleElements in array order of provided sheets", () => {
-                const cache = new Map();
-                const red = new AdoptedStyleSheetsStyles(['r', 'g'], cache);
-                const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
-                    adoptedStyleSheets: [],
-                };
-
-                red.addStylesTo(target as StyleTarget);
-
-                expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
-                expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
-            });
-        });
-    });
-}
-
-describe("StyleSheetStyles", () => {
-    it("can add and remove from the document directly", () => {
-        const styles = ``;
-        const elementStyles = new StyleElementStyles([styles]);
-        document.body.innerHTML = "";
-
-        elementStyles.addStylesTo(document);
-
-        expect(document.body.childNodes[0]).to.be.instanceof(HTMLStyleElement);
-
-        elementStyles.removeStylesFrom(document);
-
-        expect(document.body.childNodes.length).to.equal(0);
-    });
-
-    it("can add and remove from a ShadowRoot", () => {
-        const styles = ``;
-        const elementStyles = new StyleElementStyles([styles]);
-        document.body.innerHTML = "";
-
-        const element = document.createElement("div");
-        const shadowRoot = element.attachShadow({ mode: "open" });
-
-        elementStyles.addStylesTo(shadowRoot);
-
-        expect(shadowRoot.childNodes[0]).to.be.instanceof(HTMLStyleElement);
-
-        elementStyles.removeStylesFrom(shadowRoot);
-
-        expect(shadowRoot.childNodes.length).to.equal(0);
-    });
-    it("should track when added and removed from a target", () => {
-        const styles = ``;
-        const elementStyles = new StyleElementStyles([styles]);
-        document.body.innerHTML = "";
-
-        expect(elementStyles.isAttachedTo(document)).to.equal(false)
-
-        elementStyles.addStylesTo(document);
-        expect(elementStyles.isAttachedTo(document)).to.equal(true)
-
-        elementStyles.removeStylesFrom(document);
-        expect(elementStyles.isAttachedTo(document)).to.equal(false)
-    });
-
-    it("should order HTMLStyleElement order by addStyleTo() call order", () => {
-        const red = new StyleElementStyles([`body:{color:red;}`]);
-        const green = new StyleElementStyles([`body:{color:green;}`]);
-        document.body.innerHTML = "";
-
-        const element = document.createElement("div");
-        const shadowRoot = element.attachShadow({mode: "open"});
-        red.addStylesTo(shadowRoot);
-        green.addStylesTo(shadowRoot);
-
-        expect((shadowRoot.childNodes[0] as HTMLStyleElement).innerHTML).to.equal("body:{color:red;}");
-        expect((shadowRoot.childNodes[1] as HTMLStyleElement).innerHTML).to.equal("body:{color:green;}");
-    });
-    it("should order the HTMLStyleElements in array order of provided sheets", () => {
-        const red = new StyleElementStyles([`body:{color:red;}`, `body:{color:green;}`]);
-        document.body.innerHTML = "";
-
-        const element = document.createElement("div");
-        const shadowRoot = element.attachShadow({mode: "open"});
-        red.addStylesTo(shadowRoot);
-
-        expect((shadowRoot.childNodes[0] as HTMLStyleElement).innerHTML).to.equal("body:{color:red;}");
-        expect((shadowRoot.childNodes[1] as HTMLStyleElement).innerHTML).to.equal("body:{color:green;}");
-    });
-});
-
-describe("ElementStyles", () => {
-    it("can create from a string", () => {
-        const css = ".class { color: red; }";
-        const styles = ElementStyles.create([css]);
-        expect(styles.styles).to.contain(css);
-    });
-
-    it("can create from multiple strings", () => {
-        const css1 = ".class { color: red; }";
-        const css2 = ".class2 { color: red; }";
-        const styles = ElementStyles.create([css1, css2]);
-        expect(styles.styles).to.contain(css1);
-        expect(styles.styles.indexOf(css1)).to.equal(0);
-        expect(styles.styles).to.contain(css2);
-    });
-
-    it("can create from an ElementStyles", () => {
-        const css = ".class { color: red; }";
-        const existingStyles = ElementStyles.create([css]);
-        const styles = ElementStyles.create([existingStyles]);
-        expect(styles.styles).to.contain(existingStyles);
-    });
-
-    it("can create from multiple ElementStyles", () => {
-        const css1 = ".class { color: red; }";
-        const css2 = ".class2 { color: red; }";
-        const existingStyles1 = ElementStyles.create([css1]);
-        const existingStyles2 = ElementStyles.create([css2]);
-        const styles = ElementStyles.create([existingStyles1, existingStyles2]);
-        expect(styles.styles).to.contain(existingStyles1);
-        expect(styles.styles.indexOf(existingStyles1)).to.equal(0);
-        expect(styles.styles).to.contain(existingStyles2);
-    });
-
-    it("can create from mixed strings and ElementStyles", () => {
-        const css1 = ".class { color: red; }";
-        const css2 = ".class2 { color: red; }";
-        const existingStyles2 = ElementStyles.create([css2]);
-        const styles = ElementStyles.create([css1, existingStyles2]);
-        expect(styles.styles).to.contain(css1);
-        expect(styles.styles.indexOf(css1)).to.equal(0);
-        expect(styles.styles).to.contain(existingStyles2);
-    });
-
-    if (DOM.supportsAdoptedStyleSheets) {
-        it("can create from a CSSStyleSheet", () => {
-            const styleSheet = new CSSStyleSheet();
-            const styles = ElementStyles.create([styleSheet]);
-            expect(styles.styles).to.contain(styleSheet);
-        });
-
-        it("can create from multiple CSSStyleSheets", () => {
-            const styleSheet1 = new CSSStyleSheet();
-            const styleSheet2 = new CSSStyleSheet();
-            const styles = ElementStyles.create([styleSheet1, styleSheet2]);
-            expect(styles.styles).to.contain(styleSheet1);
-            expect(styles.styles.indexOf(styleSheet1)).to.equal(0);
-            expect(styles.styles).to.contain(styleSheet2);
-        });
-
-        it("can create from mixed strings, ElementStyles, and CSSStyleSheets", () => {
-            const css1 = ".class { color: red; }";
-            const css2 = ".class2 { color: red; }";
-            const existingStyles2 = ElementStyles.create([css2]);
-            const styleSheet3 = new CSSStyleSheet();
-            const styles = ElementStyles.create([css1, existingStyles2, styleSheet3]);
-            expect(styles.styles).to.contain(css1);
-            expect(styles.styles.indexOf(css1)).to.equal(0);
-            expect(styles.styles).to.contain(existingStyles2);
-            expect(styles.styles.indexOf(existingStyles2)).to.equal(1);
-            expect(styles.styles).to.contain(styleSheet3);
-        });
-    }
-});
-
-describe("css", () => {
-    describe("with a CSSDirective", () => {
-        describe("should interpolate the product of CSSDirective.createCSS() into the resulting ElementStyles CSS", () => {
-            it("when the result is a string", () => {
-                class Directive extends CSSDirective {
-                    createCSS() {
-                        return "red";
-                    }
-                }
-
-                const styles = css`host: {color: ${new Directive()};}`;
-                expect(styles.styles.some(x => x === "host: {color: red;}")).to.equal(true)
-            });
-
-            it("when the result is an ElementStyles", () => {
-                const _styles = css`:host{color: red}`
-                class Directive extends CSSDirective {
-                    createCSS() {
-                        return _styles;
-                    }
-                }
-
-                const styles = css`${new Directive()}`;
-                expect(styles.styles.includes(_styles)).to.equal(true)
-            });
-
-            if (DOM.supportsAdoptedStyleSheets) {
-                it("when the result is a CSSStyleSheet", () => {
-                    const _styles = new CSSStyleSheet();
-                    class Directive extends CSSDirective {
-                        createCSS() {
-                            return _styles;
-                        }
-                    }
-
-                    const styles = css`${new Directive()}`;
-                    expect(styles.styles.includes(_styles)).to.equal(true)
-                });
-            }
-        });
-
-
-        it("should add the behavior returned from CSSDirective.getBehavior() to the resulting ElementStyles", () => {
-            const behavior = {
-                bind(){},
-                unbind(){}
-            }
-
-            class Directive extends CSSDirective {
-                createBehavior() {
-                    return behavior;
-                }
-            }
-
-            const styles = css`${new Directive()}`;
-
-            expect(styles.behaviors?.includes(behavior)).to.equal(true)
-        });
-    })
-});
-
-describe("cssPartial", () => {
-    it("should have a createCSS method that is the CSS string interpolated with the createCSS product of any CSSDirectives", () => {
-        class myDirective extends CSSDirective {
-            createCSS() { return "red" };
-            createBehavior() { return undefined; }
-        }
-
-        const partial = cssPartial`color: ${new myDirective}`;
-        expect (partial.createCSS()).to.equal("color: red");
-    });
-
-    it("Should add behaviors from interpolated CSS directives when bound to an element", () => {
-        const behavior = {
-            bind() {},
-            unbind() {},
-        }
-
-        const behavior2 = {...behavior};
-
-        class directive extends CSSDirective {
-            createCSS() { return "" };
-            createBehavior() { return behavior; }
-        }
-        class directive2 extends CSSDirective {
-            createCSS() { return "" };
-            createBehavior() { return behavior2; }
-        }
-
-        const partial = cssPartial`${new directive}${new directive2}`;
-        const el = {
-            $fastController: {
-                addBehaviors(behaviors: Behavior<HTMLElement>[]) {
-                    expect(behaviors[0]).to.equal(behavior);
-                    expect(behaviors[1]).to.equal(behavior2);
-                }
-            }
-        } as FASTElement;
-
-        partial.createBehavior()?.bind(el, defaultExecutionContext)
-    });
-
-    it("should add any ElementStyles interpolated into the template function when bound to an element", () => {
-        const styles = css`:host {color: blue; }`;
-        const partial = cssPartial`${styles}`;
-        let called = false;
-        const el = {
-            $fastController: {
-                addStyles(style: ElementStyles) {
-                    expect(style.styles.includes(styles)).to.be.true;
-                    called = true;
-                }
-            }
-        } as FASTElement;
-
-        partial.createBehavior()?.bind(el, defaultExecutionContext)
-
-        expect(called).to.be.true;
-    })
-})
+// import { expect } from "chai";
+// import {
+//     AdoptedStyleSheetsStrategy,
+//     StyleElementStrategy,
+//     StyleTarget,
+//     ElementStyles,
+// } from "./element-styles";
+// import { DOM } from "../dom";
+// import { CSSDirective } from "./css-directive";
+// import { css, cssPartial } from "./css";
+// import type { Behavior } from "../observation/behavior";
+// import { defaultExecutionContext } from "../observation/observable";
+// import type { FASTElement } from "..";
+
+// if (DOM.supportsAdoptedStyleSheets) {
+//     describe("AdoptedStyleSheetsStyles", () => {
+//         context("when removing styles", () => {
+//             it("should remove an associated stylesheet", () => {
+//                 const cache = new Map();
+//                 const sheet = new AdoptedStyleSheetsStrategy([``], cache);
+//                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
+//                     adoptedStyleSheets: [],
+//                 };
+
+//                 sheet.addStylesTo(target as StyleTarget);
+//                 expect(target.adoptedStyleSheets!.length).to.equal(1);
+
+//                 sheet.removeStylesFrom(target as StyleTarget);
+//                 expect(target.adoptedStyleSheets!.length).to.equal(0);
+//             });
+
+//             it("should not remove unassociated styles", () => {
+//                 const cache = new Map();
+//                 const sheet = new AdoptedStyleSheetsStrategy(["test"], cache);
+//                 const style = new CSSStyleSheet();
+//                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
+//                     adoptedStyleSheets: [style],
+//                 };
+//                 sheet.addStylesTo(target as StyleTarget);
+
+//                 expect(target.adoptedStyleSheets!.length).to.equal(2);
+//                 expect(target.adoptedStyleSheets).to.contain(cache.get("test"));
+
+//                 sheet.removeStylesFrom(target as StyleTarget);
+
+//                 expect(target.adoptedStyleSheets!.length).to.equal(1);
+//                 expect(target.adoptedStyleSheets).not.to.contain(cache.get("test"));
+//             });
+
+//             it("should track when added and removed from a target", () => {
+//                 const cache = new Map();
+//                 const styles = ``;
+//                 const elementStyles = new AdoptedStyleSheetsStrategy([styles], cache);
+//                 const target = {
+//                     adoptedStyleSheets: [],
+//                 } as unknown as StyleTarget;
+
+//                 expect(elementStyles.isAttachedTo(target as StyleTarget)).to.equal(false)
+
+//                 elementStyles.addStylesTo(target);
+//                 expect(elementStyles.isAttachedTo(target)).to.equal(true)
+
+//                 elementStyles.removeStylesFrom(target);
+//                 expect(elementStyles.isAttachedTo(target)).to.equal(false)
+//             });
+
+//             it("should order HTMLStyleElement order by addStyleTo() call order", () => {
+//                 const cache = new Map();
+//                 const red = new AdoptedStyleSheetsStrategy(['r'], cache);
+//                 const green = new AdoptedStyleSheetsStrategy(['g'], cache);
+//                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
+//                     adoptedStyleSheets: [],
+//                 };
+
+//                 red.addStylesTo(target as StyleTarget);
+//                 green.addStylesTo(target as StyleTarget);
+
+//                 expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
+//                 expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
+//             });
+//             it("should order HTMLStyleElements in array order of provided sheets", () => {
+//                 const cache = new Map();
+//                 const red = new AdoptedStyleSheetsStrategy(['r', 'g'], cache);
+//                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
+//                     adoptedStyleSheets: [],
+//                 };
+
+//                 red.addStylesTo(target as StyleTarget);
+
+//                 expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
+//                 expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
+//             });
+//         });
+//     });
+// }
+
+// describe("StyleSheetStyles", () => {
+//     it("can add and remove from the document directly", () => {
+//         const styles = ``;
+//         const elementStyles = new StyleElementStrategy([styles]);
+//         document.body.innerHTML = "";
+
+//         elementStyles.addStylesTo(document);
+
+//         expect(document.body.childNodes[0]).to.be.instanceof(HTMLStyleElement);
+
+//         elementStyles.removeStylesFrom(document);
+
+//         expect(document.body.childNodes.length).to.equal(0);
+//     });
+
+//     it("can add and remove from a ShadowRoot", () => {
+//         const styles = ``;
+//         const elementStyles = new StyleElementStrategy([styles]);
+//         document.body.innerHTML = "";
+
+//         const element = document.createElement("div");
+//         const shadowRoot = element.attachShadow({ mode: "open" });
+
+//         elementStyles.addStylesTo(shadowRoot);
+
+//         expect(shadowRoot.childNodes[0]).to.be.instanceof(HTMLStyleElement);
+
+//         elementStyles.removeStylesFrom(shadowRoot);
+
+//         expect(shadowRoot.childNodes.length).to.equal(0);
+//     });
+//     it("should track when added and removed from a target", () => {
+//         const styles = ``;
+//         const elementStyles = new StyleElementStrategy([styles]);
+//         document.body.innerHTML = "";
+
+//         expect(elementStyles.isAttachedTo(document)).to.equal(false)
+
+//         elementStyles.addStylesTo(document);
+//         expect(elementStyles.isAttachedTo(document)).to.equal(true)
+
+//         elementStyles.removeStylesFrom(document);
+//         expect(elementStyles.isAttachedTo(document)).to.equal(false)
+//     });
+
+//     it("should order HTMLStyleElement order by addStyleTo() call order", () => {
+//         const red = new StyleElementStrategy([`body:{color:red;}`]);
+//         const green = new StyleElementStrategy([`body:{color:green;}`]);
+//         document.body.innerHTML = "";
+
+//         const element = document.createElement("div");
+//         const shadowRoot = element.attachShadow({mode: "open"});
+//         red.addStylesTo(shadowRoot);
+//         green.addStylesTo(shadowRoot);
+
+//         expect((shadowRoot.childNodes[0] as HTMLStyleElement).innerHTML).to.equal("body:{color:red;}");
+//         expect((shadowRoot.childNodes[1] as HTMLStyleElement).innerHTML).to.equal("body:{color:green;}");
+//     });
+//     it("should order the HTMLStyleElements in array order of provided sheets", () => {
+//         const red = new StyleElementStrategy([`body:{color:red;}`, `body:{color:green;}`]);
+//         document.body.innerHTML = "";
+
+//         const element = document.createElement("div");
+//         const shadowRoot = element.attachShadow({mode: "open"});
+//         red.addStylesTo(shadowRoot);
+
+//         expect((shadowRoot.childNodes[0] as HTMLStyleElement).innerHTML).to.equal("body:{color:red;}");
+//         expect((shadowRoot.childNodes[1] as HTMLStyleElement).innerHTML).to.equal("body:{color:green;}");
+//     });
+// });
+
+// describe("ElementStyles", () => {
+//     it("can create from a string", () => {
+//         const css = ".class { color: red; }";
+//         const styles = ElementStyles.create([css]);
+//         expect(styles.styles).to.contain(css);
+//     });
+
+//     it("can create from multiple strings", () => {
+//         const css1 = ".class { color: red; }";
+//         const css2 = ".class2 { color: red; }";
+//         const styles = ElementStyles.create([css1, css2]);
+//         expect(styles.styles).to.contain(css1);
+//         expect(styles.styles.indexOf(css1)).to.equal(0);
+//         expect(styles.styles).to.contain(css2);
+//     });
+
+//     it("can create from an ElementStyles", () => {
+//         const css = ".class { color: red; }";
+//         const existingStyles = ElementStyles.create([css]);
+//         const styles = ElementStyles.create([existingStyles]);
+//         expect(styles.styles).to.contain(existingStyles);
+//     });
+
+//     it("can create from multiple ElementStyles", () => {
+//         const css1 = ".class { color: red; }";
+//         const css2 = ".class2 { color: red; }";
+//         const existingStyles1 = ElementStyles.create([css1]);
+//         const existingStyles2 = ElementStyles.create([css2]);
+//         const styles = ElementStyles.create([existingStyles1, existingStyles2]);
+//         expect(styles.styles).to.contain(existingStyles1);
+//         expect(styles.styles.indexOf(existingStyles1)).to.equal(0);
+//         expect(styles.styles).to.contain(existingStyles2);
+//     });
+
+//     it("can create from mixed strings and ElementStyles", () => {
+//         const css1 = ".class { color: red; }";
+//         const css2 = ".class2 { color: red; }";
+//         const existingStyles2 = ElementStyles.create([css2]);
+//         const styles = ElementStyles.create([css1, existingStyles2]);
+//         expect(styles.styles).to.contain(css1);
+//         expect(styles.styles.indexOf(css1)).to.equal(0);
+//         expect(styles.styles).to.contain(existingStyles2);
+//     });
+
+//     if (DOM.supportsAdoptedStyleSheets) {
+//         it("can create from a CSSStyleSheet", () => {
+//             const styleSheet = new CSSStyleSheet();
+//             const styles = ElementStyles.create([styleSheet]);
+//             expect(styles.styles).to.contain(styleSheet);
+//         });
+
+//         it("can create from multiple CSSStyleSheets", () => {
+//             const styleSheet1 = new CSSStyleSheet();
+//             const styleSheet2 = new CSSStyleSheet();
+//             const styles = ElementStyles.create([styleSheet1, styleSheet2]);
+//             expect(styles.styles).to.contain(styleSheet1);
+//             expect(styles.styles.indexOf(styleSheet1)).to.equal(0);
+//             expect(styles.styles).to.contain(styleSheet2);
+//         });
+
+//         it("can create from mixed strings, ElementStyles, and CSSStyleSheets", () => {
+//             const css1 = ".class { color: red; }";
+//             const css2 = ".class2 { color: red; }";
+//             const existingStyles2 = ElementStyles.create([css2]);
+//             const styleSheet3 = new CSSStyleSheet();
+//             const styles = ElementStyles.create([css1, existingStyles2, styleSheet3]);
+//             expect(styles.styles).to.contain(css1);
+//             expect(styles.styles.indexOf(css1)).to.equal(0);
+//             expect(styles.styles).to.contain(existingStyles2);
+//             expect(styles.styles.indexOf(existingStyles2)).to.equal(1);
+//             expect(styles.styles).to.contain(styleSheet3);
+//         });
+//     }
+// });
+
+// describe("css", () => {
+//     describe("with a CSSDirective", () => {
+//         describe("should interpolate the product of CSSDirective.createCSS() into the resulting ElementStyles CSS", () => {
+//             it("when the result is a string", () => {
+//                 class Directive extends CSSDirective {
+//                     createCSS() {
+//                         return "red";
+//                     }
+//                 }
+
+//                 const styles = css`host: {color: ${new Directive()};}`;
+//                 expect(styles.styles.some(x => x === "host: {color: red;}")).to.equal(true)
+//             });
+
+//             it("when the result is an ElementStyles", () => {
+//                 const _styles = css`:host{color: red}`
+//                 class Directive extends CSSDirective {
+//                     createCSS() {
+//                         return _styles;
+//                     }
+//                 }
+
+//                 const styles = css`${new Directive()}`;
+//                 expect(styles.styles.includes(_styles)).to.equal(true)
+//             });
+
+//             if (DOM.supportsAdoptedStyleSheets) {
+//                 it("when the result is a CSSStyleSheet", () => {
+//                     const _styles = new CSSStyleSheet();
+//                     class Directive extends CSSDirective {
+//                         createCSS() {
+//                             return _styles;
+//                         }
+//                     }
+
+//                     const styles = css`${new Directive()}`;
+//                     expect(styles.styles.includes(_styles)).to.equal(true)
+//                 });
+//             }
+//         });
+
+
+//         it("should add the behavior returned from CSSDirective.getBehavior() to the resulting ElementStyles", () => {
+//             const behavior = {
+//                 bind(){},
+//                 unbind(){}
+//             }
+
+//             class Directive extends CSSDirective {
+//                 createBehavior() {
+//                     return behavior;
+//                 }
+//             }
+
+//             const styles = css`${new Directive()}`;
+
+//             expect(styles.behaviors?.includes(behavior)).to.equal(true)
+//         });
+//     })
+// });
+
+// describe("cssPartial", () => {
+//     it("should have a createCSS method that is the CSS string interpolated with the createCSS product of any CSSDirectives", () => {
+//         class myDirective extends CSSDirective {
+//             createCSS() { return "red" };
+//             createBehavior() { return undefined; }
+//         }
+
+//         const partial = cssPartial`color: ${new myDirective}`;
+//         expect (partial.createCSS()).to.equal("color: red");
+//     });
+
+//     it("Should add behaviors from interpolated CSS directives when bound to an element", () => {
+//         const behavior = {
+//             bind() {},
+//             unbind() {},
+//         }
+
+//         const behavior2 = {...behavior};
+
+//         class directive extends CSSDirective {
+//             createCSS() { return "" };
+//             createBehavior() { return behavior; }
+//         }
+//         class directive2 extends CSSDirective {
+//             createCSS() { return "" };
+//             createBehavior() { return behavior2; }
+//         }
+
+//         const partial = cssPartial`${new directive}${new directive2}`;
+//         const el = {
+//             $fastController: {
+//                 addBehaviors(behaviors: Behavior<HTMLElement>[]) {
+//                     expect(behaviors[0]).to.equal(behavior);
+//                     expect(behaviors[1]).to.equal(behavior2);
+//                 }
+//             }
+//         } as FASTElement;
+
+//         partial.createBehavior()?.bind(el, defaultExecutionContext)
+//     });
+
+//     it("should add any ElementStyles interpolated into the template function when bound to an element", () => {
+//         const styles = css`:host {color: blue; }`;
+//         const partial = cssPartial`${styles}`;
+//         let called = false;
+//         const el = {
+//             $fastController: {
+//                 addStyles(style: ElementStyles) {
+//                     expect(style.styles.includes(styles)).to.be.true;
+//                     called = true;
+//                 }
+//             }
+//         } as FASTElement;
+
+//         partial.createBehavior()?.bind(el, defaultExecutionContext)
+
+//         expect(called).to.be.true;
+//     })
+// })

--- a/packages/web-components/fast-element/src/styles/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles/styles.spec.ts
@@ -1,362 +1,364 @@
-// import { expect } from "chai";
-// import {
-//     AdoptedStyleSheetsStrategy,
-//     StyleElementStrategy,
-//     StyleTarget,
-//     ElementStyles,
-// } from "./element-styles";
-// import { DOM } from "../dom";
-// import { CSSDirective } from "./css-directive";
-// import { css, cssPartial } from "./css";
-// import type { Behavior } from "../observation/behavior";
-// import { defaultExecutionContext } from "../observation/observable";
-// import type { FASTElement } from "..";
-
-// if (DOM.supportsAdoptedStyleSheets) {
-//     describe("AdoptedStyleSheetsStyles", () => {
-//         context("when removing styles", () => {
-//             it("should remove an associated stylesheet", () => {
-//                 const cache = new Map();
-//                 const sheet = new AdoptedStyleSheetsStrategy([``], cache);
-//                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
-//                     adoptedStyleSheets: [],
-//                 };
-
-//                 sheet.addStylesTo(target as StyleTarget);
-//                 expect(target.adoptedStyleSheets!.length).to.equal(1);
-
-//                 sheet.removeStylesFrom(target as StyleTarget);
-//                 expect(target.adoptedStyleSheets!.length).to.equal(0);
-//             });
-
-//             it("should not remove unassociated styles", () => {
-//                 const cache = new Map();
-//                 const sheet = new AdoptedStyleSheetsStrategy(["test"], cache);
-//                 const style = new CSSStyleSheet();
-//                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
-//                     adoptedStyleSheets: [style],
-//                 };
-//                 sheet.addStylesTo(target as StyleTarget);
-
-//                 expect(target.adoptedStyleSheets!.length).to.equal(2);
-//                 expect(target.adoptedStyleSheets).to.contain(cache.get("test"));
-
-//                 sheet.removeStylesFrom(target as StyleTarget);
-
-//                 expect(target.adoptedStyleSheets!.length).to.equal(1);
-//                 expect(target.adoptedStyleSheets).not.to.contain(cache.get("test"));
-//             });
-
-//             it("should track when added and removed from a target", () => {
-//                 const cache = new Map();
-//                 const styles = ``;
-//                 const elementStyles = new AdoptedStyleSheetsStrategy([styles], cache);
-//                 const target = {
-//                     adoptedStyleSheets: [],
-//                 } as unknown as StyleTarget;
-
-//                 expect(elementStyles.isAttachedTo(target as StyleTarget)).to.equal(false)
-
-//                 elementStyles.addStylesTo(target);
-//                 expect(elementStyles.isAttachedTo(target)).to.equal(true)
-
-//                 elementStyles.removeStylesFrom(target);
-//                 expect(elementStyles.isAttachedTo(target)).to.equal(false)
-//             });
-
-//             it("should order HTMLStyleElement order by addStyleTo() call order", () => {
-//                 const cache = new Map();
-//                 const red = new AdoptedStyleSheetsStrategy(['r'], cache);
-//                 const green = new AdoptedStyleSheetsStrategy(['g'], cache);
-//                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
-//                     adoptedStyleSheets: [],
-//                 };
-
-//                 red.addStylesTo(target as StyleTarget);
-//                 green.addStylesTo(target as StyleTarget);
-
-//                 expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
-//                 expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
-//             });
-//             it("should order HTMLStyleElements in array order of provided sheets", () => {
-//                 const cache = new Map();
-//                 const red = new AdoptedStyleSheetsStrategy(['r', 'g'], cache);
-//                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
-//                     adoptedStyleSheets: [],
-//                 };
-
-//                 red.addStylesTo(target as StyleTarget);
-
-//                 expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
-//                 expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
-//             });
-//         });
-//     });
-// }
-
-// describe("StyleSheetStyles", () => {
-//     it("can add and remove from the document directly", () => {
-//         const styles = ``;
-//         const elementStyles = new StyleElementStrategy([styles]);
-//         document.body.innerHTML = "";
-
-//         elementStyles.addStylesTo(document);
-
-//         expect(document.body.childNodes[0]).to.be.instanceof(HTMLStyleElement);
-
-//         elementStyles.removeStylesFrom(document);
-
-//         expect(document.body.childNodes.length).to.equal(0);
-//     });
-
-//     it("can add and remove from a ShadowRoot", () => {
-//         const styles = ``;
-//         const elementStyles = new StyleElementStrategy([styles]);
-//         document.body.innerHTML = "";
-
-//         const element = document.createElement("div");
-//         const shadowRoot = element.attachShadow({ mode: "open" });
-
-//         elementStyles.addStylesTo(shadowRoot);
-
-//         expect(shadowRoot.childNodes[0]).to.be.instanceof(HTMLStyleElement);
-
-//         elementStyles.removeStylesFrom(shadowRoot);
-
-//         expect(shadowRoot.childNodes.length).to.equal(0);
-//     });
-//     it("should track when added and removed from a target", () => {
-//         const styles = ``;
-//         const elementStyles = new StyleElementStrategy([styles]);
-//         document.body.innerHTML = "";
-
-//         expect(elementStyles.isAttachedTo(document)).to.equal(false)
-
-//         elementStyles.addStylesTo(document);
-//         expect(elementStyles.isAttachedTo(document)).to.equal(true)
-
-//         elementStyles.removeStylesFrom(document);
-//         expect(elementStyles.isAttachedTo(document)).to.equal(false)
-//     });
-
-//     it("should order HTMLStyleElement order by addStyleTo() call order", () => {
-//         const red = new StyleElementStrategy([`body:{color:red;}`]);
-//         const green = new StyleElementStrategy([`body:{color:green;}`]);
-//         document.body.innerHTML = "";
-
-//         const element = document.createElement("div");
-//         const shadowRoot = element.attachShadow({mode: "open"});
-//         red.addStylesTo(shadowRoot);
-//         green.addStylesTo(shadowRoot);
-
-//         expect((shadowRoot.childNodes[0] as HTMLStyleElement).innerHTML).to.equal("body:{color:red;}");
-//         expect((shadowRoot.childNodes[1] as HTMLStyleElement).innerHTML).to.equal("body:{color:green;}");
-//     });
-//     it("should order the HTMLStyleElements in array order of provided sheets", () => {
-//         const red = new StyleElementStrategy([`body:{color:red;}`, `body:{color:green;}`]);
-//         document.body.innerHTML = "";
-
-//         const element = document.createElement("div");
-//         const shadowRoot = element.attachShadow({mode: "open"});
-//         red.addStylesTo(shadowRoot);
-
-//         expect((shadowRoot.childNodes[0] as HTMLStyleElement).innerHTML).to.equal("body:{color:red;}");
-//         expect((shadowRoot.childNodes[1] as HTMLStyleElement).innerHTML).to.equal("body:{color:green;}");
-//     });
-// });
-
-// describe("ElementStyles", () => {
-//     it("can create from a string", () => {
-//         const css = ".class { color: red; }";
-//         const styles = ElementStyles.create([css]);
-//         expect(styles.styles).to.contain(css);
-//     });
-
-//     it("can create from multiple strings", () => {
-//         const css1 = ".class { color: red; }";
-//         const css2 = ".class2 { color: red; }";
-//         const styles = ElementStyles.create([css1, css2]);
-//         expect(styles.styles).to.contain(css1);
-//         expect(styles.styles.indexOf(css1)).to.equal(0);
-//         expect(styles.styles).to.contain(css2);
-//     });
-
-//     it("can create from an ElementStyles", () => {
-//         const css = ".class { color: red; }";
-//         const existingStyles = ElementStyles.create([css]);
-//         const styles = ElementStyles.create([existingStyles]);
-//         expect(styles.styles).to.contain(existingStyles);
-//     });
-
-//     it("can create from multiple ElementStyles", () => {
-//         const css1 = ".class { color: red; }";
-//         const css2 = ".class2 { color: red; }";
-//         const existingStyles1 = ElementStyles.create([css1]);
-//         const existingStyles2 = ElementStyles.create([css2]);
-//         const styles = ElementStyles.create([existingStyles1, existingStyles2]);
-//         expect(styles.styles).to.contain(existingStyles1);
-//         expect(styles.styles.indexOf(existingStyles1)).to.equal(0);
-//         expect(styles.styles).to.contain(existingStyles2);
-//     });
-
-//     it("can create from mixed strings and ElementStyles", () => {
-//         const css1 = ".class { color: red; }";
-//         const css2 = ".class2 { color: red; }";
-//         const existingStyles2 = ElementStyles.create([css2]);
-//         const styles = ElementStyles.create([css1, existingStyles2]);
-//         expect(styles.styles).to.contain(css1);
-//         expect(styles.styles.indexOf(css1)).to.equal(0);
-//         expect(styles.styles).to.contain(existingStyles2);
-//     });
-
-//     if (DOM.supportsAdoptedStyleSheets) {
-//         it("can create from a CSSStyleSheet", () => {
-//             const styleSheet = new CSSStyleSheet();
-//             const styles = ElementStyles.create([styleSheet]);
-//             expect(styles.styles).to.contain(styleSheet);
-//         });
-
-//         it("can create from multiple CSSStyleSheets", () => {
-//             const styleSheet1 = new CSSStyleSheet();
-//             const styleSheet2 = new CSSStyleSheet();
-//             const styles = ElementStyles.create([styleSheet1, styleSheet2]);
-//             expect(styles.styles).to.contain(styleSheet1);
-//             expect(styles.styles.indexOf(styleSheet1)).to.equal(0);
-//             expect(styles.styles).to.contain(styleSheet2);
-//         });
-
-//         it("can create from mixed strings, ElementStyles, and CSSStyleSheets", () => {
-//             const css1 = ".class { color: red; }";
-//             const css2 = ".class2 { color: red; }";
-//             const existingStyles2 = ElementStyles.create([css2]);
-//             const styleSheet3 = new CSSStyleSheet();
-//             const styles = ElementStyles.create([css1, existingStyles2, styleSheet3]);
-//             expect(styles.styles).to.contain(css1);
-//             expect(styles.styles.indexOf(css1)).to.equal(0);
-//             expect(styles.styles).to.contain(existingStyles2);
-//             expect(styles.styles.indexOf(existingStyles2)).to.equal(1);
-//             expect(styles.styles).to.contain(styleSheet3);
-//         });
-//     }
-// });
-
-// describe("css", () => {
-//     describe("with a CSSDirective", () => {
-//         describe("should interpolate the product of CSSDirective.createCSS() into the resulting ElementStyles CSS", () => {
-//             it("when the result is a string", () => {
-//                 class Directive extends CSSDirective {
-//                     createCSS() {
-//                         return "red";
-//                     }
-//                 }
-
-//                 const styles = css`host: {color: ${new Directive()};}`;
-//                 expect(styles.styles.some(x => x === "host: {color: red;}")).to.equal(true)
-//             });
-
-//             it("when the result is an ElementStyles", () => {
-//                 const _styles = css`:host{color: red}`
-//                 class Directive extends CSSDirective {
-//                     createCSS() {
-//                         return _styles;
-//                     }
-//                 }
-
-//                 const styles = css`${new Directive()}`;
-//                 expect(styles.styles.includes(_styles)).to.equal(true)
-//             });
-
-//             if (DOM.supportsAdoptedStyleSheets) {
-//                 it("when the result is a CSSStyleSheet", () => {
-//                     const _styles = new CSSStyleSheet();
-//                     class Directive extends CSSDirective {
-//                         createCSS() {
-//                             return _styles;
-//                         }
-//                     }
-
-//                     const styles = css`${new Directive()}`;
-//                     expect(styles.styles.includes(_styles)).to.equal(true)
-//                 });
-//             }
-//         });
-
-
-//         it("should add the behavior returned from CSSDirective.getBehavior() to the resulting ElementStyles", () => {
-//             const behavior = {
-//                 bind(){},
-//                 unbind(){}
-//             }
-
-//             class Directive extends CSSDirective {
-//                 createBehavior() {
-//                     return behavior;
-//                 }
-//             }
-
-//             const styles = css`${new Directive()}`;
-
-//             expect(styles.behaviors?.includes(behavior)).to.equal(true)
-//         });
-//     })
-// });
-
-// describe("cssPartial", () => {
-//     it("should have a createCSS method that is the CSS string interpolated with the createCSS product of any CSSDirectives", () => {
-//         class myDirective extends CSSDirective {
-//             createCSS() { return "red" };
-//             createBehavior() { return undefined; }
-//         }
-
-//         const partial = cssPartial`color: ${new myDirective}`;
-//         expect (partial.createCSS()).to.equal("color: red");
-//     });
-
-//     it("Should add behaviors from interpolated CSS directives when bound to an element", () => {
-//         const behavior = {
-//             bind() {},
-//             unbind() {},
-//         }
-
-//         const behavior2 = {...behavior};
-
-//         class directive extends CSSDirective {
-//             createCSS() { return "" };
-//             createBehavior() { return behavior; }
-//         }
-//         class directive2 extends CSSDirective {
-//             createCSS() { return "" };
-//             createBehavior() { return behavior2; }
-//         }
-
-//         const partial = cssPartial`${new directive}${new directive2}`;
-//         const el = {
-//             $fastController: {
-//                 addBehaviors(behaviors: Behavior<HTMLElement>[]) {
-//                     expect(behaviors[0]).to.equal(behavior);
-//                     expect(behaviors[1]).to.equal(behavior2);
-//                 }
-//             }
-//         } as FASTElement;
-
-//         partial.createBehavior()?.bind(el, defaultExecutionContext)
-//     });
-
-//     it("should add any ElementStyles interpolated into the template function when bound to an element", () => {
-//         const styles = css`:host {color: blue; }`;
-//         const partial = cssPartial`${styles}`;
-//         let called = false;
-//         const el = {
-//             $fastController: {
-//                 addStyles(style: ElementStyles) {
-//                     expect(style.styles.includes(styles)).to.be.true;
-//                     called = true;
-//                 }
-//             }
-//         } as FASTElement;
-
-//         partial.createBehavior()?.bind(el, defaultExecutionContext)
-
-//         expect(called).to.be.true;
-//     })
-// })
+import { expect } from "chai";
+import {
+    AdoptedStyleSheetsStrategy,
+    StyleElementStrategy,
+    StyleTarget,
+    ElementStyles,
+} from "./element-styles";
+import { DOM } from "../dom";
+import { CSSDirective } from "./css-directive";
+import { css, cssPartial } from "./css";
+import type { Behavior } from "../observation/behavior";
+import { defaultExecutionContext } from "../observation/observable";
+import type { FASTElement } from "..";
+
+if (DOM.supportsAdoptedStyleSheets) {
+    describe("AdoptedStyleSheetsStrategy", () => {
+        context("when removing styles", () => {
+            it("should remove an associated stylesheet", () => {
+                const cache = new Map();
+                const strategy = new AdoptedStyleSheetsStrategy([``], cache);
+                const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
+                    adoptedStyleSheets: [],
+                };
+
+                strategy.addStylesTo(target as StyleTarget);
+                expect(target.adoptedStyleSheets!.length).to.equal(1);
+
+                strategy.removeStylesFrom(target as StyleTarget);
+                expect(target.adoptedStyleSheets!.length).to.equal(0);
+            });
+
+            it("should not remove unassociated styles", () => {
+                const cache = new Map();
+                const strategy = new AdoptedStyleSheetsStrategy(["test"], cache);
+                const style = new CSSStyleSheet();
+                const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
+                    adoptedStyleSheets: [style],
+                };
+                strategy.addStylesTo(target as StyleTarget);
+
+                expect(target.adoptedStyleSheets!.length).to.equal(2);
+                expect(target.adoptedStyleSheets).to.contain(cache.get("test"));
+
+                strategy.removeStylesFrom(target as StyleTarget);
+
+                expect(target.adoptedStyleSheets!.length).to.equal(1);
+                expect(target.adoptedStyleSheets).not.to.contain(cache.get("test"));
+            });
+
+            it("should track when added and removed from a target", () => {
+                const styles = ``;
+                const elementStyles = new ElementStyles([styles]);
+                const target = {
+                    adoptedStyleSheets: [],
+                } as unknown as StyleTarget;
+
+                expect(elementStyles.isAttachedTo(target as StyleTarget)).to.equal(false)
+
+                elementStyles.addStylesTo(target);
+                expect(elementStyles.isAttachedTo(target)).to.equal(true)
+
+                elementStyles.removeStylesFrom(target);
+                expect(elementStyles.isAttachedTo(target)).to.equal(false)
+            });
+
+            it("should order HTMLStyleElement order by addStyleTo() call order", () => {
+                const cache = new Map();
+                const red = new AdoptedStyleSheetsStrategy(['r'], cache);
+                const green = new AdoptedStyleSheetsStrategy(['g'], cache);
+                const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
+                    adoptedStyleSheets: [],
+                };
+
+                red.addStylesTo(target as StyleTarget);
+                green.addStylesTo(target as StyleTarget);
+
+                expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
+                expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
+            });
+            it("should order HTMLStyleElements in array order of provided sheets", () => {
+                const cache = new Map();
+                const red = new AdoptedStyleSheetsStrategy(['r', 'g'], cache);
+                const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
+                    adoptedStyleSheets: [],
+                };
+
+                red.addStylesTo(target as StyleTarget);
+
+                expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
+                expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
+            });
+        });
+    });
+}
+
+describe("StyleElementStrategy", () => {
+    it("can add and remove from the document directly", () => {
+        const styles = ``;
+        const strategy = new StyleElementStrategy([styles]);
+        const elementStyles = new ElementStyles([styles], strategy);
+        document.body.innerHTML = "";
+
+        elementStyles.addStylesTo(document);
+
+        expect(document.body.childNodes[0]).to.be.instanceof(HTMLStyleElement);
+
+        elementStyles.removeStylesFrom(document);
+
+        expect(document.body.childNodes.length).to.equal(0);
+    });
+
+    it("can add and remove from a ShadowRoot", () => {
+        const styles = ``;
+        const strategy = new StyleElementStrategy([styles]);
+        document.body.innerHTML = "";
+
+        const element = document.createElement("div");
+        const shadowRoot = element.attachShadow({ mode: "open" });
+
+        strategy.addStylesTo(shadowRoot);
+
+        expect(shadowRoot.childNodes[0]).to.be.instanceof(HTMLStyleElement);
+
+        strategy.removeStylesFrom(shadowRoot);
+
+        expect(shadowRoot.childNodes.length).to.equal(0);
+    });
+
+    it("should track when added and removed from a target", () => {
+        const styles = ``;
+        const elementStyles = new ElementStyles([styles]);
+        document.body.innerHTML = "";
+
+        expect(elementStyles.isAttachedTo(document)).to.equal(false)
+
+        elementStyles.addStylesTo(document);
+        expect(elementStyles.isAttachedTo(document)).to.equal(true)
+
+        elementStyles.removeStylesFrom(document);
+        expect(elementStyles.isAttachedTo(document)).to.equal(false)
+    });
+
+    it("should order HTMLStyleElement order by addStyleTo() call order", () => {
+        const red = new StyleElementStrategy([`body:{color:red;}`]);
+        const green = new StyleElementStrategy([`body:{color:green;}`]);
+        document.body.innerHTML = "";
+
+        const element = document.createElement("div");
+        const shadowRoot = element.attachShadow({mode: "open"});
+        red.addStylesTo(shadowRoot);
+        green.addStylesTo(shadowRoot);
+
+        expect((shadowRoot.childNodes[0] as HTMLStyleElement).innerHTML).to.equal("body:{color:red;}");
+        expect((shadowRoot.childNodes[1] as HTMLStyleElement).innerHTML).to.equal("body:{color:green;}");
+    });
+
+    it("should order the HTMLStyleElements in array order of provided sheets", () => {
+        const red = new StyleElementStrategy([`body:{color:red;}`, `body:{color:green;}`]);
+        document.body.innerHTML = "";
+
+        const element = document.createElement("div");
+        const shadowRoot = element.attachShadow({mode: "open"});
+        red.addStylesTo(shadowRoot);
+
+        expect((shadowRoot.childNodes[0] as HTMLStyleElement).innerHTML).to.equal("body:{color:red;}");
+        expect((shadowRoot.childNodes[1] as HTMLStyleElement).innerHTML).to.equal("body:{color:green;}");
+    });
+});
+
+describe("ElementStyles", () => {
+    it("can create from a string", () => {
+        const css = ".class { color: red; }";
+        const styles = new ElementStyles([css]);
+        expect(styles.styles).to.contain(css);
+    });
+
+    it("can create from multiple strings", () => {
+        const css1 = ".class { color: red; }";
+        const css2 = ".class2 { color: red; }";
+        const styles = new ElementStyles([css1, css2]);
+        expect(styles.styles).to.contain(css1);
+        expect(styles.styles.indexOf(css1)).to.equal(0);
+        expect(styles.styles).to.contain(css2);
+    });
+
+    it("can create from an ElementStyles", () => {
+        const css = ".class { color: red; }";
+        const existingStyles = new ElementStyles([css]);
+        const styles = new ElementStyles([existingStyles]);
+        expect(styles.styles).to.contain(existingStyles);
+    });
+
+    it("can create from multiple ElementStyles", () => {
+        const css1 = ".class { color: red; }";
+        const css2 = ".class2 { color: red; }";
+        const existingStyles1 = new ElementStyles([css1]);
+        const existingStyles2 = new ElementStyles([css2]);
+        const styles = new ElementStyles([existingStyles1, existingStyles2]);
+        expect(styles.styles).to.contain(existingStyles1);
+        expect(styles.styles.indexOf(existingStyles1)).to.equal(0);
+        expect(styles.styles).to.contain(existingStyles2);
+    });
+
+    it("can create from mixed strings and ElementStyles", () => {
+        const css1 = ".class { color: red; }";
+        const css2 = ".class2 { color: red; }";
+        const existingStyles2 = new ElementStyles([css2]);
+        const styles = new ElementStyles([css1, existingStyles2]);
+        expect(styles.styles).to.contain(css1);
+        expect(styles.styles.indexOf(css1)).to.equal(0);
+        expect(styles.styles).to.contain(existingStyles2);
+    });
+
+    if (DOM.supportsAdoptedStyleSheets) {
+        it("can create from a CSSStyleSheet", () => {
+            const styleSheet = new CSSStyleSheet();
+            const styles = new ElementStyles([styleSheet]);
+            expect(styles.styles).to.contain(styleSheet);
+        });
+
+        it("can create from multiple CSSStyleSheets", () => {
+            const styleSheet1 = new CSSStyleSheet();
+            const styleSheet2 = new CSSStyleSheet();
+            const styles = new ElementStyles([styleSheet1, styleSheet2]);
+            expect(styles.styles).to.contain(styleSheet1);
+            expect(styles.styles.indexOf(styleSheet1)).to.equal(0);
+            expect(styles.styles).to.contain(styleSheet2);
+        });
+
+        it("can create from mixed strings, ElementStyles, and CSSStyleSheets", () => {
+            const css1 = ".class { color: red; }";
+            const css2 = ".class2 { color: red; }";
+            const existingStyles2 = new ElementStyles([css2]);
+            const styleSheet3 = new CSSStyleSheet();
+            const styles = new ElementStyles([css1, existingStyles2, styleSheet3]);
+            expect(styles.styles).to.contain(css1);
+            expect(styles.styles.indexOf(css1)).to.equal(0);
+            expect(styles.styles).to.contain(existingStyles2);
+            expect(styles.styles.indexOf(existingStyles2)).to.equal(1);
+            expect(styles.styles).to.contain(styleSheet3);
+        });
+    }
+});
+
+describe("css", () => {
+    describe("with a CSSDirective", () => {
+        describe("should interpolate the product of CSSDirective.createCSS() into the resulting ElementStyles CSS", () => {
+            it("when the result is a string", () => {
+                class Directive extends CSSDirective {
+                    createCSS() {
+                        return "red";
+                    }
+                }
+
+                const styles = css`host: {color: ${new Directive()};}`;
+                expect(styles.styles.some(x => x === "host: {color: red;}")).to.equal(true)
+            });
+
+            it("when the result is an ElementStyles", () => {
+                const _styles = css`:host{color: red}`
+                class Directive extends CSSDirective {
+                    createCSS() {
+                        return _styles;
+                    }
+                }
+
+                const styles = css`${new Directive()}`;
+                expect(styles.styles.includes(_styles)).to.equal(true)
+            });
+
+            if (DOM.supportsAdoptedStyleSheets) {
+                it("when the result is a CSSStyleSheet", () => {
+                    const _styles = new CSSStyleSheet();
+                    class Directive extends CSSDirective {
+                        createCSS() {
+                            return _styles;
+                        }
+                    }
+
+                    const styles = css`${new Directive()}`;
+                    expect(styles.styles.includes(_styles)).to.equal(true)
+                });
+            }
+        });
+
+
+        it("should add the behavior returned from CSSDirective.getBehavior() to the resulting ElementStyles", () => {
+            const behavior = {
+                bind(){},
+                unbind(){}
+            }
+
+            class Directive extends CSSDirective {
+                createBehavior() {
+                    return behavior;
+                }
+            }
+
+            const styles = css`${new Directive()}`;
+
+            expect(styles.behaviors?.includes(behavior)).to.equal(true)
+        });
+    })
+});
+
+describe("cssPartial", () => {
+    it("should have a createCSS method that is the CSS string interpolated with the createCSS product of any CSSDirectives", () => {
+        class myDirective extends CSSDirective {
+            createCSS() { return "red" };
+            createBehavior() { return undefined; }
+        }
+
+        const partial = cssPartial`color: ${new myDirective}`;
+        expect (partial.createCSS()).to.equal("color: red");
+    });
+
+    it("Should add behaviors from interpolated CSS directives when bound to an element", () => {
+        const behavior = {
+            bind() {},
+            unbind() {},
+        }
+
+        const behavior2 = {...behavior};
+
+        class directive extends CSSDirective {
+            createCSS() { return "" };
+            createBehavior() { return behavior; }
+        }
+        class directive2 extends CSSDirective {
+            createCSS() { return "" };
+            createBehavior() { return behavior2; }
+        }
+
+        const partial = cssPartial`${new directive}${new directive2}`;
+        const el = {
+            $fastController: {
+                addBehaviors(behaviors: Behavior<HTMLElement>[]) {
+                    expect(behaviors[0]).to.equal(behavior);
+                    expect(behaviors[1]).to.equal(behavior2);
+                }
+            }
+        } as FASTElement;
+
+        partial.createBehavior()?.bind(el, defaultExecutionContext)
+    });
+
+    it("should add any ElementStyles interpolated into the template function when bound to an element", () => {
+        const styles = css`:host {color: blue; }`;
+        const partial = cssPartial`${styles}`;
+        let called = false;
+        const el = {
+            $fastController: {
+                addStyles(style: ElementStyles) {
+                    expect(style.styles.includes(styles)).to.be.true;
+                    called = true;
+                }
+            }
+        } as FASTElement;
+
+        partial.createBehavior()?.bind(el, defaultExecutionContext)
+
+        expect(called).to.be.true;
+    })
+})

--- a/packages/web-components/fast-element/src/styles/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles/styles.spec.ts
@@ -95,9 +95,9 @@ if (DOM.supportsAdoptedStyleSheets) {
 
 describe("StyleElementStrategy", () => {
     it("can add and remove from the document directly", () => {
-        const styles = ``;
-        const strategy = new StyleElementStrategy([styles]);
-        const elementStyles = new ElementStyles([styles], strategy);
+        const styles = [``];
+        const elementStyles = new ElementStyles(styles)
+            .withStrategy(new StyleElementStrategy(styles));
         document.body.innerHTML = "";
 
         elementStyles.addStylesTo(document);


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR reworks `ElementStyles` so that it is now a concrete class with pluggable strategies for handling how styles are added/removed to/from elements. The strategy is not created until the styles need to be added to an element.

### 🎫 Issues

* Closes #5594

## 👩‍💻 Reviewer Notes

The main purpose of this change is to enable our SSR implementation to provide a custom strategy so that it can apply special server behavior around styles. 

## 📑 Test Plan

All existing style tests were adjusted to the new APIs in order to ensure that previous functionality still works correctly.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

We will likely refine the APIs as part of the SSR integration process.