### PR TITLE
feat: create unified API for parsing markers

### DIFF
--- a/change/@microsoft-fast-element-0e2b9162-79c1-43de-adf5-13989cd29ee1.json
+++ b/change/@microsoft-fast-element-0e2b9162-79c1-43de-adf5-13989cd29ee1.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat: create unified API for parsing markers",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -49,7 +49,7 @@ export class AttributeDefinition implements Accessor {
     onAttributeChangedCallback(element: HTMLElement, value: any): void;
     readonly Owner: Function;
     setValue(source: HTMLElement, newValue: any): void;
-    }
+}
 
 // @public
 export type AttributeMode = "reflect" | "boolean" | "fromView";
@@ -457,7 +457,7 @@ export const oneTime: BindingConfig<DefaultBindingOptions> & BindingConfigResolv
 // @public
 export const Parser: Readonly<{
     parse(value: string, directives: readonly HTMLDirective[]): (string | HTMLDirective)[] | null;
-    aggregate(parts: (string | HTMLDirective)[]): InlinableHTMLDirective;
+    aggregate(parts: (string | HTMLDirective)[]): HTMLDirective;
 }>;
 
 // @public
@@ -500,14 +500,14 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
     // @internal (undocumented)
     handleChange(source: any, args: Splice[]): void;
     unbind(): void;
