### PR TITLE
feat: handle existing shadow roots when upgrading

### DIFF
--- a/change/@microsoft-fast-element-19ee7846-01d0-4dc8-babc-29a4537526a5.json
+++ b/change/@microsoft-fast-element-19ee7846-01d0-4dc8-babc-29a4537526a5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "feat: handle existing shadow roots when upgrading",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/components/controller.spec.ts
+++ b/packages/web-components/fast-element/src/components/controller.spec.ts
@@ -388,6 +388,7 @@ describe("The Controller", () => {
 
         expect(element.shadowRoot?.contains(style)).to.equal(false);
     });
+
     it("should attach and detach the HTMLStyleElement supplied to .addStyles() and .removeStyles() to the shadowRoot", () => {
         const { controller, element } = createController({
             shadowOptions: {
@@ -510,5 +511,29 @@ describe("The Controller", () => {
             controller.removeBehaviors([behavior], true);
             expect(behavior.bound).to.equal(false);
         });
-    })
+    });
+
+    context("with pre-existing shadow dom on the host", () => {
+        it("re-renders the view during connect", async () => {
+            const name = uniqueElementName();
+            const element = document.createElement(name);
+            const root = element.attachShadow({ mode: 'open' });
+            root.innerHTML = 'Test 1';
+
+            document.body.append(element);
+
+            new FASTElementDefinition(
+                class TestElement extends FASTElement {
+                    static definition = {
+                        name,
+                        template: html`Test 2`
+                    };
+                }
+            ).define();
+
+            expect(root.innerHTML).to.equal("<!---->Test 2");
+
+            document.body.removeChild(element);
+        });
+    });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

As a first step towards enabling client hydration of SSR'd components, we should not fail when Shadow DOM exists on a component when it's constructed. To accomplish this, we don't attach shadow DOM if it exits, but instead clear out the HTML so that the client view can re-populate it.

### 🎫 Issues

Closes #5627 

## 👩‍💻 Reviewer Notes

The feature involves two changes:

1. Detect the existing shadow root in the constructor and note that for later, avoiding attach of a shadow root.
2. When the component is ready to render, and the shadow root was pre-existing, clear out the HTML.

## 📑 Test Plan

Added a test to assert behavior in the presence of existing shadow dom.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

In a future iteration we'll look into upgrading existing shadow DOM content rather than re-creating it.