### PR TITLE
fix: prevent duplicative array observation patch

### DIFF
--- a/packages/web-components/fast-element/src/observation/array-observer.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.ts
@@ -5,8 +5,6 @@ import { SubscriberSet } from "./notifier";
 import type { Notifier } from "./notifier";
 import { Observable } from "./observable";
 
-let arrayObservationEnabled = false;
-
 function adjustIndex(changeRecord: Splice, array: any[]): Splice {
     let index = changeRecord.index;
     const arrayLength = array.length;
@@ -98,11 +96,13 @@ class ArrayObserver extends SubscriberSet {
  * @public
  */
 export function enableArrayObservation(): void {
-    if (arrayObservationEnabled) {
+    const arrayProto = Array.prototype;
+
+    if ((arrayProto as any).$fastObservation) {
         return;
     }
 
-    arrayObservationEnabled = true;
+    (arrayProto as any).$fastObservation = true;
 
     Observable.setArrayObserverFactory(
         (collection: any[]): Notifier => {
@@ -110,7 +110,6 @@ export function enableArrayObservation(): void {
         }
     );
 
-    const arrayProto = Array.prototype;
     const pop = arrayProto.pop;
     const push = arrayProto.push;
     const reverse = arrayProto.reverse;


### PR DESCRIPTION
# Pull Request

## 📖 Description

In the event that two copies of `fast-element` are loaded into the same browser context, this PR prevents doubly patching of Array methods

### 🎫 Issues

* Closes #5652 

## 👩‍💻 Reviewer Notes

It's important to note that we still need to configure the array observer factory per library instance but we don't want to patch Array more than once, since that's global.

## 📑 Test Plan

Nearly impossible to test this. All current tests still pass.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

There are likely other problems with having two instances of `fast-element` on the same page, particularly around looking up element definitions, observing objects built on different versions of the library, etc. We should look into whether there are ways to address these other issues as part of FASTElement 2.0. Standard decorator metadata will help with some of this eventually, but that won't land in time for FE2.0, so we can try to adopt a temporary solution with the same behavior.