-    }
+}
 
 // @public
 export class RepeatDirective<TSource = any> extends HTMLDirective {
     constructor(itemsBinding: Binding, templateBinding: Binding<TSource, SyntheticViewTemplate>, options: RepeatOptions);
     createBehavior(targets: ViewBehaviorTargets): RepeatBehavior<TSource>;
     createPlaceholder: (index: number) => string;
-    }
+}
 
 // @public
 export interface RepeatOptions {
@@ -653,7 +653,6 @@ export function volatile(target: {}, name: string | Accessor, descriptor: Proper
 
 // @public
 export function when<TSource = any, TReturn = any>(binding: Binding<TSource, TReturn>, templateOrTemplateBinding: SyntheticViewTemplate | Binding<TSource, SyntheticViewTemplate>): CaptureType<TSource>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -395,11 +395,9 @@ export const enum KernelServiceId {
 
 // @public
 export const Markup: Readonly<{
-    marker: string;
     interpolation(index: number): string;
     attribute(index: number): string;
     comment(index: number): string;
-    indexFromComment(node: Comment): number;
 }>;
 
 // Warning: (ae-internal-missing-underscore) The name "Mutable" should be prefixed with an underscore because the declaration is marked as @internal

--- a/packages/web-components/fast-element/src/components/controller.spec.ts
+++ b/packages/web-components/fast-element/src/components/controller.spec.ts
@@ -531,7 +531,7 @@ describe("The Controller", () => {
                 }
             ).define();
 
-            expect(root.innerHTML).to.equal("<!---->Test 2");
+            expect(root.innerHTML).to.equal("Test 2");
 
             document.body.removeChild(element);
         });

--- a/packages/web-components/fast-element/src/templating/compiler.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.ts
@@ -284,10 +284,10 @@ export function compileTemplate(
         // To mitigate this, we insert a stable first node. However, if we insert a node,
         // that will alter the result of the TreeWalker. So, we also need to offset the target index.
         isMarker(fragment.firstChild!, directives) ||
-        // Or if there is only one node, it means the template's content
+        // Or if there is only one node and a directive, it means the template's content
         // is *only* the directive. In that case, HTMLView.dispose() misses any nodes inserted by
         // the directive. Inserting a new node ensures proper disposal of nodes added by the directive.
-        fragment.childNodes.length === 1
+        (fragment.childNodes.length === 1 && directives.length)
     ) {
         fragment.insertBefore(document.createComment(""), fragment.firstChild);
     }

--- a/packages/web-components/fast-element/src/templating/compiler.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.ts
@@ -1,6 +1,6 @@
 import { isString } from "../interfaces.js";
 import { DOM } from "../dom.js";
-import { Markup, Parser } from "./markup.js";
+import { Parser } from "./markup.js";
 import { bind, oneTime } from "./binding.js";
 import type {
     AspectedHTMLDirective,

--- a/packages/web-components/fast-element/src/templating/compiler.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.ts
@@ -235,12 +235,11 @@ function compileNode(
 }
 
 function isMarker(node: Node, directives: ReadonlyArray<HTMLDirective>): boolean {
-    if (node && node.nodeType === Node.COMMENT_NODE) {
-        const result = Parser.parse((node as Comment).data, directives);
-        return result !== null;
-    }
-
-    return false;
+    return (
+        node &&
+        node.nodeType == 8 &&
+        Parser.parse((node as Comment).data, directives) !== null
+    );
 }
 
 /**

--- a/packages/web-components/fast-element/src/templating/markup.ts
+++ b/packages/web-components/fast-element/src/templating/markup.ts
@@ -19,11 +19,6 @@ export const nextId = (): string => `${marker}-${++id}`;
  */
 export const Markup = Object.freeze({
     /**
-     * Gets the unique marker used by FAST to annotate templates.
-     */
-    marker,
-
-    /**
      * Creates a placeholder string suitable for marking out a location *within*
      * an attribute value or HTML content.
      * @param index - The directive index to create the placeholder for.
@@ -53,15 +48,7 @@ export const Markup = Object.freeze({
      * Used internally by structural directives such as `repeat`.
      */
     comment(index: number): string {
-        return `<!--${marker}:${index}-->`;
-    },
-
-    /**
-     * Given a marker node, extract the {@link HTMLDirective} index from the placeholder.
-     * @param node - The marker node to extract the index from.
-     */
-    indexFromComment(node: Comment): number {
-        return parseInt(node.data.replace(`${marker}:`, ""));
+        return `<!--${interpolationStart}${index}${interpolationEnd}-->`;
     },
 });
 
@@ -82,16 +69,16 @@ export const Parser = Object.freeze({
         value: string,
         directives: readonly HTMLDirective[]
     ): (string | HTMLDirective)[] | null {
-        const valueParts = value.split(interpolationStart);
+        const parts = value.split(interpolationStart);
 
-        if (valueParts.length === 1) {
+        if (parts.length === 1) {
             return null;
         }
 
-        const bindingParts: (string | HTMLDirective)[] = [];
+        const result: (string | HTMLDirective)[] = [];
 
-        for (let i = 0, ii = valueParts.length; i < ii; ++i) {
-            const current = valueParts[i];
+        for (let i = 0, ii = parts.length; i < ii; ++i) {
+            const current = parts[i];
             const index = current.indexOf(interpolationEnd);
             let literal: string | HTMLDirective;
 
@@ -99,16 +86,16 @@ export const Parser = Object.freeze({
                 literal = current;
             } else {
                 const directiveIndex = parseInt(current.substring(0, index));
-                bindingParts.push(directives[directiveIndex]);
+                result.push(directives[directiveIndex]);
                 literal = current.substring(index + interpolationEndLength);
             }
 
             if (literal !== "") {
-                bindingParts.push(literal);
+                result.push(literal);
             }
         }
 
-        return bindingParts;
+        return result;
     },
 
     /**

--- a/packages/web-components/fast-element/src/templating/markup.ts
+++ b/packages/web-components/fast-element/src/templating/markup.ts
@@ -104,9 +104,9 @@ export const Parser = Object.freeze({
      * directives.
      * @returns A single inline directive that aggregates the behavior of all the parts.
      */
-    aggregate(parts: (string | HTMLDirective)[]): InlinableHTMLDirective {
+    aggregate(parts: (string | HTMLDirective)[]): HTMLDirective {
         if (parts.length === 1) {
-            return parts[0] as InlinableHTMLDirective;
+            return parts[0] as HTMLDirective;
         }
 
         let aspect: string | undefined;

--- a/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
@@ -1,4 +1,4 @@
-import { InlinableHTMLDirective } from "@microsoft/fast-element";
+import { HTMLDirective } from "@microsoft/fast-element";
 import { AttributeType } from "./attributes.js";
 
 /**
@@ -62,7 +62,7 @@ export type CustomElementShadowOp = {
  */
 export type DirectiveOp = {
     type: OpType.directive;
-    directive: InlinableHTMLDirective;
+    directive: HTMLDirective;
 };
 
 /**
@@ -70,7 +70,7 @@ export type DirectiveOp = {
  */
 export type AttributeBindingOp = {
     type: OpType.attributeBinding;
-    directive: InlinableHTMLDirective;
+    directive: HTMLDirective;
     name: string;
     attributeType: AttributeType;
     useCustomElementInstance: boolean;

--- a/packages/web-components/fast-ssr/src/template-parser/template-parser.spec.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/template-parser.spec.ts
@@ -38,7 +38,6 @@ test.describe("parseTemplateToOpCodes", () => {
             const code = codes[0] as DirectiveOp;
             expect(codes.length).toBe(1);
             expect(code.type).toBe(OpType.directive);
-            expect(code.directive.binding(null, defaultExecutionContext)).toBe("Hello World.")
     });
     test("should sandwich directive ops between text ops when binding native element content", () => {
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Previously, the syntax for embedding markers in comments was different from attributes and content. This PR unifies the markup and parsing so that a single API can be used for all scenarios.

### 🎫 Issues

* Closes #5694

## 👩‍💻 Reviewer Notes

* Previous`Markup` APIs for extracting the `HTMLDirective` index from a comment have been removed, since this is now handled by the unified `Parser` API.
* The public export of the `marker` has also been removed. With these changes, I think SSR doesn't need access to those internal details anymore. It can just use the new`Parser` APIs.
* Fixed some compiler logic that was out of sync from FE 1.0.

## 📑 Test Plan

All existing tests pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

The next item to work on is #5683 which should provide more of the parsed data via the directive structures so that SSR doesn't have to figure that out.