### PR TITLE
fix: elements with hidden attribute should not appear in tabindex

### DIFF
--- a/change/@microsoft-fast-components-425ca2e5-10ae-4ec1-9d94-78f7fe68d4ce.json
+++ b/change/@microsoft-fast-components-425ca2e5-10ae-4ec1-9d94-78f7fe68d4ce.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix hidden menu items should not be included in the tabindex",
+  "packageName": "@microsoft/fast-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-8f418cf2-dfa6-4780-a462-4d87584b70f9.json
+++ b/change/@microsoft-fast-foundation-8f418cf2-dfa6-4780-a462-4d87584b70f9.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix hidden menu items should not be included in the tabindex",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/menu/fixtures/menu.html
+++ b/packages/web-components/fast-components/src/menu/fixtures/menu.html
@@ -403,3 +403,19 @@
     </fast-menu>
     <div>Test div</div>
 </div>
+
+<h4>With hidden menu items (in menu and submenu)</h4>
+<fast-menu>
+    <fast-menu-item>Menu item 1</fast-menu-item>
+    <fast-menu-item hidden>Menu item 2</fast-menu-item>
+    <fast-menu-item disabled="true">Menu item 3</fast-menu-item>
+    <fast-menu-item>
+        Menu item 4
+        <fast-menu>
+            <fast-menu-item role="menuitemcheckbox">Checkbox 1</fast-menu-item>
+            <fast-menu-item>Nested Menu item 1.1</fast-menu-item>
+            <fast-menu-item hidden>Nested Menu item 1.2</fast-menu-item>
+            <fast-menu-item>Nested Menu item 1.3</fast-menu-item>
+        </fast-menu>
+    </fast-menu-item>
+</fast-menu>

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -307,7 +307,7 @@ export class MenuItem extends FoundationElement {
      * get an array of valid DOM children
      */
     private domChildren(): Element[] {
-        return Array.from(this.children);
+        return Array.from(this.children).filter(child => !child.hasAttribute("hidden"));
     }
 }
 

--- a/packages/web-components/fast-foundation/src/menu/menu.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.spec.ts
@@ -111,7 +111,7 @@ describe("Menu", () => {
         await disconnect();
     });
 
-    it("should not set any tabindex on non menu items elements", async () => {
+    it("should not set any tabindex on non menu item elements", async () => {
         const { element, connect, disconnect, menuItem1 } = await setup();
 
         const notMenuItem = document.createElement("div");
@@ -314,6 +314,51 @@ describe("Menu", () => {
         await disconnect();
     });
 
+    it("should not navigate to hidden items", async () => {
+        const { element, connect, disconnect, menuItem3, menuItem4 } = await setup();
+
+        const hiddenItem1 = document.createElement("fast-menu-item");
+        const hiddenItem2 = document.createElement("fast-menu-item");
+
+        (hiddenItem1 as MenuItem).setAttribute("hidden", "");
+        (hiddenItem2 as MenuItem).setAttribute("hidden", "");
+
+        element.insertBefore(hiddenItem1, menuItem3);
+        element.insertBefore(hiddenItem2, menuItem4);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        const item1 = element.querySelector('[id="id1"]');
+        (item1 as HTMLElement).focus();
+        expect(document.activeElement?.id).to.equal("id1");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id2");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id3");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id4");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id4");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
+        expect(document.activeElement?.id).to.equal("id3");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
+        expect(document.activeElement?.id).to.equal("id2");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
+        expect(document.activeElement?.id).to.equal("id1");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
+        expect(document.activeElement?.id).to.equal("id1");
+
+        await disconnect();
+    });
 
     it("should navigate the menu on arrow up/down keys", async () => {
         const { element, connect, disconnect, menuItem1, menuItem2, menuItem3, menuItem4 } = await setup();

--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -299,7 +299,7 @@ export class Menu extends FoundationElement {
      * get an array of valid DOM children
      */
     private domChildren(): Element[] {
-        return Array.from(this.children);
+        return Array.from(this.children).filter(child => !child.hasAttribute("hidden"));
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## 📖 Description
Fixes an issue with menu and menu item elements where elements including the `hidden` attribute were still present in the tabindex.

### 🎫 Issues
closes #5691

## 👩‍💻 Reviewer Notes
If you like you can run storybook and view the last example which illustrates the expected behavior


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->