### PR TITLE
prevent syntax highlighting extension from publishing to NPM

### DIFF
--- a/packages/tooling/fast-vscode-syntax-highlighting/package.json
+++ b/packages/tooling/fast-vscode-syntax-highlighting/package.json
@@ -46,5 +46,8 @@
     "bugs": {
         "url": "https://github.com/Microsoft/fast/issues/new/choose"
     },
-    "icon": "images/fast-logo.png"
+    "icon": "images/fast-logo.png",
+    "beachball": {
+        "shouldPublish": false
+    }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Sets the `shouldPublish` flag to `false` for the tagged templates syntax highlighting extension to hopefully prevent Beachball from publishing it to NPM.

## 📑 Test Plan

🤷🏻

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.
