### PR TITLE
feat: expose official Markup and Parser APIs

### DIFF
--- a/change/@microsoft-fast-element-725e8774-1f96-49df-a63d-64d0b4bf5d6b.json
+++ b/change/@microsoft-fast-element-725e8774-1f96-49df-a63d-64d0b4bf5d6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat: expose official Markup and Parser APIs",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -49,7 +49,7 @@ export class AttributeDefinition implements Accessor {
     onAttributeChangedCallback(element: HTMLElement, value: any): void;
     readonly Owner: Function;
     setValue(source: HTMLElement, newValue: any): void;
-}
+    }
 
 // @public
 export type AttributeMode = "reflect" | "boolean" | "fromView";
@@ -209,11 +209,6 @@ export const DOM: Readonly<{
     supportsAdoptedStyleSheets: boolean;
     setHTMLPolicy(policy: TrustedTypesPolicy): void;
     createHTML(html: string): string;
-    isMarker(node: Node): node is Comment;
-    extractDirectiveIndexFromMarker(node: Comment): number;
-    createInterpolationPlaceholder(index: number): string;
-    createCustomAttributePlaceholder(index: number): string;
-    createBlockPlaceholder(index: number): string;
     setUpdateMode(isAsync: boolean): void;
     queueUpdate(callable: Callable): void;
     nextUpdate(): Promise<void>;
@@ -355,13 +350,22 @@ export class HTMLView<TSource = any, TParent = any, TGrandparent = any> implemen
     unbind(): void;
 }
 
-// @public (undocumented)
+// @public
 export abstract class InlinableHTMLDirective extends AspectedHTMLDirective {
     // (undocumented)
     abstract readonly binding: Binding;
     // (undocumented)
     abstract readonly rawAspect?: string;
 }
+
+// @public
+export const Markup: Readonly<{
+    marker: string;
+    interpolation(index: number): string;
+    attribute(index: number): string;
+    comment(index: number): string;
+    indexFromComment(node: Comment): number;
+}>;
 
 // Warning: (ae-internal-missing-underscore) The name "Mutable" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -418,6 +422,12 @@ export const onChange: BindingConfig<DefaultBindingOptions> & BindingConfigResol
 export const oneTime: BindingConfig<DefaultBindingOptions> & BindingConfigResolver<DefaultBindingOptions>;
 
 // @public
+export const Parser: Readonly<{
+    parse(value: string, directives: readonly HTMLDirective[]): (string | HTMLDirective)[] | null;
+    aggregate(parts: (string | HTMLDirective)[]): InlinableHTMLDirective;
+}>;
+
+// @public
 export interface PartialFASTElementDefinition {
     readonly attributes?: (AttributeConfiguration | string)[];
     readonly elementOptions?: ElementDefinitionOptions;
@@ -457,14 +467,14 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
     // @internal (undocumented)
     handleChange(source: any, args: Splice[]): void;
     unbind(): void;
-}
+    }
 
 // @public
 export class RepeatDirective<TSource = any> extends HTMLDirective {
     constructor(itemsBinding: Binding, templateBinding: Binding<TSource, SyntheticViewTemplate>, options: RepeatOptions);
     createBehavior(targets: ViewBehaviorTargets): RepeatBehavior<TSource>;
     createPlaceholder: (index: number) => string;
-}
+    }
 
 // @public
 export interface RepeatOptions {
@@ -607,13 +617,14 @@ export class ViewTemplate<TSource = any, TParent = any, TGrandparent = any> impl
     readonly directives: ReadonlyArray<HTMLDirective>;
     readonly html: string | HTMLTemplateElement;
     render(source: TSource, host: Node, hostBindingTarget?: Element): HTMLView<TSource, TParent, TGrandparent>;
-}
+    }
 
 // @public
 export function volatile(target: {}, name: string | Accessor, descriptor: PropertyDescriptor): PropertyDescriptor;
 
 // @public
 export function when<TSource = any, TReturn = any>(binding: Binding<TSource, TReturn>, templateOrTemplateBinding: SyntheticViewTemplate | Binding<TSource, SyntheticViewTemplate>): CaptureType<TSource>;
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-element/src/dom.ts
+++ b/packages/web-components/fast-element/src/dom.ts
@@ -36,18 +36,6 @@ function tryRunTask(task: Callable): void {
     }
 }
 
