### PR TITLE
Adds TemplateOp to SSR template parser

### DIFF
--- a/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
@@ -82,10 +82,9 @@ export type AttributeBindingOp = {
 export type TemplateElementOpen = {
     type: OpType.templateElementOpen;
     staticAttributes: Map<string, string>;
-    dynamicAttributes: Map<
-        string,
-        Pick<AttributeBindingOp, "name" | "attributeType" | "directive">
-    >;
+    // We need dynamic attributes here so we can emit the `<template`, all attributes, and then `>`
+    // from one operation
+    dynamicAttributes: Pick<AttributeBindingOp, "name" | "attributeType" | "directive">[];
 };
 
 /**

--- a/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
@@ -79,7 +79,7 @@ export type AttributeBindingOp = {
 /**
  * Operation to emit a template element open tag
  */
-export type TemplateElementOpen = {
+export type TemplateElementOpenOp = {
     type: OpType.templateElementOpen;
     staticAttributes: Map<string, string>;
     // We need dynamic attributes here so we can emit the `<template`, all attributes, and then `>`
@@ -90,7 +90,7 @@ export type TemplateElementOpen = {
 /**
  * Operation to emit a template element closing tag
  */
-export type TemplateElementClose = {
+export type TemplateElementCloseOp = {
     type: OpType.templateElementClose;
 };
 
@@ -108,6 +108,6 @@ export type Op =
     | DirectiveOp
     | CustomElementAttributes
     | CustomElementShadowOp
-    | TemplateElementOpen
-    | TemplateElementClose
+    | TemplateElementOpenOp
+    | TemplateElementCloseOp
     | TextOp;

--- a/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
@@ -11,6 +11,8 @@ export enum OpType {
     customElementShadow,
     attributeBinding,
     directive,
+    templateElementOpen,
+    templateElementClose,
     text,
 }
 
@@ -75,6 +77,25 @@ export type AttributeBindingOp = {
 };
 
 /**
+ * Operation to emit a template element open tag
+ */
+export type TemplateElementOpen = {
+    type: OpType.templateElementOpen;
+    staticAttributes: Map<string, string>;
+    dynamicAttributes: Map<
+        string,
+        Pick<AttributeBindingOp, "name" | "attributeType" | "directive">
+    >;
+};
+
+/**
+ * Operation to emit a template element closing tag
+ */
+export type TemplateElementClose = {
+    type: OpType.templateElementClose;
+};
+
+/**
  * Operation to emit to custom-element attributes
  */
 export type CustomElementAttributes = {
@@ -83,9 +104,11 @@ export type CustomElementAttributes = {
 
 export type Op =
     | AttributeBindingOp
-    | TextOp
     | CustomElementOpenOp
     | CustomElementCloseOp
     | DirectiveOp
     | CustomElementAttributes
-    | CustomElementShadowOp;
+    | CustomElementShadowOp
+    | TemplateElementOpen
+    | TemplateElementClose
+    | TextOp;

--- a/packages/web-components/fast-ssr/src/template-parser/template-parser.spec.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/template-parser.spec.ts
@@ -94,4 +94,12 @@ test.describe("parseTemplateToOpCodes", () => {
         expect(codes[2].attributeType).toBe(AttributeType.idl);
         expect(codes[3].attributeType).toBe(AttributeType.event);
     });
+    test("should emit template open and close ops for a template element", () => {
+        const input = html`<template></template>`;
+        const codes = parseTemplateToOpCodes(input);
+
+        expect(codes.length).toBe(2);
+        expect(codes[0].type).toBe(OpType.templateElementOpen);
+        expect(codes[1].type).toBe(OpType.templateElementClose);
+    })
 })

--- a/packages/web-components/fast-ssr/src/template-parser/template-parser.spec.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/template-parser.spec.ts
@@ -3,7 +3,7 @@ import "@lit-labs/ssr/lib/install-global-dom-shim.js";
 import { test, expect } from "@playwright/test";
 import { parseTemplateToOpCodes} from "./template-parser.js";
 import { ViewTemplate, html, FASTElement, customElement, defaultExecutionContext } from "@microsoft/fast-element"
-import { Op, OpType, CustomElementOpenOp, AttributeBindingOp, DirectiveOp } from "./op-codes.js";
+import { Op, OpType, CustomElementOpenOp, AttributeBindingOp, DirectiveOp, TemplateElementOpenOp, TextOp } from "./op-codes.js";
 import { AttributeType } from "./attributes.js";
 
 @customElement("hello-world")
@@ -90,9 +90,13 @@ test.describe("parseTemplateToOpCodes", () => {
 
         expect(codes.length).toBe(4);
         expect(codes[0].attributeType).toBe(AttributeType.content);
+        expect(codes[0].name).toBe("string-value");
         expect(codes[1].attributeType).toBe(AttributeType.booleanContent);
+        expect(codes[1].name).toBe("bool-value");
         expect(codes[2].attributeType).toBe(AttributeType.idl);
+        expect(codes[2].name).toBe("property-value");
         expect(codes[3].attributeType).toBe(AttributeType.event);
+        expect(codes[3].name).toBe("event");
     });
     test("should emit template open and close ops for a template element", () => {
         const input = html`<template></template>`;
@@ -101,5 +105,51 @@ test.describe("parseTemplateToOpCodes", () => {
         expect(codes.length).toBe(2);
         expect(codes[0].type).toBe(OpType.templateElementOpen);
         expect(codes[1].type).toBe(OpType.templateElementClose);
+    });
+    test("should emit template open ops with static attributes", () => {
+        const input = html`<template id="foo" boolean></template>`;
+        const open = parseTemplateToOpCodes(input)[0] as TemplateElementOpenOp;
+
+        expect(open.staticAttributes.get("id")).toBe("foo");
+        expect(open.staticAttributes.get("boolean")).toBe("");
+    });
+    test("should emit template open ops with dynamic attributes", () => {
+        const input = html`<template id=${x => "foo"} ?boolean=${x => true} @event=${x => undefined} :property=${x => "value"}></template>`;
+        const open = parseTemplateToOpCodes(input)[0] as TemplateElementOpenOp;
+
+        const attrs = new Map(open.dynamicAttributes.map(x => {
+            return [x.name, x];
+        }))
+
+        expect(attrs.has("id")).toBe(true);
+        expect(attrs.get("id")!.attributeType).toBe(AttributeType.content);
+        expect(attrs.has("boolean")).toBe(true);
+        expect(attrs.get("boolean")!.attributeType).toBe(AttributeType.booleanContent);
+        expect(attrs.has("event")).toBe(true);
+        expect(attrs.get("event")!.attributeType).toBe(AttributeType.event);
+        expect(attrs.has("property")).toBe(true);
+        expect(attrs.get("property")!.attributeType).toBe(AttributeType.idl);
+    });
+    test("should emit template open ops with static and dynamic attributes", () => {
+        const input = html`<template id="foo" ?boolean=${x => true}></template>`;
+        const open = parseTemplateToOpCodes(input)[0] as TemplateElementOpenOp;
+
+        expect(open.staticAttributes.size).toBe(1);
+        expect(open.staticAttributes.get("id")).toBe("foo");
+        expect(open.dynamicAttributes.length).toBe(1);
+        expect(open.dynamicAttributes[0].name).toBe("boolean");
+    });
+
+    test("should emit template template ops between other ops when nested inside of another element", () => {
+        const input = html`<div><template></template></div>`;
+        const codes = parseTemplateToOpCodes(input);
+
+        expect(codes[0].type).toBe(OpType.text);
+        expect((codes[0] as TextOp).value).toBe(`<div>`);
+        expect(codes[1].type).toBe(OpType.templateElementOpen);
+        expect(codes[2].type).toBe(OpType.templateElementClose);
+        expect(codes[3].type).toBe(OpType.text);
+        expect((codes[3] as TextOp).value).toBe(`</div>`);
     })
-})
+});
+// TODO add test that name for property, bool, and event attrs has the prefix removed.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR adds a new op type to the template parser, as well as code to emit the op code appropriately.

**Context:**
When a `FASTElement` is registered with a `ViewTemplate` that has a `<template>` element as its root element, the templating engine reflects all of the attributes and bindings on this `<template>` element to the *host element*. It then renders the template content as if this `<template>` element did not exist. 

SSR infrastructure needs to align to this behavior, but it also needs the capability to emit a `<template>` element verbatim, just like any other native HTMLElement. To handle both cases, the template parser will emit op codes for template element opening and closing. These op codes will need to be handled in two different ways:

1. When the TemplateOpenOp is the *first* code and TempalteCloseOp is the *last* code, **and** the template is being rendered by the `ElementRenderer`, the template element will not be yielded to the SSR output, and any attributes will be applied to the host element. This is the case where the author is using the `<template>` element as an alias to the host element in a `FASTElement` template
2. Any other time the TemplateOpenOp and TemplateCloseOp are encountered, the element will be yielded to the SSR string, along with any attributes.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->