### PR TITLE
Fixed an updated export from FAST element 2.0

### DIFF
--- a/change/@microsoft-fast-router-d8d52093-fa07-417d-a12d-acdab4a96101.json
+++ b/change/@microsoft-fast-router-d8d52093-fa07-417d-a12d-acdab4a96101.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixed an updated export from FAST element 2.0",
+  "packageName": "@microsoft/fast-router",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-router/src/contributors.ts
+++ b/packages/web-components/fast-router/src/contributors.ts
@@ -1,7 +1,7 @@
 import {
     Behavior,
     HTMLDirective,
-    DOM,
+    Markup,
     ViewBehaviorTargets,
 } from "@microsoft/fast-element";
 import {
@@ -50,7 +50,7 @@ class NavigationContributorDirective extends HTMLDirective {
     }
 
     createPlaceholder(index: number) {
-        return DOM.createCustomAttributePlaceholder(index);
+        return Markup.attribute(index);
     }
 
     createBehavior(targets: ViewBehaviorTargets) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
Due to a change in https://github.com/microsoft/fast/pull/5649 the `DOM` export no longer contains `createCustomAttributePlaceholder` and has been replaced with a new export that has been utilized in this change.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Related to #5641 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.