-const marker = `fast-${Math.random().toString(36).substring(2, 8)}`;
-let id = 0;
-
-/** @internal */
-export const nextId = (): string => `${marker}-${++id}`;
-
-/** @internal */
-export const _interpolationStart = `${marker}{`;
-
-/** @internal */
-export const _interpolationEnd = `}${marker}`;
-
 /**
  * Common DOM APIs.
  * @public
@@ -87,57 +75,8 @@ export const DOM = Object.freeze({
     },
 
     /**
-     * Determines if the provided node is a template marker used by the runtime.
-     * @param node - The node to test.
-     */
-    isMarker(node: Node): node is Comment {
-        return node && node.nodeType === 8 && (node as Comment).data.startsWith(marker);
-    },
-
-    /**
-     * Given a marker node, extract the {@link HTMLDirective} index from the placeholder.
-     * @param node - The marker node to extract the index from.
-     */
-    extractDirectiveIndexFromMarker(node: Comment): number {
-        return parseInt(node.data.replace(`${marker}:`, ""));
-    },
-
-    /**
-     * Creates a placeholder string suitable for marking out a location *within*
-     * an attribute value or HTML content.
-     * @param index - The directive index to create the placeholder for.
-     * @remarks
-     * Used internally by binding directives.
-     */
-    createInterpolationPlaceholder(index: number): string {
-        return `${_interpolationStart}${index}${_interpolationEnd}`;
-    },
-
-    /**
-     * Creates a placeholder that manifests itself as an attribute on an
-     * element.
-     * @param attributeName - The name of the custom attribute.
-     * @param index - The directive index to create the placeholder for.
-     * @remarks
-     * Used internally by attribute directives such as `ref`, `slotted`, and `children`.
-     */
-    createCustomAttributePlaceholder(index: number): string {
-        return `${nextId()}="${this.createInterpolationPlaceholder(index)}"`;
-    },
-
-    /**
-     * Creates a placeholder that manifests itself as a marker within the DOM structure.
-     * @param index - The directive index to create the placeholder for.
-     * @remarks
-     * Used internally by structural directives such as `repeat`.
-     */
-    createBlockPlaceholder(index: number): string {
-        return `<!--${marker}:${index}-->`;
-    },
-
-    /**
      * Sets the update mode used by queueUpdate.
-     * @param isAsync Indicates whether DOM updates should be asynchronous.
+     * @param isAsync - Indicates whether DOM updates should be asynchronous.
      * @remarks
      * By default, the update mode is asynchronous, since that provides the best
      * performance in the browser. Passing false to setUpdateMode will instead cause

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -24,6 +24,7 @@ export { Splice } from "./observation/array-change-records.js";
 export { enableArrayObservation } from "./observation/array-observer.js";
 export { DOM } from "./dom.js";
 export type { Behavior } from "./observation/behavior.js";
+export { Markup, Parser } from "./templating/markup.js";
 export {
     bind,
     oneTime,

--- a/packages/web-components/fast-element/src/observation/array-change-records.ts
+++ b/packages/web-components/fast-element/src/observation/array-change-records.ts
@@ -13,7 +13,7 @@ const enum Edit {
 // followed by an add. By retaining this, we optimize for "keeping" the
 // maximum array items in the original array. For example:
 //
-//   'xxxx123' -> '123yyyy'
+//   'xxxx123' to '123yyyy'
 //
 // With 1-edit updates, the shortest path would be just to update all seven
 // characters. With 2-edit updates, we delete 4, leave 3, and add 4. This
@@ -169,7 +169,7 @@ function intersect(start1: number, end1: number, start2: number, end2: number): 
  * was transformed into a new array of items. Conceptually it is a list of
  * tuples of
  *
- *   <index, removed, addedCount>
+ *   (index, removed, addedCount)
  *
  * which are kept in ascending index order of. The tuple represents that at
  * the |index|, |removed| sequence of items were removed, and counting forward

--- a/packages/web-components/fast-element/src/styles/element-styles.ts
+++ b/packages/web-components/fast-element/src/styles/element-styles.ts
@@ -1,5 +1,6 @@
 import type { Behavior } from "../observation/behavior.js";
-import { DOM, nextId } from "../dom.js";
+import { DOM } from "../dom.js";
+import { nextId } from "../templating/markup.js";
 
 /**
  * A node that can be targeted by styles.

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
-import { customElement, FASTElement } from "../components/fast-element";
 import { DOM } from "../dom";
+import { customElement, FASTElement } from "../components/fast-element";
+import { Markup } from './markup';
 import { defaultExecutionContext } from "../observation/observable";
 import { css } from "../styles/css";
 import type { StyleTarget } from "../styles/element-styles";
@@ -18,7 +19,7 @@ describe("The template compiler", () => {
     }
 
     function inline(index: number) {
-        return DOM.createInterpolationPlaceholder(index);
+        return Markup.interpolation(index);
     }
 
     function binding(result = "result") {

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -1,4 +1,4 @@
-import { DOM, nextId } from "../dom.js";
+import { Markup, nextId } from "./markup.js";
 import type { Behavior } from "../observation/behavior.js";
 import type { Binding, ExecutionContext } from "../observation/observable.js";
 
@@ -99,10 +99,13 @@ export abstract class AspectedHTMLDirective extends HTMLDirective {
      * Creates a placeholder string based on the directive's index within the template.
      * @param index - The index of the directive within the template.
      */
