### PR TITLE
fork color picker from fast-tooling to remove circular dependency

### DIFF
--- a/sites/fast-color-explorer/app/components/color-picker/README.md
+++ b/sites/fast-color-explorer/app/components/color-picker/README.md
@@ -1,0 +1,3 @@
+# Color Picker
+
+This component has been forked from `@microsoft/fast-tooling` as the addition of the tooling dependency creates a circular dependency which was found while attempting to update shared dependencies. This folder can be safely removed once we are able to update the color picker's accessibility to a point where it can be added to the `@microsoft/fast-components` package. At that point in time, both the color explorer and `@microsoft/fast-tooling` would take a dependency on the core component.

--- a/sites/fast-color-explorer/app/components/color-picker/color-picker.form-associated.ts
+++ b/sites/fast-color-explorer/app/components/color-picker/color-picker.form-associated.ts
@@ -1,0 +1,15 @@
+import { FormAssociated, FoundationElement } from "@microsoft/fast-foundation";
+
+/* eslint-disable */
+class _ColorPicker extends FoundationElement {}
+interface _ColorPicker extends FormAssociated {}
+/* eslint-enable */
+
+/**
+ * A form-associated base class for the component.
+ *
+ * @internal
+ */
+export class FormAssociatedColorPicker extends FormAssociated(_ColorPicker) {
+    proxy: HTMLInputElement = document.createElement("input");
+}

--- a/sites/fast-color-explorer/app/components/color-picker/color-picker.styles.ts
+++ b/sites/fast-color-explorer/app/components/color-picker/color-picker.styles.ts
@@ -1,0 +1,132 @@
+import { css, ElementStyles } from "@microsoft/fast-element";
+import {
+    ElementDefinitionContext,
+    FoundationElementDefinition,
+} from "@microsoft/fast-foundation";
+
+export const colorPickerStyles: (
+    context: ElementDefinitionContext,
+    definition: FoundationElementDefinition
+) => ElementStyles = () => css`
+    .popup,
+    .popup__open {
+        display: none;
+        padding: 2px;
+        flex-direction: row;
+        background-color: var(--neutral-layer-floating);
+        border: calc(var(--outline-width) * 1px) solid var(--neutral-outline-rest);
+        border-radius: calc(var(--corner-radius) * 1px);
+    }
+    .popup__open {
+        display: flex;
+        position: absolute;
+        z-index: 1;
+        margin-left: -32px;
+    }
+    .pickers {
+        margin: 4px 6px 4px 4px;
+    }
+    .inputs {
+        width: 65px;
+        margin: 0 4px 4px 0;
+    }
+    .pickers-saturation {
+        position: relative;
+        width: 200px;
+        height: 200px;
+        margin-bottom: 17px;
+        background: linear-gradient(to top, #000 0%, rgba(0, 0, 0, 0) 100%),
+            linear-gradient(to right, #fff 0%, rgba(255, 255, 255, 0) 100%);
+        background-color: #f00;
+        border: 1px solid #fff;
+    }
+    .saturation-indicator {
+        position: absolute;
+        top: 0;
+        left: 0;
+        border: 1px solid #fff;
+        border-radius: 3px;
+        width: 4px;
+        height: 4px;
+        pointer-events: none;
+    }
+    .pickers-hue {
+        position: relative;
+        width: 200px;
+        height: 30px;
+        margin-bottom: 17px;
+        border: 1px solid #fff;
+        background: linear-gradient(
+            to right,
+            #f00 0%,
+            #ff0 16.66%,
+            #0f0 33.33%,
+            #0ff 50%,
+            #00f 66.66%,
+            #f0f 83.33%,
+            #f00 100%
+        );
+    }
+    .hue-indicator,
+    .alpha-indicator {
+        position: absolute;
+        left: 0;
+        top: -2px;
+        border: 1px solid #fff;
+        width: 1px;
+        height: 32px;
+        pointer-events: none;
+        margin-left: 1px;
+    }
+    .pickers-alpha {
+        position: relative;
+        width: 200px;
+        height: 30px;
+        border: 1px solid #fff;
+        background-image: linear-gradient(45deg, #999 25%, transparent 25%),
+            linear-gradient(-45deg, #999 25%, transparent 25%),
+            linear-gradient(45deg, transparent 75%, #999 75%),
+            linear-gradient(-45deg, transparent 75%, #999 75%);
+        background-size: 20px 20px;
+        background-position: 0 0, 0 10px, 10px -10px, -10px 0px;
+        background-color: #fff;
+    }
+    .alpha-mask {
+        width: 100%;
+        height: 100%;
+        background-image: linear-gradient(to right, transparent, #f00);
+        margin-bottom: 5px;
+    }
+    .control-color {
+        position: relative;
+        display: inline-block;
+        width: 25px;
+        height: 25px;
+        margin-top: auto;
+        margin-bottom: auto;
+        border: 1px solid var(--fast-tooling-l1-color, #333333);
+    }
+    .control-color::before {
+        position: absolute;
+        content: "";
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        background-image: linear-gradient(
+            to bottom left,
+            transparent calc(50% - 1px),
+            var(--fast-tooling-l1-color, #333333),
+            transparent calc(50% + 1px)
+        );
+    }
+    .control-color::after {
+        position: absolute;
+        content: "";
+        left: 0;
+        right: 0;
+        top: 0;
+        bottom: 0;
+        background-color: var(--selected-color-value);
+    }
+`;

