### PR TITLE
fix heading class name and part association in accordion item

### DIFF
--- a/change/@microsoft-fast-foundation-c3a0d9cd-9fa9-430f-8518-2da44c6c2590.json
+++ b/change/@microsoft-fast-foundation-c3a0d9cd-9fa9-430f-8518-2da44c6c2590.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "remove duplicate use of heading class in accordion item and update part location",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -28,8 +28,8 @@ export const accordionItemTemplate: FoundationElementTemplate<
                 id="${x => x.id}"
                 @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
             >
-                <span class="heading">
-                    <slot name="heading" part="heading"></slot>
+                <span class="heading-content" part="heading-content">
+                    <slot name="heading"></slot>
                 </span>
             </button>
             ${startSlotTemplate(context, definition)}


### PR DESCRIPTION
# Pull Request

## 📖 Description
The Acccordion Item had duplicate classes applied for "heading" and the `part` attribute was placed incorrectly on the slot. This PR updates the class name to be `heading-content` and moves the corresponding part to the correct node.

### 🎫 Issues
Closes #5764 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->