-    public createPlaceholder: (index: number) => string =
-        DOM.createInterpolationPlaceholder;
+    public createPlaceholder: (index: number) => string = Markup.interpolation;
 }
 
+/**
+ * A {@link HTMLDirective} that can be inlined within an attribute or text content.
+ * @public
+ */
 export abstract class InlinableHTMLDirective extends AspectedHTMLDirective {
     abstract readonly binding: Binding;
     abstract readonly rawAspect?: string;
@@ -134,7 +137,7 @@ export abstract class StatelessAttachedAttributeDirective<T> extends HTMLDirecti
      * Creates a custom attribute placeholder.
      */
     public createPlaceholder(index: number): string {
-        return DOM.createCustomAttributePlaceholder(index);
+        return Markup.attribute(index);
     }
 
     /**

--- a/packages/web-components/fast-element/src/templating/markup.ts
+++ b/packages/web-components/fast-element/src/templating/markup.ts
@@ -1,0 +1,150 @@
+import { isString } from "../interfaces.js";
+import type { ExecutionContext } from "../observation/observable.js";
+import { bind } from "./binding.js";
+import type { HTMLDirective, InlinableHTMLDirective } from "./html-directive.js";
+
+const marker = `fast-${Math.random().toString(36).substring(2, 8)}`;
+const interpolationStart = `${marker}{`;
+const interpolationEnd = `}${marker}`;
+const interpolationEndLength = interpolationEnd.length;
+
+let id = 0;
+
+/** @internal */
+export const nextId = (): string => `${marker}-${++id}`;
+
+/**
+ * Common APIs related to markup generation.
+ * @public
+ */
+export const Markup = Object.freeze({
+    /**
+     * Gets the unique marker used by FAST to annotate templates.
+     */
+    marker,
+
+    /**
+     * Creates a placeholder string suitable for marking out a location *within*
+     * an attribute value or HTML content.
+     * @param index - The directive index to create the placeholder for.
+     * @remarks
+     * Used internally by binding directives.
+     */
+    interpolation(index: number): string {
+        return `${interpolationStart}${index}${interpolationEnd}`;
+    },
+
+    /**
+     * Creates a placeholder that manifests itself as an attribute on an
+     * element.
+     * @param attributeName - The name of the custom attribute.
+     * @param index - The directive index to create the placeholder for.
+     * @remarks
+     * Used internally by attribute directives such as `ref`, `slotted`, and `children`.
+     */
+    attribute(index: number): string {
+        return `${nextId()}="${this.interpolation(index)}"`;
+    },
+
+    /**
+     * Creates a placeholder that manifests itself as a marker within the DOM structure.
+     * @param index - The directive index to create the placeholder for.
+     * @remarks
+     * Used internally by structural directives such as `repeat`.
+     */
+    comment(index: number): string {
+        return `<!--${marker}:${index}-->`;
+    },
+
+    /**
+     * Given a marker node, extract the {@link HTMLDirective} index from the placeholder.
+     * @param node - The marker node to extract the index from.
+     */
+    indexFromComment(node: Comment): number {
+        return parseInt(node.data.replace(`${marker}:`, ""));
+    },
+});
+
+/**
+ * Common APIs related to content parsing.
+ * @public
+ */
+export const Parser = Object.freeze({
+    /**
+     * Parses text content or HTML attribute content, separating out the static strings
+     * from the directives.
+     * @param value - The content or attribute string to parse.
+     * @param directives - A list of directives to search for in the string.
+     * @returns A heterogeneous array of static strings interspersed with
+     * directives or null if no directives are found in the string.
+     */
+    parse(
+        value: string,
+        directives: readonly HTMLDirective[]
+    ): (string | HTMLDirective)[] | null {
+        const valueParts = value.split(interpolationStart);
+
+        if (valueParts.length === 1) {
+            return null;
+        }
+
+        const bindingParts: (string | HTMLDirective)[] = [];
+
+        for (let i = 0, ii = valueParts.length; i < ii; ++i) {
+            const current = valueParts[i];
+            const index = current.indexOf(interpolationEnd);
+            let literal: string | HTMLDirective;
+
+            if (index === -1) {
+                literal = current;
+            } else {
+                const directiveIndex = parseInt(current.substring(0, index));
+                bindingParts.push(directives[directiveIndex]);
+                literal = current.substring(index + interpolationEndLength);
+            }
+
+            if (literal !== "") {
+                bindingParts.push(literal);
+            }
+        }
+
+        return bindingParts;
+    },
+
+    /**
+     * Aggregates an array of strings and directives into a single directive.
+     * @param parts - A heterogeneous array of static strings interspersed with
+     * directives.
+     * @returns A single inline directive that aggregates the behavior of all the parts.
+     */
+    aggregate(parts: (string | HTMLDirective)[]): InlinableHTMLDirective {
+        if (parts.length === 1) {
+            return parts[0] as InlinableHTMLDirective;
+        }
+
+        let aspect: string | undefined;
+        const partCount = parts.length;
+        const finalParts = parts.map((x: string | InlinableHTMLDirective) => {
+            if (isString(x)) {
+                return (): string => x;
+            }
+
+            aspect = x.rawAspect || aspect;
+            return x.binding;
+        });
+
+        const binding = (scope: unknown, context: ExecutionContext): string => {
+            let output = "";
+
+            for (let i = 0; i < partCount; ++i) {
+                output += finalParts[i](scope, context);
+            }
+
+            return output;
+        };
+
+        const directive = bind(binding) as InlinableHTMLDirective;
+        directive.setAspect(aspect!);
+        return directive;
+    },
+});

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -1,4 +1,4 @@
-import { DOM } from "../dom.js";
+import { Markup } from "./markup.js";
 import { isFunction } from "../interfaces.js";
 import type { Splice } from "../observation/array-change-records.js";
 import { enableArrayObservation } from "../observation/array-observer.js";
@@ -307,7 +307,7 @@ export class RepeatDirective<TSource = any> extends HTMLDirective {
      * Creates a placeholder string based on the directive's index within the template.
      * @param index - The index of the directive within the template.
      */
-    public createPlaceholder: (index: number) => string = DOM.createBlockPlaceholder;
+    public createPlaceholder: (index: number) => string = Markup.comment;
 
     /**
      * Creates an instance of RepeatDirective.

--- a/packages/web-components/fast-element/src/templating/template.spec.ts
+++ b/packages/web-components/fast-element/src/templating/template.spec.ts
@@ -1,8 +1,8 @@
 import { expect } from "chai";
 import { html, ViewTemplate } from "./template";
-import { DOM } from "../dom";
+import { Markup } from "./markup";
 import { HTMLBindingDirective } from "./binding";
-import { HTMLDirective, AspectedHTMLDirective } from "./html-directive";
+import { HTMLDirective } from "./html-directive";
 import { bind, Binding, InlinableHTMLDirective, ViewBehaviorTargets } from "..";
 
 describe(`The html tag template helper`, () => {
@@ -17,7 +17,7 @@ describe(`The html tag template helper`, () => {
         }
 
         createPlaceholder(index: number) {
-            return DOM.createBlockPlaceholder(index);
+            return Markup.comment(index);
         }
     }
 
@@ -51,40 +51,40 @@ describe(`The html tag template helper`, () => {
             type: "number",
             location: "at the beginning",
             template: html`${numberValue} end`,
-            result: `${DOM.createInterpolationPlaceholder(0)} end`,
+            result: `${Markup.interpolation(0)} end`,
         },
         {
             type: "number",
             location: "in the middle",
             template: html`beginning ${numberValue} end`,
-            result: `beginning ${DOM.createInterpolationPlaceholder(0)} end`,
+            result: `beginning ${Markup.interpolation(0)} end`,
         },
         {
             type: "number",
             location: "at the end",
             template: html`beginning ${numberValue}`,
-            result: `beginning ${DOM.createInterpolationPlaceholder(0)}`,
+            result: `beginning ${Markup.interpolation(0)}`,
         },
         // expression interpolation
         {
             type: "expression",
             location: "at the beginning",
             template: html<Model>`${x => x.value} end`,
-            result: `${DOM.createInterpolationPlaceholder(0)} end`,
+            result: `${Markup.interpolation(0)} end`,
             expectDirectives: [HTMLBindingDirective],
         },
         {
             type: "expression",
             location: "in the middle",
             template: html<Model>`beginning ${x => x.value} end`,
-            result: `beginning ${DOM.createInterpolationPlaceholder(0)} end`,
+            result: `beginning ${Markup.interpolation(0)} end`,
             expectDirectives: [HTMLBindingDirective],
         },
         {
             type: "expression",
             location: "at the end",
             template: html<Model>`beginning ${x => x.value}`,
-            result: `beginning ${DOM.createInterpolationPlaceholder(0)}`,
+            result: `beginning ${Markup.interpolation(0)}`,
             expectDirectives: [HTMLBindingDirective],
         },
         // directive interpolation
@@ -92,21 +92,21 @@ describe(`The html tag template helper`, () => {
             type: "directive",
             location: "at the beginning",
             template: html`${new TestDirective()} end`,
-            result: `${DOM.createBlockPlaceholder(0)} end`,
+            result: `${Markup.comment(0)} end`,
             expectDirectives: [TestDirective],
         },
         {
             type: "directive",
             location: "in the middle",
             template: html`beginning ${new TestDirective()} end`,
-            result: `beginning ${DOM.createBlockPlaceholder(0)} end`,
+            result: `beginning ${Markup.comment(0)} end`,
             expectDirectives: [TestDirective],
         },
         {
             type: "directive",
             location: "at the end",
             template: html`beginning ${new TestDirective()}`,
-            result: `beginning ${DOM.createBlockPlaceholder(0)}`,
+            result: `beginning ${Markup.comment(0)}`,
             expectDirectives: [TestDirective],
         },
         // template interpolation
@@ -114,21 +114,21 @@ describe(`The html tag template helper`, () => {
             type: "template",
             location: "at the beginning",
             template: html`${html`sub-template`} end`,
-            result: `${DOM.createInterpolationPlaceholder(0)} end`,
+            result: `${Markup.interpolation(0)} end`,
             expectDirectives: [HTMLBindingDirective],
         },
         {
             type: "template",
             location: "in the middle",
             template: html`beginning ${html`sub-template`} end`,
-            result: `beginning ${DOM.createInterpolationPlaceholder(0)} end`,
+            result: `beginning ${Markup.interpolation(0)} end`,
             expectDirectives: [HTMLBindingDirective],
         },
         {
             type: "template",
             location: "at the end",
             template: html`beginning ${html`sub-template`}`,
-            result: `beginning ${DOM.createInterpolationPlaceholder(0)}`,
+            result: `beginning ${Markup.interpolation(0)}`,
             expectDirectives: [HTMLBindingDirective],
         },
         // mixed interpolation
@@ -136,33 +136,33 @@ describe(`The html tag template helper`, () => {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the beginning",
             template: html<Model>`${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
-            result: `${stringValue}${DOM.createInterpolationPlaceholder(
+            result: `${stringValue}${Markup.interpolation(
                 0
-            )}${DOM.createInterpolationPlaceholder(
+            )}${Markup.interpolation(
                 1
-            )}${DOM.createBlockPlaceholder(2)} end`,
+            )}${Markup.comment(2)} end`,
             expectDirectives: [HTMLBindingDirective, HTMLBindingDirective, TestDirective],
         },
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "in the middle",
             template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()} end`,
-            result: `beginning ${stringValue}${DOM.createInterpolationPlaceholder(
+            result: `beginning ${stringValue}${Markup.interpolation(
                 0
-            )}${DOM.createInterpolationPlaceholder(
+            )}${Markup.interpolation(
                 1
-            )}${DOM.createBlockPlaceholder(2)} end`,
+            )}${Markup.comment(2)} end`,
             expectDirectives: [HTMLBindingDirective, HTMLBindingDirective, TestDirective],
         },
         {
             type: "mixed, back-to-back string, number, expression, and directive",
             location: "at the end",
             template: html<Model>`beginning ${stringValue}${numberValue}${x => x.value}${new TestDirective()}`,
-            result: `beginning ${stringValue}${DOM.createInterpolationPlaceholder(
+            result: `beginning ${stringValue}${Markup.interpolation(
                 0
-            )}${DOM.createInterpolationPlaceholder(
+            )}${Markup.interpolation(
                 1
-            )}${DOM.createBlockPlaceholder(2)}`,
+            )}${Markup.comment(2)}`,
             expectDirectives: [HTMLBindingDirective, HTMLBindingDirective, TestDirective],
         },
         {
@@ -170,11 +170,11 @@ describe(`The html tag template helper`, () => {
             location: "at the beginning",
             template: html<Model>`${stringValue}separator${numberValue}separator${x =>
                     x.value}separator${new TestDirective()} end`,
-            result: `${stringValue}separator${DOM.createInterpolationPlaceholder(
+            result: `${stringValue}separator${Markup.interpolation(
                 0
-            )}separator${DOM.createInterpolationPlaceholder(
+            )}separator${Markup.interpolation(
                 1
-            )}separator${DOM.createBlockPlaceholder(2)} end`,
+            )}separator${Markup.comment(2)} end`,
             expectDirectives: [HTMLBindingDirective, HTMLBindingDirective, TestDirective],
         },
         {
@@ -182,11 +182,11 @@ describe(`The html tag template helper`, () => {
             location: "in the middle",
             template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x =>
                     x.value}separator${new TestDirective()} end`,
-            result: `beginning ${stringValue}separator${DOM.createInterpolationPlaceholder(
+            result: `beginning ${stringValue}separator${Markup.interpolation(
                 0
-            )}separator${DOM.createInterpolationPlaceholder(
+            )}separator${Markup.interpolation(
                 1
-            )}separator${DOM.createBlockPlaceholder(2)} end`,
+            )}separator${Markup.comment(2)} end`,
             expectDirectives: [HTMLBindingDirective, HTMLBindingDirective, TestDirective],
         },
         {
@@ -194,11 +194,11 @@ describe(`The html tag template helper`, () => {
             location: "at the end",
             template: html<Model>`beginning ${stringValue}separator${numberValue}separator${x =>
                     x.value}separator${new TestDirective()}`,
-            result: `beginning ${stringValue}separator${DOM.createInterpolationPlaceholder(
+            result: `beginning ${stringValue}separator${Markup.interpolation(
                 0
-            )}separator${DOM.createInterpolationPlaceholder(
+            )}separator${Markup.interpolation(
                 1
-            )}separator${DOM.createBlockPlaceholder(2)}`,
+            )}separator${Markup.comment(2)}`,
             expectDirectives: [HTMLBindingDirective, HTMLBindingDirective, TestDirective],
         },
     ];
@@ -218,7 +218,7 @@ describe(`The html tag template helper`, () => {
 
     it(`captures a case-sensitive property name when used with an expression`, () => {
         const template = html<Model>`<my-element :someAttribute=${x => x.value}></my-element>`;
-        const placeholder = DOM.createInterpolationPlaceholder(0);
+        const placeholder = Markup.interpolation(0);
 
         expect(template.html).to.equal(
             `<my-element :someAttribute=${placeholder}></my-element>`
@@ -230,7 +230,7 @@ describe(`The html tag template helper`, () => {
 
     it(`captures a case-sensitive property name when used with a binding`, () => {
         const template = html<Model>`<my-element :someAttribute=${bind(x => x.value)}></my-element>`;
-        const placeholder = DOM.createInterpolationPlaceholder(0);
+        const placeholder = Markup.interpolation(0);
 
         expect(template.html).to.equal(
             `<my-element :someAttribute=${placeholder}></my-element>`
@@ -255,7 +255,7 @@ describe(`The html tag template helper`, () => {
         }
 
         const template = html<Model>`<my-element :someAttribute=${new TestDirective()}></my-element>`;
-        const placeholder = DOM.createInterpolationPlaceholder(0);
+        const placeholder = Markup.interpolation(0);
 
         expect(template.html).to.equal(
             `<my-element :someAttribute=${placeholder}></my-element>`


### PR DESCRIPTION
# Pull Request

## 📖 Description

This feature exposes new `Markup` and `Parser` API gateways. Some APIs from the `DOM` gateway were moved to the `Markup` gateway, constituting a breaking change. This change did allow us to better encapsulate some internal details while exposing better APIs, particularly for SSR scenarios.

### 🎫 Issues

* Closes #5639 

## 👩‍💻 Reviewer Notes

None of the functionality here is really changed. Rather, APIs are moved around to more properly expose various capabilities.

A few documentation comment warnings were also resolved during this refactor. I left the binding-related warnings as is for now since that part of the codebase is still likely to change in a way that would affect the code docs.

## 📑 Test Plan

Existing tests were fixed up to match the new APIs.

## ✅ Checklist

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Next, @nicholasrice will take advantage of these new APIs in the SSR work. Based on feedback from that process we may revise these APIs or add a few new ones.