--- a/sites/fast-color-explorer/app/components/color-picker/color-picker.template.ts
+++ b/sites/fast-color-explorer/app/components/color-picker/color-picker.template.ts
@@ -1,0 +1,143 @@
+import { html, ref, ViewTemplate } from "@microsoft/fast-element";
+import { ElementDefinitionContext } from "@microsoft/fast-foundation";
+import { TextField } from "@microsoft/fast-components";
+import { ColorPicker } from "./color-picker";
+
+/**
+ * The template for the color picker component.
+ * @public
+ */
+export const colorPickerTemplate: (
+    context: ElementDefinitionContext
+) => ViewTemplate<ColorPicker> = context => {
+    return html`
+        <template
+            @focus="${x => x.handleFocus()}"
+            @blur="${x => x.handleBlur()}"
+            @mousemove="${(x, c) =>
+                x.mouseActive ? x.handleMouseMove(c.event as MouseEvent) : null}"
+            @mouseup="${(x, c) =>
+                x.mouseActive ? x.handleMouseUp(c.event as MouseEvent) : null}"
+            style="--selected-color-value: ${x => (x.value ? x.value : "transparent")}"
+        >
+            <div class="root" part="root">
+                <${context.tagFor(TextField)}
+                    class="root-control"
+                    part="control"
+                    id="control"
+                    @input="${x => x.handleTextInput()}"
+                    @change="${x => x.handleChange()}"
+                    ?autofocus="${x => x.autofocus}"
+                    ?disabled="${x => x.disabled}"
+                    placeholder="${x => x.placeholder}"
+                    ?readonly="${x => x.readOnly}"
+                    ?required="${x => x.required}"
+                    :value="${x => x.value}"
+                    ${ref("control")}
+                >
+                    <div slot="start" class="control-color"></div>
+                </${context.tagFor(TextField)}>
+                <div class="${x => (x.open ? "popup__open" : "popup")}">
+                    <div class="pickers">
+                        <div
+                            class="pickers-saturation"
+                            style="background-color:${x => x.uiValues.HueCSSColor}"
+                            @mousedown="${(x, c) =>
+                                x.handleMouseDown("sv", c.event as MouseEvent)}"
+                        >
+                            <div
+                                class="saturation-indicator"
+                                style="left: ${x =>
+                                    x.uiValues.SatValLeftPos - 2}%; top: ${x =>
+        x.uiValues.SatValTopPos - 2}%"
+                            ></div>
+                        </div>
+                        <div
+                            class="pickers-hue"
+                            @mousedown="${(x, c) =>
+                                x.handleMouseDown("h", c.event as MouseEvent)}"
+                        >
+                            <div
+                                class="hue-indicator"
+                                style="left: ${x => x.uiValues.HuePosition - 1}%"
+                            ></div>
+                        </div>
+                        <div
+                            class="pickers-alpha"
+                            @mousedown="${(x, c) =>
+                                x.handleMouseDown("a", c.event as MouseEvent)}"
+                        >
+                            <div
+                                class="alpha-mask"
+                                style="background-image: linear-gradient(to right, transparent, ${x =>
+                                    x.uiValues.HueCSSColor})"
+                            ></div>
+                            <div
+                                class="alpha-indicator"
+                                style="left: ${x => x.uiValues.AlphaPos - 1}%"
+                            ></div>
+                        </div>
+                    </div>
+                    <div class="inputs">
+                        <${context.tagFor(TextField)}
+                            maxlength="3"
+                            size="3"
+                            @input="${(x, c) => x.handleTextValueInput("r", c.event)}"
+                            :value="${x => Math.round(x.uiValues.RGBColor.r * 255)}"
+                        >
+                            <span slot="start">R:</span>
+                        </${context.tagFor(TextField)}>
+                        <${context.tagFor(TextField)}
+                            maxlength="3"
+                            size="3"
+                            @input="${(x, c) => x.handleTextValueInput("g", c.event)}"
+                            :value="${x => Math.round(x.uiValues.RGBColor.g * 255)}"
+                        >
+                            <span slot="start">G:</span>
+                        </${context.tagFor(TextField)}>
+                        <${context.tagFor(TextField)}
+                            maxlength="3"
+                            size="3"
+                            @input="${(x, c) => x.handleTextValueInput("b", c.event)}"
+                            :value="${x => Math.round(x.uiValues.RGBColor.b * 255)}"
+                        >
+                            <span slot="start">B:</span>
+                        </${context.tagFor(TextField)}>
+                        <${context.tagFor(TextField)}
+                            maxlength="3"
+                            size="3"
+                            @input="${(x, c) => x.handleTextValueInput("h", c.event)}"
+                            :value="${x => Math.round(x.uiValues.HSVColor.h)}"
+                        >
+                            <span slot="start">H:</span>
+                        </${context.tagFor(TextField)}>
+                        <${context.tagFor(TextField)}
+                            maxlength="3"
+                            size="3"
+                            @input="${(x, c) => x.handleTextValueInput("s", c.event)}"
+                            :value="${x => Math.round(x.uiValues.HSVColor.s * 100)}"
+                        >
+                            <span slot="start">S:</span>
+                        </${context.tagFor(TextField)}>
+                        <${context.tagFor(TextField)}
+                            maxlength="3"
+                            size="3"
+                            @input="${(x, c) => x.handleTextValueInput("v", c.event)}"
+                            :value="${x => Math.round(x.uiValues.HSVColor.v * 100)}"
+                        >
+                            <span slot="start">V:</span>
+                        </${context.tagFor(TextField)}>
+                        <${context.tagFor(TextField)}
+                            maxlength="3"
+                            size="3"
+                            @input="${(x, c) => x.handleTextValueInput("a", c.event)}"
+                            :value="${x => Math.round(x.uiValues.RGBColor.a * 100)}"
+                        >
+                            <span slot="start">A:</span>
+                        </${context.tagFor(TextField)}>
+                    </div>
+                </div>
+            </div>
+        </template>
+    `;
+};

