### PR TITLE
refactor: move template/style resolution to lazy getter

### DIFF
--- a/change/@microsoft-fast-element-47b69b7f-3b12-4084-b343-e7ee172f5539.json
+++ b/change/@microsoft-fast-element-47b69b7f-3b12-4084-b343-e7ee172f5539.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "refactor: move template/style resolution to lazy getter",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -160,7 +160,7 @@ export class Controller extends PropertyChangeNotifier {
     // @internal
     constructor(element: HTMLElement, definition: FASTElementDefinition);
     addBehaviors(behaviors: ReadonlyArray<Behavior<HTMLElement>>): void;
-    addStyles(styles: ElementStyles | HTMLStyleElement): void;
+    addStyles(styles: ElementStyles | HTMLStyleElement | null | undefined): void;
     readonly definition: FASTElementDefinition;
     readonly element: HTMLElement;
     emit(type: string, detail?: any, options?: Omit<CustomEventInit, "detail">): void | boolean;
@@ -170,7 +170,7 @@ export class Controller extends PropertyChangeNotifier {
     onConnectedCallback(): void;
     onDisconnectedCallback(): void;
     removeBehaviors(behaviors: ReadonlyArray<Behavior<HTMLElement>>, force?: boolean): void;
-    removeStyles(styles: ElementStyles | HTMLStyleElement): void;
+    removeStyles(styles: ElementStyles | HTMLStyleElement | null | undefined): void;
     get styles(): ElementStyles | null;
     set styles(value: ElementStyles | null);
     get template(): ElementViewTemplate | null;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR moves the template and style resolution logic into the property getters where it is lazily evaluated. This can then be used by SSR to gain access to the fully resolved template/styles.

### 🎫 Issues

* Closes #5638 
* Closes #5618 

## 👩‍💻 Reviewer Notes

Mostly a move of internal code so the functionality can be access for SSR scenarios. Some guards were added to style APIs to make them more resilient and to parallel template APIs.

## 📑 Test Plan

All existing tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

None at this time.