### PR TITLE
fix: prevent duplicative array observation patch (FE2)

### DIFF
--- a/change/@microsoft-fast-element-715828c0-7339-4dde-a445-8a5407f0a3b9.json
+++ b/change/@microsoft-fast-element-715828c0-7339-4dde-a445-8a5407f0a3b9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: prevent duplicative array observation patch",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/observation/array-observer.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.ts
@@ -4,21 +4,6 @@ import { SubscriberSet } from "./notifier.js";
 import type { Notifier } from "./notifier.js";
 import { Observable } from "./observable.js";
 
-function adjustIndex(changeRecord: Splice, array: any[]): Splice {
-    let index = changeRecord.index;
-    const arrayLength = array.length;
-
-    if (index > arrayLength) {
-        index = arrayLength - changeRecord.addedCount;
-    } else if (index < 0) {
-        index =
-            arrayLength + changeRecord.removed.length + index - changeRecord.addedCount;
-    }
-
-    changeRecord.index = index < 0 ? 0 : index;
-    return changeRecord;
-}
-
 class ArrayObserver extends SubscriberSet {
     private oldCollection: any[] | undefined = void 0;
     private splices: Splice[] | undefined = void 0;
@@ -68,117 +53,7 @@ class ArrayObserver extends SubscriberSet {
     }
 }
 
-const proto = Array.prototype;
-const pop = proto.pop;
-const push = proto.push;
-const reverse = proto.reverse;
-const shift = proto.shift;
-const sort = proto.sort;
-const splice = proto.splice;
-const unshift = proto.unshift;
-const arrayOverrides = {
-    pop(...args) {
-        const notEmpty = this.length > 0;
-        const result = pop.apply(this, args);
-        const o = this.$fastController as ArrayObserver;
-
-        if (o !== void 0 && notEmpty) {
-            o.addSplice(new Splice(this.length, [result], 0));
-        }
-
-        return result;
-    },
-
-    push(...args) {
-        const result = push.apply(this, args);
-        const o = this.$fastController as ArrayObserver;
-
-        if (o !== void 0) {
-            o.addSplice(
-                adjustIndex(new Splice(this.length - args.length, [], args.length), this)
-            );
-        }
-
-        return result;
-    },
-
-    reverse(...args) {
-        let oldArray;
-        const o = this.$fastController as ArrayObserver;
-
-        if (o !== void 0) {
-            o.flush();
-            oldArray = this.slice();
-        }
-
-        const result = reverse.apply(this, args);
-
-        if (o !== void 0) {
-            o.reset(oldArray);
-        }
-
-        return result;
-    },
-
-    shift(...args) {
-        const notEmpty = this.length > 0;
-        const result = shift.apply(this, args);
-        const o = this.$fastController as ArrayObserver;
-
-        if (o !== void 0 && notEmpty) {
-            o.addSplice(new Splice(0, [result], 0));
-        }
-
-        return result;
-    },
-
-    sort(...args) {
-        let oldArray;
-        const o = this.$fastController as ArrayObserver;
-
-        if (o !== void 0) {
-            o.flush();
-            oldArray = this.slice();
-        }
-
-        const result = sort.apply(this, args);
-
-        if (o !== void 0) {
-            o.reset(oldArray);
-        }
-
-        return result;
-    },
-
-    splice(...args) {
-        const result = splice.apply(this, args);
-        const o = this.$fastController as ArrayObserver;
-
-        if (o !== void 0) {
-            o.addSplice(
-                adjustIndex(
-                    new Splice(+args[0], result, args.length > 2 ? args.length - 2 : 0),
-                    this
-                )
-            );
-        }
-
-        return result;
-    },
-
-    unshift(...args) {
-        const result = unshift.apply(this, args);
-        const o = this.$fastController as ArrayObserver;
-
-        if (o !== void 0) {
-            o.addSplice(adjustIndex(new Splice(0, [], args.length), this));
-        }
-
-        return result;
-    },
-};
-
-let needsEnablement = true;
+let enabled = false;
 
 /* eslint-disable prefer-rest-params */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