--- a/sites/fast-color-explorer/app/components/color-picker/color-picker.ts
+++ b/sites/fast-color-explorer/app/components/color-picker/color-picker.ts
@@ -1,0 +1,398 @@
+import {
+    ColorHSV,
+    ColorRGBA64,
+    hsvToRGB,
+    parseColor,
+    rgbToHSV,
+} from "@microsoft/fast-colors";
+import { attr, DOM, observable } from "@microsoft/fast-element";
+import { isNullOrWhiteSpace } from "@microsoft/fast-web-utilities";
+import { FormAssociatedColorPicker } from "./color-picker.form-associated";
+
+/**
+ * This is currently experimental, any use of the color picker must include the following
+ * imports and register with the DesignSystem
+ *
+ * import { fastTextField } from "@microsoft/fast-components";
+ * import { DesignSystem } from "@microsoft/fast-foundation";
+ * DesignSystem.getOrCreate().register(fastTextField());
+ */
+
+/**
+ * Simple class for storing all of the color picker UI observable values.
+ */
+class ColorPickerUI {
+    public RGBColor: ColorRGBA64;
+    public HSVColor: ColorHSV;
+    public HueCSSColor: string;
+    public HuePosition: number;
+    public SatValTopPos: number;
+    public SatValLeftPos: number;
+    public AlphaPos: number;
+
+    constructor(rgbColor: ColorRGBA64, hsvColor: ColorHSV) {
+        this.RGBColor = rgbColor;
+        this.HSVColor = hsvColor;
+        this.HueCSSColor = hsvToRGB(new ColorHSV(this.HSVColor.h, 1, 1)).toStringHexRGB();
+        this.HuePosition = (this.HSVColor.h / 360) * 100;
+        this.SatValLeftPos = this.HSVColor.s * 100;
+        this.SatValTopPos = 100 - this.HSVColor.v * 100;
+        this.AlphaPos = this.RGBColor.a * 100;
+    }
+}
+
+/**
+ * A Color Picker Custom HTML Element.
+ *
+ * @public
+ */
+export class ColorPicker extends FormAssociatedColorPicker {
+    /**
+     * When true, the control will be immutable by user interaction. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Attributes/readonly | readonly HTML attribute} for more information.
+     * @public
+     * @remarks
+     * HTML Attribute: readonly
+     */
+    @attr({ attribute: "readonly", mode: "boolean" })
+    public readOnly: boolean;
+    private readOnlyChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.readOnly = this.readOnly;
+        }
+    }
+
+    /**
+     * Indicates that this element should get focus after the page finishes loading. See {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/input#htmlattrdefautofocus | autofocus HTML attribute} for more information.
+     * @public
+     * @remarks
+     * HTML Attribute: autofocus
+     */
+    @attr({ mode: "boolean" })
+    public autofocus: boolean;
+    private autofocusChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.autofocus = this.autofocus;
+        }
+    }
+
+    /**
+     * Sets the placeholder value of the element, generally used to provide a hint to the user.
+     * @public
+     * @remarks
+     * HTML Attribute: placeholder
+     * Using this attribute does is not a valid substitute for a labeling element.
+     */
+    @attr
+    public placeholder: string;
+    private placeholderChanged(): void {
+        if (this.proxy instanceof HTMLElement) {
+            this.proxy.placeholder = this.placeholder;
+        }
+    }
+
+    /**
+     * Flag indicating that the color UI is visible.
+     */
+    @observable
+    public open: boolean;
+
+    /**
+     * Flag indicating that the color UI is activily listening for mouse move and up events.
+     */
+    @observable
+    public mouseActive: boolean = false;
+
+    /**
+     * Object containing all of the properties displayed in the color picker UI.
+     */
+    @observable
+    public uiValues: ColorPickerUI = new ColorPickerUI(
+        new ColorRGBA64(1, 0, 0),
+        new ColorHSV(0, 1, 1)
+    );
+
+    /**
+     * A reference to the internal input element
+     * @internal
+     */
+    public control: HTMLInputElement;
+
+    /**
+     * A reference to the HTMLElement that is the current target of mouse move events.
+     */
+    private currentMouseTarget: HTMLElement = null;
+
+    /**
+     * A string indicating which of the three graphical elements is the current mouse target. ['sv','h','a']
+     */
+    private currentMouseParam: string;
+
+    /**
+     * The ColorRGBA64 representation of the current color value.
+     */
+    private currentRGBColor: ColorRGBA64;
+
+    /**
+     * The ColorHSV representation of the current color value.
+     */
+    private currentHSVColor: ColorHSV;
+
+    /**
+     * @internal
+     */
+    public connectedCallback(): void {
+        super.connectedCallback();
+        this.open = false;
+        this.initColorValues();
+        this.proxy.setAttribute("type", "color");
+
+        if (this.autofocus) {
+            DOM.queueUpdate(() => {
+                this.focus();
+            });
+        }
+    }
+
+    /**
+     * Handles the focus event. When the template has focus the color UI will be visable.
+     * @internal
+     */
+    public handleFocus(): void {
+        // Re-init colors in case the value changed externally since the UI was last visible.
+        this.initColorValues();
+        this.open = true;
+    }
+
+    /**
+     * Handles the blur event. Hides the color UI when the template loses focus.
+     * @internal
+     */
+    public handleBlur(): void {
+        this.open = false;
+    }
+
+    /**
+     * Handles the internal control's `input` event. This event is fired whenever a user types directly into the primary text field.
+     * @internal
+     */
+    public handleTextInput(): void {
+        this.initialValue = this.control.value;
+        if (this.isValideCSSColor(this.value)) {
+            this.currentRGBColor = parseColor(this.value);
+            this.currentHSVColor = rgbToHSV(this.currentRGBColor);
+            this.updateUIValues(false);
+            this.$emit("change");
+        }
+    }
+
+    /**
+     * Handles the mouse down event on the Sat/Val square and Hue and Alpha sliders. Sets the current targeted element and begins listening for mouse move events.
+     * @param param ['sv','h','a'] - string specifying which color property is being modified with the mouse.
+     * @param e - A reference to the mouse event.
+     */
+    public handleMouseDown(param: string, e: MouseEvent) {
+        this.currentMouseTarget = e.composedPath()[0] as HTMLElement;
+        this.currentMouseParam = param;
+        this.updateFromMouseEvent(e.pageX, e.pageY);
+        this.mouseActive = true;
+    }
+
+    /**
+     * Handles the mouse move event within the color UI. Is only called once the mouseActive is set to true.
+     * @param e - Reference to the Mouse Event
+     */
+    public handleMouseMove(e: MouseEvent) {
+        this.updateFromMouseEvent(e.pageX, e.pageY);
+    }
+
+    /**
+     * Handles the mouse up event within the color UI. Disables listening for mouse move events.
+     * @param e - Reference to the Mouse Event
+     */
+    public handleMouseUp(e: MouseEvent) {
+        this.updateFromMouseEvent(e.pageX, e.pageY);
+        this.currentMouseTarget = null;
+        this.currentMouseParam = null;
+        this.mouseActive = false;
+    }
+
+    /**
+     * Handles changes to any of the color property text inputs typed by the user.
+     * @param param ['r','g','b','a','h','s','v'] - String specifying which color value is being modified.
+     * @param e - Reference to the event.
+     */
+    public handleTextValueInput(param: string, e: Event) {
+        const inputVal = (e.composedPath()[0] as HTMLInputElement).value;
+        if (isNullOrWhiteSpace(inputVal) || Number.isNaN(inputVal)) {
+            return;
+        }
+        const newVal: number = parseInt(inputVal, 10);
+
+        if (["r", "g", "b", "a"].includes(param)) {
+            if (
+                (param !== "a" && this.isValidRGB(newVal)) ||
+                (param === "a" && this.isValidAlpha(newVal))
+            ) {
+                this.currentRGBColor = new ColorRGBA64(
+                    param === "r" ? newVal / 255 : this.currentRGBColor.r,
+                    param === "g" ? newVal / 255 : this.currentRGBColor.g,
+                    param === "b" ? newVal / 255 : this.currentRGBColor.b,
+                    param === "a" ? newVal / 100 : this.currentRGBColor.a
+                );
+                this.currentHSVColor = rgbToHSV(this.currentRGBColor);
+                this.updateUIValues(true);
+            }
+        } else if (["h", "s", "v"].includes(param)) {
+            if (
+                (param !== "h" && this.isValidSaturationValue(newVal)) ||
+                (param === "h" && this.isValidHue(newVal))
+            ) {
+                this.updateHSV(
+                    param === "h" ? newVal : this.currentHSVColor.h,
+                    param === "s" ? newVal / 100 : this.currentHSVColor.s,
+                    param === "v" ? newVal / 100 : this.currentHSVColor.v
+                );
+            }
+        }
+    }
+
+    /**
+     * Change event handler for inner control.
+     * @remarks
+     * "Change" events are not `composable` so they will not
+     * permeate the shadow DOM boundary. This fn effectively proxies
+     * the change event, emitting a `change` event whenever the internal
+     * control emits a `change` event
+     * @internal
+     */
+    public handleChange(): void {
+        this.$emit("change");
+    }
+
+    /**
+     * Initialize internal color values based on input value and set the UI elements
+     * to the correct positions / values.
+     */
+    private initColorValues(): void {
+        if (!isNullOrWhiteSpace(this.value)) {
+            this.currentRGBColor = parseColor(this.value);
+        } else {
+            this.currentRGBColor = new ColorRGBA64(1, 0, 0, 1);
+        }
+        this.currentHSVColor = rgbToHSV(this.currentRGBColor);
+        this.updateUIValues(false);
+    }
+
+    /**
+     * Determines if a number value is within the valid range for an R, G, or B color channel.
+     * @param val - Number to be evaluated.
+     */
+    private isValidRGB(val: number): boolean {
+        return val >= 0 && val <= 255;
+    }
+
+    /**
+     * Determines if a number value is within the valid range for the alpha channel.
+     * @param val - Number to be evaluated.
+     */
+    private isValidAlpha(val: number): boolean {
+        return val >= 0 && val <= 100;
+    }
+
+    /**
+     * Determines if a number value is within the valid range for the saturation or value color channels.
+     * @param val - Number to be evaluated.
+     */
+    private isValidSaturationValue(val: number): boolean {
+        return val >= 0 && val <= 100;
+    }
+
+    /**
+     * Determines if a number value is within the valid range for the hue color channel.
+     * @param val - Number to be evaluated.
+     */
+    private isValidHue(val: number): boolean {
+        return val >= 0 && val <= 359;
+    }
+
+    /**
+     * Checks if input is a valid CSS color.
+     * After placing an invalid css color value into a color style property the value will be an empty string when read back.
+     * @internal
+     */
+    private isValideCSSColor(testValue: string): boolean {
+        /* Set the background color of the proxy element since it is not visible in the UI. */
+        this.proxy.style.backgroundColor = "";
+        this.proxy.style.backgroundColor = testValue;
+        /* Read the value back out. If it was not a valid color value then it will be an empty string when read back out. */
+        return this.proxy.style.backgroundColor !== "";
+    }
+
+    /**
+     * Update the current color values to a new HSV color.
+     * @param hue The new Hue value.
+     * @param sat The new saturation value.
+     * @param val The new Value value.
+     */
+    private updateHSV(hue: number, sat: number, val: number) {
+        this.currentHSVColor = new ColorHSV(hue, sat, val);
+        this.currentRGBColor = hsvToRGB(this.currentHSVColor, this.currentRGBColor.a);
+        this.updateUIValues(true);
+    }
+
+    /**
+     * Update the current color values based on the mouse position over one of the three UI elements (hue, saturation/value, or alpha).
+     * @param pageX The pageX position of the mouse.
+     * @param pageY The pageY position of the mouse.
+     */
+    private updateFromMouseEvent(pageX: number, pageY: number) {
+        const pos: DOMRect = this.currentMouseTarget.getBoundingClientRect();
+        let x = pageX - pos.left;
+        let y = pageY - pos.top;
+        const width = pos.width;
+        const height = pos.height;
+
+        if (x > width) x = width;
+        if (y > height) y = height;
+        if (x < 0) x = 0;
+        if (y < 0) y = 0;
+
+        if (this.currentMouseParam === "h") {
+            this.updateHSV(
+                (359 * x) / width,
+                this.currentHSVColor.s,
+                this.currentHSVColor.v
+            );
+        } else if (this.currentMouseParam === "sv") {
+            this.updateHSV(
+                this.currentHSVColor.h,
+                Math.round((x * 100) / width) / 100,
+                Math.round(100 - (y * 100) / height) / 100
+            );
+        } else if (this.currentMouseParam === "a") {
+            this.currentRGBColor = new ColorRGBA64(
+                this.currentRGBColor.r,
+                this.currentRGBColor.g,
+                this.currentRGBColor.b,
+                Math.round((x * 100) / width) / 100
+            );
+            this.updateUIValues(true);
+        }
+    }
+
+    /**
+     * Update the UI values with the current color. This updates the position of the indicators over the Sat/Val, Hue and Alpha elements
+     * and the values in all of the text fields at once.
+     * @param updateValue - Flag to trigger updating of the main text field value and emitting the change event.
+     */
+    private updateUIValues(updateValue: boolean) {
+        this.uiValues = new ColorPickerUI(this.currentRGBColor, this.currentHSVColor);
+        if (updateValue) {
+            this.initialValue =
+                this.currentRGBColor.a !== 1
+                    ? this.currentRGBColor.toStringWebRGBA()
+                    : this.currentRGBColor.toStringHexRGB();
+            this.$emit("change");
+        }
+    }
+}

