### PR TITLE
Added a failing test for the when binding inside compile tests

### DIFF
--- a/change/@microsoft-fast-element-8e22509b-caa4-4954-badd-617c76f29ace.json
+++ b/change/@microsoft-fast-element-8e22509b-caa4-4954-badd-617c76f29ace.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Added a failing test for the when binding inside compile tests",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -10,6 +10,7 @@ import { bind, HTMLBindingDirective } from "./binding";
 import { compileTemplate } from "./compiler";
 import type { HTMLDirective } from "./html-directive";
 import { html } from "./template";
+import { when } from "./when";
 
 describe("The template compiler", () => {
     function compile(html: string, directives: HTMLDirective[]) {
@@ -174,6 +175,52 @@ describe("The template compiler", () => {
                         );
                     }
                 }
+            });
+        });
+    });
+
+    context("when compiling FAST bindings", () => {
+        const scenarios = [
+            {
+                type: "when",
+                html: `<div>${inline(0)}</div>`,
+                directives: [when(() => true, html`test`) as HTMLBindingDirective],
+                fragment: `<div>test</div>`,
+                targetIds: ['r.1'],
+                childCount: 2,
+            },
+        ];
+
+        scenarios.forEach(x => {
+            it(`handles ${x.type} binding expression(s)`, () => {
+                const { fragment, factories } = compile(x.html, x.directives);
+
+                expect(toHTML(fragment)).to.equal(x.fragment);
+                expect(toHTML(fragment.cloneNode(true) as DocumentFragment)).to.equal(
+                    x.fragment
+                );
+
+                if (x.childCount) {
+                    expect(fragment.childNodes.length).to.equal(x.childCount);
+                    expect(fragment.cloneNode(true).childNodes.length).to.equal(
+                        x.childCount
+                    );
+                }
+
+                const length = factories.length;
+
+                expect(length).to.equal(x.directives.length);
+
+                if (x.targetIds) {
+                    expect(length).to.equal(x.targetIds.length);
+
+                    for (let i = 0; i < length; ++i) {
+                        expect(factories[i].targetId).to.equal(
+                            x.targetIds[i]
+                        );
+                    }
+                }
+                console.log("FRAGMENT", fragment);
             });
         });
     });

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -220,7 +220,6 @@ describe("The template compiler", () => {
                         );
                     }
                 }
-                console.log("FRAGMENT", fragment);
             });
         });
     });


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change adds a failing test as part of a diagnosis on why the `when` directive might be failing inside of tests in `@microsoft/fast-foundation`, where accessing the `shadowRoot` reveals that the directive is not being executed.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
Please check that the binding is being executed in the way that you would expect, this section of the code is pretty new to me.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.