### PR TITLE
feat: new CSSDirective design

### DIFF
--- a/change/@microsoft-fast-components-0f5602ef-a1c2-4f35-83a0-3e883906645e.json
+++ b/change/@microsoft-fast-components-0f5602ef-a1c2-4f35-83a0-3e883906645e.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "fix: update components to new CSSDirective API",
+  "packageName": "@microsoft/fast-components",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-e7b9adf7-1b40-4e7e-896f-c29600f26654.json
+++ b/change/@microsoft-fast-element-e7b9adf7-1b40-4e7e-896f-c29600f26654.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "feat: new CSSDirective design",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-b8a22db2-e6e3-4ba0-a9e1-725a4ef68eda.json
+++ b/change/@microsoft-fast-foundation-b8a22db2-e6e3-4ba0-a9e1-725a4ef68eda.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "fix: update foundation to new CSSDirective API",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/styles/size.ts
+++ b/packages/web-components/fast-components/src/styles/size.ts
@@ -1,4 +1,4 @@
-import { cssPartial } from "@microsoft/fast-element";
+import { css } from "@microsoft/fast-element";
 import { baseHeightMultiplier, density, designUnit } from "../design-tokens.js";
 
 /**
@@ -6,4 +6,4 @@ import { baseHeightMultiplier, density, designUnit } from "../design-tokens.js";
  * Use this as the value of any CSS property that
  * accepts a pixel size.
  */
