### PR TITLE
feat: new execution context design

### DIFF
--- a/change/@microsoft-fast-components-9bddf676-bcae-4054-bb49-e554ec2091eb.json
+++ b/change/@microsoft-fast-components-9bddf676-bcae-4054-bb49-e554ec2091eb.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "fix: update foundation and components template types",
+  "packageName": "@microsoft/fast-components",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-cb2ca562-779a-4f22-9b87-3fdc5483c7d5.json
+++ b/change/@microsoft-fast-element-cb2ca562-779a-4f22-9b87-3fdc5483c7d5.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "refactor: new design for execution context",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-087192c5-d2a2-4873-b209-f8965bc11d14.json
+++ b/change/@microsoft-fast-foundation-087192c5-d2a2-4873-b209-f8965bc11d14.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "fix: update foundation and components template types",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-router-989db3af-0549-4d20-b4f6-c462d43aa913.json
+++ b/change/@microsoft-fast-router-989db3af-0549-4d20-b4f6-c462d43aa913.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "refactor: new design for execution context",
+  "packageName": "@microsoft/fast-router",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/data-grid/data-grid.stories.ts
+++ b/packages/web-components/fast-components/src/data-grid/data-grid.stories.ts
@@ -1,4 +1,4 @@
-import { html } from "@microsoft/fast-element";
+import { html, item } from "@microsoft/fast-element";
 import type {
     Button,
     ColumnDefinition,
@@ -17,7 +17,7 @@ const defaultRowData: object = newDataRow("default");
 
 const columnWidths: string[] = ["1fr", "1fr", "1fr", "1fr"];
 
-const defaultRowItemTemplate = html`
+const defaultRowItemTemplate = item`
     <fast-data-grid-row
         :rowData="${x => x}"
         :cellItemTemplate="${(x, c) => c.parent.cellItemTemplate}"
@@ -25,7 +25,7 @@ const defaultRowItemTemplate = html`
     ></fast-data-grid-row>
 `;
 
-const customRowItemTemplate = html`
+const customRowItemTemplate = item`
     <fast-data-grid-row
         :rowData="${x => x}"
         :cellItemTemplate="${(x, c) => c.parent.cellItemTemplate}"
@@ -34,7 +34,7 @@ const customRowItemTemplate = html`
     <fast-divider style="margin-bottom: 6px; margin-top: 6px;"></fast-divider>
 `;
 
-const customCellItemTemplate = html`
+const customCellItemTemplate = item`
     <fast-data-grid-cell
         style="background: brown"
         grid-column="${(x, c) => c.index + 1}"
@@ -43,7 +43,7 @@ const customCellItemTemplate = html`
     ></fast-data-grid-cell>
 `;
 
-const customHeaderCellItemTemplate = html`
+const customHeaderCellItemTemplate = item`
     <fast-data-grid-cell
         style="background: orange"
         cell-type="columnheader"

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -166,7 +166,7 @@ export type ChildrenDirectiveOptions<T = any> = ChildListDirectiveOptions<T> | S
 export interface ChildViewTemplate<TSource = any, TParent = any> {
     create(): SyntheticView<TSource, TParent, ChildContext<TParent>>;
     // (undocumented)
-    type: 'child';
+    type: "child";
 }
 
 // @public
@@ -288,7 +288,7 @@ export interface ElementViewTemplate<TSource = any, TParent = any> {
     create(hostBindingTarget: Element): ElementView<TSource, TParent>;
     render(source: TSource, host: Node, hostBindingTarget?: Element): ElementView<TSource, TParent>;
     // (undocumented)
-    type: 'element';
+    type: "element";
 }
 
 // Warning: (ae-internal-missing-underscore) The name "emptyArray" should be prefixed with an underscore because the declaration is marked as @internal
@@ -413,7 +413,7 @@ export interface ItemContext<TParentSource = any> extends ChildContext<TParentSo
 export interface ItemViewTemplate<TSource = any, TParent = any> {
     create(): SyntheticView<TSource, TParent, ItemContext<TParent>>;
     // (undocumented)
-    type: 'item';
+    type: "item";
 }
 
 // @public
@@ -594,6 +594,8 @@ export interface RepeatOptions {
 export interface RootContext {
     createChildContext<TParentSource>(source: TParentSource): ChildContext<TParentSource>;
     readonly event: Event;
+    eventDetail<TDetail = any>(): TDetail;
+    eventTarget<TTarget extends EventTarget = EventTarget>(): TTarget;
 }
 
 // @public
@@ -686,7 +688,7 @@ export interface SyntheticView<TSource = any, TParent = any, TContext extends Ex
 export interface SyntheticViewTemplate<TSource = any, TParent = any, TContext extends ExecutionContext<TParent> = ExecutionContext<TParent>> {
     create(): SyntheticView<TSource, TParent, TContext>;
     // (undocumented)
-    type: 'synthetic';
+    type: "synthetic";
 }
 
 // @public

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -22,6 +22,16 @@ export type Mutable<T> = {
 };
 
 /**
+ * Extracts the item type from an array.
+ * @public
+ */
+export type ArrayItem<T> = T extends ReadonlyArray<infer TItem>
+    ? TItem
+    : T extends Array<infer TItem>
+    ? TItem
+    : any;
+
+/**
  * A policy for use with the standard trustedTypes platform API.
  * @public
  */

--- a/packages/web-components/fast-element/src/observation/behavior.ts
+++ b/packages/web-components/fast-element/src/observation/behavior.ts
@@ -1,21 +1,25 @@
-import type { ExecutionContext } from "./observable.js";
+import type { ExecutionContext, RootContext } from "./observable.js";
 
 /**
  * Represents an object that can contribute behavior to a view or
  * element's bind/unbind operations.
  * @public
  */
-export interface Behavior<TSource = any, TParent = any, TGrandparent = any> {
+export interface Behavior<
+    TSource = any,
+    TParent = any,
+    TContext extends ExecutionContext<TParent> = RootContext
+> {
     /**
      * Bind this behavior to the source.
      * @param source - The source to bind to.
      * @param context - The execution context that the binding is operating within.
      */
-    bind(source: TSource, context: ExecutionContext<TParent, TGrandparent>): void;
+    bind(source: TSource, context: TContext): void;
 
     /**
      * Unbinds this behavior from the source.
      * @param source - The source to unbind from.
      */
-    unbind(source: TSource, context: ExecutionContext<TParent, TGrandparent>): void;
+    unbind(source: TSource, context: TContext): void;
 }

--- a/packages/web-components/fast-element/src/observation/execution-context.spec.ts
+++ b/packages/web-components/fast-element/src/observation/execution-context.spec.ts
@@ -1,0 +1,154 @@
+import { expect } from "chai";
+import { ExecutionContext, ItemContext } from "./observable";
+
+describe("The ExecutionContext", () => {
+    it("has a default", () => {
+        const defaultContext = ExecutionContext.default;
+        const newContext = ExecutionContext.create();
+
+        expect(defaultContext.constructor).equals(newContext.constructor);
+    });
+
+    function createEvent() {
+        const detail = { hello: "world" };
+        const event = new CustomEvent('my-event', { detail });
+
+        return { event, detail };
+    }
+
+    it("can get the current event", () => {
+        const { event } = createEvent();
+
+        ExecutionContext.setEvent(event);
+        const context = ExecutionContext.create();
+
+        expect(context.event).equals(event);
+
+        ExecutionContext.setEvent(null);
+    });
+
+    it("can get the current event detail", () => {
+        const { event, detail } = createEvent();
+
+        ExecutionContext.setEvent(event);
+        const context = ExecutionContext.create();
+
+        expect(context.eventDetail()).equals(detail);
+        expect(context.eventDetail<typeof detail>().hello).equals(detail.hello);
+
+        ExecutionContext.setEvent(null);
+    });
+
+    it("can create a child context for a parent source", () => {
+        const parentSource = {};
+        const parentContext = ExecutionContext.create();
+        const childContext = parentContext.createChildContext(parentSource);
+
+        expect(childContext.parent).equals(parentSource);
+        expect(childContext.parentContext).equals(parentContext);
+    });
+
+    it("can create an item context from a child context", () => {
+        const parentSource = {};
+        const parentContext = ExecutionContext.create();
+        const childContext = parentContext.createChildContext(parentSource);
+        const itemContext = childContext.createItemContext(7, 42);
+
+        expect(itemContext.parent).equals(parentSource);
+        expect(itemContext.parentContext).equals(parentContext);
+        expect(itemContext.index).equals(7);
+        expect(itemContext.length).equals(42);
+    });
+
+    context("item context", () => {
+        const scenarios = [
+            {
+                name: "even is first",
+                index: 0,
+                length: 42,
+                isEven: true,
+                isOdd: false,
+                isFirst: true,
+                isMiddle: false,
+                isLast: false
+            },
+            {
+                name: "odd in middle",
+                index: 7,
+                length: 42,
+                isEven: false,
+                isOdd: true,
+                isFirst: false,
+                isMiddle: true,
+                isLast: false
+            },
+            {
+                name: "even in middle",
+                index: 8,
+                length: 42,
+                isEven: true,
+                isOdd: false,
+                isFirst: false,
+                isMiddle: true,
+                isLast: false
+            },
+            {
+                name: "odd at end",
+                index: 41,
+                length: 42,
+                isEven: false,
+                isOdd: true,
+                isFirst: false,
+                isMiddle: false,
+                isLast: true
+            },
+            {
+                name: "even at end",
+                index: 40,
+                length: 41,
+                isEven: true,
+                isOdd: false,
+                isFirst: false,
+                isMiddle: false,
+                isLast: true
+            }
+        ];
+
+        function assert(itemContext: ItemContext, scenario: typeof scenarios[0]) {
+            expect(itemContext.index).equals(scenario.index);
+            expect(itemContext.length).equals(scenario.length);
+            expect(itemContext.isEven).equals(scenario.isEven);
+            expect(itemContext.isOdd).equals(scenario.isOdd);
+            expect(itemContext.isFirst).equals(scenario.isFirst);
+            expect(itemContext.isInMiddle).equals(scenario.isMiddle);
+            expect(itemContext.isLast).equals(scenario.isLast);
+        }
+
+        for (const scenario of scenarios) {
+            it(`has correct position when ${scenario.name}`, () => {
+                const parentSource = {};
+                const parentContext = ExecutionContext.create();
+                const childContext = parentContext.createChildContext(parentSource);
+                const itemContext = childContext.createItemContext(scenario.index, scenario.length);
+
+                assert(itemContext, scenario);
+            });
+        }
+
+        it ("can update its index and length", () => {
+            const scenario1 = scenarios[0];
+            const scenario2 = scenarios[1];
+
+            const parentSource = {};
+            const parentContext = ExecutionContext.create();
+            const childContext = parentContext.createChildContext(parentSource);
+            const itemContext = childContext.createItemContext(scenario1.index, scenario1.length);
+
+            assert(itemContext, scenario1);
+
+            itemContext.updatePosition(scenario2.index, scenario2.length);
+
+            assert(itemContext, scenario2);
+        });
+    });
+});

--- a/packages/web-components/fast-element/src/observation/observable.spec.ts
+++ b/packages/web-components/fast-element/src/observation/observable.spec.ts
@@ -1,8 +1,7 @@
 import { expect } from "chai";
 import { DOM } from "../dom";
-import { enableArrayObservation } from "./array-observer";
 import { PropertyChangeNotifier, SubscriberSet } from "./notifier";
-import { defaultExecutionContext, Observable, observable, volatile } from "./observable";
+import { ExecutionContext, Observable, observable, volatile } from "./observable";
 
 describe("The Observable", () => {
     class Model {
@@ -146,7 +145,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child);
 
             expect(wasNotified).to.be.false;
@@ -156,7 +155,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child);
         });
 
@@ -170,7 +169,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child.value);
 
             expect(wasNotified).to.be.false;
@@ -180,7 +179,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child.value);
         });
         it("notifies on changes in a sub-property binding after disconnecting before notification has been processed", async () => {
@@ -193,7 +192,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child.value);
 
             expect(called).to.be.false;
@@ -204,7 +203,7 @@ describe("The Observable", () => {
 
             expect(called).to.be.false;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child.value);
 
             model.child.value = "another completely different thing";
@@ -225,7 +224,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child.value + model.child2.value);
 
             // change child.value
@@ -236,7 +235,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child.value + model.child2.value);
 
             // change child2.value
@@ -247,7 +246,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child.value + model.child2.value);
 
             // change child
@@ -258,7 +257,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child.value + model.child2.value);
 
             // change child 2
@@ -269,7 +268,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.child.value + model.child2.value);
         });
 
@@ -284,7 +283,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             expect(wasNotified).to.be.false;
@@ -294,7 +293,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             wasNotified = false;
@@ -304,7 +303,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
         });
 
@@ -319,7 +318,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             expect(wasNotified).to.be.false;
@@ -329,7 +328,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             wasNotified = false;
@@ -339,7 +338,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
         });
 
@@ -360,7 +359,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             expect(wasNotified).to.be.false;
@@ -370,7 +369,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             wasNotified = false;
@@ -380,7 +379,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
         });
 
@@ -395,7 +394,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             expect(wasNotified).to.be.false;
@@ -405,7 +404,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             wasNotified = false;
@@ -415,7 +414,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
         });
 
@@ -430,7 +429,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             expect(wasNotified).to.be.false;
@@ -440,7 +439,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             wasNotified = false;
@@ -450,7 +449,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
         });
 
@@ -465,7 +464,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             expect(wasNotified).to.be.false;
@@ -475,7 +474,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             wasNotified = false;
@@ -485,7 +484,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
         });
 
@@ -502,7 +501,7 @@ describe("The Observable", () => {
             const model = new Model();
             model.incrementTrigger();
 
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             expect(wasNotified).to.be.false;
@@ -512,7 +511,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             wasNotified = false;
@@ -522,7 +521,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
         });
 
@@ -544,7 +543,7 @@ describe("The Observable", () => {
             });
 
             const model = new Model();
-            let value = observer.observe(model, defaultExecutionContext);
+            let value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             expect(wasNotified).to.be.false;
@@ -554,7 +553,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
 
             wasNotified = false;
@@ -564,7 +563,7 @@ describe("The Observable", () => {
 
             expect(wasNotified).to.be.true;
 
-            value = observer.observe(model, defaultExecutionContext);
+            value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(binding(model));
         });
 
@@ -579,7 +578,7 @@ describe("The Observable", () => {
 
             const model = new Model();
 
-            const value = observer.observe(model, defaultExecutionContext);
+            const value = observer.observe(model, ExecutionContext.default);
             expect(value).to.equal(model.value);
             expect(wasCalled).to.equal(false);
 
@@ -604,7 +603,7 @@ describe("The Observable", () => {
             }
 
             const bindingObserver = Observable.binding(binding);
-            bindingObserver.observe({}, defaultExecutionContext);
+            bindingObserver.observe({}, ExecutionContext.default);
 
             let i = 0;
             for (const record of bindingObserver.records()) {

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -439,6 +439,16 @@ export interface RootContext {
     readonly event: Event;
 
     /**
+     * Returns the typed event detail of a custom event.
+     */
+    eventDetail<TDetail = any>(): TDetail;
+
+    /**
+     * Returns the typed event target of the event.
+     */
+    eventTarget<TTarget extends EventTarget = EventTarget>(): TTarget;
+
+    /**
      * Creates a new execution context descendent from the current context.
      * @param source - The source for the context if different than the parent.
      * @returns A child execution context.
@@ -534,42 +544,50 @@ class DefaultExecutionContext implements RootContext, ChildContext, ItemContext 
         this.parentContext = parentContext as any;
     }
 
-    public get event(): Event {
+    get event(): Event {
         return contextEvent.get()!;
     }
 
-    public get isEven(): boolean {
+    get isEven(): boolean {
         return this.index % 2 === 0;
     }
 
-    public get isOdd(): boolean {
+    get isOdd(): boolean {
         return this.index % 2 !== 0;
     }
 
-    public get isFirst(): boolean {
+    get isFirst(): boolean {
         return this.index === 0;
     }
 
-    public get isInMiddle(): boolean {
+    get isInMiddle(): boolean {
         return !this.isFirst && !this.isLast;
     }
 
-    public get isLast(): boolean {
+    get isLast(): boolean {
         return this.index === this.length - 1;
     }
 
-    public updatePosition(index: number, length: number): void {
+    eventDetail<TDetail>(): TDetail {
+        return (this.event as CustomEvent<TDetail>).detail;
+    }
+
+    eventTarget<TTarget extends EventTarget>(): TTarget {
+        return this.event.target! as TTarget;
+    }
+
+    updatePosition(index: number, length: number): void {
         this.index = index;
         this.length = length;
     }
 
-    public createChildContext<TParentSource>(
+    createChildContext<TParentSource>(
         parentSource: TParentSource
     ): ChildContext<TParentSource> {
         return new DefaultExecutionContext(parentSource, this);
     }
 
-    public createItemContext(index: number, length: number): ItemContext {
+    createItemContext(index: number, length: number): ItemContext {
         const childContext = Object.create(this);
         childContext.index = index;
         childContext.length = length;

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -33,10 +33,11 @@ export interface Accessor {
  * as part of a template binding update.
  * @public
  */
-export type Binding<TSource = any, TReturn = any, TParent = any> = (
-    source: TSource,
-    context: ExecutionContext<TParent>
-) => TReturn;
+export type Binding<
+    TSource = any,
+    TReturn = any,
+    TContext extends ExecutionContext = ExecutionContext
+> = (source: TSource, context: TContext) => TReturn;
 
 /**
  * A record of observable property access.
@@ -63,7 +64,6 @@ interface SubscriptionRecord extends ObservationRecord {
  * Enables evaluation of and subscription to a binding.
  * @public
  */
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 export interface BindingObserver<TSource = any, TReturn = any, TParent = any>
     extends Notifier {
     /**
@@ -72,7 +72,7 @@ export interface BindingObserver<TSource = any, TReturn = any, TParent = any>
      * @param context - The execution context to execute the binding within.
      * @returns The value of the binding.
      */
-    observe(source: TSource, context: ExecutionContext): TReturn;
+    observe(source: TSource, context: ExecutionContext<TParent>): TReturn;
 
     /**
      * Unsubscribe from all dependent observables of the binding.
@@ -170,9 +170,9 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         }
     }
 
-    class BindingObserverImplementation<TSource = any, TReturn = any, TParent = any>
+    class BindingObserverImplementation<TSource = any, TReturn = any>
         extends SubscriberSet
-        implements BindingObserver<TSource, TReturn, TParent> {
+        implements BindingObserver<TSource, TReturn> {
         public needsRefresh: boolean = true;
         private needsQueue: boolean = true;
 
@@ -184,7 +184,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         private next: SubscriptionRecord | undefined = void 0;
 
         constructor(
-            private binding: Binding<TSource, TReturn, TParent>,
+            private binding: Binding<TSource, TReturn>,
             initialSubscriber?: Subscriber,
             private isVolatileBinding: boolean = false
         ) {
@@ -359,11 +359,11 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
          * @param initialSubscriber - An initial subscriber to changes in the binding value.
          * @param isVolatileBinding - Indicates whether the binding's dependency list must be re-evaluated on every value evaluation.
          */
-        binding<TSource = any, TReturn = any, TParent = any>(
-            binding: Binding<TSource, TReturn, TParent>,
+        binding<TSource = any, TReturn = any>(
+            binding: Binding<TSource, TReturn>,
             initialSubscriber?: Subscriber,
             isVolatileBinding: boolean = this.isVolatileBinding(binding)
-        ): BindingObserver<TSource, TReturn, TParent> {
+        ): BindingObserver<TSource, TReturn> {
             /* eslint-disable-next-line @typescript-eslint/no-use-before-define */
             return new BindingObserverImplementation(
                 binding,
@@ -377,8 +377,8 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
          * on every evaluation of the value.
          * @param binding - The binding to inspect.
          */
-        isVolatileBinding<TSource = any, TReturn = any, TParent = any>(
-            binding: Binding<TSource, TReturn, TParent>
+        isVolatileBinding<TSource = any, TReturn = any>(
+            binding: Binding<TSource, TReturn>
         ): boolean {
             return volatileRegex.test(binding.toString());
         },
@@ -432,89 +432,184 @@ const contextEvent = FAST.getById(KernelServiceId.contextEvent, () => {
  * Provides additional contextual information available to behaviors and expressions.
  * @public
  */
-export class ExecutionContext<TParent = any, TGrandparent = any> {
+export interface RootContext {
     /**
-     * The index of the current item within a repeat context.
+     * The current event within an event handler.
      */
-    public index: number = 0;
+    readonly event: Event;
 
     /**
-     * The length of the current collection within a repeat context.
+     * Creates a new execution context descendent from the current context.
+     * @param source - The source for the context if different than the parent.
+     * @returns A child execution context.
      */
-    public length: number = 0;
+    createChildContext<TParentSource>(source: TParentSource): ChildContext<TParentSource>;
+}
 
+/**
+ * Provides additional contextual information when inside a child template.
+ * @public
+ */
+export interface ChildContext<TParentSource = any> extends RootContext {
     /**
-     * The parent data object within a repeat context.
+     * The parent data source within a nested context.
      */
-    public parent: TParent = null as any;
+    readonly parent: TParentSource;
 
     /**
      * The parent execution context when in nested context scenarios.
      */
-    public parentContext: ExecutionContext<TGrandparent> = null as any;
+    readonly parentContext: ChildContext<TParentSource>;
 
     /**
-     * The current event within an event handler.
+     * Creates a new execution context descent suitable for use in list rendering.
+     * @param item - The list item to serve as the source.
+     * @param index - The index of the item in the list.
+     * @param length - The length of the list.
      */
-    public get event(): Event {
-        return contextEvent.get()!;
-    }
+    createItemContext(index: number, length: number): ItemContext<TParentSource>;
+}
+
+/**
+ * Provides additional contextual information when inside a repeat item template.s
+ * @public
+ */
+export interface ItemContext<TParentSource = any> extends ChildContext<TParentSource> {
+    /**
+     * The index of the current item within a repeat context.
+     */
+    readonly index: number;
+
+    /**
+     * The length of the current collection within a repeat context.
+     */
+    readonly length: number;
 
     /**
      * Indicates whether the current item within a repeat context
      * has an even index.
      */
-    public get isEven(): boolean {
-        return this.index % 2 === 0;
-    }
+    readonly isEven: boolean;
 
     /**
      * Indicates whether the current item within a repeat context
      * has an odd index.
      */
-    public get isOdd(): boolean {
-        return this.index % 2 !== 0;
-    }
+    readonly isOdd: boolean;
 
     /**
      * Indicates whether the current item within a repeat context
      * is the first item in the collection.
      */
-    public get isFirst(): boolean {
-        return this.index === 0;
-    }
+    readonly isFirst: boolean;
 
     /**
      * Indicates whether the current item within a repeat context
      * is somewhere in the middle of the collection.
      */
-    public get isInMiddle(): boolean {
-        return !this.isFirst && !this.isLast;
-    }
+    readonly isInMiddle: boolean;
 
     /**
      * Indicates whether the current item within a repeat context
      * is the last item in the collection.
      */
+    readonly isLast: boolean;
+
+    /**
+     * Updates the position/size on a context associated with a list item.
+     * @param index - The new index of the item.
+     * @param length - The new length of the list.
+     */
+    updatePosition(index: number, length: number): void;
+}
+
+class DefaultExecutionContext implements RootContext, ChildContext, ItemContext {
+    public index: number = 0;
+    public length: number = 0;
+    public readonly parent: any;
+    public readonly parentContext: ChildContext<any>;
+
+    constructor(parentSource: any = null, parentContext: ExecutionContext | null = null) {
+        this.parent = parentSource;
+        this.parentContext = parentContext as any;
+    }
+
+    public get event(): Event {
+        return contextEvent.get()!;
+    }
+
+    public get isEven(): boolean {
+        return this.index % 2 === 0;
+    }
+
+    public get isOdd(): boolean {
+        return this.index % 2 !== 0;
+    }
+
+    public get isFirst(): boolean {
+        return this.index === 0;
+    }
+
+    public get isInMiddle(): boolean {
+        return !this.isFirst && !this.isLast;
+    }
+
     public get isLast(): boolean {
         return this.index === this.length - 1;
     }
+
+    public updatePosition(index: number, length: number): void {
+        this.index = index;
+        this.length = length;
+    }
+
+    public createChildContext<TParentSource>(
+        parentSource: TParentSource
+    ): ChildContext<TParentSource> {
+        return new DefaultExecutionContext(parentSource, this);
+    }
+
+    public createItemContext(index: number, length: number): ItemContext {
+        const childContext = Object.create(this);
+        childContext.index = index;
+        childContext.length = length;
+        return childContext;
+    }
+}
+
+Observable.defineProperty(DefaultExecutionContext.prototype, "index");
+Observable.defineProperty(DefaultExecutionContext.prototype, "length");
+
+/**
+ * The common execution context APIs.
+ * @public
+ */
+export const ExecutionContext = Object.freeze({
+    default: new DefaultExecutionContext() as RootContext,
 
     /**
      * Sets the event for the current execution context.
      * @param event - The event to set.
      * @internal
      */
-    public static setEvent(event: Event | null): void {
+    setEvent(event: Event | null): void {
         contextEvent.set(event);
-    }
-}
+    },
 
-Observable.defineProperty(ExecutionContext.prototype, "index");
-Observable.defineProperty(ExecutionContext.prototype, "length");
+    /**
+     * Creates a new root execution context.
+     * @returns A new execution context.
+     */
+    create(): RootContext {
+        return new DefaultExecutionContext();
+    },
+});
 
 /**
- * The default execution context used in binding expressions.
+ * Represents some sort of execution context.
  * @public
  */
-export const defaultExecutionContext = Object.seal(new ExecutionContext());
+export type ExecutionContext<TParentSource = any> =
+    | RootContext
+    | ChildContext<TParentSource>
+    | ItemContext<TParentSource>;

--- a/packages/web-components/fast-element/src/styles/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles/styles.spec.ts
@@ -7,10 +7,10 @@ import { DOM } from "../dom";
 import { CSSDirective } from "./css-directive";
 import { css, cssPartial } from "./css";
 import type { Behavior } from "../observation/behavior";
-import { defaultExecutionContext } from "../observation/observable";
 import type { FASTElement } from "..";
 import { StyleElementStrategy } from "../polyfills";
 import type { StyleTarget } from "../interfaces";
+import { ExecutionContext } from "../observation/observable";
 
 if (DOM.supportsAdoptedStyleSheets) {
     describe("AdoptedStyleSheetsStrategy", () => {
@@ -337,7 +337,7 @@ describe("cssPartial", () => {
             }
         } as FASTElement;
 
-        partial.createBehavior()?.bind(el, defaultExecutionContext)
+        partial.createBehavior()?.bind(el, ExecutionContext.default)
     });
 
     it("should add any ElementStyles interpolated into the template function when bound to an element", () => {
@@ -353,7 +353,7 @@ describe("cssPartial", () => {
             }
         } as FASTElement;
 
-        partial.createBehavior()?.bind(el, defaultExecutionContext)
+        partial.createBehavior()?.bind(el, ExecutionContext.default)
 
         expect(called).to.be.true;
     })

--- a/packages/web-components/fast-element/src/templating/binding.spec.ts
+++ b/packages/web-components/fast-element/src/templating/binding.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { bind, HTMLBindingDirective } from "./binding";
-import { observable, defaultExecutionContext } from "../observation/observable";
+import { ExecutionContext, observable } from "../observation/observable";
 import { DOM } from "../dom";
 import { html, ViewTemplate } from "./template";
 import { toHTML } from "../__test__/helpers";
@@ -46,7 +46,7 @@ describe("The HTML binding directive", () => {
             const { behavior, node, targets } = contentBinding();
             const model = new Model("This is a test");
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(node.textContent).to.equal(model.value);
         });
@@ -55,7 +55,7 @@ describe("The HTML binding directive", () => {
             const { behavior, node, targets } = contentBinding();
             const model = new Model("This is a test");
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(node.textContent).to.equal(model.value);
 
@@ -73,7 +73,7 @@ describe("The HTML binding directive", () => {
             const template = html<Model>`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
         });
@@ -83,7 +83,7 @@ describe("The HTML binding directive", () => {
             const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
@@ -99,7 +99,7 @@ describe("The HTML binding directive", () => {
             const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
@@ -115,7 +115,7 @@ describe("The HTML binding directive", () => {
             const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
@@ -131,7 +131,7 @@ describe("The HTML binding directive", () => {
             const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
@@ -148,7 +148,7 @@ describe("The HTML binding directive", () => {
             const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             const view = (node as any).$fastView as SyntheticView;
             const capturedTemplate = (node as any).$fastTemplate as ViewTemplate;
@@ -180,7 +180,7 @@ describe("The HTML binding directive", () => {
             const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
@@ -199,13 +199,13 @@ describe("The HTML binding directive", () => {
             const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             const newView = (node as any).$fastView as SyntheticView;
             expect(newView.source).to.equal(model);
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
-            behavior.unbind(model, defaultExecutionContext, targets);
+            behavior.unbind(model, ExecutionContext.default, targets);
 
             expect(newView.source).to.equal(null);
         });
@@ -215,17 +215,17 @@ describe("The HTML binding directive", () => {
             const template = html`This is a template. ${x => x.knownValue}`;
             const model = new Model(template);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             const view = (node as any).$fastView as SyntheticView;
             expect(view.source).to.equal(model);
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
 
-            behavior.unbind(model, defaultExecutionContext, targets);
+            behavior.unbind(model, ExecutionContext.default, targets);
 
             expect(view.source).to.equal(null);
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             const newView = (node as any).$fastView as SyntheticView;
             expect(newView.source).to.equal(model);

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -288,11 +288,7 @@ export function sendSignal(signal: string): void {
 }
 
 class OnSignalBinding extends TargetUpdateBinding {
-    bind(
-        source: any,
-        context: ExecutionContext<any, any>,
-        targets: ViewBehaviorTargets
-    ): void {
+    bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
         const directive = this.directive;
         const target = targets[directive.targetId];
         const signal = this.getSignal(source, context);
@@ -319,11 +315,7 @@ class OnSignalBinding extends TargetUpdateBinding {
         }
     }
 
-    unbind(
-        source: any,
-        context: ExecutionContext<any, any>,
-        targets: ViewBehaviorTargets
-    ): void {
+    unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
         const signal = this.getSignal(source, context);
         const found = signals[signal];
 
@@ -340,7 +332,7 @@ class OnSignalBinding extends TargetUpdateBinding {
         }
     }
 
-    private getSignal(source: any, context: ExecutionContext<any, any>): string {
+    private getSignal(source: any, context: ExecutionContext): string {
         const options = this.directive.options;
         return isString(options) ? options : options(source, context);
     }

--- a/packages/web-components/fast-element/src/templating/children.spec.ts
+++ b/packages/web-components/fast-element/src/templating/children.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { children, ChildrenDirective } from "./children";
-import { defaultExecutionContext, observable } from "../observation/observable";
+import { ExecutionContext, observable } from "../observation/observable";
 import { elements } from "./node-observation";
 import { DOM } from "../dom";
 
@@ -57,7 +57,7 @@ describe("The children", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children);
         });
@@ -71,7 +71,7 @@ describe("The children", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children.filter(elements("foo-bar")));
         });
@@ -84,7 +84,7 @@ describe("The children", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children);
 
@@ -104,7 +104,7 @@ describe("The children", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children);
 
@@ -137,7 +137,7 @@ describe("The children", () => {
 
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(subtreeChildren);
 
@@ -164,11 +164,11 @@ describe("The children", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children);
 
-            behavior.unbind(model, defaultExecutionContext, targets);
+            behavior.unbind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members([]);
 

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -2,7 +2,7 @@ import { expect } from "chai";
 import { DOM } from "../dom";
 import { customElement, FASTElement } from "../components/fast-element";
 import { Markup } from './markup';
-import { defaultExecutionContext } from "../observation/observable";
+import { ExecutionContext } from "../observation/observable";
 import { css } from "../styles/css";
 import { toHTML, uniqueElementName } from "../__test__/helpers";
 import { bind, HTMLBindingDirective } from "./binding";
@@ -333,7 +333,7 @@ describe("The template compiler", () => {
                     expect(
                         (factories[0] as HTMLBindingDirective).binding(
                             scope,
-                            defaultExecutionContext
+                            ExecutionContext.default
                         )
                     ).to.equal(x.result);
                 }

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -14,7 +14,7 @@ export type ViewBehaviorTargets = {
  * Represents an object that can contribute behavior to a view.
  * @public
  */
-export interface ViewBehavior<TSource = any, TParent = any, TGrandparent = any> {
+export interface ViewBehavior<TSource = any, TParent = any> {
     /**
      * Bind this behavior to the source.
      * @param source - The source to bind to.
@@ -23,7 +23,7 @@ export interface ViewBehavior<TSource = any, TParent = any, TGrandparent = any> 
      */
     bind(
         source: TSource,
-        context: ExecutionContext<TParent, TGrandparent>,
+        context: ExecutionContext<TParent>,
         targets: ViewBehaviorTargets
     ): void;
 
@@ -35,7 +35,7 @@ export interface ViewBehavior<TSource = any, TParent = any, TGrandparent = any> 
      */
     unbind(
         source: TSource,
-        context: ExecutionContext<TParent, TGrandparent>,
+        context: ExecutionContext<TParent>,
         targets: ViewBehaviorTargets
     ): void;
 }

--- a/packages/web-components/fast-element/src/templating/node-observation.ts
+++ b/packages/web-components/fast-element/src/templating/node-observation.ts
@@ -57,11 +57,7 @@ export abstract class NodeObservationDirective<
      * @param context - The execution context that the binding is operating within.
      * @param targets - The targets that behaviors in a view can attach to.
      */
-    bind(
-        source: any,
-        context: ExecutionContext<any, any>,
-        targets: ViewBehaviorTargets
-    ): void {
+    bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
         const target = targets[this.targetId] as any;
         target.$fastSource = source;
         this.updateTarget(source, this.computeNodes(target));
@@ -74,11 +70,7 @@ export abstract class NodeObservationDirective<
      * @param context - The execution context that the binding is operating within.
      * @param targets - The targets that behaviors in a view can attach to.
      */
-    unbind(
-        source: any,
-        context: ExecutionContext<any, any>,
-        targets: ViewBehaviorTargets
-    ): void {
+    unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
         const target = targets[this.targetId] as any;
         this.updateTarget(source, emptyArray);
         this.disconnect(target);

--- a/packages/web-components/fast-element/src/templating/repeat.spec.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { repeat, RepeatDirective, RepeatBehavior } from "./repeat";
-import { html } from "./template";
-import { defaultExecutionContext, observable } from "../observation/observable";
+import { child, html } from "./template";
+import { ExecutionContext, observable } from "../observation/observable";
 import { DOM } from "../dom";
 import { toHTML } from "../__test__/helpers";
 
@@ -107,7 +107,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 expect(toHTML(parent)).to.equal(createOutput(size));
             });
@@ -124,7 +124,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const data = new ViewModel(size);
 
-                behavior.bind(data, defaultExecutionContext);
+                behavior.bind(data, ExecutionContext.default);
 
                 expect(toHTML(parent)).to.equal(
                     createOutput(size, void 0, void 0, input => `<div>${input}</div>`)
@@ -157,7 +157,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
                 vm.items.push({ name: "newitem" });
 
                 await DOM.nextUpdate();
@@ -177,7 +177,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 const index = size - 1;
                 vm.items.splice(index, 1);
@@ -201,7 +201,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 vm.items.splice(0, 1);
 
@@ -222,7 +222,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 const index = size - 1;
                 vm.items.splice(index, 1, { name: "newitem1" }, { name: "newitem2" });
@@ -246,7 +246,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 vm.items.splice(0, 1, { name: "newitem1" }, { name: "newitem2" });
 
@@ -269,7 +269,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 expect(toHTML(parent)).to.equal(createOutput(size));
 
@@ -286,7 +286,7 @@ describe("The repeat", () => {
                 const deepItemTemplate = html<Item>`
                     parent-${x => x.name}${repeat(
                         x => x.items!,
-                        html<Item>`child-${x => x.name}root-${(x, c) => c.parentContext.parent.name}`
+                        child<Item>`child-${x => x.name}root-${(x, c) => c.parentContext.parent.name}`
                     )}
                 `;
 
@@ -299,7 +299,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size, true);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 const text = toHTML(parent);
 
@@ -321,7 +321,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 vm.items.shift();
                 vm.items.unshift({ name: "shift" });
@@ -345,7 +345,7 @@ describe("The repeat", () => {
                 const behavior = directive.createBehavior(targets);
                 const vm = new ViewModel(size);
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 await DOM.nextUpdate();
 
@@ -353,7 +353,7 @@ describe("The repeat", () => {
 
                 await DOM.nextUpdate();
 
-                behavior.bind(vm, defaultExecutionContext);
+                behavior.bind(vm, ExecutionContext.default);
 
                 await DOM.nextUpdate();
 

--- a/packages/web-components/fast-element/src/templating/slotted.spec.ts
+++ b/packages/web-components/fast-element/src/templating/slotted.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { slotted, SlottedDirective } from "./slotted";
-import { defaultExecutionContext, observable } from "../observation/observable";
+import { ExecutionContext, observable } from "../observation/observable";
 import { elements } from "./node-observation";
 import { DOM } from "../dom";
 
@@ -61,7 +61,7 @@ describe("The slotted", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children);
         });
@@ -75,7 +75,7 @@ describe("The slotted", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children.filter(elements("foo-bar")));
         });
@@ -86,7 +86,7 @@ describe("The slotted", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children);
 
@@ -106,7 +106,7 @@ describe("The slotted", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children);
 
@@ -123,11 +123,11 @@ describe("The slotted", () => {
             behavior.targetId = targetId;
             const model = new Model();
 
-            behavior.bind(model, defaultExecutionContext, targets);
+            behavior.bind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members(children);
 
-            behavior.unbind(model, defaultExecutionContext, targets);
+            behavior.unbind(model, ExecutionContext.default, targets);
 
             expect(model.nodes).members([]);
 

--- a/packages/web-components/fast-element/src/templating/view.ts
+++ b/packages/web-components/fast-element/src/templating/view.ts
@@ -1,5 +1,5 @@
 import type { Behavior } from "../observation/behavior.js";
-import type { ExecutionContext } from "../observation/observable.js";
+import type { ExecutionContext, RootContext } from "../observation/observable.js";
 import type {
     ViewBehavior,
     ViewBehaviorFactory,
@@ -10,11 +10,15 @@ import type {
  * Represents a collection of DOM nodes which can be bound to a data source.
  * @public
  */
-export interface View<TSource = any, TParent = any, TGrandparent = any> {
+export interface View<
+    TSource = any,
+    TParent = any,
+    TContext extends ExecutionContext<TParent> = ExecutionContext<TParent>
+> {
     /**
      * The execution context the view is running within.
      */
-    readonly context: ExecutionContext<TParent, TGrandparent> | null;
+    readonly context: TContext | null;
 
     /**
      * The data that the view is bound to.
@@ -26,7 +30,7 @@ export interface View<TSource = any, TParent = any, TGrandparent = any> {
      * @param source - The binding source for the view's binding behaviors.
      * @param context - The execution context to run the view within.
      */
-    bind(source: TSource, context: ExecutionContext<TParent, TGrandparent>): void;
+    bind(source: TSource, context: TContext): void;
 
     /**
      * Unbinds a view's behaviors from its binding source and context.
@@ -44,8 +48,8 @@ export interface View<TSource = any, TParent = any, TGrandparent = any> {
  * A View representing DOM nodes specifically for rendering the view of a custom element.
  * @public
  */
-export interface ElementView<TSource = any, TParent = any, TGrandparent = any>
-    extends View<TSource, TParent, TGrandparent> {
+export interface ElementView<TSource = any, TParent = any>
+    extends View<TSource, TParent, RootContext> {
     /**
      * Appends the view's DOM nodes to the referenced node.
      * @param node - The parent node to append the view's DOM nodes to.
@@ -57,8 +61,11 @@ export interface ElementView<TSource = any, TParent = any, TGrandparent = any>
  * A view representing a range of DOM nodes which can be added/removed ad hoc.
  * @public
  */
-export interface SyntheticView<TSource = any, TParent = any, TGrandparent = any>
-    extends View<TSource, TParent, TGrandparent> {
+export interface SyntheticView<
+    TSource = any,
+    TParent = any,
+    TContext extends ExecutionContext<TParent> = ExecutionContext<TParent>
+> extends View<TSource, TParent, TContext> {
     /**
      * The first DOM node in the range of nodes that make up the view.
      */
@@ -106,10 +113,11 @@ function removeNodeSequence(firstNode: Node, lastNode: Node): void {
  * The standard View implementation, which also implements ElementView and SyntheticView.
  * @public
  */
-export class HTMLView<TSource = any, TParent = any, TGrandparent = any>
-    implements
-        ElementView<TSource, TParent, TGrandparent>,
-        SyntheticView<TSource, TParent, TGrandparent> {
+export class HTMLView<
+    TSource = any,
+    TParent = any,
+    TContext extends ExecutionContext<TParent> = ExecutionContext<TParent>
+> implements ElementView<TSource, TParent>, SyntheticView<TSource, TParent, TContext> {
     private behaviors: ViewBehavior[] | null = null;
 
     /**
@@ -120,7 +128,7 @@ export class HTMLView<TSource = any, TParent = any, TGrandparent = any>
     /**
      * The execution context the view is running within.
      */
-    public context: ExecutionContext<TParent, TGrandparent> | null = null;
+    public context: TContext | null = null;
 
     /**
      * The first DOM node in the range of nodes that make up the view.
@@ -210,7 +218,7 @@ export class HTMLView<TSource = any, TParent = any, TGrandparent = any>
      * @param source - The binding source for the view's binding behaviors.
      * @param context - The execution context to run the behaviors within.
      */
-    public bind(source: TSource, context: ExecutionContext<TParent, TGrandparent>): void {
+    public bind(source: TSource, context: TContext): void {
         let behaviors = this.behaviors;
         const oldSource = this.source;
 

--- a/packages/web-components/fast-element/src/templating/when.spec.ts
+++ b/packages/web-components/fast-element/src/templating/when.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { when } from "./when";
 import { html } from "./template";
-import { Binding, defaultExecutionContext } from "../observation/observable";
+import { Binding, ExecutionContext } from "../observation/observable";
 
 describe("The 'when' template function", () => {
     it("returns an expression", () => {
@@ -15,13 +15,13 @@ describe("The 'when' template function", () => {
 
         it("returns a template when the condition is true", () => {
             const expression = when(() => true, template) as Binding;
-            const result = expression(scope, defaultExecutionContext);
+            const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(template);
         });
 
         it("returns null when the condition is false", () => {
             const expression = when(() => false, template) as Binding;
-            const result = expression(scope, defaultExecutionContext);
+            const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(null);
         });
 
@@ -30,7 +30,7 @@ describe("The 'when' template function", () => {
                 () => true,
                 () => template
             ) as Binding;
-            const result = expression(scope, defaultExecutionContext);
+            const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(template);
         });
     });

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -6,6 +6,7 @@
 
 import { AttributeConfiguration } from '@microsoft/fast-element';
 import { Behavior } from '@microsoft/fast-element';
+import { ChildViewTemplate } from '@microsoft/fast-element';
 import { ComposableStyles } from '@microsoft/fast-element';
 import { Constructable } from '@microsoft/fast-element';
 import { CSSDirective } from '@microsoft/fast-element';
@@ -351,7 +352,7 @@ export type CalendarOptions = FoundationElementDefinition & StartEndOptions & {
 };
 
 // @public (undocumented)
-export const calendarRowTemplate: (context: ElementDefinitionContext, todayString: string) => ViewTemplate;
+export const calendarRowTemplate: (context: ElementDefinitionContext, todayString: string) => ChildViewTemplate;
 
 // @public
 export const calendarTemplate: FoundationElementTemplate<ViewTemplate<Calendar>, CalendarOptions>;
@@ -624,12 +625,12 @@ export const darkModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaSt
 // @public
 export class DataGrid extends FoundationElement {
     constructor();
-    cellItemTemplate?: ViewTemplate;
+    cellItemTemplate?: ItemViewTemplate;
     columnDefinitions: ColumnDefinition[] | null;
     // @internal (undocumented)
     connectedCallback(): void;
     // @internal
-    defaultRowItemTemplate: ViewTemplate;
+    defaultRowItemTemplate: ItemViewTemplate;
     // @internal (undocumented)
     disconnectedCallback(): void;
     focusColumnIndex: number;
@@ -645,11 +646,11 @@ export class DataGrid extends FoundationElement {
     handleKeydown(e: KeyboardEvent): void;
     // @internal (undocumented)
     handleRowFocus(e: Event): void;
-    headerCellItemTemplate?: ViewTemplate;
+    headerCellItemTemplate?: ItemViewTemplate;
     // @internal
     rowElements: HTMLElement[];
     rowElementTag: string;
-    rowItemTemplate: ViewTemplate;
+    rowItemTemplate: ItemViewTemplate;
     rowsData: object[];
     }
 
@@ -687,17 +688,17 @@ export enum DataGridCellTypes {
 // @public
 export class DataGridRow extends FoundationElement {
     // @internal
-    activeCellItemTemplate?: ViewTemplate;
+    activeCellItemTemplate?: ItemViewTemplate;
     // @internal
     cellElements: HTMLElement[];
-    cellItemTemplate?: ViewTemplate;
+    cellItemTemplate?: ItemViewTemplate;
     columnDefinitions: ColumnDefinition[] | null;
     // @internal (undocumented)
     connectedCallback(): void;
     // @internal
-    defaultCellItemTemplate?: ViewTemplate;
+    defaultCellItemTemplate?: ItemViewTemplate;
     // @internal
-    defaultHeaderCellItemTemplate?: ViewTemplate;
+    defaultHeaderCellItemTemplate?: ItemViewTemplate;
     // @internal (undocumented)
     disconnectedCallback(): void;
     // @internal (undocumented)
@@ -709,7 +710,7 @@ export class DataGridRow extends FoundationElement {
     handleFocusout(e: FocusEvent): void;
     // (undocumented)
     handleKeydown(e: KeyboardEvent): void;
-    headerCellItemTemplate?: ViewTemplate;
+    headerCellItemTemplate?: ItemViewTemplate;
     // @internal
     isActiveRow: boolean;
     rowData: object | null;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -13,6 +13,7 @@ import { Direction } from '@microsoft/fast-web-utilities';
 import { ElementStyles } from '@microsoft/fast-element';
 import { ElementViewTemplate } from '@microsoft/fast-element';
 import { FASTElement } from '@microsoft/fast-element';
+import { ItemViewTemplate } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import { PartialFASTElementDefinition } from '@microsoft/fast-element';
 import { SyntheticViewTemplate } from '@microsoft/fast-element';
@@ -312,10 +313,7 @@ export class Calendar extends FoundationElement {
     getDayClassNames(date: CalendarDateInfo, todayString?: string): string;
     getDays(info?: CalendarInfo, minWeeks?: number): CalendarDateInfo[][];
     getMonthInfo(month?: number, year?: number): CalendarInfo;
-    getWeekdayText(): {
-        text: string;
-        abbr?: string;
-    }[];
+    getWeekdayText(): WeekdayText[];
     handleDateSelect(event: Event, day: CalendarDateInfo): void;
     handleKeydown(event: KeyboardEvent, date: CalendarDateInfo): boolean;
     locale: string;
@@ -330,7 +328,7 @@ export class Calendar extends FoundationElement {
     }
 
 // @public
-export const calendarCellTemplate: (context: ElementDefinitionContext, todayString: string) => ViewTemplate<CalendarDateInfo>;
+export const calendarCellTemplate: (context: ElementDefinitionContext, todayString: string) => ItemViewTemplate<CalendarDateInfo>;
 
 // @public
 export type CalendarDateInfo = {
@@ -362,7 +360,7 @@ export const calendarTemplate: FoundationElementTemplate<ViewTemplate<Calendar>,
 export const CalendarTitleTemplate: ViewTemplate<Calendar>;
 
 // @public
-export const calendarWeekdayTemplate: (context: any) => ViewTemplate;
+export const calendarWeekdayTemplate: (context: any) => ItemViewTemplate;
 
 // @public
 export class Card extends FoundationElement {
@@ -2746,6 +2744,12 @@ export type VerticalPosition = "top" | "bottom" | "center" | "unset";
 
 // @public
 export type WeekdayFormat = "long" | "narrow" | "short";
+
+// @public
+export type WeekdayText = {
+    text: string;
+    abbr?: string;
+};
 
 // @public
 export function whitespaceFilter(value: Node, index: number, array: Node[]): boolean;

--- a/packages/web-components/fast-foundation/src/calendar/calendar.template.ts
+++ b/packages/web-components/fast-foundation/src/calendar/calendar.template.ts
@@ -1,5 +1,6 @@
 import {
     child,
+    ChildViewTemplate,
     html,
     item,
     ItemViewTemplate,
@@ -112,9 +113,9 @@ export const calendarCellTemplate: (
 export const calendarRowTemplate: (
     context: ElementDefinitionContext,
     todayString: string
-) => ViewTemplate = (context: ElementDefinitionContext, todayString: string) => {
+) => ChildViewTemplate = (context: ElementDefinitionContext, todayString: string) => {
     const rowTag = context.tagFor(DataGridRow);
-    return html`
+    return child`
         <${rowTag}
             class="week"
             part="week"
@@ -184,7 +185,7 @@ export const noninteractiveCalendarTemplate: (todayString: string) => ViewTempla
                     `
                 )}
             </div>
-            ${repeat(
+            ${repeat<Calendar>(
                 x => x.getDays(),
                 child<CalendarDateInfo[]>`
                     <div class="week">

--- a/packages/web-components/fast-foundation/src/calendar/calendar.template.ts
+++ b/packages/web-components/fast-foundation/src/calendar/calendar.template.ts
@@ -1,10 +1,22 @@
-import { html, repeat, when } from "@microsoft/fast-element";
+import {
+    child,
+    html,
+    item,
+    ItemViewTemplate,
+    repeat,
+    when,
+} from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { endTemplate, startTemplate } from "../patterns/start-end";
 import { DataGrid, DataGridCell, DataGridRow } from "../data-grid";
 import type { FoundationElementTemplate } from "../foundation-element";
 import type { ElementDefinitionContext } from "../design-system";
-import type { Calendar, CalendarDateInfo, CalendarOptions } from "./calendar";
+import type {
+    Calendar,
+    CalendarDateInfo,
+    CalendarOptions,
+    WeekdayText,
+} from "./calendar";
 
 /**
  * A basic Calendar title template that includes the month and year
@@ -33,9 +45,9 @@ export const CalendarTitleTemplate: ViewTemplate<Calendar> = html`
  * @returns - The weekday labels template
  * @public
  */
-export const calendarWeekdayTemplate: (context) => ViewTemplate = context => {
+export const calendarWeekdayTemplate: (context) => ItemViewTemplate = context => {
     const cellTag = context.tagFor(DataGridCell);
-    return html`
+    return item<WeekdayText>`
         <${cellTag}
             class="week-day"
             part="week-day"
@@ -58,12 +70,12 @@ export const calendarWeekdayTemplate: (context) => ViewTemplate = context => {
 export const calendarCellTemplate: (
     context: ElementDefinitionContext,
     todayString: string
-) => ViewTemplate<CalendarDateInfo> = (
+) => ItemViewTemplate<CalendarDateInfo> = (
     context: ElementDefinitionContext,
     todayString: string
 ) => {
     const cellTag: string = context.tagFor(DataGridCell);
-    return html`
+    return item`
         <${cellTag}
             class="${(x, c) => c.parentContext.parent.getDayClassNames(x, todayString)}"
             part="day"
@@ -132,7 +144,7 @@ export const interactiveCalendarGridTemplate: (
     const gridTag: string = context.tagFor(DataGrid);
     const rowTag: string = context.tagFor(DataGridRow);
 
-    return html`
+    return html<Calendar>`
     <${gridTag} class="days interact" part="days" generate-header="none">
         <${rowTag}
             class="week-days"
@@ -160,12 +172,12 @@ export const interactiveCalendarGridTemplate: (
 export const noninteractiveCalendarTemplate: (todayString: string) => ViewTemplate = (
     todayString: string
 ) => {
-    return html`
+    return html<Calendar>`
         <div class="days" part="days">
             <div class="week-days" part="week-days">
                 ${repeat(
                     x => x.getWeekdayText(),
-                    html`
+                    html<WeekdayText>`
                         <div class="week-day" part="week-day" abbr="${x => x.abbr}">
                             ${x => x.text}
                         </div>
@@ -174,11 +186,11 @@ export const noninteractiveCalendarTemplate: (todayString: string) => ViewTempla
             </div>
             ${repeat(
                 x => x.getDays(),
-                html`
+                child<CalendarDateInfo[]>`
                     <div class="week">
                         ${repeat(
                             x => x,
-                            html`
+                            child<CalendarDateInfo>`
                                 <div
                                     class="${(x, c) =>
                                         c.parentContext.parent.getDayClassNames(
@@ -207,7 +219,7 @@ export const noninteractiveCalendarTemplate: (todayString: string) => ViewTempla
                                     </div>
                                     <slot
                                         name="${x => x.month}-${x => x.day}-${x =>
-                                            x.year}"
+                                x.year}"
                                     ></slot>
                                 </div>
                             `
@@ -235,7 +247,7 @@ export const calendarTemplate: FoundationElementTemplate<
     const todayString: string = `${
         today.getMonth() + 1
     }-${today.getDate()}-${today.getFullYear()}`;
-    return html`
+    return html<Calendar>`
         <template>
             ${startTemplate}
             ${definition.title instanceof Function

--- a/packages/web-components/fast-foundation/src/calendar/calendar.ts
+++ b/packages/web-components/fast-foundation/src/calendar/calendar.ts
@@ -48,6 +48,12 @@ export type CalendarDateInfo = {
 };
 
 /**
+ * Calendar weekday text.
+ * @public
+ */
+export type WeekdayText = { text: string; abbr?: string };
+
+/**
  * Calendar configuration options
  * @public
  */
@@ -309,7 +315,7 @@ export class Calendar extends FoundationElement {
      * @returns An array of weekday text and full text if abbreviated
      * @public
      */
-    public getWeekdayText(): { text: string; abbr?: string }[] {
+    public getWeekdayText(): WeekdayText[] {
         const weekdayText: {
             text: string;
             abbr?: string;

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { customElement, html, ViewTemplate } from "@microsoft/fast-element";
+import { html, ViewTemplate } from "@microsoft/fast-element";
 import { fixture } from "../test-utilities/fixture";
 import { dataGridCellTemplate, DataGridCell } from "./index";
 import { newDataRow } from "./data-grid.spec";

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
@@ -1,12 +1,22 @@
-import { children, elements, html, slotted } from "@microsoft/fast-element";
+import {
+    children,
+    elements,
+    html,
+    item,
+    ItemViewTemplate,
+    slotted,
+} from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import type { FoundationElementTemplate } from "../foundation-element";
 import type { DataGridRow } from "./data-grid-row";
 import { DataGridCell } from "./data-grid-cell";
+import type { ColumnDefinition } from "./data-grid";
 
-function createCellItemTemplate(context): ViewTemplate {
+function createCellItemTemplate(
+    context
+): ItemViewTemplate<ColumnDefinition, DataGridRow> {
     const cellTag = context.tagFor(DataGridCell);
-    return html`
+    return item<ColumnDefinition, DataGridRow>`
     <${cellTag}
         cell-type="${x => (x.isRowHeader ? "rowheader" : undefined)}"
         grid-column="${(x, c) => c.index + 1}"
@@ -16,9 +26,11 @@ function createCellItemTemplate(context): ViewTemplate {
 `;
 }
 
-function createHeaderCellItemTemplate(context): ViewTemplate {
+function createHeaderCellItemTemplate(
+    context
+): ItemViewTemplate<ColumnDefinition, DataGridRow> {
     const cellTag = context.tagFor(DataGridCell);
-    return html`
+    return item<ColumnDefinition, DataGridRow>`
     <${cellTag}
         cell-type="columnheader"
         grid-column="${(x, c) => c.index + 1}"
@@ -37,8 +49,8 @@ export const dataGridRowTemplate: FoundationElementTemplate<ViewTemplate<DataGri
     context,
     definition
 ) => {
-    const cellItemTemplate: ViewTemplate = createCellItemTemplate(context);
-    const headerCellItemTemplate: ViewTemplate = createHeaderCellItemTemplate(context);
+    const cellItemTemplate = createCellItemTemplate(context);
+    const headerCellItemTemplate = createHeaderCellItemTemplate(context);
     return html<DataGridRow>`
         <template
             role="row"

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
@@ -1,9 +1,9 @@
 import {
     attr,
+    ItemViewTemplate,
     observable,
     RepeatBehavior,
     RepeatDirective,
-    ViewTemplate,
 } from "@microsoft/fast-element";
 import {
     eventFocusOut,
@@ -81,7 +81,7 @@ export class DataGridRow extends FoundationElement {
      * @public
      */
     @observable
-    public cellItemTemplate?: ViewTemplate;
+    public cellItemTemplate?: ItemViewTemplate;
     private cellItemTemplateChanged(): void {
         this.updateItemTemplate();
     }
@@ -92,7 +92,7 @@ export class DataGridRow extends FoundationElement {
      * @public
      */
     @observable
-    public headerCellItemTemplate?: ViewTemplate;
+    public headerCellItemTemplate?: ItemViewTemplate;
     private headerCellItemTemplateChanged(): void {
         this.updateItemTemplate();
     }
@@ -120,7 +120,7 @@ export class DataGridRow extends FoundationElement {
      * @internal
      */
     @observable
-    public activeCellItemTemplate?: ViewTemplate;
+    public activeCellItemTemplate?: ItemViewTemplate;
 
     /**
      * The default cell item template.  Set by the component templates.
@@ -128,7 +128,7 @@ export class DataGridRow extends FoundationElement {
      * @internal
      */
     @observable
-    public defaultCellItemTemplate?: ViewTemplate;
+    public defaultCellItemTemplate?: ItemViewTemplate;
 
     /**
      * The default header cell item template.  Set by the component templates.
@@ -136,7 +136,7 @@ export class DataGridRow extends FoundationElement {
      * @internal
      */
     @observable
-    public defaultHeaderCellItemTemplate?: ViewTemplate;
+    public defaultHeaderCellItemTemplate?: ItemViewTemplate;
 
     /**
      * Children that are cells

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
@@ -1,12 +1,18 @@
-import { children, elements, html } from "@microsoft/fast-element";
+import {
+    child,
+    children,
+    ChildViewTemplate,
+    elements,
+    html,
+} from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import type { FoundationElementTemplate } from "../foundation-element";
 import type { DataGrid } from "./data-grid";
 import { DataGridRow } from "./data-grid-row";
 
-function createRowItemTemplate(context): ViewTemplate {
+function createRowItemTemplate(context): ChildViewTemplate<any, DataGrid> {
     const rowTag = context.tagFor(DataGridRow);
-    return html`
+    return child<any, DataGrid>`
     <${rowTag}
         :rowData="${x => x}"
         :cellItemTemplate="${(x, c) => c.parent.cellItemTemplate}"
@@ -25,7 +31,7 @@ export const dataGridTemplate: FoundationElementTemplate<ViewTemplate<DataGrid>>
     context,
     definition
 ) => {
-    const rowItemTemplate: ViewTemplate = createRowItemTemplate(context);
+    const rowItemTemplate = createRowItemTemplate(context);
     const rowTag = context.tagFor(DataGridRow);
     return html<DataGrid>`
         <template

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
@@ -1,18 +1,18 @@
 import {
-    child,
     children,
-    ChildViewTemplate,
     elements,
     html,
+    item,
+    ItemViewTemplate,
 } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
 import type { FoundationElementTemplate } from "../foundation-element";
 import type { DataGrid } from "./data-grid";
 import { DataGridRow } from "./data-grid-row";
 
-function createRowItemTemplate(context): ChildViewTemplate<any, DataGrid> {
+function createRowItemTemplate(context): ItemViewTemplate<any, DataGrid> {
     const rowTag = context.tagFor(DataGridRow);
-    return child<any, DataGrid>`
+    return item<any, DataGrid>`
     <${rowTag}
         :rowData="${x => x}"
         :cellItemTemplate="${(x, c) => c.parent.cellItemTemplate}"

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -1,6 +1,7 @@
 import {
     attr,
     DOM,
+    ItemViewTemplate,
     observable,
     RepeatBehavior,
     RepeatDirective,
@@ -196,7 +197,7 @@ export class DataGrid extends FoundationElement {
      * @public
      */
     @observable
-    public rowItemTemplate: ViewTemplate;
+    public rowItemTemplate: ItemViewTemplate;
 
     /**
      * The template used to render cells in generated rows.
@@ -204,7 +205,7 @@ export class DataGrid extends FoundationElement {
      * @public
      */
     @observable
-    public cellItemTemplate?: ViewTemplate;
+    public cellItemTemplate?: ItemViewTemplate;
 
     /**
      * The template used to render header cells in generated rows.
@@ -212,7 +213,7 @@ export class DataGrid extends FoundationElement {
      * @public
      */
     @observable
-    public headerCellItemTemplate?: ViewTemplate;
+    public headerCellItemTemplate?: ItemViewTemplate;
     private headerCellItemTemplateChanged(): void {
         if (this.$fastController.isConnected) {
             if (this.generatedHeader !== null) {
@@ -259,7 +260,7 @@ export class DataGrid extends FoundationElement {
      * @internal
      */
     @observable
-    public defaultRowItemTemplate: ViewTemplate;
+    public defaultRowItemTemplate: ItemViewTemplate;
 
     /**
      * Set by the component templates.

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -3,7 +3,7 @@ import {
     Binding,
     BindingObserver,
     CSSDirective,
-    defaultExecutionContext,
+    ExecutionContext,
     FASTElement,
     observable,
     Observable,
@@ -380,7 +380,7 @@ class DesignTokenBindingObserver<T> {
 
             (this.observer.observe(
                 this.node.target,
-                defaultExecutionContext
+                ExecutionContext.default
             ) as unknown) as StaticDesignTokenValue<T>
         );
     }

--- a/packages/web-components/fast-foundation/src/picker/picker.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.template.ts
@@ -1,4 +1,11 @@
-import { html, ref, ViewTemplate, when } from "@microsoft/fast-element";
+import {
+    child,
+    ChildViewTemplate,
+    html,
+    ref,
+    ViewTemplate,
+    when,
+} from "@microsoft/fast-element";
 import { AnchoredRegion } from "../anchored-region";
 import type { FoundationElementTemplate } from "../foundation-element";
 import type { Picker } from "./picker";
@@ -7,9 +14,9 @@ import { PickerMenuOption } from "./picker-menu-option";
 import { PickerList } from "./picker-list";
 import { PickerListItem } from "./picker-list-item";
 
-function createDefaultListItemTemplate(context): ViewTemplate {
+function createDefaultListItemTemplate(context): ChildViewTemplate {
     const pickerListItemTag: string = context.tagFor(PickerListItem);
-    return html`
+    return child`
     <${pickerListItemTag}
         value="${x => x}"
         :contentsTemplate="${(x, c) => c.parent.listItemContentsTemplate}"
@@ -18,9 +25,9 @@ function createDefaultListItemTemplate(context): ViewTemplate {
     `;
 }
 
-function createDefaultMenuOptionTemplate(context): ViewTemplate {
+function createDefaultMenuOptionTemplate(context): ChildViewTemplate {
     const pickerMenuOptionTag: string = context.tagFor(PickerMenuOption);
-    return html`
+    return child`
     <${pickerMenuOptionTag}
         value="${x => x}"
         :contentsTemplate="${(x, c) => c.parent.menuOptionContentsTemplate}"
@@ -41,10 +48,8 @@ export const pickerTemplate: FoundationElementTemplate<ViewTemplate<Picker>> = (
     const pickerMenuTag: string = context.tagFor(PickerMenu);
     const pickerListTag: string = context.tagFor(PickerList);
     const progressRingTag: string = context.tagFor(PickerList);
-    const defaultListItemTemplate: ViewTemplate = createDefaultListItemTemplate(context);
-    const defaultMenuOptionTemplate: ViewTemplate = createDefaultMenuOptionTemplate(
-        context
-    );
+    const defaultListItemTemplate = createDefaultListItemTemplate(context);
+    const defaultMenuOptionTemplate = createDefaultMenuOptionTemplate(context);
     return html<Picker>`
         <template
             :selectedListTag="${() => pickerListTag}"

--- a/packages/web-components/fast-foundation/src/test-utilities/fixture.ts
+++ b/packages/web-components/fast-foundation/src/test-utilities/fixture.ts
@@ -1,6 +1,5 @@
 import {
     Constructable,
-    defaultExecutionContext,
     ExecutionContext,
     HTMLView,
     ViewTemplate,
@@ -143,7 +142,7 @@ export async function fixture<TElement = HTMLElement>(
     const document = options.document || globalThis.document;
     const parent = options.parent || document.createElement("div");
     const source = options.source || {};
-    const context = options.context || defaultExecutionContext;
+    const context = options.context || ExecutionContext.default;
 
     if (typeof templateNameOrRegistry === "string") {
         const html = `<${templateNameOrRegistry}></${templateNameOrRegistry}>`;

--- a/packages/web-components/fast-router/src/view.ts
+++ b/packages/web-components/fast-router/src/view.ts
@@ -1,6 +1,5 @@
 import {
     ComposableStyles,
-    defaultExecutionContext,
     ElementStyles,
     ExecutionContext,
     html,
@@ -20,7 +19,7 @@ export type RouterExecutionContext = ExecutionContext & {
  */
 export const RouterExecutionContext = Object.freeze({
     create(router: Router) {
-        return Object.create(defaultExecutionContext, {
+        return Object.create(ExecutionContext.default, {
             router: {
                 value: router,
             },

--- a/packages/web-components/fast-ssr/src/element-renderer/element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/element-renderer.ts
@@ -1,11 +1,5 @@
 import { ElementRenderer, RenderInfo } from "@lit-labs/ssr";
-import {
-    Aspect,
-    ComposableStyles,
-    defaultExecutionContext,
-    DOM,
-    FASTElement,
-} from "@microsoft/fast-element";
+import { Aspect, ExecutionContext, DOM, FASTElement } from "@microsoft/fast-element";
 import { TemplateRenderer } from "../template-renderer/template-renderer.js";
 import { SSRView } from "../view.js";
 import { StyleRenderer } from "../styles/style-renderer.js";
@@ -56,7 +50,7 @@ export abstract class FASTElementRenderer extends ElementRenderer {
 
             if (view.hostDynamicAttributes) {
                 for (const attr of view.hostDynamicAttributes) {
-                    const result = attr.binding(this.element, defaultExecutionContext);
+                    const result = attr.binding(this.element, ExecutionContext.default);
 
                     const { target } = attr;
                     switch (attr.aspect) {
@@ -133,7 +127,7 @@ export abstract class FASTElementRenderer extends ElementRenderer {
                 ((view as unknown) as SSRView).codes,
                 renderInfo,
                 this.element,
-                defaultExecutionContext
+                ExecutionContext.default
             );
         }
     }

--- a/packages/web-components/fast-ssr/src/template-renderer/directives.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/directives.ts
@@ -3,6 +3,7 @@ import {
     ChildrenDirective,
     Constructable,
     ExecutionContext,
+    ItemContext,
     RefDirective,
     RepeatDirective,
     SlottedDirective,
@@ -36,18 +37,16 @@ export const RepeatDirectiveRenderer: DirectiveRenderer<typeof RepeatDirective> 
         ): IterableIterator<string> {
             const items = directive.itemsBinding(source, context);
             const template = directive.templateBinding(source, context);
-            const childContext: ExecutionContext = Object.create(context);
-            childContext.parent = source;
-            childContext.parentContext = context;
+            const childContext = context.createChildContext(source);
 
             if (template instanceof ViewTemplate) {
                 if (directive.options.positioning) {
                     for (let i = 0, length = items.length; i < length; i++) {
-                        const ctx: ExecutionContext = Object.create(childContext);
-                        // Match fast-element context creation behavior. Perhaps this should be abstracted
-                        // So both fast-ssr and fast-element leverage the same context creation code?
-                        ctx.index = i;
-                        ctx.length = length;
+                        // Match fast-element repeater item context code.
+                        const ctx: ItemContext = childContext.createItemContext(
+                            i,
+                            length
+                        );
                         yield* renderer.render(template, renderInfo, items[i], ctx);
                     }
                 } else {

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
@@ -1,5 +1,5 @@
 import "../dom-shim.js";
-import { children, customElement, defaultExecutionContext, FASTElement, html, ref, repeat, slotted, when } from "@microsoft/fast-element";
+import { child, children, customElement, ExecutionContext, FASTElement, html, item, ref, repeat, slotted, when } from "@microsoft/fast-element";
 import { expect, test } from "@playwright/test";
 import fastSSR from "../exports.js";
 import { consolidate } from "../test-utils.js";
@@ -135,7 +135,7 @@ test.describe("TemplateRenderer", () => {
         const { templateRenderer, defaultRenderInfo} = fastSSR();
         consolidate(templateRenderer.render(html`${(x, c) => {calledWith = c}}`, defaultRenderInfo));
 
-        expect(calledWith).toBe(defaultExecutionContext);
+        expect(calledWith).toBe(ExecutionContext.default);
     });
 
 
@@ -226,11 +226,11 @@ test.describe("TemplateRenderer", () => {
             const source = {
                 data: ["foo", "bar", "bat"]
             };
-            const ctx = Object.create(defaultExecutionContext);
-            consolidate(templateRenderer.render(html<typeof source>`${repeat(x => x.data, html<string>`${(x, c) => {
+            const ctx = ExecutionContext.default;
+            consolidate(templateRenderer.render(html<typeof source>`${repeat(x => x.data, child<string>`${(x, c) => {
                 expect(c.parent).toBe(source);
                 expect(c.parentContext).toBe(ctx)
-            }}`, { positioning: true})}`, defaultRenderInfo, source, ctx))
+            }}`)}`, defaultRenderInfo, source, ctx))
         });
         test("should provide positioning information when invoked with the positioning config", () => {
 
@@ -239,7 +239,7 @@ test.describe("TemplateRenderer", () => {
                 data: ["foo", "bar", "bat"]
             };
             let i = 0;
-            consolidate(templateRenderer.render(html<typeof source>`${repeat(x => x.data, html<string>`${(x, c) => {
+            consolidate(templateRenderer.render(html<typeof source>`${repeat(x => x.data, item<string>`${(x, c) => {
                 expect(c.index).toBe(i);
                 i++;
                 expect(c.length).toBe(c.parent.data.length)

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
@@ -3,14 +3,13 @@ import { getElementRenderer } from "@lit-labs/ssr/lib/element-renderer.js";
 import {
     Aspect,
     AspectedHTMLDirective,
-    defaultExecutionContext,
     ExecutionContext,
     ViewTemplate,
 } from "@microsoft/fast-element";
 import { Op, OpType } from "../template-parser/op-codes.js";
 import {
-    parseTemplateToOpCodes,
     parseStringToOpCodes,
+    parseTemplateToOpCodes,
 } from "../template-parser/template-parser.js";
 import { DirectiveRenderer } from "./directives.js";
 
@@ -57,7 +56,7 @@ export class TemplateRenderer
         template: ViewTemplate | string,
         renderInfo: RenderInfo,
         source: unknown = undefined,
-        context: ExecutionContext = defaultExecutionContext
+        context: ExecutionContext = ExecutionContext.default
     ): IterableIterator<string> {
         const codes =
             template instanceof ViewTemplate


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR reworks the design of `ExecutionContext` which is passed to all bindings and behaviors. The original goal was to reduce duplication between FASTElement and the SSR renderer. While that was achieved some other long-standing issues were tackled as part of the new design:

* Official execution context APIs for creating root, child, and item contexts were added.
* Contexts are now typed so they only provided appropriate APIs based on where they are used.
* New view types for child and item views were added.
* The `repeat` function was updated to recognize the new view types and ensure that the repeat is properly configured when using item views.
* New tag helpers for `child` and `item` were created to enable creating child and item views. These are mostly intended to be used with `repeat` but can be used by other directives. (They are just aliases to the `html` function but with more specific types.)
* A couple of helper functions were added to the root execution context to ease the access to typed event details and targets.

### Developer Experience Screenshots

TypeScript errors when trying to use child context properties from a root template, where they don't exist:

 <img width="1369" alt="Screen Shot 2022-04-04 at 2 55 41 PM" src="https://user-images.githubusercontent.com/131485/161613905-8bd20502-f993-4634-bf2b-460c5ca2a3ad.png">

Specify that you have a template intended to be used in a child context, and TypeScript complies:

<img width="1381" alt="Screen Shot 2022-04-04 at 2 56 14 PM" src="https://user-images.githubusercontent.com/131485/161614138-2df5226f-7bdb-4c1e-90f1-95210aba1fe8.png">

Trying to access positioning properties from a non-item template will cause a TypeScript error:

<img width="1393" alt="Screen Shot 2022-04-04 at 2 57 04 PM" src="https://user-images.githubusercontent.com/131485/161614284-b71fc7fd-b20f-4918-8847-0a7b9fa960cf.png">

Trying to use an item template when you haven't enabled the repeater's positioning features also causes an error:

<img width="1390" alt="Screen Shot 2022-04-04 at 2 57 27 PM" src="https://user-images.githubusercontent.com/131485/161614495-36674d73-7a19-4813-8bb2-e4fe1349946f.png">

Doing this properly by using both an item template and enabling positioning makes TypeScript happy:

<img width="1390" alt="Screen Shot 2022-04-04 at 2 57 53 PM" src="https://user-images.githubusercontent.com/131485/161614668-64b0aa5b-1dd1-439a-bc31-1c5faf5536d8.png">

And you get proper autocomplete:

<img width="1393" alt="Screen Shot 2022-04-04 at 2 58 57 PM" src="https://user-images.githubusercontent.com/131485/161614791-560f7b13-fa98-4f1c-8fa3-65e06e12d7ec.png">

But if you turn on positioning and don't actually use it, TypeScript gives you an error because you are accidentally de-performance optimizing your code by turning on a more costly feature without using it:

<img width="1020" alt="Screen Shot 2022-04-04 at 2 59 14 PM" src="https://user-images.githubusercontent.com/131485/161614990-3918f390-ed91-42eb-adae-9bc21163b708.png">

### 🎫 Issues

* Closes #5772 

## 👩‍💻 Reviewer Notes

**This is a breaking change.** I had to fix up a number of templates in fast-foundation and fast-components in order to meet the new type requirements for child and item templates. The components affected were the data grid and calendar components because they leverage repeat directives that use item contexts.

## 📑 Test Plan

All existing tests pass and new execution context tests were added to cover the new APIs.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

While working on context I ended up realizing there were other improvements that could be made to directives. I'll tackle that next, represented by issue #5799 