### PR TITLE
feat: enable multiple instances of fast-element on a page at once

### DIFF
--- a/change/@microsoft-fast-element-a472079b-2d1a-4c93-a8e4-786429b46d18.json
+++ b/change/@microsoft-fast-element-a472079b-2d1a-4c93-a8e4-786429b46d18.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enable multiple instances of fast-element on a page at once",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -49,7 +49,7 @@ export class AttributeDefinition implements Accessor {
     onAttributeChangedCallback(element: HTMLElement, value: any): void;
     readonly Owner: Function;
     setValue(source: HTMLElement, newValue: any): void;
-}
+    }
 
 // @public
 export type AttributeMode = "reflect" | "boolean" | "fromView";
@@ -209,10 +209,10 @@ export const DOM: Readonly<{
     supportsAdoptedStyleSheets: boolean;
     setHTMLPolicy(policy: TrustedTypesPolicy): void;
     createHTML(html: string): string;
-    setUpdateMode(isAsync: boolean): void;
-    queueUpdate(callable: Callable): void;
+    setUpdateMode: (isAsync: boolean) => void;
+    queueUpdate: (callable: Callable) => void;
     nextUpdate(): Promise<void>;
-    processUpdates(): void;
+    processUpdates: () => void;
     setAttribute(element: HTMLElement, attributeName: string, value: any): void;
     setBooleanAttribute(element: HTMLElement, attributeName: string, value: boolean): void;
 }>;
@@ -274,7 +274,14 @@ export class ExecutionContext<TParent = any, TGrandparent = any> {
     length: number;
     parent: TParent;
     parentContext: ExecutionContext<TGrandparent>;
+    // @internal
+    static setEvent(event: Event | null): void;
 }
+
+// Warning: (ae-internal-missing-underscore) The name "FAST" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export const FAST: FASTGlobal;
 
 // @public
 export interface FASTElement extends HTMLElement {
@@ -301,8 +308,8 @@ export class FASTElementDefinition<TType extends Function = Function> {
     readonly attributes: ReadonlyArray<AttributeDefinition>;
     define(registry?: CustomElementRegistry): this;
     readonly elementOptions?: ElementDefinitionOptions;
-    static forType<TType extends Function>(type: TType): FASTElementDefinition | undefined;
-    readonly isDefined: boolean;
+    static readonly forType: <TType_1 extends Function>(key: TType_1) => FASTElementDefinition<Function> | undefined;
+    get isDefined(): boolean;
     readonly name: string;
     readonly propertyLookup: Record<string, AttributeDefinition>;
     readonly shadowOptions?: ShadowRootInit;
@@ -311,9 +318,20 @@ export class FASTElementDefinition<TType extends Function = Function> {
     readonly type: TType;
 }
 
+// Warning: (ae-internal-missing-underscore) The name "FASTGlobal" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export interface FASTGlobal {
+    getById<T>(id: string | number): T | null;
+    // (undocumented)
+    getById<T>(id: string | number, initialize: () => T): T;
+    readonly versions: string[];
+}
+
 // @public
 export type Global = typeof globalThis & {
     trustedTypes: TrustedTypes;
+    readonly FAST: FASTGlobal;
 };
 
 // @public
@@ -358,6 +376,20 @@ export abstract class InlinableHTMLDirective extends AspectedHTMLDirective {
     abstract readonly rawAspect?: string;
 }
 
+// Warning: (ae-internal-missing-underscore) The name "KernelServiceId" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export const enum KernelServiceId {
+    // (undocumented)
+    contextEvent = 3,
+    // (undocumented)
+    elementRegistry = 4,
+    // (undocumented)
+    observable = 2,
+    // (undocumented)
+    updateQueue = 1
+}
+
 // @public
 export const Markup: Readonly<{
     marker: string;
@@ -394,12 +426,12 @@ export const nullableNumberConverter: ValueConverter;
 // @public
 export const Observable: Readonly<{
     setArrayObserverFactory(factory: (collection: any[]) => Notifier): void;
-    getNotifier(source: any): Notifier;
+    getNotifier: (source: any) => Notifier;
     track(source: unknown, propertyName: string): void;
     trackVolatile(): void;
     notify(source: unknown, args: any): void;
     defineProperty(target: {}, nameOrAccessor: string | Accessor): void;
-    getAccessors(target: {}): Accessor[];
+    getAccessors: (target: {}) => Accessor[];
     binding<TSource = any, TReturn = any, TParent = any>(binding: Binding<TSource, TReturn, TParent>, initialSubscriber?: Subscriber | undefined, isVolatileBinding?: boolean): BindingObserver<TSource, TReturn, TParent>;
     isVolatileBinding<TSource_1 = any, TReturn_1 = any, TParent_1 = any>(binding: Binding<TSource_1, TReturn_1, TParent_1>): boolean;
 }>;
@@ -467,25 +499,20 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
     // @internal (undocumented)
     handleChange(source: any, args: Splice[]): void;
     unbind(): void;
-}
+    }
 
 // @public
 export class RepeatDirective<TSource = any> extends HTMLDirective {
     constructor(itemsBinding: Binding, templateBinding: Binding<TSource, SyntheticViewTemplate>, options: RepeatOptions);
     createBehavior(targets: ViewBehaviorTargets): RepeatBehavior<TSource>;
     createPlaceholder: (index: number) => string;
-}
+    }
 
 // @public
 export interface RepeatOptions {
     positioning?: boolean;
     recycle?: boolean;
 }
