### PR TITLE
fix: generate grid columns for manual grid

### DIFF
--- a/change/@microsoft-fast-components-cc08498d-1968-49eb-82f8-b94e4abb7154.json
+++ b/change/@microsoft-fast-components-cc08498d-1968-49eb-82f8-b94e4abb7154.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "generate grid columns for manual grid",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-aa1aae9c-ad90-401b-ae91-c23afb148cf6.json
+++ b/change/@microsoft-fast-foundation-aa1aae9c-ad90-401b-ae91-c23afb148cf6.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "generate grid columns for manual grid",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/data-grid/fixtures/base.html
+++ b/packages/web-components/fast-components/src/data-grid/fixtures/base.html
@@ -72,7 +72,7 @@
 <fast-data-grid-cell id="headerCell" cell-type="columnheader"></fast-data-grid-cell>
 
 <h2>Manual grid</h2>
-<fast-data-grid id="manualGrid" grid-template-columns="1fr 1fr" generate-header="none">
+<fast-data-grid id="manualGrid" grid-template-columns="10px 1fr">
     <fast-data-grid-row>
         <fast-data-grid-cell grid-column="1">1.1</fast-data-grid-cell>
         <fast-data-grid-cell grid-column="2">1.2</fast-data-grid-cell>

--- a/packages/web-components/fast-components/src/data-grid/fixtures/base.html
+++ b/packages/web-components/fast-components/src/data-grid/fixtures/base.html
@@ -72,7 +72,7 @@
 <fast-data-grid-cell id="headerCell" cell-type="columnheader"></fast-data-grid-cell>
 
 <h2>Manual grid</h2>
-<fast-data-grid id="manualGrid" grid-template-columns="10px 1fr">
+<fast-data-grid id="manualGrid">
     <fast-data-grid-row>
         <fast-data-grid-cell grid-column="1">1.1</fast-data-grid-cell>
         <fast-data-grid-cell grid-column="2">1.2</fast-data-grid-cell>

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.spec.ts
@@ -153,6 +153,17 @@ describe("Data grid", () => {
         await disconnect();
     });
 
+    it("should not generate a header when rowsData is empty", async () => {
+        const {  document, element, connect, disconnect } = await setup();
+        await connect();
+
+        const rows: DataGridRow[] = Array.from(element.querySelectorAll('[role="row"]'));
+
+        expect(rows.length).to.equal(0);
+
+        await disconnect();
+    });
+
     it("should generate a sticky header when generateHeader is set to 'sticky'", async () => {
         const {  document, element, connect, disconnect } = await setup();
         element.rowsData = newDataSet(5);

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -167,6 +167,9 @@ export class DataGrid extends FoundationElement {
         if (this.columnDefinitions === null && this.rowsData.length > 0) {
             this.columnDefinitions = DataGrid.generateColumns(this.rowsData[0]);
         }
+        if (this.$fastController.isConnected) {
+            this.toggleGeneratedHeader();
+        }
     }
 
     /**
@@ -551,7 +554,10 @@ export class DataGrid extends FoundationElement {
             this.generatedHeader = null;
         }
 
-        if (this.generateHeader !== GenerateHeaderOptions.none) {
+        if (
+            this.generateHeader !== GenerateHeaderOptions.none &&
+            this.rowsData.length > 0
+        ) {
             const generatedHeaderElement: HTMLElement = document.createElement(
                 this.rowElementTag
             );
@@ -601,10 +607,25 @@ export class DataGrid extends FoundationElement {
     };
 
     private updateRowIndexes = (): void => {
-        const newGridTemplateColumns =
-            this.gridTemplateColumns === undefined
-                ? this.generatedGridTemplateColumns
-                : this.gridTemplateColumns;
+        let newGridTemplateColumns = this.gridTemplateColumns;
+
+        if (newGridTemplateColumns === undefined) {
+            // try to generate columns based on manual rows
+            if (this.generatedGridTemplateColumns === "" && this.rowElements.length > 0) {
+                const firstRow = this.rowElements[0] as DataGridRow;
+
+                let templateColumns: string = "";
+                firstRow.cellElements.forEach(() => {
+                    templateColumns = `${templateColumns}${
+                        templateColumns === "" ? "" : " "
+                    }${"1fr"}`;
+                });
+
+                this.generatedGridTemplateColumns = templateColumns;
+            }
+
+            newGridTemplateColumns = this.generatedGridTemplateColumns;
+        }
 
         this.rowElements.forEach((element: Element, index: number): void => {
             const thisRow = element as DataGridRow;

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -612,13 +612,9 @@ export class DataGrid extends FoundationElement {
         if (newGridTemplateColumns === undefined) {
             // try to generate columns based on manual rows
             if (this.generatedGridTemplateColumns === "" && this.rowElements.length > 0) {
-                const firstRow = this.rowElements[0] as DataGridRow;
-
-                firstRow.cellElements.forEach(() => {
-                    this.generatedGridTemplateColumns = `${
-                        this.generatedGridTemplateColumns
-                    }${this.generatedGridTemplateColumns === "" ? "" : " "}${"1fr"}`;
-                });
+                this.generatedGridTemplateColumns = new Array(this.rowElements.length)
+                    .fill("1fr")
+                    .join(" ");
             }
 
             newGridTemplateColumns = this.generatedGridTemplateColumns;

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -614,7 +614,6 @@ export class DataGrid extends FoundationElement {
             if (this.generatedGridTemplateColumns === "" && this.rowElements.length > 0) {
                 const firstRow = this.rowElements[0] as DataGridRow;
 
-                this.generatedGridTemplateColumns = "";
                 firstRow.cellElements.forEach(() => {
                     this.generatedGridTemplateColumns = `${
                         this.generatedGridTemplateColumns

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -614,14 +614,12 @@ export class DataGrid extends FoundationElement {
             if (this.generatedGridTemplateColumns === "" && this.rowElements.length > 0) {
                 const firstRow = this.rowElements[0] as DataGridRow;
 
-                let templateColumns: string = "";
+                this.generatedGridTemplateColumns = "";
                 firstRow.cellElements.forEach(() => {
-                    templateColumns = `${templateColumns}${
-                        templateColumns === "" ? "" : " "
-                    }${"1fr"}`;
+                    this.generatedGridTemplateColumns = `${
+                        this.generatedGridTemplateColumns
+                    }${this.generatedGridTemplateColumns === "" ? "" : " "}${"1fr"}`;
                 });
-
-                this.generatedGridTemplateColumns = templateColumns;
             }
 
             newGridTemplateColumns = this.generatedGridTemplateColumns;


### PR DESCRIPTION
## 📖 Description

With this change data-grid will attempt to generate 'grid-template-columns' for a manually constructed grid.

### 🎫 Issues
closes https://github.com/microsoft/fast/issues/5659

## 📑 Test Plan
Tests pass, added check to confirm we don't generate a header when rowsData is empty.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps