### PR TITLE
Fix: tree view single select

### DIFF
--- a/change/@microsoft-fast-foundation-5c1ea5fd-9497-4846-bfa7-a8d305856136.json
+++ b/change/@microsoft-fast-foundation-5c1ea5fd-9497-4846-bfa7-a8d305856136.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "tree view single select",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.spec.ts
@@ -102,4 +102,28 @@ describe("TreeView", () => {
 
         await disconnect();
     });
+
+    it("should deselect a selected item when clicked", async () => {
+        const { element, connect, disconnect } = await setup();
+        const item1 = document.createElement("fast-tree-item");
+        const item2 = document.createElement("fast-tree-item");
+        const item3 = document.createElement("fast-tree-item");
+
+        element.appendChild(item1);
+        element.appendChild(item2);
+        element.appendChild(item3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        item3.click();
+        await DOM.nextUpdate();
+        expect(item3.getAttribute("aria-selected")).to.equal("true");
+
+        item3.click();
+        await DOM.nextUpdate();
+        expect(item3.getAttribute("aria-selected")).to.equal("false");
+
+        await disconnect();
+    });
 });

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.spec.ts
@@ -77,4 +77,29 @@ describe("TreeView", () => {
 
         await disconnect();
     });
+
+    it("should only allow one tree item to be selected at a time", async () => {
+        const { element, connect, disconnect } = await setup();
+        const item1 = document.createElement("fast-tree-item");
+        const item2 = document.createElement("fast-tree-item");
+        const item3 = document.createElement("fast-tree-item");
+
+        element.appendChild(item1);
+        element.appendChild(item2);
+        element.appendChild(item3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        item3.click();
+        await DOM.nextUpdate();
+        expect(item3.getAttribute("aria-selected")).to.equal("true");
+
+        item2.click();
+        await DOM.nextUpdate();
+        expect(item3.getAttribute("aria-selected")).to.equal("false");
+        expect(item2.getAttribute("aria-selected")).to.equal("true");
+
+        await disconnect();
+    });
 });

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -223,7 +223,10 @@ export class TreeView extends FoundationElement {
 
         const item: TreeItem = e.target as TreeItem;
 
-        if (item.selected && this.currentSelected !== item) {
+        if (item.selected) {
+            if (this.currentSelected && this.currentSelected !== item) {
+                (this.currentSelected as TreeItem).selected = false;
+            }
             // new selected item
             this.currentSelected = item;
         } else if (!item.selected && this.currentSelected === item) {


### PR DESCRIPTION
## 📖 Description
Fix to limit tree view selection to a single item.  Regression from here - https://github.com/microsoft/fast/pull/5350.

### 🎫 Issues
closes https://github.com/microsoft/fast-blazor/issues/158


## 📑 Test Plan
Added test for this

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
