### PR TITLE
feat: change open attribute in select component from internal to public

### DIFF
--- a/change/@microsoft-fast-foundation-697dbb73-2147-43e2-83dc-a6cf59cb41fb.json
+++ b/change/@microsoft-fast-foundation-697dbb73-2147-43e2-83dc-a6cf59cb41fb.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Changed Select open attribute to public",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "44823142+williamw2@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2161,7 +2161,6 @@ export class Select extends FormAssociatedSelect {
     listboxId: string;
     // @internal
     maxHeight: number;
-    // @internal
     open: boolean;
     // (undocumented)
     protected openChanged(): void;
@@ -2592,7 +2591,7 @@ export class Toolbar extends FoundationElement {
     protected slottedItemsChanged(): void;
     // @internal
     slottedLabel: HTMLElement[];
-}
+    }
 
 // @internal (undocumented)
 export interface Toolbar extends StartEnd, DelegatesARIAToolbar {

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -29,7 +29,9 @@ export class Select extends FormAssociatedSelect {
     /**
      * The open attribute.
      *
-     * @internal
+     * @public
+     * @remarks
+     * HTML Attribute: open
      */
     @attr({ attribute: "open", mode: "boolean" })
     public open: boolean = false;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
Changing the "open" attribute in the Select component in Fast-Foundation from @internal to @public. 
When "open" was changed from just a property into an attribute it was not made public as an oversight. This is causing problems with integrating the Custom Element Manifest Analyzer which sees this as an error.
This change also brings the Select component in line with ComboBox which does have a public "open" attribute. 

This is a non-breaking API change.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->