### PR TITLE
refactor: enable pluggable template compiler for SSR scenarios

### DIFF
--- a/change/@microsoft-fast-element-5027f6e6-0686-40b1-965f-adc905136502.json
+++ b/change/@microsoft-fast-element-5027f6e6-0686-40b1-965f-adc905136502.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "refactor: enable pluggable template compiler for SSR scenarios",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -140,7 +140,7 @@ export class ChildrenDirective extends NodeObservationDirective<ChildrenDirectiv
 export type ChildrenDirectiveOptions<T = any> = ChildListDirectiveOptions<T> | SubtreeDirectiveOptions<T>;
 
 // @public
-export function compileTemplate(template: HTMLTemplateElement, directives: ReadonlyArray<HTMLDirective>): HTMLTemplateCompilationResult;
+export function compileTemplate(html: string | HTMLTemplateElement, directives: ReadonlyArray<HTMLDirective>): HTMLTemplateCompilationResult;
 
 // @public
 export type ComposableStyles = string | ElementStyles | CSSStyleSheet;
@@ -347,10 +347,13 @@ export abstract class HTMLDirective implements ViewBehaviorFactory {
 
 // @public
 export interface HTMLTemplateCompilationResult {
-    createTargets(root: Node, host?: Node): ViewBehaviorTargets;
-    readonly factories: ReadonlyArray<ViewBehaviorFactory>;
-    readonly fragment: DocumentFragment;
+    createView(hostBindingTarget?: Element): HTMLView;
 }
+
+// @public
+export type HTMLTemplateCompiler = (
+html: string | HTMLTemplateElement,
+directives: readonly HTMLDirective[]) => HTMLTemplateCompilationResult;
 
 // @public
 export class HTMLView<TSource = any, TParent = any, TGrandparent = any> implements ElementView<TSource, TParent, TGrandparent>, SyntheticView<TSource, TParent, TGrandparent> {
@@ -644,7 +647,8 @@ export class ViewTemplate<TSource = any, TParent = any, TGrandparent = any> impl
     readonly directives: ReadonlyArray<HTMLDirective>;
     readonly html: string | HTMLTemplateElement;
     render(source: TSource, host: Node, hostBindingTarget?: Element): HTMLView<TSource, TParent, TGrandparent>;
-    }
+    static setDefaultCompiler(compiler: HTMLTemplateCompiler): void;
+}
 
 // @public
 export function volatile(target: {}, name: string | Accessor, descriptor: PropertyDescriptor): PropertyDescriptor;

--- a/packages/web-components/fast-element/src/styles/element-styles.ts
+++ b/packages/web-components/fast-element/src/styles/element-styles.ts
@@ -165,7 +165,7 @@ export class ElementStyles {
      * Sets the default strategy type to use when creating style strategies.
      * @param Strategy - The strategy type to construct.
      */
-    public static setDefaultStrategy(Strategy: ConstructibleStyleStrategy) {
+    public static setDefaultStrategy(Strategy: ConstructibleStyleStrategy): void {
         DefaultStyleStrategy = Strategy;
     }
 }

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -8,14 +8,21 @@ import type { StyleTarget } from "../styles/element-styles";
 import { toHTML, uniqueElementName } from "../__test__/helpers";
 import { bind, HTMLBindingDirective } from "./binding";
 import { compileTemplate } from "./compiler";
-import type { HTMLDirective } from "./html-directive";
+import type { HTMLDirective, ViewBehaviorFactory } from "./html-directive";
 import { html } from "./template";
+
+/**
+ * Used to satisfy TS by exposing some internal properties of the
+ * compilation result that we want to make assertions against.
+ */
+interface CompilationResultInternals {
+    readonly fragment: DocumentFragment;
+    readonly factories: ViewBehaviorFactory[];
+}
 
 describe("The template compiler", () => {
     function compile(html: string, directives: HTMLDirective[]) {
-        const template = document.createElement("template");
-        template.innerHTML = html;
-        return compileTemplate(template, directives);
+        return compileTemplate(html, directives) as any as CompilationResultInternals;
     }
 
     function inline(index: number) {

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -1,4 +1,3 @@
-import { Markup } from "./markup.js";
 import { isFunction } from "../interfaces.js";
 import type { Splice } from "../observation/array-change-records.js";
 import { enableArrayObservation } from "../observation/array-observer.js";
@@ -11,6 +10,7 @@ import {
     Observable,
 } from "../observation/observable.js";
 import { emptyArray } from "../platform.js";
+import { Markup } from "./markup.js";
 import { HTMLDirective, ViewBehaviorTargets } from "./html-directive.js";
 import type { CaptureType, SyntheticViewTemplate } from "./template.js";
 import { HTMLView, SyntheticView } from "./view.js";


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR refactors the template compilation process so that the template compiler can be swapped out, which is particularly important for SSR. Along those lines, the code from `ViewTemplate` that worked directly with template elements has been moved into the default compiler so that the SSR compiler doesn't have to work around that.

### 🎫 Issues

Closes #5703 

## 👩‍💻 Reviewer Notes

This is mostly a move of code and an addition of an API to configure the compilation function that is used. Not much to it in the end.

## 📑 Test Plan

All existing compiler and template tests continue to pass. The new API is exercised through the default set of the existing compiler as part of the templating system.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Next steps are for @nicholasrice to leverage these features in the SSR renderer.