-
-// Warning: (ae-internal-missing-underscore) The name "setCurrentEvent" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal (undocumented)
-export function setCurrentEvent(event: Event | null): void;
 
 // @public
 export function slotted<T = any>(propertyOrOptions: (keyof T & string) | SlottedDirectiveOptions<keyof T & string>): CaptureType<T>;
@@ -617,13 +644,14 @@ export class ViewTemplate<TSource = any, TParent = any, TGrandparent = any> impl
     readonly directives: ReadonlyArray<HTMLDirective>;
     readonly html: string | HTMLTemplateElement;
     render(source: TSource, host: Node, hostBindingTarget?: Element): HTMLView<TSource, TParent, TGrandparent>;
-}
+    }
 
 // @public
 export function volatile(target: {}, name: string | Accessor, descriptor: PropertyDescriptor): PropertyDescriptor;
 
 // @public
 export function when<TSource = any, TReturn = any>(binding: Binding<TSource, TReturn>, templateOrTemplateBinding: SyntheticViewTemplate | Binding<TSource, SyntheticViewTemplate>): CaptureType<TSource>;
+
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -1,15 +1,8 @@
 import { DOM } from "../dom.js";
 import { isFunction, isString } from "../interfaces.js";
+import { FAST, KernelServiceId } from "../platform.js";
 import { PropertyChangeNotifier, SubscriberSet } from "./notifier.js";
 import type { Notifier, Subscriber } from "./notifier.js";
-
-const volatileRegex = /(:|&&|\|\||if)/;
-const notifierLookup = new WeakMap<any, Notifier>();
-const accessorLookup = new WeakMap<any, Accessor[]>();
-let watcher: BindingObserverImplementation | undefined = void 0;
-let createArrayObserver = (array: any[]): Notifier => {
-    throw new Error("Must call enableArrayObservation before observing arrays.");
-};
 
 /**
  * Represents a getter/setter property accessor on an object.
@@ -34,307 +27,6 @@ export interface Accessor {
      */
     setValue(source: any, value: any): void;
 }