--- a/sites/fast-color-explorer/app/components/color-picker/index.ts
+++ b/sites/fast-color-explorer/app/components/color-picker/index.ts
@@ -1,0 +1,16 @@
+import { ColorPicker } from "./color-picker";
+import { colorPickerTemplate as template } from "./color-picker.template";
+import { colorPickerStyles as styles } from "./color-picker.styles";
+
+/**
+ * A web component used for updating color values.
+ *
+ * @alpha
+ * @remarks
+ * HTML Element: \<color-picker\>
+ */
+export const fastToolingColorPicker = ColorPicker.compose({
+    baseName: "color-picker",
+    template,
+    styles,
+});

--- a/sites/fast-color-explorer/app/index.ts
+++ b/sites/fast-color-explorer/app/index.ts
@@ -2,7 +2,7 @@ import {
     allComponents as fastComponents,
     provideFASTDesignSystem,
 } from "@microsoft/fast-components";
-import { fastToolingColorPicker } from "@microsoft/fast-tooling";
+import { fastToolingColorPicker } from "../app/components/color-picker";
 import { App } from "./app";
 import { appComponents } from "./custom-elements";
 

--- a/sites/fast-color-explorer/package.json
+++ b/sites/fast-color-explorer/package.json
@@ -60,7 +60,6 @@
     "@microsoft/fast-components": "^2.25.3",
     "@microsoft/fast-element": "^1.8.0",
     "@microsoft/fast-foundation": "^2.38.0",
