### PR TITLE
fix: tooltips remain visible when hovered

### DIFF
--- a/change/@microsoft-fast-components-e25eb67c-a6bb-4476-b996-5049eb18f26a.json
+++ b/change/@microsoft-fast-components-e25eb67c-a6bb-4476-b996-5049eb18f26a.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "tooltip hover",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-dd0eb23b-8eef-49ad-b97d-9b367f71c782.json
+++ b/change/@microsoft-fast-foundation-dd0eb23b-8eef-49ad-b97d-9b367f71c782.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "tooltip hover",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/tooltip/fixtures/base.html
+++ b/packages/web-components/fast-components/src/tooltip/fixtures/base.html
@@ -106,35 +106,51 @@
 
 <h2>Fixed positions</h2>
 <div style="height: 400px; width: 400px; background: lightgray; overflow: scroll;">
-    <fast-tooltip position="top" anchor="anchor-positions">
+    <fast-tooltip anchor="anchor-positions" position="top" style="position: absolute;">
         Top
     </fast-tooltip>
 
-    <fast-tooltip anchor="anchor-positions" position="right">
+    <fast-tooltip anchor="anchor-positions" position="right" style="position: absolute;">
         Right
     </fast-tooltip>
 
-    <fast-tooltip anchor="anchor-positions" position="bottom">
+    <fast-tooltip anchor="anchor-positions" position="bottom" style="position: absolute;">
         Bottom
     </fast-tooltip>
 
-    <fast-tooltip anchor="anchor-positions" position="left">
+    <fast-tooltip anchor="anchor-positions" position="left" style="position: absolute;">
         Left
     </fast-tooltip>
 
-    <fast-tooltip anchor="anchor-positions" position="top-left">
+    <fast-tooltip
+        anchor="anchor-positions"
+        position="top-left"
+        style="position: absolute;"
+    >
         Top Left
     </fast-tooltip>
 
-    <fast-tooltip anchor="anchor-positions" position="top-right">
+    <fast-tooltip
+        anchor="anchor-positions"
+        position="top-right"
+        style="position: absolute;"
+    >
         Top Right
     </fast-tooltip>
 
-    <fast-tooltip anchor="anchor-positions" position="bottom-left">
+    <fast-tooltip
+        anchor="anchor-positions"
+        position="bottom-left"
+        style="position: absolute;"
+    >
         Bottom Left
     </fast-tooltip>
 
-    <fast-tooltip anchor="anchor-positions" position="bottom-right">
+    <fast-tooltip
+        anchor="anchor-positions"
+        position="bottom-right"
+        style="position: absolute;"
+    >
         Bottom Right
     </fast-tooltip>
 

