### PR TITLE
fix select dropdown positioning

### DIFF
--- a/change/@microsoft-fast-foundation-22faaad5-04d8-4a4c-bb54-a2790225d32c.json
+++ b/change/@microsoft-fast-foundation-22faaad5-04d8-4a4c-bb54-a2790225d32c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix positioning of select dropdown",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "abris96@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -477,9 +477,9 @@ export class Combobox extends FormAssociatedCombobox {
     // @internal
     protected placeholderChanged(): void;
     position?: SelectPosition;
-    positionAttribute: SelectPosition;
+    positionAttribute?: SelectPosition;
     // (undocumented)
-    protected positionChanged(prev: SelectPosition | undefined, next: SelectPosition): void;
+    protected positionChanged(prev: SelectPosition | undefined, next: SelectPosition | undefined): void;
     // @internal
     selectedIndexChanged(prev: number | undefined, next: number): void;
     // @internal
@@ -2189,9 +2189,9 @@ export class Select extends FormAssociatedSelect {
     // @internal
     protected openChanged(prev: boolean | undefined, next: boolean): void;
     position?: SelectPosition;
-    positionAttribute: SelectPosition;
+    positionAttribute?: SelectPosition;
     // (undocumented)
-    protected positionChanged(prev: SelectPosition | undefined, next: SelectPosition): void;
+    protected positionChanged(prev: SelectPosition | undefined, next: SelectPosition | undefined): void;
     // @internal
     selectedIndexChanged(prev: number | undefined, next: number): void;
     // @internal @override

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -476,10 +476,10 @@ export class Combobox extends FormAssociatedCombobox {
     placeholder: string;
     // @internal
     protected placeholderChanged(): void;
-    position: SelectPosition;
+    position?: SelectPosition;
     positionAttribute: SelectPosition;
     // (undocumented)
-    protected positionChanged(): void;
+    protected positionChanged(prev: SelectPosition | undefined, next: SelectPosition): void;
     // @internal
     selectedIndexChanged(prev: number | undefined, next: number): void;
     // @internal
@@ -2188,10 +2188,10 @@ export class Select extends FormAssociatedSelect {
     open: boolean;
     // @internal
     protected openChanged(prev: boolean | undefined, next: boolean): void;
-    position: SelectPosition;
+    position?: SelectPosition;
     positionAttribute: SelectPosition;
     // (undocumented)
-    protected positionChanged(): void;
+    protected positionChanged(prev: SelectPosition | undefined, next: SelectPosition): void;
     // @internal
     selectedIndexChanged(prev: number | undefined, next: number): void;
     // @internal @override

--- a/packages/web-components/fast-foundation/src/combobox/README.md
+++ b/packages/web-components/fast-foundation/src/combobox/README.md
@@ -121,7 +121,7 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | `open`              | public    | `boolean`                             | `false` | The open attribute.                                                                                                                                                                 |                        |
 | `options`           | public    | `ListboxOption[]`                     |         | The list of options.                                                                                                                                                                | Listbox                |
 | `placeholder`       | public    | `string`                              |         | Sets the placeholder value of the element, generally used to provide a hint to the user.                                                                                            |                        |
-| `positionAttribute` | public    | `SelectPosition`                      |         | The placement for the listbox when the combobox is open.                                                                                                                            |                        |
+| `positionAttribute` | public    | `SelectPosition or undefined`         |         | The placement for the listbox when the combobox is open.                                                                                                                            |                        |
 | `position`          | public    | `SelectPosition or undefined`         |         | The current state of the calculated position of the listbox.                                                                                                                        |                        |
 | `value`             | public    |                                       |         | The value property.                                                                                                                                                                 |                        |
 | `proxy`             |           |                                       |         |                                                                                                                                                                                     | FormAssociatedCombobox |
@@ -136,15 +136,15 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 #### Methods
 
-| Name                 | Privacy   | Description                                                                | Parameters                                                | Return | Inherited From    |
-| -------------------- | --------- | -------------------------------------------------------------------------- | --------------------------------------------------------- | ------ | ----------------- |
-| `positionChanged`    | protected |                                                                            | `prev: SelectPosition or undefined, next: SelectPosition` | `void` |                   |
-| `filterOptions`      | public    | Filter available options by text value.                                    |                                                           | `void` |                   |
-| `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. | `force`                                                   | `void` |                   |
-| `selectFirstOption`  | public    | Moves focus to the first selectable option.                                |                                                           | `void` | Listbox           |
-| `setSelectedOptions` | public    | Sets an option as selected and gives it focus.                             |                                                           |        | Listbox           |
-| `templateChanged`    | protected |                                                                            |                                                           | `void` | FoundationElement |
-| `stylesChanged`      | protected |                                                                            |                                                           | `void` | FoundationElement |
+| Name                 | Privacy   | Description                                                                | Parameters                                                             | Return | Inherited From    |
+| -------------------- | --------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------ | ----------------- |
+| `positionChanged`    | protected |                                                                            | `prev: SelectPosition or undefined, next: SelectPosition or undefined` | `void` |                   |
+| `filterOptions`      | public    | Filter available options by text value.                                    |                                                                        | `void` |                   |
+| `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. | `force`                                                                | `void` |                   |
+| `selectFirstOption`  | public    | Moves focus to the first selectable option.                                |                                                                        | `void` | Listbox           |
+| `setSelectedOptions` | public    | Sets an option as selected and gives it focus.                             |                                                                        |        | Listbox           |
+| `templateChanged`    | protected |                                                                            |                                                                        | `void` | FoundationElement |
+| `stylesChanged`      | protected |                                                                            |                                                                        | `void` | FoundationElement |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/combobox/README.md
+++ b/packages/web-components/fast-foundation/src/combobox/README.md
@@ -122,7 +122,7 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | `options`           | public    | `ListboxOption[]`                     |         | The list of options.                                                                                                                                                                | Listbox                |
 | `placeholder`       | public    | `string`                              |         | Sets the placeholder value of the element, generally used to provide a hint to the user.                                                                                            |                        |
 | `positionAttribute` | public    | `SelectPosition`                      |         | The placement for the listbox when the combobox is open.                                                                                                                            |                        |
-| `position`          | public    | `SelectPosition`                      |         | The current state of the calculated position of the listbox.                                                                                                                        |                        |
+| `position`          | public    | `SelectPosition or undefined`         |         | The current state of the calculated position of the listbox.                                                                                                                        |                        |
 | `value`             | public    |                                       |         | The value property.                                                                                                                                                                 |                        |
 | `proxy`             |           |                                       |         |                                                                                                                                                                                     | FormAssociatedCombobox |
 | `length`            | public    | `number`                              |         | The number of options.                                                                                                                                                              | Listbox                |
@@ -136,15 +136,15 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 #### Methods
 
-| Name                 | Privacy   | Description                                                                | Parameters | Return | Inherited From    |
-| -------------------- | --------- | -------------------------------------------------------------------------- | ---------- | ------ | ----------------- |
-| `positionChanged`    | protected |                                                                            |            |        |                   |
-| `filterOptions`      | public    | Filter available options by text value.                                    |            | `void` |                   |
-| `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. | `force`    | `void` |                   |
-| `selectFirstOption`  | public    | Moves focus to the first selectable option.                                |            | `void` | Listbox           |
-| `setSelectedOptions` | public    | Sets an option as selected and gives it focus.                             |            |        | Listbox           |
-| `templateChanged`    | protected |                                                                            |            | `void` | FoundationElement |
-| `stylesChanged`      | protected |                                                                            |            | `void` | FoundationElement |
+| Name                 | Privacy   | Description                                                                | Parameters                                                | Return | Inherited From    |
+| -------------------- | --------- | -------------------------------------------------------------------------- | --------------------------------------------------------- | ------ | ----------------- |
+| `positionChanged`    | protected |                                                                            | `prev: SelectPosition or undefined, next: SelectPosition` | `void` |                   |
+| `filterOptions`      | public    | Filter available options by text value.                                    |                                                           | `void` |                   |
+| `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. | `force`                                                   | `void` |                   |
+| `selectFirstOption`  | public    | Moves focus to the first selectable option.                                |                                                           | `void` | Listbox           |
+| `setSelectedOptions` | public    | Sets an option as selected and gives it focus.                             |                                                           |        | Listbox           |
+| `templateChanged`    | protected |                                                                            |                                                           | `void` | FoundationElement |
+| `stylesChanged`      | protected |                                                                            |                                                           | `void` | FoundationElement |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -1,11 +1,11 @@
-import { attr, DOM, Observable, observable } from "@microsoft/fast-element";
 import type { SyntheticViewTemplate } from "@microsoft/fast-element";
+import { attr, DOM, Observable, observable } from "@microsoft/fast-element";
 import { limit, uniqueId } from "@microsoft/fast-web-utilities";
 import type { FoundationElementDefinition } from "../foundation-element/foundation-element.js";
-import { DelegatesARIAListbox } from "../listbox/listbox.js";
 import type { ListboxOption } from "../listbox-option/listbox-option.js";
-import { StartEnd } from "../patterns/start-end.js";
+import { DelegatesARIAListbox } from "../listbox/listbox.js";
 import type { StartEndOptions } from "../patterns/start-end.js";
+import { StartEnd } from "../patterns/start-end.js";
 import { SelectPosition } from "../select/select.options.js";
 import { applyMixins } from "../utilities/apply-mixins.js";
 import { FormAssociatedCombobox } from "./combobox.form-associated.js";
@@ -217,9 +217,12 @@ export class Combobox extends FormAssociatedCombobox {
      * @public
      */
     @observable
-    public position: SelectPosition = SelectPosition.below;
-    protected positionChanged() {
-        this.positionAttribute = this.position;
+    public position?: SelectPosition;
+    protected positionChanged(
+        prev: SelectPosition | undefined,
+        next: SelectPosition
+    ): void {
+        this.positionAttribute = next;
         this.setPositioning();
     }
 

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -209,7 +209,7 @@ export class Combobox extends FormAssociatedCombobox {
      * @public
      */
     @attr({ attribute: "position" })
-    public positionAttribute: SelectPosition;
+    public positionAttribute?: SelectPosition;
 
     /**
      * The current state of the calculated position of the listbox.
@@ -220,7 +220,7 @@ export class Combobox extends FormAssociatedCombobox {
     public position?: SelectPosition;
     protected positionChanged(
         prev: SelectPosition | undefined,
-        next: SelectPosition
+        next: SelectPosition | undefined
     ): void {
         this.positionAttribute = next;
         this.setPositioning();

--- a/packages/web-components/fast-foundation/src/select/README.md
+++ b/packages/web-components/fast-foundation/src/select/README.md
@@ -108,7 +108,7 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | ------------------- | --------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | -------------------- |
 | `open`              | public    | `boolean`                             | `false` | The open attribute.                                                                                                                                                                 |                      |
 | `value`             | public    |                                       |         | The value property.                                                                                                                                                                 |                      |
-| `positionAttribute` | public    | `SelectPosition`                      |         | Reflects the placement for the listbox when the select is open.                                                                                                                     |                      |
+| `positionAttribute` | public    | `SelectPosition or undefined`         |         | Reflects the placement for the listbox when the select is open.                                                                                                                     |                      |
 | `position`          | public    | `SelectPosition or undefined`         |         | Holds the current state for the calculated position of the listbox.                                                                                                                 |                      |
 | `displayValue`      | public    | `string`                              |         | The value displayed on the button.                                                                                                                                                  |                      |
 | `proxy`             |           |                                       |         |                                                                                                                                                                                     | FormAssociatedSelect |
@@ -126,15 +126,15 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 #### Methods
 
-| Name                 | Privacy   | Description                                                                | Parameters                                                | Return | Inherited From    |
-| -------------------- | --------- | -------------------------------------------------------------------------- | --------------------------------------------------------- | ------ | ----------------- |
-| `positionChanged`    | protected |                                                                            | `prev: SelectPosition or undefined, next: SelectPosition` | `void` |                   |
-| `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. |                                                           | `void` |                   |
-| `multipleChanged`    | public    | Sets the multiple property on the proxy element.                           | `prev: boolean or undefined, next: boolean`               |        |                   |
-| `setSelectedOptions` | public    | Sets an option as selected and gives it focus.                             |                                                           |        | Listbox           |
-| `selectFirstOption`  | public    | Moves focus to the first selectable option.                                |                                                           | `void` | Listbox           |
-| `templateChanged`    | protected |                                                                            |                                                           | `void` | FoundationElement |
-| `stylesChanged`      | protected |                                                                            |                                                           | `void` | FoundationElement |
+| Name                 | Privacy   | Description                                                                | Parameters                                                             | Return | Inherited From    |
+| -------------------- | --------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------ | ----------------- |
+| `positionChanged`    | protected |                                                                            | `prev: SelectPosition or undefined, next: SelectPosition or undefined` | `void` |                   |
+| `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. |                                                                        | `void` |                   |
+| `multipleChanged`    | public    | Sets the multiple property on the proxy element.                           | `prev: boolean or undefined, next: boolean`                            |        |                   |
+| `setSelectedOptions` | public    | Sets an option as selected and gives it focus.                             |                                                                        |        | Listbox           |
+| `selectFirstOption`  | public    | Moves focus to the first selectable option.                                |                                                                        | `void` | Listbox           |
+| `templateChanged`    | protected |                                                                            |                                                                        | `void` | FoundationElement |
+| `stylesChanged`      | protected |                                                                            |                                                                        | `void` | FoundationElement |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/select/README.md
+++ b/packages/web-components/fast-foundation/src/select/README.md
@@ -109,7 +109,7 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | `open`              | public    | `boolean`                             | `false` | The open attribute.                                                                                                                                                                 |                      |
 | `value`             | public    |                                       |         | The value property.                                                                                                                                                                 |                      |
 | `positionAttribute` | public    | `SelectPosition`                      |         | Reflects the placement for the listbox when the select is open.                                                                                                                     |                      |
-| `position`          | public    | `SelectPosition`                      |         | Holds the current state for the calculated position of the listbox.                                                                                                                 |                      |
+| `position`          | public    | `SelectPosition or undefined`         |         | Holds the current state for the calculated position of the listbox.                                                                                                                 |                      |
 | `displayValue`      | public    | `string`                              |         | The value displayed on the button.                                                                                                                                                  |                      |
 | `proxy`             |           |                                       |         |                                                                                                                                                                                     | FormAssociatedSelect |
 | `multiple`          | public    | `boolean`                             |         | Indicates if the listbox is in multi-selection mode.                                                                                                                                | ListboxElement       |
@@ -126,15 +126,15 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 #### Methods
 
-| Name                 | Privacy   | Description                                                                | Parameters                                  | Return | Inherited From    |
-| -------------------- | --------- | -------------------------------------------------------------------------- | ------------------------------------------- | ------ | ----------------- |
-| `positionChanged`    | protected |                                                                            |                                             |        |                   |
-| `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. |                                             | `void` |                   |
-| `multipleChanged`    | public    | Sets the multiple property on the proxy element.                           | `prev: boolean or undefined, next: boolean` |        |                   |
-| `setSelectedOptions` | public    | Sets an option as selected and gives it focus.                             |                                             |        | Listbox           |
-| `selectFirstOption`  | public    | Moves focus to the first selectable option.                                |                                             | `void` | Listbox           |
-| `templateChanged`    | protected |                                                                            |                                             | `void` | FoundationElement |
-| `stylesChanged`      | protected |                                                                            |                                             | `void` | FoundationElement |
+| Name                 | Privacy   | Description                                                                | Parameters                                                | Return | Inherited From    |
+| -------------------- | --------- | -------------------------------------------------------------------------- | --------------------------------------------------------- | ------ | ----------------- |
+| `positionChanged`    | protected |                                                                            | `prev: SelectPosition or undefined, next: SelectPosition` | `void` |                   |
+| `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. |                                                           | `void` |                   |
+| `multipleChanged`    | public    | Sets the multiple property on the proxy element.                           | `prev: boolean or undefined, next: boolean`               |        |                   |
+| `setSelectedOptions` | public    | Sets an option as selected and gives it focus.                             |                                                           |        | Listbox           |
+| `selectFirstOption`  | public    | Moves focus to the first selectable option.                                |                                                           | `void` | Listbox           |
+| `templateChanged`    | protected |                                                                            |                                                           | `void` | FoundationElement |
+| `stylesChanged`      | protected |                                                                            |                                                           | `void` | FoundationElement |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -195,7 +195,7 @@ export class Select extends FormAssociatedSelect {
      * @public
      */
     @attr({ attribute: "position" })
-    public positionAttribute: SelectPosition;
+    public positionAttribute?: SelectPosition;
 
     /**
      * Indicates the initial state of the position attribute.
@@ -213,7 +213,7 @@ export class Select extends FormAssociatedSelect {
     public position?: SelectPosition;
     protected positionChanged(
         prev: SelectPosition | undefined,
-        next: SelectPosition
+        next: SelectPosition | undefined
     ): void {
         this.positionAttribute = next;
         this.setPositioning();

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -210,9 +210,12 @@ export class Select extends FormAssociatedSelect {
      * @public
      */
     @observable
-    public position: SelectPosition = SelectPosition.below;
-    protected positionChanged() {
-        this.positionAttribute = this.position;
+    public position?: SelectPosition;
+    protected positionChanged(
+        prev: SelectPosition | undefined,
+        next: SelectPosition
+    ): void {
+        this.positionAttribute = next;
         this.setPositioning();
     }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

This PR fixes the issue that select always operated in "forcedPosition" mode and due to this the direction where the dropdown is opening was never recalculated.

A more detailed description of the issue can be found in the linked issue

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

Fixes #5810 

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

All the current tests are passing without modification. I don't know if this can be tested programmatically, if so I'm happy to write those tests.

I've manually tested the changes with the `fast-components` storybook and the component seemed to work as it is expected.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes. (Not sure if applicable, see above at the Test Plan section)
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes. (Don't think any docs changes are necessary)
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [x] I have modified an existing component