-    "@microsoft/fast-tooling": "^0.37.6",
     "@microsoft/fast-web-utilities": "^5.1.0"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3510,19 +3510,6 @@
     "@microsoft/fast-web-utilities" "^4.8.1"
     vscode-html-languageservice "^3.1.3"
 
-"@microsoft/fast-tooling@^0.37.6":
-  version "0.37.6"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-tooling/-/fast-tooling-0.37.6.tgz#045847c19c2c4fd3f9b33c930b31ca7ae963eeb1"
-  integrity sha512-bMlIIrUGO9UQgEeZi1bealXNrVoZfB8sTgQfrwKN1Nu5mM/wa0NjHvDDQzqVfFrgU0/Ou7AFVUyvz0jTwsFYOQ==
-  dependencies:
-    "@microsoft/fast-colors" "^5.1.3"
-    "@microsoft/fast-components" "^2.9.2"
-    "@microsoft/fast-element" "^1.5.1"
-    "@microsoft/fast-foundation" "^2.13.1"
-    "@microsoft/fast-web-utilities" "^4.8.1"
-    vscode-html-languageservice "^3.1.3"
-    vscode-web-custom-data "^0.3.5"
-
 "@microsoft/fast-tooling@^0.7.0":
   version "0.7.0"
   resolved "https://registry.yarnpkg.com/@microsoft/fast-tooling/-/fast-tooling-0.7.0.tgz#a8487eb5ca85fc796c1b9149496f6fa7b4763e47"
