### PR TITLE
Updated api-extractor version and exported markdown

### DIFF
--- a/change/@microsoft-fast-element-7ca9a49d-04d0-477b-8e6b-23249c19a3f2.json
+++ b/change/@microsoft-fast-element-7ca9a49d-04d0-477b-8e6b-23249c19a3f2.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Updated api-extractor version and exported markdown",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -49,7 +49,7 @@ export class AttributeDefinition implements Accessor {
     onAttributeChangedCallback(element: HTMLElement, value: any): void;
     readonly Owner: Function;
     setValue(source: HTMLElement, newValue: any): void;
-    }
+}
 
 // @public
 export type AttributeMode = "reflect" | "boolean" | "fromView";
@@ -409,11 +409,13 @@ export interface ObservationRecord {
     propertySource: any;
 }
 
+// Warning: (ae-forgotten-export) The symbol "BindingConfigResolver" needs to be exported by the entry point index.d.ts
+//
 // @public (undocumented)
-export const onChange: BindingConfig<any> & ((options?: DefaultBindingOptions | undefined) => BindingConfig);
+export const onChange: BindingConfig<DefaultBindingOptions> & BindingConfigResolver<DefaultBindingOptions>;
 
 // @public (undocumented)
-export const oneTime: BindingConfig<any> & ((options?: DefaultBindingOptions | undefined) => BindingConfig);
+export const oneTime: BindingConfig<DefaultBindingOptions> & BindingConfigResolver<DefaultBindingOptions>;
 
 // @public
 export interface PartialFASTElementDefinition {
@@ -455,14 +457,14 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
     // @internal (undocumented)
     handleChange(source: any, args: Splice[]): void;
     unbind(): void;
-    }
+}
 
 // @public
 export class RepeatDirective<TSource = any> extends HTMLDirective {
     constructor(itemsBinding: Binding, templateBinding: Binding<TSource, SyntheticViewTemplate>, options: RepeatOptions);
     createBehavior(targets: ViewBehaviorTargets): RepeatBehavior<TSource>;
     createPlaceholder: (index: number) => string;
-    }
+}
 
 // @public
 export interface RepeatOptions {
@@ -605,14 +607,13 @@ export class ViewTemplate<TSource = any, TParent = any, TGrandparent = any> impl
     readonly directives: ReadonlyArray<HTMLDirective>;
     readonly html: string | HTMLTemplateElement;
     render(source: TSource, host: Node, hostBindingTarget?: Element): HTMLView<TSource, TParent, TGrandparent>;
-    }
+}
 
 // @public
 export function volatile(target: {}, name: string | Accessor, descriptor: PropertyDescriptor): PropertyDescriptor;
 
 // @public
 export function when<TSource = any, TReturn = any>(binding: Binding<TSource, TReturn>, templateOrTemplateBinding: SyntheticViewTemplate | Binding<TSource, SyntheticViewTemplate>): CaptureType<TSource>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-element/package.json
+++ b/packages/web-components/fast-element/package.json
@@ -46,7 +46,7 @@
     "test-firefox:verbose": "karma start karma.conf.cjs --browsers=FirefoxHeadless --single-run --coverage --reporter=mocha"
   },
   "devDependencies": {
-    "@microsoft/api-extractor": "7.8.1",
+    "@microsoft/api-extractor": "7.19.4",
     "@types/chai": "^4.2.11",
     "@types/karma": "^5.0.0",
     "@types/mocha": "^7.0.2",


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
When running `npm run build` inside `@microsoft/fast-element` package, the following error is encountered:

`Error: Error parsing tsconfig.json content: Unknown compiler option 'importsNotUsedAsValues'.`

This happens because running `api-extractor` happens as a final step in the `build`, and the reason this error occurs is that the currently pinned version `typescript` used by `api-extractor` is below `3.8.0` when `importsNotUsedAsValues` was introduced as a flag. This change updates the version, we now have no errors, but the following warnings with this change:

```
Warning: You have changed the public API signature for this project. Updating docs/api-report.md
Warning: dist/dts/dom.d.ts:70:8 - (tsdoc-param-tag-missing-hyphen) The @param block should be followed by a parameter name and then a hyphen
Warning: dist/dts/observation/array-change-records.d.ts:6:33 - (tsdoc-escape-greater-than) The ">" character should be escaped using a backslash to avoid confusion with an HTML tag
Warning: dist/dts/observation/array-change-records.d.ts:6:6 - (tsdoc-html-tag-missing-greater-than) The HTML tag has invalid syntax: Expecting an attribute or ">" or "/>"
Warning: dist/dts/templating/binding.d.ts:4:1 - (ae-missing-release-tag) "BindingBehaviorFactory" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: dist/dts/templating/binding.d.ts:7:1 - (ae-missing-release-tag) "BindingType" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: dist/dts/templating/binding.d.ts:9:1 - (ae-missing-release-tag) "BindingMode" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: dist/dts/templating/binding.d.ts:17:1 - (ae-missing-release-tag) "BindingConfig" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: dist/dts/templating/binding.d.ts:23:1 - (ae-missing-release-tag) "DefaultBindingOptions" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: dist/dts/templating/binding.d.ts:26:22 - (ae-missing-release-tag) "onChange" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: dist/dts/templating/binding.d.ts:27:22 - (ae-missing-release-tag) "oneTime" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: dist/dts/templating/binding.d.ts:43:1 - (ae-missing-release-tag) "bind" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
Warning: dist/dts/templating/html-directive.d.ts:84:1 - (ae-missing-release-tag) "InlinableHTMLDirective" is exported by the package, but it is missing a release tag (@alpha, @beta, @public, or @internal)
```

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Partially addresses #5641 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Please take a look at the above warnings and determine if these are legitimate and we should proceed with the version update.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.