-
-class DefaultObservableAccessor implements Accessor {
-    private field: string;
-    private callback: string;
-
-    constructor(public name: string) {
-        this.field = `_${name}`;
-        this.callback = `${name}Changed`;
-    }
-
-    getValue(source: any): any {
-        if (watcher !== void 0) {
-            watcher.watch(source, this.name);
-        }
-
-        return source[this.field];
-    }
-
-    setValue(source: any, newValue: any): void {
-        const field = this.field;
-        const oldValue = source[field];
-
-        if (oldValue !== newValue) {
-            source[field] = newValue;
-
-            const callback = source[this.callback];
-
-            if (isFunction(callback)) {
-                callback.call(source, oldValue, newValue);
-            }
-
-            /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-            getNotifier(source).notify(this.name);
-        }
-    }
-}
-
-/**
- * Common Observable APIs.
- * @public
- */
-export const Observable = Object.freeze({
-    /**
-     * @internal
-     * @param factory - The factory used to create array observers.
-     */
-    setArrayObserverFactory(factory: (collection: any[]) => Notifier): void {
-        createArrayObserver = factory;
-    },
-
-    /**
-     * Gets a notifier for an object or Array.
-     * @param source - The object or Array to get the notifier for.
-     */
-    getNotifier(source: any): Notifier {
-        let found = source.$fastController ?? notifierLookup.get(source);
-
-        if (found === void 0) {
-            Array.isArray(source)
-                ? (found = createArrayObserver(source))
-                : notifierLookup.set(
-                      source,
-                      (found = new PropertyChangeNotifier(source))
-                  );
-        }
-
-        return found;
-    },
-
-    /**
-     * Records a property change for a source object.
-     * @param source - The object to record the change against.
-     * @param propertyName - The property to track as changed.
-     */
-    track(source: unknown, propertyName: string): void {
-        watcher && watcher.watch(source, propertyName);
-    },
-
-    /**
-     * Notifies watchers that the currently executing property getter or function is volatile
-     * with respect to its observable dependencies.
-     */
-    trackVolatile(): void {
-        watcher && (watcher.needsRefresh = true);
-    },
-
-    /**
-     * Notifies subscribers of a source object of changes.
-     * @param source - the object to notify of changes.
-     * @param args - The change args to pass to subscribers.
-     */
-    notify(source: unknown, args: any): void {
-        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-        getNotifier(source).notify(args);
-    },
-
-    /**
-     * Defines an observable property on an object or prototype.
-     * @param target - The target object to define the observable on.
-     * @param nameOrAccessor - The name of the property to define as observable;
-     * or a custom accessor that specifies the property name and accessor implementation.
-     */
-    defineProperty(target: {}, nameOrAccessor: string | Accessor): void {
-        if (isString(nameOrAccessor)) {
-            nameOrAccessor = new DefaultObservableAccessor(nameOrAccessor);
-        }
-
-        this.getAccessors(target).push(nameOrAccessor);
-
-        Reflect.defineProperty(target, nameOrAccessor.name, {
-            enumerable: true,
-            get(this: any) {
-                return (nameOrAccessor as Accessor).getValue(this);
-            },
-            set(this: any, newValue: any) {
-                (nameOrAccessor as Accessor).setValue(this, newValue);
-            },
-        });
-    },
-
-    /**
-     * Finds all the observable accessors defined on the target,
-     * including its prototype chain.
-     * @param target - The target object to search for accessor on.
-     */
-    getAccessors(target: {}): Accessor[] {
-        let accessors = accessorLookup.get(target);
-
-        if (accessors === void 0) {
-            let currentTarget = Reflect.getPrototypeOf(target);
-
-            while (accessors === void 0 && currentTarget !== null) {
-                accessors = accessorLookup.get(currentTarget);
-                currentTarget = Reflect.getPrototypeOf(currentTarget);
-            }
-
-            accessors = accessors === void 0 ? [] : accessors.slice(0);
-
-            accessorLookup.set(target, accessors);
-        }
-
-        return accessors;
-    },
-
-    /**
-     * Creates a {@link BindingObserver} that can watch the
-     * provided {@link Binding} for changes.
-     * @param binding - The binding to observe.
-     * @param initialSubscriber - An initial subscriber to changes in the binding value.
-     * @param isVolatileBinding - Indicates whether the binding's dependency list must be re-evaluated on every value evaluation.
-     */
-    binding<TSource = any, TReturn = any, TParent = any>(
-        binding: Binding<TSource, TReturn, TParent>,
-        initialSubscriber?: Subscriber,
-        isVolatileBinding: boolean = this.isVolatileBinding(binding)
-    ): BindingObserver<TSource, TReturn, TParent> {
-        /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
-        return new BindingObserverImplementation(
-            binding,
-            initialSubscriber,
-            isVolatileBinding
-        );
-    },
-
-    /**
-     * Determines whether a binding expression is volatile and needs to have its dependency list re-evaluated
-     * on every evaluation of the value.
-     * @param binding - The binding to inspect.
-     */
-    isVolatileBinding<TSource = any, TReturn = any, TParent = any>(
-        binding: Binding<TSource, TReturn, TParent>
-    ): boolean {
-        return volatileRegex.test(binding.toString());
-    },
-});
-
-const getNotifier = Observable.getNotifier;
-const trackVolatile = Observable.trackVolatile;
-const queueUpdate = DOM.queueUpdate;
-
-/**
- * Decorator: Defines an observable property on the target.
- * @param target - The target to define the observable on.
- * @param nameOrAccessor - The property name or accessor to define the observable as.
- * @public
- */
-export function observable(target: {}, nameOrAccessor: string | Accessor): void {
-    Observable.defineProperty(target, nameOrAccessor);
-}
-
-/**
- * Decorator: Marks a property getter as having volatile observable dependencies.
- * @param target - The target that the property is defined on.
- * @param name - The property name.
- * @param name - The existing descriptor.
- * @public
- */
-export function volatile(
-    target: {},
-    name: string | Accessor,
-    descriptor: PropertyDescriptor
-): PropertyDescriptor {
-    return Object.assign({}, descriptor, {
-        get(this: any) {
-            trackVolatile();
-            return descriptor.get!.apply(this);
-        },
-    });
-}
-
-let currentEvent: Event | null = null;
-
-/**
- * @param event - The event to set as current for the context.
- * @internal
- */
-export function setCurrentEvent(event: Event | null): void {
-    currentEvent = event;
-}
-
-/**
- * Provides additional contextual information available to behaviors and expressions.
- * @public
- */
-export class ExecutionContext<TParent = any, TGrandparent = any> {
-    /**
-     * The index of the current item within a repeat context.
-     */
-    public index: number = 0;
-
-    /**
-     * The length of the current collection within a repeat context.
-     */
-    public length: number = 0;
-
-    /**
-     * The parent data object within a repeat context.
-     */
-    public parent: TParent = null as any;
-
-    /**
-     * The parent execution context when in nested context scenarios.
-     */
-    public parentContext: ExecutionContext<TGrandparent> = null as any;
-
-    /**
-     * The current event within an event handler.
-     */
-    public get event(): Event {
-        return currentEvent!;
-    }
-
-    /**
-     * Indicates whether the current item within a repeat context
-     * has an even index.
-     */
-    public get isEven(): boolean {
-        return this.index % 2 === 0;
-    }
-
-    /**
-     * Indicates whether the current item within a repeat context
-     * has an odd index.
-     */
-    public get isOdd(): boolean {
-        return this.index % 2 !== 0;
-    }
-
-    /**
-     * Indicates whether the current item within a repeat context
-     * is the first item in the collection.
-     */
-    public get isFirst(): boolean {
-        return this.index === 0;
-    }
-
-    /**
-     * Indicates whether the current item within a repeat context
-     * is somewhere in the middle of the collection.
-     */
-    public get isInMiddle(): boolean {
-        return !this.isFirst && !this.isLast;
-    }
-
-    /**
-     * Indicates whether the current item within a repeat context
-     * is the last item in the collection.
-     */
-    public get isLast(): boolean {
-        return this.index === this.length - 1;
-    }
-}
-
-Observable.defineProperty(ExecutionContext.prototype, "index");
-Observable.defineProperty(ExecutionContext.prototype, "length");
-
-/**
- * The default execution context used in binding expressions.
- * @public
- */
-export const defaultExecutionContext = Object.seal(new ExecutionContext());
 
 /**
  * The signature of an arrow function capable of being evaluated
@@ -394,111 +86,435 @@ export interface BindingObserver<TSource = any, TReturn = any, TParent = any>
     records(): IterableIterator<ObservationRecord>;
 }
 
-class BindingObserverImplementation<TSource = any, TReturn = any, TParent = any>
-    extends SubscriberSet
-    implements BindingObserver<TSource, TReturn, TParent> {
-    public needsRefresh: boolean = true;
-    private needsQueue: boolean = true;
+/**
+ * Common Observable APIs.
+ * @public
+ */
+export const Observable = FAST.getById(KernelServiceId.observable, () => {
+    const queueUpdate = DOM.queueUpdate;
+    const volatileRegex = /(:|&&|\|\||if)/;
+    const notifierLookup = new WeakMap<any, Notifier>();
+    const accessorLookup = new WeakMap<any, Accessor[]>();
+    let watcher: BindingObserverImplementation | undefined = void 0;
+    let createArrayObserver = (array: any[]): Notifier => {
+        throw new Error("Must call enableArrayObservation before observing arrays.");
+    };
 
-    private first: SubscriptionRecord = this as any;
-    private last: SubscriptionRecord | null = null;
-    private propertySource: any = void 0;
-    private propertyName: string | undefined = void 0;
-    private notifier: Notifier | undefined = void 0;
-    private next: SubscriptionRecord | undefined = void 0;
+    function getNotifier(source: any): Notifier {
+        let found = source.$fastController ?? notifierLookup.get(source);
 
-    constructor(
-        private binding: Binding<TSource, TReturn, TParent>,
-        initialSubscriber?: Subscriber,
-        private isVolatileBinding: boolean = false
-    ) {
-        super(binding, initialSubscriber);
-    }
-
-    public observe(source: TSource, context: ExecutionContext): TReturn {
-        if (this.needsRefresh && this.last !== null) {
-            this.disconnect();
+        if (found === void 0) {
+            Array.isArray(source)
+                ? (found = createArrayObserver(source))
+                : notifierLookup.set(
+                      source,
+                      (found = new PropertyChangeNotifier(source))
+                  );
         }
 
-        const previousWatcher = watcher;
-        watcher = this.needsRefresh ? this : void 0;
-        this.needsRefresh = this.isVolatileBinding;
-        const result = this.binding(source, context);
-        watcher = previousWatcher;
-
-        return result;
+        return found;
     }
 
-    public disconnect(): void {
-        if (this.last !== null) {
-            let current = this.first;
+    function getAccessors(target: {}): Accessor[] {
+        let accessors = accessorLookup.get(target);
 
-            while (current !== void 0) {
-                current.notifier.unsubscribe(this, current.propertyName);
-                current = current.next!;
+        if (accessors === void 0) {
+            let currentTarget = Reflect.getPrototypeOf(target);
+
+            while (accessors === void 0 && currentTarget !== null) {
+                accessors = accessorLookup.get(currentTarget);
+                currentTarget = Reflect.getPrototypeOf(currentTarget);
             }
 
-            this.last = null;
-            this.needsRefresh = this.needsQueue = true;
+            accessors = accessors === void 0 ? [] : accessors.slice(0);
+
+            accessorLookup.set(target, accessors);
         }
+
+        return accessors;
     }
 
-    /** @internal */
-    public watch(propertySource: unknown, propertyName: string): void {
-        const prev = this.last;
-        const notifier = getNotifier(propertySource);
-        const current: SubscriptionRecord = prev === null ? this.first : ({} as any);
+    class DefaultObservableAccessor implements Accessor {
+        private field: string;
+        private callback: string;
 
-        current.propertySource = propertySource;
-        current.propertyName = propertyName;
-        current.notifier = notifier;
+        constructor(public name: string) {
+            this.field = `_${name}`;
+            this.callback = `${name}Changed`;
+        }
 
-        notifier.subscribe(this, propertyName);
+        getValue(source: any): any {
+            if (watcher !== void 0) {
+                watcher.watch(source, this.name);
+            }
 
-        if (prev !== null) {
-            if (!this.needsRefresh) {
-                // Declaring the variable prior to assignment below circumvents
-                // a bug in Angular's optimization process causing infinite recursion
-                // of this watch() method. Details https://github.com/microsoft/fast/issues/4969
-                let prevValue;
-                watcher = void 0;
-                /* eslint-disable-next-line */
-                prevValue = prev.propertySource[prev.propertyName];
-                watcher = this;
+            return source[this.field];
+        }
 
-                if (propertySource === prevValue) {
-                    this.needsRefresh = true;
+        setValue(source: any, newValue: any): void {
+            const field = this.field;
+            const oldValue = source[field];
+
+            if (oldValue !== newValue) {
+                source[field] = newValue;
+
+                const callback = source[this.callback];
+
+                if (isFunction(callback)) {
+                    callback.call(source, oldValue, newValue);
                 }
+
+                /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+                getNotifier(source).notify(this.name);
+            }
+        }
+    }
+
+    class BindingObserverImplementation<TSource = any, TReturn = any, TParent = any>
+        extends SubscriberSet
+        implements BindingObserver<TSource, TReturn, TParent> {
+        public needsRefresh: boolean = true;
+        private needsQueue: boolean = true;
+
+        private first: SubscriptionRecord = this as any;
+        private last: SubscriptionRecord | null = null;
+        private propertySource: any = void 0;
+        private propertyName: string | undefined = void 0;
+        private notifier: Notifier | undefined = void 0;
+        private next: SubscriptionRecord | undefined = void 0;
+
+        constructor(
+            private binding: Binding<TSource, TReturn, TParent>,
+            initialSubscriber?: Subscriber,
+            private isVolatileBinding: boolean = false
+        ) {
+            super(binding, initialSubscriber);
+        }
+
+        public observe(source: TSource, context: ExecutionContext): TReturn {
+            if (this.needsRefresh && this.last !== null) {
+                this.disconnect();
             }
 
-            prev.next = current;
+            const previousWatcher = watcher;
+            watcher = this.needsRefresh ? this : void 0;
+            this.needsRefresh = this.isVolatileBinding;
+            const result = this.binding(source, context);
+            watcher = previousWatcher;
+
+            return result;
         }
 
-        this.last = current!;
+        public disconnect(): void {
+            if (this.last !== null) {
+                let current = this.first;
+
+                while (current !== void 0) {
+                    current.notifier.unsubscribe(this, current.propertyName);
+                    current = current.next!;
+                }
+
+                this.last = null;
+                this.needsRefresh = this.needsQueue = true;
+            }
+        }
+
+        /** @internal */
+        public watch(propertySource: unknown, propertyName: string): void {
+            const prev = this.last;
+            const notifier = getNotifier(propertySource);
+            const current: SubscriptionRecord = prev === null ? this.first : ({} as any);
+
+            current.propertySource = propertySource;
+            current.propertyName = propertyName;
+            current.notifier = notifier;
+
+            notifier.subscribe(this, propertyName);
+
+            if (prev !== null) {
+                if (!this.needsRefresh) {
+                    // Declaring the variable prior to assignment below circumvents
+                    // a bug in Angular's optimization process causing infinite recursion
+                    // of this watch() method. Details https://github.com/microsoft/fast/issues/4969
+                    let prevValue;
+                    watcher = void 0;
+                    /* eslint-disable-next-line */
+                    prevValue = prev.propertySource[prev.propertyName];
+                    watcher = this;
+
+                    if (propertySource === prevValue) {
+                        this.needsRefresh = true;
+                    }
+                }
+
+                prev.next = current;
+            }
+
+            this.last = current!;
+        }
+
+        /** @internal */
+        handleChange(): void {
+            if (this.needsQueue) {
+                this.needsQueue = false;
+                queueUpdate(this);
+            }
+        }
+
+        /** @internal */
+        call(): void {
+            if (this.last !== null) {
+                this.needsQueue = true;
+                this.notify(this);
+            }
+        }
+
+        public *records(): IterableIterator<ObservationRecord> {
+            let next = this.first;
+
+            while (next !== void 0) {
+                yield next;
+                next = next.next!;
+            }
+        }
     }
 
-    /** @internal */
-    handleChange(): void {
-        if (this.needsQueue) {
-            this.needsQueue = false;
-            queueUpdate(this);
-        }
+    return Object.freeze({
+        /**
+         * @internal
+         * @param factory - The factory used to create array observers.
+         */
+        setArrayObserverFactory(factory: (collection: any[]) => Notifier): void {
+            createArrayObserver = factory;
+        },
+
+        /**
+         * Gets a notifier for an object or Array.
+         * @param source - The object or Array to get the notifier for.
+         */
+        getNotifier,
+
+        /**
+         * Records a property change for a source object.
+         * @param source - The object to record the change against.
+         * @param propertyName - The property to track as changed.
+         */
+        track(source: unknown, propertyName: string): void {
+            watcher && watcher.watch(source, propertyName);
+        },
+
+        /**
+         * Notifies watchers that the currently executing property getter or function is volatile
+         * with respect to its observable dependencies.
+         */
+        trackVolatile(): void {
+            watcher && (watcher.needsRefresh = true);
+        },
+
+        /**
+         * Notifies subscribers of a source object of changes.
+         * @param source - the object to notify of changes.
+         * @param args - The change args to pass to subscribers.
+         */
+        notify(source: unknown, args: any): void {
+            /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+            getNotifier(source).notify(args);
+        },
+
+        /**
+         * Defines an observable property on an object or prototype.
+         * @param target - The target object to define the observable on.
+         * @param nameOrAccessor - The name of the property to define as observable;
+         * or a custom accessor that specifies the property name and accessor implementation.
+         */
+        defineProperty(target: {}, nameOrAccessor: string | Accessor): void {
+            if (isString(nameOrAccessor)) {
+                nameOrAccessor = new DefaultObservableAccessor(nameOrAccessor);
+            }
+
+            getAccessors(target).push(nameOrAccessor);
+
+            Reflect.defineProperty(target, nameOrAccessor.name, {
+                enumerable: true,
+                get(this: any) {
+                    return (nameOrAccessor as Accessor).getValue(this);
+                },
+                set(this: any, newValue: any) {
+                    (nameOrAccessor as Accessor).setValue(this, newValue);
+                },
+            });
+        },
+
+        /**
+         * Finds all the observable accessors defined on the target,
+         * including its prototype chain.
+         * @param target - The target object to search for accessor on.
+         */
+        getAccessors,
+
+        /**
+         * Creates a {@link BindingObserver} that can watch the
+         * provided {@link Binding} for changes.
+         * @param binding - The binding to observe.
+         * @param initialSubscriber - An initial subscriber to changes in the binding value.
+         * @param isVolatileBinding - Indicates whether the binding's dependency list must be re-evaluated on every value evaluation.
+         */
+        binding<TSource = any, TReturn = any, TParent = any>(
+            binding: Binding<TSource, TReturn, TParent>,
+            initialSubscriber?: Subscriber,
+            isVolatileBinding: boolean = this.isVolatileBinding(binding)
+        ): BindingObserver<TSource, TReturn, TParent> {
+            /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
+            return new BindingObserverImplementation(
+                binding,
+                initialSubscriber,
+                isVolatileBinding
+            );
+        },
+
+        /**
+         * Determines whether a binding expression is volatile and needs to have its dependency list re-evaluated
+         * on every evaluation of the value.
+         * @param binding - The binding to inspect.
+         */
+        isVolatileBinding<TSource = any, TReturn = any, TParent = any>(
+            binding: Binding<TSource, TReturn, TParent>
+        ): boolean {
+            return volatileRegex.test(binding.toString());
+        },
+    });
+});
+
+/**
+ * Decorator: Defines an observable property on the target.
+ * @param target - The target to define the observable on.
+ * @param nameOrAccessor - The property name or accessor to define the observable as.
+ * @public
+ */
+export function observable(target: {}, nameOrAccessor: string | Accessor): void {
+    Observable.defineProperty(target, nameOrAccessor);
+}
+
+/**
+ * Decorator: Marks a property getter as having volatile observable dependencies.
+ * @param target - The target that the property is defined on.
+ * @param name - The property name.
+ * @param name - The existing descriptor.
+ * @public
+ */
+export function volatile(
+    target: {},
+    name: string | Accessor,
+    descriptor: PropertyDescriptor
+): PropertyDescriptor {
+    return Object.assign({}, descriptor, {
+        get(this: any) {
+            Observable.trackVolatile();
+            return descriptor.get!.apply(this);
+        },
+    });
+}
+
+const contextEvent = FAST.getById(KernelServiceId.contextEvent, () => {
+    let current: Event | null = null;
+
+    return {
+        get() {
+            return current;
+        },
+        set(event: Event | null) {
+            current = event;
+        },
+    };
+});
+
+/**
+ * Provides additional contextual information available to behaviors and expressions.
+ * @public
+ */
+export class ExecutionContext<TParent = any, TGrandparent = any> {
+    /**
+     * The index of the current item within a repeat context.
+     */
+    public index: number = 0;
+
+    /**
+     * The length of the current collection within a repeat context.
+     */
+    public length: number = 0;
+
+    /**
+     * The parent data object within a repeat context.
+     */
+    public parent: TParent = null as any;
+
+    /**
+     * The parent execution context when in nested context scenarios.
+     */
+    public parentContext: ExecutionContext<TGrandparent> = null as any;
+
+    /**
+     * The current event within an event handler.
+     */
+    public get event(): Event {
+        return contextEvent.get()!;
     }
 
-    /** @internal */
-    call(): void {
-        if (this.last !== null) {
-            this.needsQueue = true;
-            this.notify(this);
-        }
+    /**
+     * Indicates whether the current item within a repeat context
+     * has an even index.
+     */
+    public get isEven(): boolean {
+        return this.index % 2 === 0;
     }
 
-    public *records(): IterableIterator<ObservationRecord> {
-        let next = this.first;
+    /**
+     * Indicates whether the current item within a repeat context
+     * has an odd index.
+     */
+    public get isOdd(): boolean {
+        return this.index % 2 !== 0;
+    }
 
-        while (next !== void 0) {
-            yield next;
-            next = next.next!;
-        }
+    /**
+     * Indicates whether the current item within a repeat context
+     * is the first item in the collection.
+     */
+    public get isFirst(): boolean {
+        return this.index === 0;
+    }
+
+    /**
+     * Indicates whether the current item within a repeat context
+     * is somewhere in the middle of the collection.
+     */
+    public get isInMiddle(): boolean {
+        return !this.isFirst && !this.isLast;
+    }
+
+    /**
+     * Indicates whether the current item within a repeat context
+     * is the last item in the collection.
+     */
+    public get isLast(): boolean {
+        return this.index === this.length - 1;
+    }
+
+    /**
+     * Sets the event for the current execution context.
+     * @param event - The event to set.
+     * @internal
+     */
+    public static setEvent(event: Event | null): void {
+        contextEvent.set(event);
     }
 }
+
+Observable.defineProperty(ExecutionContext.prototype, "index");
+Observable.defineProperty(ExecutionContext.prototype, "length");
+
+/**
+ * The default execution context used in binding expressions.
+ * @public
+ */
+export const defaultExecutionContext = Object.seal(new ExecutionContext());

--- a/packages/web-components/fast-element/src/platform.spec.ts
+++ b/packages/web-components/fast-element/src/platform.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from "chai";
+import { FAST } from './platform';
+
+describe("The FAST global", () => {
+    context("kernel API", () => {
+        it("can get a lazily defined service by id", () => {
+            const id = 'test-id';
+            const service = {};
+            const found = FAST.getById(id, () => service);
+
+            expect(found).to.equal(service);
+        });
+
+        it("returns the first service defined for an id", () => {
+            const id = 'test-id-2';
+            const service1 = {};
+            const service2 = {};
+            const found1 = FAST.getById(id, () => service1);
+            const found2 = FAST.getById(id, () => service2);
+
+            expect(found1).to.equal(service1);
+            expect(found2).to.equal(service1);
+        });
+
+        it("returns null for optional services", () => {
+            const id = 'test-id-3';
+            const found = FAST.getById(id);
+
+            expect(found).to.be.null;
+        });
+    });
+});

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -24,6 +24,25 @@ export type TrustedTypes = {
 };
 
 /**
+ * The FAST global.
+ * @internal
+ */
+export interface FASTGlobal {
+    /**
+     * The list of loaded versions.
+     */
+    readonly versions: string[];
+
+    /**
+     * Gets a kernel value.
+     * @param id - The id to get the value for.
+     * @param initialize - Creates the initial value for the id if not already existing.
+     */
+    getById<T>(id: string | number): T | null;
+    getById<T>(id: string | number, initialize: () => T): T;
+}
+
+/**
  * The platform global type.
  * @public
  */
@@ -32,6 +51,12 @@ export type Global = typeof globalThis & {
      * Enables working with trusted types.
      */
     trustedTypes: TrustedTypes;
+
+    /**
+     * The FAST global.
+     * @internal
+     */
+    readonly FAST: FASTGlobal;
 };
 
 declare const global: any;
@@ -77,6 +102,53 @@ export const $global: Global = (function () {
 // API-only Polyfill for trustedTypes
 if (!$global.trustedTypes) {
     $global.trustedTypes = { createPolicy: (n: string, r: TrustedTypesPolicy) => r };
+}
+
+const propConfig = {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+};
+
+if ($global.FAST === void 0) {
+    Reflect.defineProperty($global, "FAST", {
+        value: Object.create(null),
+        ...propConfig,
+    });
+}
+
+/**
+ * The FAST global.
+ * @internal
+ */
+export const FAST = $global.FAST;
+
+if (FAST.getById === void 0) {
+    const storage = Object.create(null);
+
+    Reflect.defineProperty(FAST, "getById", {
+        value<T>(id: string | number, initialize?: () => T): T | null {
+            let found = storage[id];
+
+            if (found === void 0) {
+                found = initialize ? (storage[id] = initialize()) : null;
+            }
+
+            return found;
+        },
+        ...propConfig,
+    });
+}
+
+/**
+ * Core services shared across FAST instances.
+ * @internal
+ */
+export const enum KernelServiceId {
+    updateQueue = 1,
+    observable = 2,
+    contextEvent = 3,
+    elementRegistry = 4,
 }
 
 /**

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -5,7 +5,6 @@ import {
     BindingObserver,
     ExecutionContext,
     Observable,
-    setCurrentEvent,
 } from "../observation/observable.js";
 import {
     InlinableHTMLDirective,
@@ -449,9 +448,9 @@ class EventListener extends BindingBase {
         const source = target.$fastSource;
         const context = target.$fastContext;
 
-        setCurrentEvent(event);
+        ExecutionContext.setEvent(event);
         const result = this.directive.binding(source, context);
-        setCurrentEvent(null);
+        ExecutionContext.setEvent(null);
 
         if (result !== true) {
             event.preventDefault();


### PR DESCRIPTION
# Pull Request

## 📖 Description

Currently, you cannot have multiple copies of `@microsoft/fast-element` running on the same page at the same time. This has to do with certain core services and their private state which break each other. For example, an observable defined by one instance of FAST cannot be observed by another because the notifier cache is not shared between the two versions.

This PR attempts to extract a set of core services that can be shared across all instances of `@microsoft/fast-element` running on the same page.

At present, kernel services across fast-element 1.x and 2.x can be shared, provided that fast-element 2.x is loaded first. Another way to put it is that the 2.x kernel is backwards compatible with the 1.x kernel, but the 1.x kernel is not forward compatible with the 2.x kernel, due to new functionality added in 2.x.

### 🎫 Issues

No public issues. Various public and internal instances where this has been a challenge.

## 👩‍💻 Reviewer Notes

The basic approach is that fast-element now establishes a `FAST` global which can be accessed by all running instances. The global exposes a single `getById` method to retrieve shared services by id. This means that whichever fast-element version is loaded first on the page gets to define the version of the service that all instances will use.

Throughout the codebase, core services first attempt to retrieve the shared service. The API facilitates a "get or create" mechanism so that if the service is not available, the caller is able to provide an implementation.

The shared services are as follows:

* Update Queue - The DOM update queue that is used by the binding system.
* Observable - The observable system that is the core of observing state changes in templates.
* Context Event - Controls what event is available through the execution context within an event binding.
* FAST Element Definitions - The registry that maps web components to their FASTElementDefinition instances.

The API report shows breaking API changes but that is only a change from several functions on objects to properties that are functions on object. The invocation pattern doesn't change for consumers, so this isn't really a breaking change.

## 📑 Test Plan

Testing this is a challenge. All of our existing tests pass, but those don't really exercise the scenario that this is a fix for. To test this, we'd need to have two separate bundles with two versions of fast-element, on the same page at once. We don't have infrastructure setup for doing that sort of test in this repo.

However, the previous PR for multi-instance support validated the kernel with a manual test.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

This PR only attempts to handle scenarios where there are multiple copies of fast-element present. There may be additional issues with multiple copies of `fast-foundation`. That would need to be explored separately. Any fixes there would be dependent on the version of fast-element with this set of changes.

Furthermore, there are some things that are just not fixable, such as cross version `instanceof` checks or libraries that attempt to call `customElements.define` with the same tag name. No attempt will be made to hack around those platform restrictions.

A future PR for 2.x will likely remove duplicative APIs on gateways like `DOM` in favor of exposing the kernel service directly.