@@ -23453,11 +23440,6 @@ vscode-web-custom-data@^0.3.1:
   version "0.3.3"
   resolved "https://registry.yarnpkg.com/vscode-web-custom-data/-/vscode-web-custom-data-0.3.3.tgz#9e1f2388c718d6f190038a19d144834a436b876f"
   integrity sha512-orMjjj1r4efP5ocODYZm3orpANakRBsxPZPDoD5UIrFOPKDFtMJQLp6PIH1rb3AYVRD1iYXMhDQoC6tZ+DrigA==
-
-vscode-web-custom-data@^0.3.5:
-  version "0.3.6"
-  resolved "https://registry.yarnpkg.com/vscode-web-custom-data/-/vscode-web-custom-data-0.3.6.tgz#7ff374bd39ee4a7c05c77c997d9410520e1d02bc"
-  integrity sha512-9r2DOv4YMXL/WBTBB6zxde93hmg6AM7thr7GMR6c5LvPxXe/lwD8gsrJGe0tha4CUvoz86ElUieThGVpM+4PLg==
 
 w3c-hr-time@^1.0.1, w3c-hr-time@^1.0.2:
   version "1.0.2"


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR forks the color picker added from FAST tooling to remove a circular dependency. `@microsoft/fast-tooling` takes a dependency on FAST packages, which in turn are hoisted via yarn/lerna. This issue came up while working to unblock #5198. 

### 🎫 Issues
n/a

## 👩‍💻 Reviewer Notes
<img width="1630" alt="image" src="https://user-images.githubusercontent.com/13071055/160894611-c5665bb8-7fd1-41cc-851c-8c560eb740fe.png">


## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->