@@ -191,20 +66,156 @@ let needsEnablement = true;
  * @public
  */
 export function enableArrayObservation(): void {
-    if (needsEnablement) {
-        needsEnablement = false;
+    if (enabled) {
+        return;
+    }
 
-        Observable.setArrayObserverFactory(
-            (collection: any[]): Notifier => {
-                return new ArrayObserver(collection);
-            }
-        );
+    enabled = true;
 
-        if (!(proto as any).$fastPatch) {
-            (proto as any).$fastPatch = true;
-            Object.assign(proto, arrayOverrides);
+    Observable.setArrayObserverFactory(
+        (collection: any[]): Notifier => {
+            return new ArrayObserver(collection);
         }
+    );
+
+    const proto = Array.prototype;
+
+    if (!(proto as any).$fastPatch) {
+        (proto as any).$fastPatch = true;
+
+        const pop = proto.pop;
+        const push = proto.push;
+        const reverse = proto.reverse;
+        const shift = proto.shift;
+        const sort = proto.sort;
+        const splice = proto.splice;
+        const unshift = proto.unshift;
+
+        function adjustIndex(changeRecord: Splice, array: any[]): Splice {
+            let index = changeRecord.index;
+            const arrayLength = array.length;
+
+            if (index > arrayLength) {
+                index = arrayLength - changeRecord.addedCount;
+            } else if (index < 0) {
+                index =
+                    arrayLength +
+                    changeRecord.removed.length +
+                    index -
+                    changeRecord.addedCount;
+            }
+
+            changeRecord.index = index < 0 ? 0 : index;
+            return changeRecord;
+        }
+
+        Object.assign(proto, {
+            pop(...args) {
+                const notEmpty = this.length > 0;
+                const result = pop.apply(this, args);
+                const o = this.$fastController as ArrayObserver;
+
+                if (o !== void 0 && notEmpty) {
+                    o.addSplice(new Splice(this.length, [result], 0));
+                }
+
+                return result;
+            },
+
+            push(...args) {
+                const result = push.apply(this, args);
+                const o = this.$fastController as ArrayObserver;
+
+                if (o !== void 0) {
+                    o.addSplice(
+                        adjustIndex(
+                            new Splice(this.length - args.length, [], args.length),
+                            this
+                        )
+                    );
+                }
+
+                return result;
+            },
+
+            reverse(...args) {
+                let oldArray;
+                const o = this.$fastController as ArrayObserver;
+
+                if (o !== void 0) {
+                    o.flush();
+                    oldArray = this.slice();
+                }
+
+                const result = reverse.apply(this, args);
+
+                if (o !== void 0) {
+                    o.reset(oldArray);
+                }
+
+                return result;
+            },
+
+            shift(...args) {
+                const notEmpty = this.length > 0;
+                const result = shift.apply(this, args);
+                const o = this.$fastController as ArrayObserver;
+
+                if (o !== void 0 && notEmpty) {
+                    o.addSplice(new Splice(0, [result], 0));
+                }
+
+                return result;
+            },
+
+            sort(...args) {
+                let oldArray;
+                const o = this.$fastController as ArrayObserver;
+
+                if (o !== void 0) {
+                    o.flush();
+                    oldArray = this.slice();
+                }
+
+                const result = sort.apply(this, args);
+
+                if (o !== void 0) {
+                    o.reset(oldArray);
+                }
+
+                return result;
+            },
+
+            splice(...args) {
+                const result = splice.apply(this, args);
+                const o = this.$fastController as ArrayObserver;
+
+                if (o !== void 0) {
+                    o.addSplice(
+                        adjustIndex(
+                            new Splice(
+                                +args[0],
+                                result,
+                                args.length > 2 ? args.length - 2 : 0
+                            ),
+                            this
+                        )
+                    );
+                }
+
+                return result;
+            },
+
+            unshift(...args) {
+                const result = unshift.apply(this, args);
+                const o = this.$fastController as ArrayObserver;
+
+                if (o !== void 0) {
+                    o.addSplice(adjustIndex(new Splice(0, [], args.length), this));
+                }
+
+                return result;
+            },
+        });
     }
 }
-/* eslint-enable prefer-rest-params */
-/* eslint-enable @typescript-eslint/explicit-function-return-type */

--- a/packages/web-components/fast-element/src/observation/array-observer.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.ts
@@ -178,6 +178,8 @@ const arrayOverrides = {
     },
 };
 
+let needsEnablement = true;
+
 /* eslint-disable prefer-rest-params */
 /* eslint-disable @typescript-eslint/explicit-function-return-type */
 /**
@@ -189,19 +191,20 @@ const arrayOverrides = {
  * @public
  */
 export function enableArrayObservation(): void {
-    if ((proto as any).$fastObservation) {
-        return;
-    }
+    if (needsEnablement) {
+        needsEnablement = false;
 
-    (proto as any).$fastObservation = true;
+        Observable.setArrayObserverFactory(
+            (collection: any[]): Notifier => {
+                return new ArrayObserver(collection);
+            }
+        );
 
-    Observable.setArrayObserverFactory(
-        (collection: any[]): Notifier => {
-            return new ArrayObserver(collection);
+        if (!(proto as any).$fastPatch) {
+            (proto as any).$fastPatch = true;
+            Object.assign(proto, arrayOverrides);
         }
-    );
-
-    Object.assign(proto, arrayOverrides);
+    }
 }
 /* eslint-enable prefer-rest-params */
 /* eslint-enable @typescript-eslint/explicit-function-return-type */


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes a bug in my previous attempt for FE2 to fix duplicate array patching. I discovered this while fixing duplicate patching in FE1.

### 🎫 Issues

* Closes #5652 

## 👩‍💻 Reviewer Notes

This is the FE2 version. This was separately applied since the source of this file has significantly changes from FE1.

It's important to note that we still need to configure the array observer factory per library instance but we don't want to patch Array more than once, since that's global.

Please also review #5654

## 📑 Test Plan

Nearly impossible to test this. All current tests still pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

I discovered a circular reference from binding through to Markup and back to binding. I have any idea for how to fix this but will do it in a follow-up PR along with some refactoring of the compiler APIs.