--- a/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
+++ b/packages/web-components/fast-components/src/tooltip/tooltip.styles.ts
@@ -61,7 +61,6 @@ export const tooltipStyles: (
                 align-items: center;
                 overflow: visible;
                 flex-direction: row;
-                pointer-events: none;
             }
 
             ${anchoredRegionTag}.right,

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -376,12 +376,10 @@ export class Tooltip extends FoundationElement {
      * starts the hide timer
      */
     private startHideDelayTimer = (): void => {
+        this.clearHideDelayTimer();
+
         if (!this.tooltipVisible) {
             return;
-        }
-
-        if (this.hideDelayTimer !== null) {
-            this.clearHideDelayTimer();
         }
 
         // allow 60 ms for account for pointer to move between anchor/tooltip

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -149,7 +149,7 @@ export class Tooltip extends FoundationElement {
                         .querySelectorAll(":hover")
                         .forEach(element => {
                             if (element.id === anchorId) {
-                                this.startHoverTimer();
+                                this.startShowDelayTimer();
                             }
                         });
                 }
@@ -256,12 +256,22 @@ export class Tooltip extends FoundationElement {
     /**
      * The timer that tracks delay time before the tooltip is shown on hover
      */
-    private delayTimer: number | null = null;
+    private showDelayTimer: number | null = null;
 
     /**
-     * Indicates whether the anchor is currently being hovered
+     * The timer that tracks delay time before the tooltip is hidden
+     */
+    private hideDelayTimer: number | null = null;
+
+    /**
+     * Indicates whether the anchor is currently being hovered or has focus
      */
     private isAnchorHoveredFocused: boolean = false;
+
+    /**
+     * Indicates whether the region is currently being hovered
+     */
+    private isRegionHovered: boolean = false;
 
     public connectedCallback(): void {
         super.connectedCallback();
@@ -271,7 +281,8 @@ export class Tooltip extends FoundationElement {
 
     public disconnectedCallback(): void {
         this.hideTooltip();
-        this.clearDelayTimer();
+        this.clearShowDelayTimer();
+        this.clearHideDelayTimer();
         super.disconnectedCallback();
     }
 
@@ -310,10 +321,30 @@ export class Tooltip extends FoundationElement {
     };
 
     /**
+     * mouse enters region
+     */
+    private handleRegionMouseOver = (ev: Event): void => {
+        this.isRegionHovered = true;
+    };
+
+    /**
+     * mouse leaves region
+     */
+    private handleRegionMouseOut = (ev: Event): void => {
+        this.isRegionHovered = false;
+        this.startHideDelayTimer();
+    };
+
+    /**
      * mouse enters anchor
      */
     private handleAnchorMouseOver = (ev: Event): void => {
-        this.startHoverTimer();
+        if (this.tooltipVisible) {
+            // tooltip is already visible, just set the anchor hover flag
+            this.isAnchorHoveredFocused = true;
+            return;
+        }
+        this.startShowDelayTimer();
     };
 
     /**
@@ -321,31 +352,66 @@ export class Tooltip extends FoundationElement {
      */
     private handleAnchorMouseOut = (ev: Event): void => {
         this.isAnchorHoveredFocused = false;
-        this.updateTooltipVisibility();
-        this.clearDelayTimer();
-    };
-
-    private handleAnchorFocusIn = (ev: Event): void => {
-        this.startHoverTimer();
-    };
-
-    private handleAnchorFocusOut = (ev: Event): void => {
-        this.isAnchorHoveredFocused = false;
-        this.updateTooltipVisibility();
-        this.clearDelayTimer();
+        this.clearShowDelayTimer();
+        this.startHideDelayTimer();
     };
 
     /**
-     * starts the hover timer if not currently running
+     * anchor gets focus
      */
-    private startHoverTimer = (): void => {
+    private handleAnchorFocusIn = (ev: Event): void => {
+        this.startShowDelayTimer();
+    };
+
+    /**
+     * anchor loses focus
+     */
+    private handleAnchorFocusOut = (ev: Event): void => {
+        this.isAnchorHoveredFocused = false;
+        this.clearShowDelayTimer();
+        this.startHideDelayTimer();
+    };
+
+    /**
+     * starts the hide timer
+     */
+    private startHideDelayTimer = (): void => {
+        if (!this.tooltipVisible) {
+            return;
+        }
+
+        if (this.hideDelayTimer !== null) {
+            this.clearHideDelayTimer();
+        }
+
+        // allow 60 ms for account for pointer to move between anchor/tooltip
+        // without hiding tooltip
+        this.hideDelayTimer = window.setTimeout((): void => {
+            this.updateTooltipVisibility();
+        }, 60);
+    };
+
+    /**
+     * clears the hide delay
+     */
+    private clearHideDelayTimer = (): void => {
+        if (this.hideDelayTimer !== null) {
+            clearTimeout(this.hideDelayTimer);
+            this.hideDelayTimer = null;
+        }
+    };
+
+    /**
+     * starts the show timer if not currently running
+     */
+    private startShowDelayTimer = (): void => {
         if (this.isAnchorHoveredFocused) {
             return;
         }
 
         if (this.delay > 1) {
-            if (this.delayTimer === null)
-                this.delayTimer = window.setTimeout((): void => {
+            if (this.showDelayTimer === null)
+                this.showDelayTimer = window.setTimeout((): void => {
                     this.startHover();
                 }, this.delay);
             return;
@@ -355,7 +421,7 @@ export class Tooltip extends FoundationElement {
     };
 
     /**
-     * starts the hover delay timer
+     * start hover
      */
     private startHover = (): void => {
         this.isAnchorHoveredFocused = true;
@@ -363,12 +429,12 @@ export class Tooltip extends FoundationElement {
     };
 
     /**
-     * clears the hover delay
+     * clears the show delay
      */
-    private clearDelayTimer = (): void => {
-        if (this.delayTimer !== null) {
-            clearTimeout(this.delayTimer);
-            this.delayTimer = null;
+    private clearShowDelayTimer = (): void => {
+        if (this.showDelayTimer !== null) {
+            clearTimeout(this.showDelayTimer);
+            this.showDelayTimer = null;
         }
     };
 
@@ -481,7 +547,7 @@ export class Tooltip extends FoundationElement {
             this.showTooltip();
             return;
         } else {
-            if (this.isAnchorHoveredFocused) {
+            if (this.isAnchorHoveredFocused || this.isRegionHovered) {
                 this.showTooltip();
                 return;
             }
@@ -509,6 +575,7 @@ export class Tooltip extends FoundationElement {
         if (!this.tooltipVisible) {
             return;
         }
+        this.clearHideDelayTimer();
         if (this.region !== null && this.region !== undefined) {
             (this.region as any).removeEventListener(
                 "positionchange",
@@ -516,6 +583,9 @@ export class Tooltip extends FoundationElement {
             );
             this.region.viewportElement = null;
             this.region.anchorElement = null;
+
+            this.region.removeEventListener("mouseover", this.handleRegionMouseOver);
+            this.region.removeEventListener("mouseout", this.handleRegionMouseOut);
         }
         document.removeEventListener("keydown", this.handleDocumentKeydown);
         this.tooltipVisible = false;
@@ -535,5 +605,12 @@ export class Tooltip extends FoundationElement {
             "positionchange",
             this.handlePositionChange
         );
+
+        this.region.addEventListener("mouseover", this.handleRegionMouseOver, {
+            passive: true,
+        });
+        this.region.addEventListener("mouseout", this.handleRegionMouseOut, {
+            passive: true,
+        });
     };
 }


### PR DESCRIPTION
## 📖 Description

According to standards, the tooltip content should remain visible if the pointer is hovered over it:

Hoverable
If pointer hover can trigger the additional content, then the pointer can be moved over the additional content without the additional content disappearing;

Source: https://www.w3.org/TR/WCAG21/#content-on-hover-or-focus

This change adds a short 60ms delay before tooltips are dismissed after mouseOut.  Tooltips remain visible if the anchor or tooltip are hovered before the delay elapses.

### 🎫 Issues
closes https://github.com/microsoft/fast/issues/5660


## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
