### PR TITLE
fix: defend against for/in use on arrays (FE2)

### DIFF
--- a/change/@microsoft-fast-element-8e5ad334-ac12-466b-8440-415abd011eb0.json
+++ b/change/@microsoft-fast-element-8e5ad334-ac12-466b-8440-415abd011eb0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: defend against for/in use on arrays",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/observation/array-observer.spec.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.spec.ts
@@ -1,0 +1,56 @@
+import { expect } from "chai";
+import { Observable } from "./observable";
+import { enableArrayObservation } from "./array-observer";
+import { SubscriberSet } from "./notifier";
+
+describe("The ArrayObserver", () => {
+    it("can be retrieved through Observable.getNotifier()", () => {
+        enableArrayObservation();
+        const array = [];
+        const notifier = Observable.getNotifier(array);
+        expect(notifier).to.be.instanceOf(SubscriberSet);
+    });
+
+    it("is the same instance for multiple calls to Observable.getNotifier() on the same array", () => {
+        enableArrayObservation();
+        const array = [];
+        const notifier = Observable.getNotifier(array);
+        const notifier2 = Observable.getNotifier(array);
+        expect(notifier).to.equal(notifier2);
+    });
+
+    it("is different for different arrays", () => {
+        enableArrayObservation();
+        const notifier = Observable.getNotifier([]);
+        const notifier2 = Observable.getNotifier([]);
+        expect(notifier).to.not.equal(notifier2);
+    });
+
+    it("doesn't affect for/in loops on arrays when enabled", () => {
+        enableArrayObservation();
+
+        const array = [1, 2, 3];
+        const keys: string[] = [];
+
+        for (const key in array) {
+            keys.push(key);
+        }
+
+        expect(keys).eql(["0", "1", "2"]);
+    });
+
+    it("doesn't affect for/in loops on arrays when the array is observed", () => {
+        enableArrayObservation();
+
+        const array = [1, 2, 3];
+        const keys: string[] = [];
+        const notifier = Observable.getNotifier(array);
+
+        for (const key in array) {
+            keys.push(key);
+        }
+
+        expect(notifier).to.be.instanceOf(SubscriberSet);
+        expect(keys).eql(["0", "1", "2"])
+    });
+});

--- a/packages/web-components/fast-element/src/observation/array-observer.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.ts
@@ -80,9 +80,7 @@ export function enableArrayObservation(): void {
     enabled = true;
 
     Observable.setArrayObserverFactory(
-        (collection: any[]): Notifier => {
-            return new ArrayObserver(collection);
-        }
+        (collection: any[]): Notifier => new ArrayObserver(collection)
     );
 
     const proto = Array.prototype;

--- a/packages/web-components/fast-element/src/observation/array-observer.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.ts
@@ -4,6 +4,13 @@ import { SubscriberSet } from "./notifier.js";
 import type { Notifier } from "./notifier.js";
 import { Observable } from "./observable.js";
 
+function setNonEnumerable(target: any, property: string, value: any) {
+    Reflect.defineProperty(target, property, {
+        value,
+        enumerable: false,
+    });
+}
+
 class ArrayObserver extends SubscriberSet {
     private oldCollection: any[] | undefined = void 0;
     private splices: Splice[] | undefined = void 0;
@@ -12,7 +19,7 @@ class ArrayObserver extends SubscriberSet {
 
     constructor(subject: any[]) {
         super(subject);
-        (subject as any).$fastController = this;
+        setNonEnumerable(subject, "$fastController", this);
     }
 
     public addSplice(splice: Splice): void {
@@ -81,7 +88,7 @@ export function enableArrayObservation(): void {
     const proto = Array.prototype;
 
     if (!(proto as any).$fastPatch) {
-        (proto as any).$fastPatch = true;
+        setNonEnumerable(proto, "$fastPatch", 1);
 
         const pop = proto.pop;
         const push = proto.push;

--- a/packages/web-components/fast-element/src/observation/observable.spec.ts
+++ b/packages/web-components/fast-element/src/observation/observable.spec.ts
@@ -61,14 +61,6 @@ describe("The Observable", () => {
     }
 
     context("facade", () => {
-        it("can set an array observer factory", () => {
-            const fakeObserver = new SubscriberSet([]);
-            Observable.setArrayObserverFactory((array: any[]) => fakeObserver);
-            const array = [];
-            const observer = Observable.getNotifier(array);
-            expect(observer).to.equal(fakeObserver);
-        });
-
         it("can get a notifier for an object", () => {
             const instance = new Model();
             const notifier = Observable.getNotifier(instance);
@@ -84,19 +76,11 @@ describe("The Observable", () => {
             expect(notifier).to.equal(notifier2);
         });
 
-        it("can get a notifier for an array", () => {
-            enableArrayObservation();
-            const array = [];
-            const notifier = Observable.getNotifier(array);
-            expect(notifier).to.be.instanceOf(SubscriberSet);
-        });
+        it("gets different notifiers for different objects", () => {
+            const notifier = Observable.getNotifier(new Model());
+            const notifier2 = Observable.getNotifier(new Model());
 
-        it("gets the same notifier for the same array", () => {
-            enableArrayObservation();
-            const array = [];
-            const notifier = Observable.getNotifier(array);
-            const notifier2 = Observable.getNotifier(array);
-            expect(notifier).to.equal(notifier2);
+            expect(notifier).to.not.equal(notifier2);
         });
 
         it("can notify a change on an object", () => {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Some folks incorrectly use `for/in` on `Array` instances. This is a bad practice but people still do it and there is lots of legacy code in existence that makes this mistake which may never be updated.

This PR makes our Array observation bookkeeping properties non-numerable so that `for/in` does not return them in the event that a developer makes the above mistake or is using a 3rd party library which makes this mistake.

### 🎫 Issues

* #5652

## 👩‍💻 Reviewer Notes

This is a very small change that shifts the code from simple field assignments to `defineProperty` calls, so we can provide descriptor data and make the properties non-enumerable.

## 📑 Test Plan

All existing tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Further improvements to array observation planned next sprint.