### PR TITLE
Fix: horizontal-scroll to previous doesn't work for 2 item width

### DIFF
--- a/change/@microsoft-fast-components-fb0919b2-9a12-43b9-a7da-8a4f0b405f01.json
+++ b/change/@microsoft-fast-components-fb0919b2-9a12-43b9-a7da-8a4f0b405f01.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing no previous scroll when only 2 items",
+  "packageName": "@microsoft/fast-components",
+  "email": "robarb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-f5abd6ff-1492-4d34-80dc-b57d1489c3df.json
+++ b/change/@microsoft-fast-foundation-f5abd6ff-1492-4d34-80dc-b57d1489c3df.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fixing no previous scroll when only 2 items",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "robarb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/horizontal-scroll/fixtures/horizontal-scroll.html
+++ b/packages/web-components/fast-components/src/horizontal-scroll/fixtures/horizontal-scroll.html
@@ -55,9 +55,75 @@
         }
     }, 2000);
 </script>
-
 <h2>Default</h2>
 <fast-horizontal-scroll>
+    <fast-card>
+        Card number 1
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 2
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 3
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 4
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 5
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 6
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 7
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 8
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 9
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 10
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 11
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 12
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 13
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 14
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 15
+        <fast-button>A button</fast-button>
+    </fast-card>
+    <fast-card>
+        Card number 16
+        <fast-button>A button</fast-button>
+    </fast-card>
+</fast-horizontal-scroll>
+<h2>2 column layout</h2>
+<fast-horizontal-scroll style="width: 245px;">
     <fast-card>
         Card number 1
         <fast-button>A button</fast-button>

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.spec.ts
@@ -57,7 +57,9 @@ const cardTemplate: string = `<div class="card" style="width: ${cardWidth}px; he
  */
 const getCards = (cnt: number): string => new Array(cnt).fill(cardTemplate).reduce((s, c) => s += c, '');
 
-async function setup() {
+async function setup(options: {
+    width?: number
+} = {}) {
     const { element, connect, disconnect }:
         {
             element: HorizontalScroll & HTMLElement;
@@ -68,7 +70,7 @@ async function setup() {
     // Removing animated scroll so that tests don't have to wait on DOM updates
     element.speed = 0;
 
-    element.setAttribute("style", `width: ${horizontalScrollWidth}px;`);
+    element.setAttribute("style", `width: ${options && options.width ? options.width : horizontalScrollWidth}px;`);
     element.innerHTML = getCards(8);
 
     await connect();
@@ -254,5 +256,25 @@ describe("HorizontalScroll", () => {
             await disconnect();
         });
 
+        it("should scroll to previous when only 2 items wide", async () => {
+            const { element, disconnect } = await setup({width: cardSpace * 2});
+
+            element.scrollToNext();
+
+            await DOM.nextUpdate();
+
+            const firstXPos: number | null = getXPosition(element);
+            expect(firstXPos).to.not.null;
+            expect(firstXPos).to.gte(cardSpace);
+
+            element.scrollToPrevious();
+
+            await DOM.nextUpdate();
+
+            const secondXPosition: number | null = getXPosition(element);
+            expect(secondXPosition).to.equal(0);
+
+            await disconnect();
+        });
     });
 });

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.ts
@@ -380,7 +380,7 @@ export class HorizontalScroll extends FoundationElement {
             stop => Math.abs(stop) + this.width > right
         );
 
-        if (nextIndex > current || nextIndex === -1) {
+        if (nextIndex >= current || nextIndex === -1) {
             nextIndex = current > 0 ? current - 1 : 0;
         }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

When there are only 2 items in view, the scroll to previous flipper is not working.

### 🎫 Issues

https://github.com/microsoft/fast/issues/5676

## 👩‍💻 Reviewer Notes

The boundary check didn't include if the 
## 📑 Test Plan

I added a test that includes a container that has only 2 items in view. I also created an example in storybook.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->