-export const heightNumber = cssPartial`(${baseHeightMultiplier} + ${density}) * ${designUnit}`;
+export const heightNumber = css.partial`(${baseHeightMultiplier} + ${density}) * ${designUnit}`;

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -1,4 +1,4 @@
-import { css, cssPartial, ElementStyles } from "@microsoft/fast-element";
+import { css, ElementStyles } from "@microsoft/fast-element";
 import {
     DesignToken,
     disabledCursor,
@@ -68,7 +68,7 @@ const rtl = css`
  * Tree item expand collapse button size CSS Partial
  * @public
  */
-export const expandCollapseButtonSize = cssPartial`((${baseHeightMultiplier} / 2) * ${designUnit}) + ((${designUnit} * ${density}) / 2)`;
+export const expandCollapseButtonSize = css.partial`((${baseHeightMultiplier} / 2) * ${designUnit}) + ((${designUnit} * ${density}) / 2)`;
 
 const expandCollapseHoverBehavior = DesignToken.create<Swatch>(
     "tree-item-expand-collapse-hover"

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -12,6 +12,9 @@ export interface Accessor {
 }
 
 // @public
+export type AddBehavior = (behavior: Behavior<HTMLElement>) => void;
+
+// @public
 export type AddViewBehaviorFactory = (factory: ViewBehaviorFactory) => string;
 
 // Warning: (ae-internal-missing-underscore) The name "AdoptedStyleSheetsStrategy" should be prefixed with an underscore because the declaration is marked as @internal
@@ -230,9 +233,23 @@ export function createTypeRegistry<TDefinition extends TypeDefinition>(): TypeRe
 export function css(strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]): ElementStyles;
 
 // @public
-export class CSSDirective {
-    createBehavior(): Behavior<HTMLElement> | undefined;
-    createCSS(): ComposableStyles;
+export interface CSSDirective {
+    createCSS(add: AddBehavior): ComposableStyles;
+}
+
+// @public
+export const CSSDirective: Readonly<{
+    getForInstance: (object: any) => CSSDirectiveDefinition<Constructable<CSSDirective>> | undefined;
+    getByType: (key: Function) => CSSDirectiveDefinition<Constructable<CSSDirective>> | undefined;
+    define<TType extends Constructable<CSSDirective>>(type: any): TType;
+}>;
+
+// @public
+export function cssDirective(): (type: Constructable<CSSDirective>) => void;
+
+// @public
+export interface CSSDirectiveDefinition<TType extends Constructable<CSSDirective> = Constructable<CSSDirective>> {
+    readonly type: TType;
 }
 
 // @public

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -230,7 +230,7 @@ export class Controller<TElement extends HTMLElement = HTMLElement> extends Prop
 export function createTypeRegistry<TDefinition extends TypeDefinition>(): TypeRegistry<TDefinition>;
 
 // @public
-export function css(strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]): ElementStyles;
+export const css: CSSTemplateTag;
 
 // @public
 export interface CSSDirective {
@@ -252,8 +252,10 @@ export interface CSSDirectiveDefinition<TType extends Constructable<CSSDirective
     readonly type: TType;
 }
 
-// @public
-export function cssPartial(strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]): CSSDirective;
+// @public (undocumented)
+export type CSSTemplateTag = ((strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]) => ElementStyles) & {
+    partial(strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]): CSSDirective;
+};
 
 // @public
 export function customElement(nameOrDef: string | PartialFASTElementDefinition): (type: Constructable<HTMLElement>) => void;

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -252,7 +252,7 @@ export interface CSSDirectiveDefinition<TType extends Constructable<CSSDirective
     readonly type: TType;
 }
 
-// @public (undocumented)
+// @public
 export type CSSTemplateTag = ((strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]) => ElementStyles) & {
     partial(strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]): CSSDirective;
 };

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -252,6 +252,9 @@ export interface CSSDirectiveDefinition<TType extends Constructable<CSSDirective
     readonly type: TType;
 }
 
+// @public @deprecated (undocumented)
+export const cssPartial: (strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]) => CSSDirective;
+
 // @public
 export type CSSTemplateTag = ((strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]) => ElementStyles) & {
     partial(strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]): CSSDirective;

--- a/packages/web-components/fast-element/src/styles/css-directive.ts
+++ b/packages/web-components/fast-element/src/styles/css-directive.ts
@@ -1,25 +1,63 @@
+import type { Constructable } from "../interfaces.js";
 import type { Behavior } from "../observation/behavior.js";
+import { createTypeRegistry } from "../platform.js";
 import type { ComposableStyles } from "./element-styles.js";
+
+/**
+ * Used to add behaviors when constructing styles.
+ * @public
+ */
+export type AddBehavior = (behavior: Behavior<HTMLElement>) => void;
 
 /**
  * Directive for use in {@link css}.
  *
  * @public
  */
-export class CSSDirective {
+export interface CSSDirective {
     /**
      * Creates a CSS fragment to interpolate into the CSS document.
      * @returns - the string to interpolate into CSS
      */
-    public createCSS(): ComposableStyles {
-        return "";
-    }
+    createCSS(add: AddBehavior): ComposableStyles;
+}
 
+/**
+ * Defines metadata for a CSSDirective.
+ * @public
+ */
+export interface CSSDirectiveDefinition<
+    TType extends Constructable<CSSDirective> = Constructable<CSSDirective>
+> {
     /**
-     * Creates a behavior to bind to the host element.
-     * @returns - the behavior to bind to the host element, or undefined.
+     * The type that the definition provides metadata for.
      */
-    public createBehavior(): Behavior<HTMLElement> | undefined {
-        return undefined;
-    }
+    readonly type: TType;
+}
+
+const registry = createTypeRegistry<CSSDirectiveDefinition>();
+
+/**
+ * Instructs the css engine to provide dynamic styles or
+ * associate behaviors with styles.
+ * @public
+ */
+export const CSSDirective = Object.freeze({
+    getForInstance: registry.getForInstance,
+    getByType: registry.getByType,
+    define<TType extends Constructable<CSSDirective>>(type): TType {
+        registry.register({ type });
+        return type;
+    },
+});
+
+/**
+ * Decorator: Defines a CSSDirective.
+ * @public
+ */
+export function cssDirective() {
+    /* eslint-disable-next-line @typescript-eslint/explicit-function-return-type */
+    return function (type: Constructable<CSSDirective>) {
+        CSSDirective.define(type);
+    };
 }

--- a/packages/web-components/fast-element/src/styles/css.ts
+++ b/packages/web-components/fast-element/src/styles/css.ts
@@ -146,3 +146,9 @@ css.partial = (
     const { styles, behaviors } = collectStyles(strings, values);
     return new CSSPartial(styles, behaviors);
 };
+
+/**
+ * @deprecated Use css.partial instead.
+ * @public
+ */
+export const cssPartial = css.partial;

--- a/packages/web-components/fast-element/src/styles/css.ts
+++ b/packages/web-components/fast-element/src/styles/css.ts
@@ -47,6 +47,22 @@ function collectStyles(
     };
 }
 
+export type CSSTemplateTag = ((
+    strings: TemplateStringsArray,
+    ...values: (ComposableStyles | CSSDirective)[]
+) => ElementStyles) & {
+    /**
+     * Transforms a template literal string into partial CSS.
+     * @param strings - The string fragments that are interpolated with the values.
+     * @param values - The values that are interpolated with the string fragments.
+     * @public
+     */
+    partial(
+        strings: TemplateStringsArray,
+        ...values: (ComposableStyles | CSSDirective)[]
+    ): CSSDirective;
+};
+
 /**
  * Transforms a template literal string into styles.
  * @param strings - The string fragments that are interpolated with the values.
@@ -55,14 +71,14 @@ function collectStyles(
  * The css helper supports interpolation of strings and ElementStyle instances.
  * @public
  */
-export function css(
+export const css: CSSTemplateTag = ((
     strings: TemplateStringsArray,
     ...values: (ComposableStyles | CSSDirective)[]
-): ElementStyles {
+): ElementStyles => {
     const { styles, behaviors } = collectStyles(strings, values);
     const elementStyles = new ElementStyles(styles);
     return behaviors.length ? elementStyles.withBehaviors(...behaviors) : elementStyles;
-}
+}) as any;
 
 class CSSPartial implements CSSDirective, Behavior<HTMLElement> {
     private css: string = "";
@@ -114,16 +130,10 @@ class CSSPartial implements CSSDirective, Behavior<HTMLElement> {
 
 CSSDirective.define(CSSPartial);
 
-/**
- * Transforms a template literal string into partial CSS.
- * @param strings - The string fragments that are interpolated with the values.
- * @param values - The values that are interpolated with the string fragments.
- * @public
- */
-export function cssPartial(
+css.partial = (
     strings: TemplateStringsArray,
     ...values: (ComposableStyles | CSSDirective)[]
-): CSSDirective {
+): CSSDirective => {
     const { styles, behaviors } = collectStyles(strings, values);
     return new CSSPartial(styles, behaviors);
-}
+};

--- a/packages/web-components/fast-element/src/styles/css.ts
+++ b/packages/web-components/fast-element/src/styles/css.ts
@@ -47,6 +47,15 @@ function collectStyles(
     };
 }
 
+/**
+ * Transforms a template literal string into styles.
+ * @param strings - The string fragments that are interpolated with the values.
+ * @param values - The values that are interpolated with the string fragments.
+ * @remarks
+ * The css helper supports interpolation of strings and ElementStyle instances.
+ * Use the .partial method to create partial CSS fragments.
+ * @public
+ */
 export type CSSTemplateTag = ((
     strings: TemplateStringsArray,
     ...values: (ComposableStyles | CSSDirective)[]

--- a/packages/web-components/fast-element/src/styles/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles/styles.spec.ts
@@ -6,7 +6,7 @@ import {
 } from "./element-styles";
 import { DOM } from "../dom";
 import { AddBehavior, cssDirective, CSSDirective } from "./css-directive";
-import { css, cssPartial } from "./css";
+import { css } from "./css";
 import type { Behavior } from "../observation/behavior";
 import { StyleElementStrategy } from "../polyfills";
 import type { StyleTarget } from "../interfaces";
@@ -315,7 +315,7 @@ describe("cssPartial", () => {
             createCSS() { return "red" };
         }
 
-        const partial = cssPartial`color: ${new myDirective}`;
+        const partial = css.partial`color: ${new myDirective}`;
         expect (partial.createCSS(add)).to.equal("color: red");
     });
 
@@ -343,7 +343,7 @@ describe("cssPartial", () => {
             };
         }
 
-        const partial = cssPartial`${new directive}${new directive2}`;
+        const partial = css.partial`${new directive}${new directive2}`;
         const behaviors: Behavior<HTMLElement>[] = [];
         const add = (x: Behavior) => behaviors.push(x);
 
@@ -355,7 +355,7 @@ describe("cssPartial", () => {
 
     it("should add any ElementStyles interpolated into the template function when bound to an element", () => {
         const styles = css`:host {color: blue; }`;
-        const partial = cssPartial`${styles}`;
+        const partial = css.partial`${styles}`;
         let called = false;
         const el = {
             $fastController: {

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -4,7 +4,6 @@ import { DesignSystem } from "../design-system";
 import { uniqueElementName } from "../test-utilities/fixture";
 import { FoundationElement } from "../foundation-element";
 import { CSSDesignToken, DesignToken, DesignTokenChangeRecord, DesignTokenSubscriber } from "./design-token";
-import { defaultElement } from "./custom-property-manager";
 import spies from "chai-spies";
 
 chia.use(spies);
@@ -54,7 +53,8 @@ describe("A DesignToken", () => {
 
     describe("that is a CSSDesignToken", () => {
         it("should have a createCSS() method that returns a string with the name property formatted as a CSS variable", () => {
-            expect(DesignToken.create<number>("implicit").createCSS()).to.equal("var(--implicit)");
+            const add = () => void 0;
+            expect(DesignToken.create<number>("implicit").createCSS(add)).to.equal("var(--implicit)");
         });
         it("should have a readonly cssCustomProperty property that is the name formatted as a CSS custom property", () => {
             expect(DesignToken.create<number>("implicit").cssCustomProperty).to.equal("--implicit");

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -128,8 +128,8 @@ export interface DesignTokenSubscriber<T extends DesignToken<any>> {
 /**
  * Implementation of {@link (DesignToken:interface)}
  */
-class DesignTokenImpl<T extends { createCSS?(): string }> extends CSSDirective
-    implements DesignToken<T> {
+class DesignTokenImpl<T extends { createCSS?(): string }>
+    implements CSSDirective, DesignToken<T> {
     public readonly name: string;
     public readonly cssCustomProperty: string | undefined;
     public readonly id: string;
@@ -201,8 +201,6 @@ class DesignTokenImpl<T extends { createCSS?(): string }> extends CSSDirective
     }
 
     constructor(configuration: Required<DesignTokenConfiguration>) {
-        super();
-
         this.name = configuration.name;
 
         if (configuration.cssCustomPropertyName !== null) {
@@ -255,7 +253,6 @@ class DesignTokenImpl<T extends { createCSS?(): string }> extends CSSDirective
 
     public withDefault(value: DesignTokenValue<T> | DesignToken<T>) {
         this.setValueFor(defaultElement, value);
-
         return this;
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR implements a new design for `CSSDirective` that matches the new `HTMLDirective` API. The changes are as follows:

* Decouples directives and behaviors.
* Directives can now add 0-N behaviors when they generate CSS.
* createCSS() now receives a method for adding behaviors.
* Base classes removed for directive. Everything is based on interfaces and registration now.
* Directives are now registered with `CSSDirective.define` API
* You can also decorate a class to register it as a directive with `@cssDirective`
* `cssPartial` is now optimized so that it doesn't need to add itself as a behavior unless it is composing `ElementStyles`. This means that partials that compose design tokens should perform better.
* `cssPartial` is changed to `css.partial` to reduce import count

### Examples

Here's an example of the most basic `CSSDirective`:

```ts
@cssDirective()
class HelloWorldDirective implements CSSDirective {
  createCSS() {
    return "color: red";
  }
}

// alternative to the decorator
// CSSDirective.define(HelloWorldDirective); 
```

Here's an example that adds behaviors:

```ts
@cssDirective()
class HelloWorldDirective implements CSSDirective {
  createCSS(add: AddBehavior) {
    add(someBehaviorInstance);
    return "color: red";
  }
}
```

### 🎫 Issues

This is the second half of and completes #5799 

## 👩‍💻 Reviewer Notes

This one is much less destructive than the `HTMLDirective` change. Only a few places are affected by the work. One additional change I made was to change `cssPartial` to css.partial` to reduce the number of imports when working with CSS. Not sure what folks think about this. I like it but I can revert this change if other folks don't.

## 📑 Test Plan

Existing tests updated and passing against the new APIs.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

I think this completes the work on directive APIs.