### PR TITLE
refactor: extract polyfill and polyfill-like code to an optional module

### DIFF
--- a/change/@microsoft-fast-element-06c5f5c1-f172-4ba0-864e-9d9b494adda5.json
+++ b/change/@microsoft-fast-element-06c5f5c1-f172-4ba0-864e-9d9b494adda5.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "refactor: extract polyfill and polyfill-like code to an optional module",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-e05243ea-6de7-4694-abe1-2c4b64a25077.json
+++ b/change/@microsoft-fast-foundation-e05243ea-6de7-4694-abe1-2c4b64a25077.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: update templates to use classList and fix classList bug",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -5,18 +5,37 @@
 ```ts
 
 // @public
-export const $global: Global;
-
-// @public
 export interface Accessor {
     getValue(source: any): any;
     name: string;
     setValue(source: any, value: any): void;
 }
 
+// Warning: (ae-internal-missing-underscore) The name "AdoptedStyleSheetsStrategy" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export class AdoptedStyleSheetsStrategy implements StyleStrategy {
+    constructor(styles: (string | CSSStyleSheet)[]);
+    // (undocumented)
+    addStylesTo(target: StyleTarget): void;
+    // (undocumented)
+    removeStylesFrom(target: StyleTarget): void;
+    // (undocumented)
+    readonly sheets: CSSStyleSheet[];
+}
+
+// @public
+export enum Aspect {
+    attribute = 0,
+    booleanAttribute = 1,
+    content = 3,
+    event = 5,
+    property = 2,
+    tokenList = 4
+}
+
 // @public
 export abstract class AspectedHTMLDirective extends HTMLDirective {
-    // Warning: (ae-forgotten-export) The symbol "Aspect" needs to be exported by the entry point index.d.ts
     abstract readonly aspect: Aspect;
     abstract readonly binding?: Binding;
     abstract captureSource(source: string): void;
@@ -117,7 +136,7 @@ export interface ChildListDirectiveOptions<T = any> extends NodeBehaviorOptions<
 // @public
 export function children<T = any>(propertyOrOptions: (keyof T & string) | ChildListDirectiveOptions<keyof T & string>): CaptureType<T>;
 
-// Warning: (ae-forgotten-export) The symbol "NodeObservationDirective" needs to be exported by the entry point index.d.ts
+// Warning: (ae-incompatible-release-tags) The symbol "ChildrenDirective" is marked as @public, but its signature references "NodeObservationDirective" which is marked as @internal
 //
 // @public
 export class ChildrenDirective extends NodeObservationDirective<ChildrenDirectiveOptions> {
@@ -329,12 +348,6 @@ export interface FASTGlobal {
 }
 
 // @public
-export type Global = typeof globalThis & {
-    trustedTypes: TrustedTypes;
-    readonly FAST: FASTGlobal;
-};
-
-// @public
 export function html<TSource = any, TParent = any, TGrandparent = any>(strings: TemplateStringsArray, ...values: TemplateValue<TSource, TParent>[]): ViewTemplate<TSource, TParent, TGrandparent>;
 
 // @public
@@ -366,20 +379,6 @@ export class HTMLView<TSource = any, TParent = any, TGrandparent = any> implemen
     unbind(): void;
 }
 
-// Warning: (ae-internal-missing-underscore) The name "KernelServiceId" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export const enum KernelServiceId {
-    // (undocumented)
-    contextEvent = 3,
-    // (undocumented)
-    elementRegistry = 4,
-    // (undocumented)
-    observable = 2,
-    // (undocumented)
-    updateQueue = 1
-}
-
 // @public
 export const Markup: Readonly<{
     interpolation: (index: number) => string;
@@ -398,6 +397,19 @@ export type Mutable<T> = {
 export interface NodeBehaviorOptions<T = any> {
     filter?: ElementsFilter;
     property: T;
+}
+
+// Warning: (ae-internal-missing-underscore) The name "NodeObservationDirective" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export abstract class NodeObservationDirective<T extends NodeBehaviorOptions> extends StatelessAttachedAttributeDirective<T> {
+    bind(source: any, context: ExecutionContext<any, any>, targets: ViewBehaviorTargets): void;
+    protected computeNodes(target: any): Node[];
+    protected abstract disconnect(target: any): void;
+    protected abstract getNodes(target: any): Node[];
+    protected abstract observe(target: any): void;
+    unbind(source: any, context: ExecutionContext<any, any>, targets: ViewBehaviorTargets): void;
+    protected updateTarget(source: any, value: ReadonlyArray<any>): void;
 }
 
 // @public
@@ -468,8 +480,6 @@ export class PropertyChangeNotifier implements Notifier {
 // @public
 export const ref: <T = any>(propertyName: keyof T & string) => CaptureType<T>;
 
-// Warning: (ae-forgotten-export) The symbol "StatelessAttachedAttributeDirective" needs to be exported by the entry point index.d.ts
-//
 // @public
 export class RefDirective extends StatelessAttachedAttributeDirective<string> {
     bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
@@ -504,6 +514,8 @@ export interface RepeatOptions {
 // @public
 export function slotted<T = any>(propertyOrOptions: (keyof T & string) | SlottedDirectiveOptions<keyof T & string>): CaptureType<T>;
 
+// Warning: (ae-incompatible-release-tags) The symbol "SlottedDirective" is marked as @public, but its signature references "NodeObservationDirective" which is marked as @internal
+//
 // @public
 export class SlottedDirective extends NodeObservationDirective<SlottedDirectiveOptions> {
     disconnect(target: EventSource): void;
@@ -528,6 +540,17 @@ export class Splice {
     // (undocumented)
     static normalize(previous: unknown[] | undefined, current: unknown[], changes: Splice[] | undefined): Splice[] | undefined;
     removed: any[];
+}
+
+// @public
+export abstract class StatelessAttachedAttributeDirective<T> extends HTMLDirective implements ViewBehavior {
+    constructor(options: T);
+    abstract bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
+    createBehavior(targets: ViewBehaviorTargets): ViewBehavior;
+    createPlaceholder: (index: number) => string;
+    // (undocumented)
+    protected options: T;
+    abstract unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
 }
 
 // @public

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -156,6 +156,7 @@ directives: readonly HTMLDirective[]) => HTMLTemplateCompilationResult;
 
 // @public
 export const Compiler: {
+    setHTMLPolicy(policy: TrustedTypesPolicy): void;
     compile(html: string | HTMLTemplateElement, directives: ReadonlyArray<HTMLDirective>): HTMLTemplateCompilationResult;
     setDefaultStrategy(strategy: CompilationStrategy): void;
     aggregate(parts: (string | HTMLDirective)[]): HTMLDirective;
@@ -226,8 +227,6 @@ export const defaultExecutionContext: ExecutionContext<any, any>;
 // @public
 export const DOM: Readonly<{
     supportsAdoptedStyleSheets: boolean;
-    setHTMLPolicy(policy: TrustedTypesPolicy): void;
-    createHTML(html: string): string;
     setUpdateMode: (isAsync: boolean) => void;
     queueUpdate: (callable: Callable) => void;
     nextUpdate(): Promise<void>;

--- a/packages/web-components/fast-element/src/components/controller.ts
+++ b/packages/web-components/fast-element/src/components/controller.ts
@@ -1,8 +1,8 @@
-import type { Mutable } from "../interfaces.js";
+import type { Mutable, StyleTarget } from "../interfaces.js";
 import type { Behavior } from "../observation/behavior.js";
 import { PropertyChangeNotifier } from "../observation/notifier.js";
 import { defaultExecutionContext, Observable } from "../observation/observable.js";
-import type { ElementStyles, StyleTarget } from "../styles/element-styles.js";
+import type { ElementStyles } from "../styles/element-styles.js";
 import type { ElementViewTemplate } from "../templating/template.js";
 import type { ElementView } from "../templating/view.js";
 import { FASTElementDefinition } from "./fast-definitions.js";

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -1,6 +1,6 @@
-import { isString } from "../interfaces.js";
+import { isString, KernelServiceId } from "../interfaces.js";
 import { Observable } from "../observation/observable.js";
-import { FAST, KernelServiceId } from "../platform.js";
+import { FAST } from "../platform.js";
 import { ComposableStyles, ElementStyles } from "../styles/element-styles.js";
 import type { ElementViewTemplate } from "../templating/template.js";
 import { AttributeConfiguration, AttributeDefinition } from "./attributes.js";

--- a/packages/web-components/fast-element/src/dom.ts
+++ b/packages/web-components/fast-element/src/dom.ts
@@ -1,8 +1,8 @@
-import type { Callable } from "./interfaces.js";
-import { $global, KernelServiceId, TrustedTypesPolicy } from "./platform.js";
+import { Callable, KernelServiceId, TrustedTypesPolicy } from "./interfaces.js";
+import { FAST } from "./platform.js";
 
 /* eslint-disable */
-const fastHTMLPolicy: TrustedTypesPolicy = $global.trustedTypes.createPolicy(
+const fastHTMLPolicy: TrustedTypesPolicy = globalThis.trustedTypes.createPolicy(
     "fast-html",
     {
         createHTML: html => html,
@@ -10,10 +10,10 @@ const fastHTMLPolicy: TrustedTypesPolicy = $global.trustedTypes.createPolicy(
 );
 /* eslint-enable */
 
-const updateQueue = $global.FAST.getById(KernelServiceId.updateQueue, () => {
+const updateQueue = FAST.getById(KernelServiceId.updateQueue, () => {
     const tasks: Callable[] = [];
     const pendingErrors: any[] = [];
-    const rAF = $global.requestAnimationFrame;
+    const rAF = globalThis.requestAnimationFrame;
     let updateAsync = true;
 
     function throwFirstError(): void {

--- a/packages/web-components/fast-element/src/dom.ts
+++ b/packages/web-components/fast-element/src/dom.ts
@@ -1,14 +1,5 @@
-import { Callable, KernelServiceId, TrustedTypesPolicy } from "./interfaces.js";
+import { Callable, KernelServiceId } from "./interfaces.js";
 import { FAST } from "./platform.js";
-
-/* eslint-disable */
-const fastHTMLPolicy: TrustedTypesPolicy = globalThis.trustedTypes.createPolicy(
-    "fast-html",
-    {
-        createHTML: html => html,
-    }
-);
-/* eslint-enable */
 
 const updateQueue = FAST.getById(KernelServiceId.updateQueue, () => {
     const tasks: Callable[] = [];
@@ -85,8 +76,6 @@ const updateQueue = FAST.getById(KernelServiceId.updateQueue, () => {
     });
 });
 
-let htmlPolicy: TrustedTypesPolicy = fastHTMLPolicy;
-
 /**
  * Common DOM APIs.
  * @public
@@ -98,32 +87,6 @@ export const DOM = Object.freeze({
     supportsAdoptedStyleSheets:
         Array.isArray((document as any).adoptedStyleSheets) &&
         "replace" in CSSStyleSheet.prototype,
-
-    /**
-     * Sets the HTML trusted types policy used by the templating engine.
-     * @param policy - The policy to set for HTML.
-     * @remarks
-     * This API can only be called once, for security reasons. It should be
-     * called by the application developer at the start of their program.
-     */
-    setHTMLPolicy(policy: TrustedTypesPolicy) {
-        if (htmlPolicy !== fastHTMLPolicy) {
-            throw new Error("The HTML policy can only be set once.");
-        }
-
-        htmlPolicy = policy;
-    },
-
-    /**
-     * Turns a string into trusted HTML using the configured trusted types policy.
-     * @param html - The string to turn into trusted HTML.
-     * @remarks
-     * Used internally by the template engine when creating templates
-     * and setting innerHTML.
-     */
-    createHTML(html: string): string {
-        return htmlPolicy.createHTML(html);
-    },
 
     /**
      * Sets the update mode used by queueUpdate.

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -1,28 +1,28 @@
 export * from "./platform.js";
 export * from "./templating/template.js";
 export * from "./components/fast-element.js";
-export {
-    FASTElementDefinition,
-    PartialFASTElementDefinition,
-} from "./components/fast-definitions.js";
+export * from "./components/fast-definitions.js";
 export * from "./components/attributes.js";
 export * from "./components/controller.js";
-export type { Callable, Constructable, Mutable } from "./interfaces.js";
-export * from "./templating/compiler.js";
-export {
-    ElementStyles,
+export type {
+    Callable,
+    Constructable,
+    FASTGlobal,
+    Mutable,
     StyleStrategy,
-    ConstructibleStyleStrategy,
-    ComposableStyles,
     StyleTarget,
-} from "./styles/element-styles.js";
-export { css, cssPartial } from "./styles/css.js";
-export { CSSDirective } from "./styles/css-directive.js";
+    TrustedTypes,
+    TrustedTypesPolicy,
+} from "./interfaces.js";
+export * from "./templating/compiler.js";
+export * from "./styles/element-styles.js";
+export * from "./styles/css.js";
+export * from "./styles/css-directive.js";
 export * from "./observation/observable.js";
 export * from "./observation/notifier.js";
-export { Splice } from "./observation/array-change-records.js";
-export { enableArrayObservation } from "./observation/array-observer.js";
-export { DOM } from "./dom.js";
+export * from "./observation/array-change-records.js";
+export * from "./observation/array-observer.js";
+export * from "./dom.js";
 export type { Behavior } from "./observation/behavior.js";
 export { Markup, Parser } from "./templating/markup.js";
 export {
@@ -35,21 +35,11 @@ export {
     BindingBehaviorFactory,
     DefaultBindingOptions,
 } from "./templating/binding.js";
-export {
-    ViewBehaviorTargets,
-    ViewBehavior,
-    ViewBehaviorFactory,
-    HTMLDirective,
-    AspectedHTMLDirective,
-} from "./templating/html-directive.js";
+export * from "./templating/html-directive.js";
 export * from "./templating/ref.js";
 export * from "./templating/when.js";
 export * from "./templating/repeat.js";
 export * from "./templating/slotted.js";
 export * from "./templating/children.js";
 export * from "./templating/view.js";
-export {
-    elements,
-    ElementsFilter,
-    NodeBehaviorOptions,
-} from "./templating/node-observation.js";
+export * from "./templating/node-observation.js";

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -22,6 +22,110 @@ export type Mutable<T> = {
 };
 
 /**
+ * A policy for use with the standard trustedTypes platform API.
+ * @public
+ */
+export type TrustedTypesPolicy = {
+    /**
+     * Creates trusted HTML.
+     * @param html - The HTML to clear as trustworthy.
+     */
+    createHTML(html: string): string;
+};
+
+/**
+ * Enables working with trusted types.
+ * @public
+ */
+export type TrustedTypes = {
+    /**
+     * Creates a trusted types policy.
+     * @param name - The policy name.
+     * @param rules - The policy rules implementation.
+     */
+    createPolicy(name: string, rules: TrustedTypesPolicy): TrustedTypesPolicy;
+};
+
+/**
+ * The FAST global.
+ * @internal
+ */
+export interface FASTGlobal {
+    /**
+     * The list of loaded versions.
+     */
+    readonly versions: string[];
+
+    /**
+     * Gets a kernel value.
+     * @param id - The id to get the value for.
+     * @param initialize - Creates the initial value for the id if not already existing.
+     */
+    getById<T>(id: string | number): T | null;
+    getById<T>(id: string | number, initialize: () => T): T;
+}
+
+/**
+ * Core services shared across FAST instances.
+ * @internal
+ */
+export const enum KernelServiceId {
+    updateQueue = 1,
+    observable = 2,
+    contextEvent = 3,
+    elementRegistry = 4,
+    styleSheetStrategy = 5,
+}
+
+/**
+ * A node that can be targeted by styles.
+ * @public
+ */
+export interface StyleTarget {
+    /**
+     * Stylesheets to be adopted by the node.
+     */
+    adoptedStyleSheets?: CSSStyleSheet[];
+
+    /**
+     * Adds styles to the target by appending the styles.
+     * @param styles - The styles element to add.
+     */
+    append(styles: HTMLStyleElement): void;
+
+    /**
+     * Removes styles from the target.
+     * @param styles - The styles element to remove.
+     */
+    removeChild(styles: HTMLStyleElement): void;
+
+    /**
+     * Returns all element descendants of node that match selectors.
+     * @param selectors - The CSS selector to use for the query.
+     */
+    querySelectorAll<E extends Element = Element>(selectors: string): NodeListOf<E>;
+}
+
+/**
+ * Implemented to provide specific behavior when adding/removing styles
+ * for elements.
+ * @public
+ */
+export interface StyleStrategy {
+    /**
+     * Adds styles to the target.
+     * @param target - The target to add the styles to.
+     */
+    addStylesTo(target: StyleTarget): void;
+
+    /**
+     * Removes styles from the target.
+     * @param target - The target to remove the styles from.
+     */
+    removeStylesFrom(target: StyleTarget): void;
+}
+
+/**
  * @internal
  */
 export const isFunction = (object: any): object is Function =>

--- a/packages/web-components/fast-element/src/observation/array-observer.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.ts
@@ -4,7 +4,7 @@ import { SubscriberSet } from "./notifier.js";
 import type { Notifier } from "./notifier.js";
 import { Observable } from "./observable.js";
 
-function setNonEnumerable(target: any, property: string, value: any) {
+function setNonEnumerable(target: any, property: string, value: any): void {
     Reflect.defineProperty(target, property, {
         value,
         enumerable: false,
@@ -95,8 +95,7 @@ export function enableArrayObservation(): void {
         const sort = proto.sort;
         const splice = proto.splice;
         const unshift = proto.unshift;
-
-        function adjustIndex(changeRecord: Splice, array: any[]): Splice {
+        const adjustIndex = (changeRecord: Splice, array: any[]): Splice => {
             let index = changeRecord.index;
             const arrayLength = array.length;
 
@@ -112,7 +111,7 @@ export function enableArrayObservation(): void {
 
             changeRecord.index = index < 0 ? 0 : index;
             return changeRecord;
-        }
+        };
 
         Object.assign(proto, {
             pop(...args) {

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -1,6 +1,6 @@
 import { DOM } from "../dom.js";
-import { isFunction, isString } from "../interfaces.js";
-import { FAST, KernelServiceId } from "../platform.js";
+import { isFunction, isString, KernelServiceId } from "../interfaces.js";
+import { FAST } from "../platform.js";
 import { PropertyChangeNotifier, SubscriberSet } from "./notifier.js";
 import type { Notifier, Subscriber } from "./notifier.js";
 

--- a/packages/web-components/fast-element/src/platform.spec.ts
+++ b/packages/web-components/fast-element/src/platform.spec.ts
@@ -1,5 +1,7 @@
 import { expect } from "chai";
-import { FAST } from './platform';
+import type { FASTGlobal } from "./interfaces";
+
+declare const FAST: FASTGlobal;
 
 describe("The FAST global", () => {
     context("kernel API", () => {

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -1,117 +1,14 @@
-/**
- * A policy for use with the standard trustedTypes platform API.
- * @public
- */
-export type TrustedTypesPolicy = {
-    /**
-     * Creates trusted HTML.
-     * @param html - The HTML to clear as trustworthy.
-     */
-    createHTML(html: string): string;
-};
+import type { FASTGlobal } from "./interfaces.js";
 
-/**
- * Enables working with trusted types.
- * @public
- */
-export type TrustedTypes = {
-    /**
-     * Creates a trusted types policy.
-     * @param name - The policy name.
-     * @param rules - The policy rules implementation.
-     */
-    createPolicy(name: string, rules: TrustedTypesPolicy): TrustedTypesPolicy;
-};
-
-/**
- * The FAST global.
- * @internal
- */
-export interface FASTGlobal {
-    /**
-     * The list of loaded versions.
-     */
-    readonly versions: string[];
-
-    /**
-     * Gets a kernel value.
-     * @param id - The id to get the value for.
-     * @param initialize - Creates the initial value for the id if not already existing.
-     */
-    getById<T>(id: string | number): T | null;
-    getById<T>(id: string | number, initialize: () => T): T;
-}
-
-/**
- * The platform global type.
- * @public
- */
-export type Global = typeof globalThis & {
-    /**
-     * Enables working with trusted types.
-     */
-    trustedTypes: TrustedTypes;
-
-    /**
-     * The FAST global.
-     * @internal
-     */
-    readonly FAST: FASTGlobal;
-};
-
-declare const global: any;
-
-/**
- * A reference to globalThis, with support
- * for browsers that don't yet support the spec.
- * @public
- */
-export const $global: Global = (function () {
-    if (typeof globalThis !== "undefined") {
-        // We're running in a modern environment.
-        return globalThis;
-    }
-
-    if (typeof global !== "undefined") {
-        // We're running in NodeJS
-        return global;
-    }
-
-    if (typeof self !== "undefined") {
-        // We're running in a worker.
-        return self;
-    }
-
-    if (typeof window !== "undefined") {
-        // We're running in the browser's main thread.
-        return window;
-    }
-
-    try {
-        // Hopefully we never get here...
-        // Not all environments allow eval and Function. Use only as a last resort:
-        // eslint-disable-next-line no-new-func
-        return new Function("return this")();
-    } catch {
-        // If all fails, give up and create an object.
-        // eslint-disable-next-line @typescript-eslint/consistent-type-assertions
-        return {};
-    }
-})();
-
-// API-only Polyfill for trustedTypes
-if (!$global.trustedTypes) {
-    $global.trustedTypes = { createPolicy: (n: string, r: TrustedTypesPolicy) => r };
-}
-
+// ensure FAST global - duplicated in polyfills.ts
 const propConfig = {
     configurable: false,
     enumerable: false,
     writable: false,
 };
 
-if ($global.FAST === void 0) {
-    Reflect.defineProperty($global, "FAST", {
+if (globalThis.FAST === void 0) {
+    Reflect.defineProperty(globalThis, "FAST", {
         value: Object.create(null),
         ...propConfig,
     });
@@ -121,7 +18,7 @@ if ($global.FAST === void 0) {
  * The FAST global.
  * @internal
  */
-export const FAST = $global.FAST;
+export const FAST: FASTGlobal = globalThis.FAST;
 
 if (FAST.getById === void 0) {
     const storage = Object.create(null);
@@ -138,17 +35,6 @@ if (FAST.getById === void 0) {
         },
         ...propConfig,
     });
-}
-
-/**
- * Core services shared across FAST instances.
- * @internal
- */
-export const enum KernelServiceId {
-    updateQueue = 1,
-    observable = 2,
-    contextEvent = 3,
-    elementRegistry = 4,
 }
 
 /**

--- a/packages/web-components/fast-element/src/polyfills.ts
+++ b/packages/web-components/fast-element/src/polyfills.ts
@@ -1,0 +1,124 @@
+import {
+    FASTGlobal,
+    KernelServiceId,
+    StyleStrategy,
+    StyleTarget,
+    TrustedTypesPolicy,
+} from "./interfaces.js";
+
+declare const global: any;
+
+(function ensureGlobalThis() {
+    if (typeof globalThis !== "undefined") {
+        // We're running in a modern environment.
+        return;
+    }
+
+    if (typeof global !== "undefined") {
+        // We're running in NodeJS
+        global.globalThis = global;
+    } else if (typeof self !== "undefined") {
+        (self as any).globalThis = self;
+    } else if (typeof window !== "undefined") {
+        // We're running in the browser's main thread.
+        (window as any).globalThis = window;
+    } else {
+        // Hopefully we never get here...
+        // Not all environments allow eval and Function. Use only as a last resort:
+        // eslint-disable-next-line no-new-func
+        const result = new Function("return this")();
+        result.globalThis = result;
+    }
+})();
+
+// API-only Polyfill for trustedTypes
+(function ensureTrustedTypes() {
+    if (!globalThis.trustedTypes) {
+        globalThis.trustedTypes = {
+            createPolicy: (n: string, r: TrustedTypesPolicy) => r,
+        };
+    }
+})();
+
+// ensure FAST global - duplicated in platform.ts
+const propConfig = {
+    configurable: false,
+    enumerable: false,
+    writable: false,
+};
+
+if (globalThis.FAST === void 0) {
+    Reflect.defineProperty(globalThis, "FAST", {
+        value: Object.create(null),
+        ...propConfig,
+    });
+}
+
+const FAST: FASTGlobal = globalThis.FAST;
+
+if (FAST.getById === void 0) {
+    const storage = Object.create(null);
+
+    Reflect.defineProperty(FAST, "getById", {
+        value<T>(id: string | number, initialize?: () => T): T | null {
+            let found = storage[id];
+
+            if (found === void 0) {
+                found = initialize ? (storage[id] = initialize()) : null;
+            }
+
+            return found;
+        },
+        ...propConfig,
+    });
+}
+
+// duplicated from DOM
+const supportsAdoptedStyleSheets =
+    Array.isArray((document as any).adoptedStyleSheets) &&
+    "replace" in CSSStyleSheet.prototype;
+
+function usableStyleTarget(target: StyleTarget): StyleTarget {
+    return target === document ? document.body : target;
+}
+
+let id = 0;
+const nextStyleId = (): string => `fast-${++id}`;
+
+export class StyleElementStrategy implements StyleStrategy {
+    private readonly styleClass: string;
+
+    public constructor(private readonly styles: string[]) {
+        this.styleClass = nextStyleId();
+    }
+
+    public addStylesTo(target: StyleTarget): void {
+        target = usableStyleTarget(target);
+
+        const styles = this.styles;
+        const styleClass = this.styleClass;
+
+        for (let i = 0; i < styles.length; i++) {
+            const element = document.createElement("style");
+            element.innerHTML = styles[i];
+            element.className = styleClass;
+            target.append(element);
+        }
+    }
+
+    public removeStylesFrom(target: StyleTarget): void {
+        const styles: NodeListOf<HTMLStyleElement> = target.querySelectorAll(
+            `.${this.styleClass}`
+        );
+
+        target = usableStyleTarget(target);
+
+        for (let i = 0, ii = styles.length; i < ii; ++i) {
+            target.removeChild(styles[i]);
+        }
+    }
+}
+
+if (!supportsAdoptedStyleSheets) {
+    FAST.getById(KernelServiceId.styleSheetStrategy, () => StyleElementStrategy);
+}

--- a/packages/web-components/fast-element/src/polyfills.ts
+++ b/packages/web-components/fast-element/src/polyfills.ts
@@ -1,6 +1,5 @@
-import {
+import type {
     FASTGlobal,
-    KernelServiceId,
     StyleStrategy,
     StyleTarget,
     TrustedTypesPolicy,
@@ -118,5 +117,5 @@ export class StyleElementStrategy implements StyleStrategy {
 }
 
 if (!supportsAdoptedStyleSheets) {
-    FAST.getById(KernelServiceId.styleSheetStrategy, () => StyleElementStrategy);
+    FAST.getById(/* KernelServiceId.styleSheetStrategy */ 5, () => StyleElementStrategy);
 }

--- a/packages/web-components/fast-element/src/polyfills.ts
+++ b/packages/web-components/fast-element/src/polyfills.ts
@@ -32,13 +32,11 @@ declare const global: any;
 })();
 
 // API-only Polyfill for trustedTypes
-(function ensureTrustedTypes() {
-    if (!globalThis.trustedTypes) {
-        globalThis.trustedTypes = {
-            createPolicy: (n: string, r: TrustedTypesPolicy) => r,
-        };
-    }
-})();
+if (!globalThis.trustedTypes) {
+    globalThis.trustedTypes = {
+        createPolicy: (n: string, r: TrustedTypesPolicy) => r,
+    };
+}
 
 // ensure FAST global - duplicated in platform.ts
 const propConfig = {

--- a/packages/web-components/fast-element/src/styles/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles/styles.spec.ts
@@ -1,8 +1,6 @@
 import { expect } from "chai";
 import {
     AdoptedStyleSheetsStrategy,
-    StyleElementStrategy,
-    StyleTarget,
     ElementStyles,
 } from "./element-styles";
 import { DOM } from "../dom";
@@ -11,6 +9,8 @@ import { css, cssPartial } from "./css";
 import type { Behavior } from "../observation/behavior";
 import { defaultExecutionContext } from "../observation/observable";
 import type { FASTElement } from "..";
+import { StyleElementStrategy } from "../polyfills";
+import type { StyleTarget } from "../interfaces";
 
 if (DOM.supportsAdoptedStyleSheets) {
     describe("AdoptedStyleSheetsStrategy", () => {

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -493,6 +493,19 @@ export const signal = <T = any>(options: string | Binding<T>): BindingConfig<T> 
     return { mode: signalMode, options };
 };
 
+declare class TrustedHTML {}
+const createInnerHTMLBinding = globalThis.TrustedHTML
+    ? (binding: Binding) => (s, c) => {
+          const value = binding(s, c);
+
+          if (value instanceof TrustedHTML) {
+              return value;
+          }
+
+          throw new Error("To bind innerHTML, you must use a TrustedTypesPolicy.");
+      }
+    : (binding: Binding) => binding;
+
 /**
  * @internal
  */
@@ -523,9 +536,7 @@ export class HTMLBindingDirective extends AspectedHTMLDirective {
                 (this as Mutable<this>).target = value.substring(1);
                 switch (this.target) {
                     case "innerHTML":
-                        const binding = this.binding;
-                        /* eslint-disable-next-line */
-                        this.binding = (s, c) => DOM.createHTML(binding(s, c));
+                        this.binding = createInnerHTMLBinding(this.binding);
                         (this as Mutable<this>).aspect = Aspect.property;
                         break;
                     case "classList":

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -176,9 +176,9 @@ function updateTokenListTarget(
     value: any
 ): void {
     const directive = this.directive;
+    const lookup = `${directive.uniqueId}-token-list`;
     const state: TokenListState =
-        target[directive.uniqueId] ??
-        (target[directive.uniqueId] = { c: 0, v: Object.create(null) });
+        target[lookup] ?? (target[lookup] = { c: 0, v: Object.create(null) });
     const versions = state.v;
     let currentVersion = state.c;
     const tokenList = target[aspect] as DOMTokenList;

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -4,12 +4,12 @@ import { customElement, FASTElement } from "../components/fast-element";
 import { Markup } from './markup';
 import { defaultExecutionContext } from "../observation/observable";
 import { css } from "../styles/css";
-import type { StyleTarget } from "../styles/element-styles";
 import { toHTML, uniqueElementName } from "../__test__/helpers";
 import { bind, HTMLBindingDirective } from "./binding";
 import { Compiler } from "./compiler";
 import type { HTMLDirective, ViewBehaviorFactory } from "./html-directive";
 import { html } from "./template";
+import type { StyleTarget } from "../interfaces";
 
 /**
  * Used to satisfy TS by exposing some internal properties of the

--- a/packages/web-components/fast-element/src/templating/compiler.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.ts
@@ -226,8 +226,8 @@ function compileNode(
         case 8: // comment
             const parts = Parser.parse((node as Comment).data, context.directives);
             if (parts !== null) {
-                /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
                 context.addFactory(
+                    /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
                     Compiler.aggregate(parts),
                     parentId,
                     nodeId,

--- a/packages/web-components/fast-element/src/templating/compiler.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.ts
@@ -1,5 +1,4 @@
 import { isString, TrustedTypesPolicy } from "../interfaces.js";
-import { DOM } from "../dom.js";
 import type { ExecutionContext } from "../observation/observable.js";
 import { Parser } from "./markup.js";
 import { bind, oneTime } from "./binding.js";
@@ -267,10 +266,11 @@ export type CompilationStrategy = (
 ) => TemplateCompilationResult;
 
 const templateTag = "TEMPLATE";
-const fastHTMLPolicy: TrustedTypesPolicy = { createHTML: html => html };
+const policyOptions: TrustedTypesPolicy = { createHTML: html => html };
 let htmlPolicy: TrustedTypesPolicy = globalThis.trustedTypes
-    ? globalThis.trustedTypes.createPolicy("fast-html", fastHTMLPolicy)
-    : fastHTMLPolicy;
+    ? globalThis.trustedTypes.createPolicy("fast-html", policyOptions)
+    : policyOptions;
+const fastHTMLPolicy = htmlPolicy;
 
 /**
  * Common APIs related to compilation.

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -89,6 +89,7 @@ export abstract class HTMLDirective implements ViewBehaviorFactory {
 
 /**
  * The type of HTML aspect to target.
+ * @public
  */
 export enum Aspect {
     /**
@@ -156,7 +157,10 @@ export abstract class AspectedHTMLDirective extends HTMLDirective {
     public createPlaceholder: (index: number) => string = Markup.interpolation;
 }
 
-/** @internal */
+/**
+ * A base class used for attribute directives that don't need internal state.
+ * @public
+ */
 export abstract class StatelessAttachedAttributeDirective<T> extends HTMLDirective
     implements ViewBehavior {
     /**

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.template.ts
@@ -15,7 +15,7 @@ export const dataGridCellTemplate: FoundationElementTemplate<ViewTemplate<
         <template
             tabindex="-1"
             role="${x => x.cellType ?? "gridcell"}"
-            class="
+            :classList="
             ${x =>
                 x.cellType === "columnheader"
                     ? "column-header"

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
@@ -42,7 +42,7 @@ export const dataGridRowTemplate: FoundationElementTemplate<ViewTemplate<DataGri
     return html<DataGridRow>`
         <template
             role="row"
