### PR TITLE
fix horizontal scroll playwright test

### DIFF
--- a/change/@microsoft-fast-components-069ebb02-c4b4-418d-b067-b778330ef651.json
+++ b/change/@microsoft-fast-components-069ebb02-c4b4-418d-b067-b778330ef651.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "wait for stable state in horizontal-scroll playwright test",
+  "packageName": "@microsoft/fast-components",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
@@ -189,6 +189,8 @@ describe("FASTHorizontalScroll", function () {
             }
         });
 
+        await element.waitForElementState("stable");
+
         expect(
             await element.evaluate(node =>
                 node.shadowRoot?.querySelector(".scroll-next")
@@ -264,9 +266,9 @@ describe("FASTHorizontalScroll", function () {
 
         await this.page.evaluateHandle(node => {
             if (node.firstElementChild) {
-            node.scrollContainer.scrollLeft =
-                node.scrollContainer.scrollWidth -
-                node.scrollContainer.offsetWidth -
+                node.scrollContainer.scrollLeft =
+                    node.scrollContainer.scrollWidth -
+                    node.scrollContainer.offsetWidth -
                     node.firstElementChild.clientWidth;
             }
         }, element);

--- a/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
+++ b/packages/web-components/fast-components/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
@@ -183,14 +183,15 @@ describe("FASTHorizontalScroll", function () {
 
         await element.evaluateHandle(node => {
             while (node.childElementCount > 1) {
-                node.removeChild(node.lastElementChild!);
+                if (node.lastElementChild) {
+                    node.removeChild(node.lastElementChild);
+                }
             }
         });
 
         expect(
             await element.evaluate(node =>
-                node
-                    .shadowRoot!.querySelector(".scroll-next")
+                node.shadowRoot?.querySelector(".scroll-next")
                     ?.classList.contains("disabled")
             )
         ).to.be.true;
@@ -203,9 +204,7 @@ describe("FASTHorizontalScroll", function () {
 
         expect(
             await element.evaluate(node =>
-                node
-                    .shadowRoot!.querySelector(".scroll-prev")
-                    ?.classList.contains("disabled")
+                node.shadowRoot?.querySelector(".scroll-prev")?.classList.contains("disabled")
             )
         ).to.be.true;
     });
@@ -264,10 +263,12 @@ describe("FASTHorizontalScroll", function () {
         )) as ElementHandle<fastHorizontalScroll>;
 
         await this.page.evaluateHandle(node => {
+            if (node.firstElementChild) {
             node.scrollContainer.scrollLeft =
                 node.scrollContainer.scrollWidth -
                 node.scrollContainer.offsetWidth -
-                node.firstElementChild!.clientWidth;
+                    node.firstElementChild.clientWidth;
+            }
         }, element);
 
         await element.evaluateHandle(node => node.scrollToNext());
@@ -296,7 +297,9 @@ describe("FASTHorizontalScroll", function () {
 
         await element.evaluateHandle(node => {
             // Move the scrollLeft almost to the end
-            node.scrollContainer.scrollLeft = node.firstElementChild!.clientWidth;
+            if (node.firstElementChild) {
+                node.scrollContainer.scrollLeft = node.firstElementChild.clientWidth;
+            }
 
             node.scrollToPrevious();
         });


### PR DESCRIPTION
# Pull Request

## 📖 Description

* Fixes the "FASTHorizontalScroll should disable the next flipper if content is less than horizontal-scroll width" test.
* Fixes minor lint warnings in the horizontal scroll playwright tests.

## 👩‍💻 Reviewer Notes

This test was failing on GH Actions for some browsers.

## 📑 Test Plan

The "FASTHorizontalScroll should disable the next flipper if content is less than horizontal-scroll width" test should pass in all playwright browsers.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

This is part of a series of fixes for our Playwright tests:

* #5646