### PR TITLE
Fix form attribute bug in <fast-button>

### DIFF
--- a/change/@microsoft-fast-foundation-e8096bfe-0996-4971-ab89-4f9a1221538c.json
+++ b/change/@microsoft-fast-foundation-e8096bfe-0996-4971-ab89-4f9a1221538c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: form attribute in button doesn't work and throws error",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "corylaviska@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/button/button.spec.ts
+++ b/packages/web-components/fast-foundation/src/button/button.spec.ts
@@ -537,6 +537,33 @@ describe("Button", () => {
 
             await disconnect();
         });
+
+        it ("should submit the associated form when the button is outside of the form and has the form attribute", async () => {
+            const { element, connect, disconnect, parent } = await setup();
+            const form = document.createElement("form");
+
+            form.id = 'a';
+            element.setAttribute('type', 'submit');
+            element.setAttribute('form', 'a');
+
+            parent.appendChild(form);
+            parent.appendChild(element);
+
+            await connect();
+
+            const wasSubmitted = await new Promise(resolve => {
+                form.addEventListener("submit", event => {
+                    event.preventDefault();
+                    resolve(true);
+                });
+                element.click();
+                DOM.queueUpdate(() => resolve(false));
+            });
+
+            expect(wasSubmitted).to.equal(true);
+
+            await disconnect();
+        });
     });
 
     describe("of type 'reset'", () => {
@@ -609,7 +636,7 @@ describe("Button", () => {
                spans.forEach((span: HTMLSpanElement) => {
                    span.click()
                    expect(wasClicked).to.equal(false);
-               }) 
+               })
             }
 
             await disconnect();

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -599,12 +599,19 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
                 // still undefined. We should find a better way to address this.
                 this.proxy.disabled = this.disabled;
                 this.proxy.required = this.required;
+
                 if (typeof this.name === "string") {
                     this.proxy.name = this.name;
                 }
 
                 if (typeof this.value === "string") {
                     this.proxy.value = this.value;
+                }
+
+                if (this.hasAttribute("form")) {
+                    this.proxy.setAttribute("form", this.getAttribute("form") as string);
+                } else {
+                    this.proxy.removeAttribute("form");
                 }
 
                 this.proxy.setAttribute("slot", proxySlotName);


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes the `form` attribute on `<fast-button>` work when the button is placed outside of a form, e.g.

```html
<form id="a"></form>

<fast-button type="submit" form="a">Submit</fast-button>
```

### 🎫 Issues

Fixes #5675

## 👩‍💻 Reviewer Notes

The fiddle from #5675 provides a more complete example should you want to test this manually.

## 📑 Test Plan

- I added one test to verify that buttons placed outside of a form will submit as expected when they have a `form` attribute
- Existing tests were unaffected

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes. N/A
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->