-            class="${x => (x.rowType !== "default" ? x.rowType : "")}"
+            :classList="${x => (x.rowType !== "default" ? x.rowType : "")}"
             :defaultCellItemTemplate="${cellItemTemplate}"
             :defaultHeaderCellItemTemplate="${headerCellItemTemplate}"
             ${children({

--- a/packages/web-components/fast-foundation/src/radio/radio.template.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.template.ts
@@ -13,7 +13,7 @@ export const radioTemplate: FoundationElementTemplate<
 > = (context, definition) => html`
     <template
         role="radio"
-        class="${x => (x.checked ? "checked" : "")} ${x =>
+        :classList="${x => (x.checked ? "checked" : "")} ${x =>
             x.readOnly ? "readonly" : ""}"
         aria-checked="${x => x.checked}"
         aria-required="${x => x.required}"

--- a/packages/web-components/fast-foundation/src/utilities/intersection-service.ts
+++ b/packages/web-components/fast-foundation/src/utilities/intersection-service.ts
@@ -1,5 +1,3 @@
-import { $global } from "@microsoft/fast-element";
-
 /**
  *  A service to batch intersection event callbacks so multiple elements can share a single observer
  *
@@ -55,7 +53,7 @@ export class IntersectionService {
      * initialize intersection detector
      */
     private initializeIntersectionDetector = (): void => {
-        if (!$global.IntersectionObserver) {
+        if (!globalThis.IntersectionObserver) {
             //intersection observer not supported
             return;
         }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR removes all polyfill and polyfill-like code from fast-element. This reduces the size of fast-element. The polyfills can be included optionally if needed, which is still required for all non-Chromium browsers (due to adoptedStyleSheets). However, if you are targeting a Chromium-based environment only (Edge, WebView2, Electron, etc.) then you no longer have to pay the cost of this code.

### 🎫 Issues

* Closes #5751 

## 👩‍💻 Reviewer Notes

It may look like a lot of changes, but it's mostly just moving things around. The one exception is the approach to style strategies which moves that to a core service so that the polyfill-like implementation can be remove from the core and the core can still detect its presence.

## 📑 Test Plan

All tests continue to pass after the refactor.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.


## ⏭ Next Steps

Next, I'll be looking at whether we can reduce the amount of code and simplify array mutation observation. I may extract another optional module that uses kernel services to add service overrides in.