### PR TITLE
feat: aspected html directive exposes metadata

### DIFF
--- a/change/@microsoft-fast-element-4013c3d3-7d0e-405e-b3d0-c516701f2438.json
+++ b/change/@microsoft-fast-element-4013c3d3-7d0e-405e-b3d0-c516701f2438.json
@@ -1,5 +1,6 @@
 {
   "type": "major",
+  "comment": "feat: aspected html directive exposes metadata",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-fast-element-4013c3d3-7d0e-405e-b3d0-c516701f2438.json
+++ b/change/@microsoft-fast-element-4013c3d3-7d0e-405e-b3d0-c516701f2438.json
@@ -1,0 +1,6 @@
+{
+  "type": "major",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -16,13 +16,13 @@ export interface Accessor {
 
 // @public
 export abstract class AspectedHTMLDirective extends HTMLDirective {
+    // Warning: (ae-forgotten-export) The symbol "Aspect" needs to be exported by the entry point index.d.ts
+    abstract readonly aspect: Aspect;
     abstract readonly binding?: Binding;
     abstract captureSource(source: string): void;
     createPlaceholder: (index: number) => string;
     abstract readonly source: string;
     abstract readonly target: string;
-    // Warning: (ae-forgotten-export) The symbol "HTMLAspect" needs to be exported by the entry point index.d.ts
-    abstract readonly type: HTMLAspect;
 }
 
 // @public
@@ -84,7 +84,7 @@ export interface BindingConfig<T = any> {
 }
 
 // @alpha (undocumented)
-export type BindingMode = Record<HTMLAspect, BindingType>;
+export type BindingMode = Record<Aspect, BindingType>;
 
 // @public
 export interface BindingObserver<TSource = any, TReturn = any, TParent = any> extends Notifier {

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -16,9 +16,13 @@ export interface Accessor {
 
 // @public
 export abstract class AspectedHTMLDirective extends HTMLDirective {
+    abstract readonly binding?: Binding;
+    abstract captureSource(source: string): void;
     createPlaceholder: (index: number) => string;
-    // (undocumented)
-    abstract setAspect(value: string): void;
+    abstract readonly source: string;
+    abstract readonly target: string;
+    // Warning: (ae-forgotten-export) The symbol "HTMLAspect" needs to be exported by the entry point index.d.ts
+    abstract readonly type: HTMLAspect;
 }
 
 // @public
@@ -80,20 +84,7 @@ export interface BindingConfig<T = any> {
 }
 
 // @alpha (undocumented)
-export interface BindingMode {
-    // (undocumented)
-    attribute: BindingType;
-    // (undocumented)
-    booleanAttribute: BindingType;
-    // (undocumented)
-    content: BindingType;
-    // (undocumented)
-    event: BindingType;
-    // (undocumented)
-    property: BindingType;
-    // (undocumented)
-    tokenList: BindingType;
-}
+export type BindingMode = Record<HTMLAspect, BindingType>;
 
 // @public
 export interface BindingObserver<TSource = any, TReturn = any, TParent = any> extends Notifier {
@@ -140,7 +131,16 @@ export class ChildrenDirective extends NodeObservationDirective<ChildrenDirectiv
 export type ChildrenDirectiveOptions<T = any> = ChildListDirectiveOptions<T> | SubtreeDirectiveOptions<T>;
 
 // @public
-export function compileTemplate(html: string | HTMLTemplateElement, directives: ReadonlyArray<HTMLDirective>): HTMLTemplateCompilationResult;
+export type CompilationStrategy = (
+html: string | HTMLTemplateElement,
+directives: readonly HTMLDirective[]) => HTMLTemplateCompilationResult;
+
+// @public
+export const Compiler: {
+    compile(html: string | HTMLTemplateElement, directives: ReadonlyArray<HTMLDirective>): HTMLTemplateCompilationResult;
+    setDefaultStrategy(strategy: CompilationStrategy): void;
+    aggregate(parts: (string | HTMLDirective)[]): HTMLDirective;
+};
 
 // @public
 export type ComposableStyles = string | ElementStyles | CSSStyleSheet;
@@ -351,11 +351,6 @@ export interface HTMLTemplateCompilationResult {
 }
 
 // @public
-export type HTMLTemplateCompiler = (
-html: string | HTMLTemplateElement,
-directives: readonly HTMLDirective[]) => HTMLTemplateCompilationResult;
-
-// @public
 export class HTMLView<TSource = any, TParent = any, TGrandparent = any> implements ElementView<TSource, TParent, TGrandparent>, SyntheticView<TSource, TParent, TGrandparent> {
     constructor(fragment: DocumentFragment, factories: ReadonlyArray<ViewBehaviorFactory>, targets: ViewBehaviorTargets);
     appendTo(node: Node): void;
@@ -369,14 +364,6 @@ export class HTMLView<TSource = any, TParent = any, TGrandparent = any> implemen
     remove(): void;
     source: TSource | null;
     unbind(): void;
-}
-
-// @public
-export abstract class InlinableHTMLDirective extends AspectedHTMLDirective {
-    // (undocumented)
-    abstract readonly binding: Binding;
-    // (undocumented)
-    abstract readonly rawAspect?: string;
 }
 
 // Warning: (ae-internal-missing-underscore) The name "KernelServiceId" should be prefixed with an underscore because the declaration is marked as @internal
@@ -457,7 +444,6 @@ export const oneTime: BindingConfig<DefaultBindingOptions> & BindingConfigResolv
 // @public
 export const Parser: Readonly<{
     parse(value: string, directives: readonly HTMLDirective[]): (string | HTMLDirective)[] | null;
-    aggregate(parts: (string | HTMLDirective)[]): HTMLDirective;
 }>;
 
 // @public
@@ -645,7 +631,6 @@ export class ViewTemplate<TSource = any, TParent = any, TGrandparent = any> impl
     readonly directives: ReadonlyArray<HTMLDirective>;
     readonly html: string | HTMLTemplateElement;
     render(source: TSource, host: Node, hostBindingTarget?: Element): HTMLView<TSource, TParent, TGrandparent>;
-    static setDefaultCompiler(compiler: HTMLTemplateCompiler): void;
 }
 
 // @public

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -382,9 +382,9 @@ export const enum KernelServiceId {
 
 // @public
 export const Markup: Readonly<{
-    interpolation(index: number): string;
-    attribute(index: number): string;
-    comment(index: number): string;
+    interpolation: (index: number) => string;
+    attribute: (index: number) => string;
+    comment: (index: number) => string;
 }>;
 
 // Warning: (ae-internal-missing-underscore) The name "Mutable" should be prefixed with an underscore because the declaration is marked as @internal

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -41,7 +41,6 @@ export {
     ViewBehaviorFactory,
     HTMLDirective,
     AspectedHTMLDirective,
-    InlinableHTMLDirective,
 } from "./templating/html-directive.js";
 export * from "./templating/ref.js";
 export * from "./templating/when.js";

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -7,8 +7,8 @@ import {
     Observable,
 } from "../observation/observable.js";
 import {
+    Aspect,
     AspectedHTMLDirective,
-    HTMLAspect,
     ViewBehavior,
     ViewBehaviorTargets,
 } from "./html-directive.js";
@@ -39,7 +39,7 @@ export const notSupportedBindingType: BindingType = () => {
 /**
  * @alpha
  */
-export type BindingMode = Record<HTMLAspect, BindingType>;
+export type BindingMode = Record<Aspect, BindingType>;
 
 /**
  * @alpha
@@ -246,14 +246,12 @@ class TargetUpdateBinding extends BindingBase {
         eventType: BindingType = notSupportedBindingType
     ): BindingMode {
         return Object.freeze({
-            [HTMLAspect.attribute]: this.createType(DOM.setAttribute),
-            [HTMLAspect.booleanAttribute]: this.createType(DOM.setBooleanAttribute),
-            [HTMLAspect.property]: this.createType((t, a, v) => (t[a] = v)),
-            [HTMLAspect.content]: createContentBinding(this).createType(
-                updateContentTarget
-            ),
-            [HTMLAspect.tokenList]: this.createType(updateTokenListTarget),
-            [HTMLAspect.event]: eventType,
+            [Aspect.attribute]: this.createType(DOM.setAttribute),
+            [Aspect.booleanAttribute]: this.createType(DOM.setBooleanAttribute),
+            [Aspect.property]: this.createType((t, a, v) => (t[a] = v)),
+            [Aspect.content]: createContentBinding(this).createType(updateContentTarget),
+            [Aspect.tokenList]: this.createType(updateTokenListTarget),
+            [Aspect.event]: eventType,
         });
     }
 
@@ -503,7 +501,7 @@ export class HTMLBindingDirective extends AspectedHTMLDirective {
 
     public readonly source: string = "";
     public readonly target: string = "";
-    public readonly type: HTMLAspect = HTMLAspect.content;
+    public readonly aspect: Aspect = Aspect.content;
 
     public constructor(
         public binding: Binding,
@@ -528,31 +526,31 @@ export class HTMLBindingDirective extends AspectedHTMLDirective {
                         const binding = this.binding;
                         /* eslint-disable-next-line */
                         this.binding = (s, c) => DOM.createHTML(binding(s, c));
-                        (this as Mutable<this>).type = HTMLAspect.property;
+                        (this as Mutable<this>).aspect = Aspect.property;
                         break;
                     case "classList":
-                        (this as Mutable<this>).type = HTMLAspect.tokenList;
+                        (this as Mutable<this>).aspect = Aspect.tokenList;
                         break;
                     default:
-                        (this as Mutable<this>).type = HTMLAspect.property;
+                        (this as Mutable<this>).aspect = Aspect.property;
                         break;
                 }
                 break;
             case "?":
                 (this as Mutable<this>).target = value.substring(1);
-                (this as Mutable<this>).type = HTMLAspect.booleanAttribute;
+                (this as Mutable<this>).aspect = Aspect.booleanAttribute;
                 break;
             case "@":
                 (this as Mutable<this>).target = value.substring(1);
-                (this as Mutable<this>).type = HTMLAspect.event;
+                (this as Mutable<this>).aspect = Aspect.event;
                 break;
             default:
                 if (value === "class") {
                     (this as Mutable<this>).target = "className";
-                    (this as Mutable<this>).type = HTMLAspect.property;
+                    (this as Mutable<this>).aspect = Aspect.property;
                 } else {
                     (this as Mutable<this>).target = value;
-                    (this as Mutable<this>).type = HTMLAspect.attribute;
+                    (this as Mutable<this>).aspect = Aspect.attribute;
                 }
                 break;
         }
@@ -560,7 +558,7 @@ export class HTMLBindingDirective extends AspectedHTMLDirective {
 
     createBehavior(targets: ViewBehaviorTargets): ViewBehavior {
         if (this.factory == null) {
-            this.factory = this.mode[this.type](this);
+            this.factory = this.mode[this.aspect](this);
         }
 
         return this.factory.createBehavior(targets);

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -7,7 +7,7 @@ import { css } from "../styles/css";
 import type { StyleTarget } from "../styles/element-styles";
 import { toHTML, uniqueElementName } from "../__test__/helpers";
 import { bind, HTMLBindingDirective } from "./binding";
-import { compileTemplate } from "./compiler";
+import { Compiler } from "./compiler";
 import type { HTMLDirective, ViewBehaviorFactory } from "./html-directive";
 import { html } from "./template";
 
@@ -22,7 +22,7 @@ interface CompilationResultInternals {
 
 describe("The template compiler", () => {
     function compile(html: string, directives: HTMLDirective[]) {
-        return compileTemplate(html, directives) as any as CompilationResultInternals;
+        return Compiler.compile(html, directives) as any as CompilationResultInternals;
     }
 
     function inline(index: number) {

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -1,6 +1,6 @@
-import { Markup, nextId } from "./markup.js";
 import type { Behavior } from "../observation/behavior.js";
 import type { Binding, ExecutionContext } from "../observation/observable.js";
+import { Markup, nextId } from "./markup.js";
 
 /**
  * The target nodes available to a behavior.
@@ -88,27 +88,72 @@ export abstract class HTMLDirective implements ViewBehaviorFactory {
 }
 
 /**
+ * The type of HTML aspect to target.
+ */
+export enum HTMLAspect {
+    /**
+     * An attribute.
+     */
+    attribute = 0,
+    /**
+     * A boolean attribute.
+     */
+    booleanAttribute = 1,
+    /**
+     * A property.
+     */
+    property = 2,
+    /**
+     * Content
+     */
+    content = 3,
+    /**
+     * A token list.
+     */
+    tokenList = 4,
+    /**
+     * An event.
+     */
+    event = 5,
+}
+
+/**
  * A {@link HTMLDirective} that targets a particular aspect
  * (attribute, property, event, etc.) of a node.
  * @public
  */
 export abstract class AspectedHTMLDirective extends HTMLDirective {
-    abstract setAspect(value: string): void;
+    /**
+     * The original source aspect exactly as represented in the HTML.
+     */
+    abstract readonly source: string;
+
+    /**
+     * The evaluated target aspect, determined after processing the source.
+     */
+    abstract readonly target: string;
+
+    /**
+     * The type of aspect to target.
+     */
+    abstract readonly type: HTMLAspect;
+
+    /**
+     * A binding to apply to the target, if applicable.
+     */
+    abstract readonly binding?: Binding;
+
+    /**
+     * Captures the original source aspect from HTML.
+     * @param source - The original source aspect.
+     */
+    abstract captureSource(source: string): void;
 
     /**
      * Creates a placeholder string based on the directive's index within the template.
      * @param index - The index of the directive within the template.
      */
     public createPlaceholder: (index: number) => string = Markup.interpolation;
-}
-
-/**
- * A {@link HTMLDirective} that can be inlined within an attribute or text content.
- * @public
- */
-export abstract class InlinableHTMLDirective extends AspectedHTMLDirective {
-    abstract readonly binding: Binding;
-    abstract readonly rawAspect?: string;
 }
 
 /** @internal */
@@ -136,9 +181,7 @@ export abstract class StatelessAttachedAttributeDirective<T> extends HTMLDirecti
      * @remarks
      * Creates a custom attribute placeholder.
      */
-    public createPlaceholder(index: number): string {
-        return Markup.attribute(index);
-    }
+    public createPlaceholder: (index: number) => string = Markup.attribute;
 
     /**
      * Bind this behavior to the source.

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -90,7 +90,7 @@ export abstract class HTMLDirective implements ViewBehaviorFactory {
 /**
  * The type of HTML aspect to target.
  */
-export enum HTMLAspect {
+export enum Aspect {
     /**
      * An attribute.
      */
@@ -136,7 +136,7 @@ export abstract class AspectedHTMLDirective extends HTMLDirective {
     /**
      * The type of aspect to target.
      */
-    abstract readonly type: HTMLAspect;
+    abstract readonly aspect: Aspect;
 
     /**
      * A binding to apply to the target, if applicable.

--- a/packages/web-components/fast-element/src/templating/markup.ts
+++ b/packages/web-components/fast-element/src/templating/markup.ts
@@ -1,7 +1,4 @@
-import { isString } from "../interfaces.js";
-import type { ExecutionContext } from "../observation/observable.js";
-import { bind } from "./binding.js";
-import type { HTMLDirective, InlinableHTMLDirective } from "./html-directive.js";
+import type { HTMLDirective } from "./html-directive.js";
 
 const marker = `fast-${Math.random().toString(36).substring(2, 8)}`;
 const interpolationStart = `${marker}{`;
@@ -96,42 +93,5 @@ export const Parser = Object.freeze({
         }
 
         return result;
-    },
-
-    /**
-     * Aggregates an array of strings and directives into a single directive.
-     * @param parts - A heterogeneous array of static strings interspersed with
-     * directives.
-     * @returns A single inline directive that aggregates the behavior of all the parts.
-     */
-    aggregate(parts: (string | HTMLDirective)[]): HTMLDirective {
-        if (parts.length === 1) {
-            return parts[0] as HTMLDirective;
-        }
-
-        let aspect: string | undefined;
-        const partCount = parts.length;
-        const finalParts = parts.map((x: string | InlinableHTMLDirective) => {
-            if (isString(x)) {
-                return (): string => x;
-            }
-
-            aspect = x.rawAspect || aspect;
-            return x.binding;
-        });
-
-        const binding = (scope: unknown, context: ExecutionContext): string => {
-            let output = "";
-
-            for (let i = 0; i < partCount; ++i) {
-                output += finalParts[i](scope, context);
-            }
-
-            return output;
-        };
-
-        const directive = bind(binding) as InlinableHTMLDirective;
-        directive.setAspect(aspect!);
-        return directive;
     },
 });

--- a/packages/web-components/fast-element/src/templating/markup.ts
+++ b/packages/web-components/fast-element/src/templating/markup.ts
@@ -22,9 +22,7 @@ export const Markup = Object.freeze({
      * @remarks
      * Used internally by binding directives.
      */
-    interpolation(index: number): string {
-        return `${interpolationStart}${index}${interpolationEnd}`;
-    },
+    interpolation: (index: number) => `${interpolationStart}${index}${interpolationEnd}`,
 
     /**
      * Creates a placeholder that manifests itself as an attribute on an
@@ -34,9 +32,8 @@ export const Markup = Object.freeze({
      * @remarks
      * Used internally by attribute directives such as `ref`, `slotted`, and `children`.
      */
-    attribute(index: number): string {
-        return `${nextId()}="${this.interpolation(index)}"`;
-    },
+    attribute: (index: number) =>
+        `${nextId()}="${interpolationStart}${index}${interpolationEnd}"`,
 
     /**
      * Creates a placeholder that manifests itself as a marker within the DOM structure.
@@ -44,9 +41,7 @@ export const Markup = Object.freeze({
      * @remarks
      * Used internally by structural directives such as `repeat`.
      */
-    comment(index: number): string {
-        return `<!--${interpolationStart}${index}${interpolationEnd}-->`;
-    },
+    comment: (index: number) => `<!--${interpolationStart}${index}${interpolationEnd}-->`,
 });
 
 /**

--- a/packages/web-components/fast-element/src/templating/template.spec.ts
+++ b/packages/web-components/fast-element/src/templating/template.spec.ts
@@ -2,8 +2,8 @@ import { expect } from "chai";
 import { html, ViewTemplate } from "./template";
 import { Markup } from "./markup";
 import { HTMLBindingDirective } from "./binding";
-import { HTMLDirective } from "./html-directive";
-import { bind, Binding, InlinableHTMLDirective, ViewBehaviorTargets } from "..";
+import { AspectedHTMLDirective, HTMLAspect, HTMLDirective } from "./html-directive";
+import { bind, Binding, ViewBehaviorTargets } from "..";
 
 describe(`The html tag template helper`, () => {
     it(`transforms a string into a ViewTemplate.`, () => {
@@ -223,7 +223,7 @@ describe(`The html tag template helper`, () => {
         expect(template.html).to.equal(
             `<my-element :someAttribute=${placeholder}></my-element>`
         );
-        expect((template.directives[0] as HTMLBindingDirective).rawAspect).to.equal(
+        expect((template.directives[0] as HTMLBindingDirective).source).to.equal(
             ":someAttribute"
         );
     });
@@ -235,18 +235,20 @@ describe(`The html tag template helper`, () => {
         expect(template.html).to.equal(
             `<my-element :someAttribute=${placeholder}></my-element>`
         );
-        expect((template.directives[0] as HTMLBindingDirective).rawAspect).to.equal(
+        expect((template.directives[0] as HTMLBindingDirective).source).to.equal(
             ":someAttribute"
         );
     });
 
     it(`captures a case-sensitive property name when used with an inline directive`, () => {
-        class TestDirective extends InlinableHTMLDirective {
+        class TestDirective extends AspectedHTMLDirective {
             binding: Binding;
-            rawAspect: string;
+            source: string;
+            target: string;
+            type = HTMLAspect.property;
 
-            setAspect(value) {
-                this.rawAspect = value;
+            captureSource(value) {
+                this.source = value;
             }
 
             createBehavior(targets: ViewBehaviorTargets) {
@@ -260,7 +262,7 @@ describe(`The html tag template helper`, () => {
         expect(template.html).to.equal(
             `<my-element :someAttribute=${placeholder}></my-element>`
         );
-        expect((template.directives[0] as TestDirective).rawAspect).to.equal(
+        expect((template.directives[0] as TestDirective).source).to.equal(
             ":someAttribute"
         );
     });

--- a/packages/web-components/fast-ssr/src/template-parser/template-parser.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/template-parser.ts
@@ -2,7 +2,7 @@
  * This code is largely a fork of lit's rendering implementation: https://github.com/lit/lit/blob/main/packages/labs/ssr/src/lib/render-lit-html.ts
  * with changes as necessary to render FAST components. A big thank you to those who contributed to lit's code above.
  */
-import { Parser, ViewTemplate } from "@microsoft/fast-element";
+import { Compiler, Parser, ViewTemplate } from "@microsoft/fast-element";
 import {
     Attribute,
     DefaultTreeCommentNode,
@@ -172,7 +172,7 @@ export function parseTemplateToOpCodes(template: ViewTemplate): Op[] {
                             attributeType === AttributeType.content
                                 ? current.name
                                 : current.name.substring(1),
-                        directive: Parser.aggregate(parsed),
+                        directive: Compiler.aggregate(parsed),
                         attributeType,
                         useCustomElementInstance: Boolean(node.isDefinedCustomElement),
                     });
@@ -296,7 +296,7 @@ export function parseTemplateToOpCodes(template: ViewTemplate): Op[] {
                     flushTo(node.sourceCodeLocation!.startOffset);
                     opCodes.push({
                         type: OpType.directive,
-                        directive: Parser.aggregate(parsed),
+                        directive: Compiler.aggregate(parsed),
                     });
                     skipTo(node.sourceCodeLocation!.endOffset);
                 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Expose more metadata about captured bindings through the `AspectedHTMLDirective` interface. This should enable us to remove duplication in the SSR template parser.

### 🎫 Issues

* Closes #5683 
 
## 👩‍💻 Reviewer Notes

This is mostly a refactoring and exposing of metadata that was either present or was implicit. So, it formalizes this as part of the `AspectedHTMLDirective` interface.

The `InlineHTMLDirective` was removed. It seemed like it could be merged with `AspectedHTMLDirective`.

While doing this work, I uncovered a cyclic dependency related to a couple of the areas I was working on. So, I moved the `aggregate` method off the `Parser` gateway. I created a new `Compiler` gateway to host the `aggregate` method as well as the `compile` API and method of changing the strategy for compilation.

## 📑 Test Plan

Current tests were expanded to validate the new metadata. Some additional tests were added where I saw gaps.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Will likely need @nicholasrice to fix up SSR based on any breaks I made here and to use the new APIs.