### PR TITLE
fix: defend against for/in use on arrays

### DIFF
--- a/change/@microsoft-fast-element-e1bbb99b-6d2f-43cf-ab46-772843f26be9.json
+++ b/change/@microsoft-fast-element-e1bbb99b-6d2f-43cf-ab46-772843f26be9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: defend against for/in use on arrays",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/observation/array-observer.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.ts
@@ -34,7 +34,11 @@ class ArrayObserver extends SubscriberSet {
 
     constructor(source: any[]) {
         super(source);
-        (source as any).$fastController = this;
+
+        Reflect.defineProperty(source, "$fastController", {
+            value: this,
+            enumerable: false,
+        });
     }
 
     public addSplice(splice: Splice): void {
@@ -118,7 +122,10 @@ export function enableArrayObservation(): void {
         return;
     }
 
-    (proto as any).$fastPatch = true;
+    Reflect.defineProperty(proto, "$fastPatch", {
+        value: 1,
+        enumerable: false,
+    });
 
     const pop = proto.pop;
     const push = proto.push;


### PR DESCRIPTION
# Pull Request

## 📖 Description

Some folks incorrectly use `for/in` on `Array` instances. This is a bad practice but people still do it and there is lots of legacy code in existence that makes this mistake which may never be updated.

This PR makes our Array observation bookkeeping properties non-numerable so that `for/in` does not return them in the event that a developer makes the above mistake or is using a 3rd party library which makes this mistake.

### 🎫 Issues

* #5652

## 👩‍💻 Reviewer Notes

This is a very small change that shifts the code from simple field assignments to `defineProperty` calls, so we can provide descriptor data and make the properties non-enumerable.

## 📑 Test Plan

All existing tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

A second matching PR will be incoming soon for FASTElement 2.0.