### PR TITLE
fix tree view item visual bug on expansion

### DIFF
--- a/change/@microsoft-fast-components-531327b4-265f-452f-b41b-3b0f7feaebbd.json
+++ b/change/@microsoft-fast-components-531327b4-265f-452f-b41b-3b0f7feaebbd.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fixes a rendering glitch which flasehes when intially expanding a group of tree items",
+  "packageName": "@microsoft/fast-components",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -94,6 +94,11 @@ export const treeItemStyles: FoundationElementTemplate<ElementStyles, TreeItemOp
     definition
 ) =>
     css`
+    /**
+     * This animation exists because when tree item children are conditionally loaded
+     * there is a visual bug where the DOM exists but styles have not yet been applied (essentially FOUC).
+     * This subtle animation provides a ever so slight timing adjustment for loading that solves the issue.
+     */
     @keyframes treeItemLoading {
         0% {
             opacity: 0;

--- a/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
+++ b/packages/web-components/fast-components/src/tree-item/tree-item.styles.ts
@@ -94,6 +94,15 @@ export const treeItemStyles: FoundationElementTemplate<ElementStyles, TreeItemOp
     definition
 ) =>
     css`
+    @keyframes treeItemLoading {
+        0% {
+            opacity: 0;
+        }
+        100% {
+            opacity: 1;
+         }
+    }
+
     ${display("block")} :host {
         contain: content;
         position: relative;
@@ -156,7 +165,6 @@ export const treeItemStyles: FoundationElementTemplate<ElementStyles, TreeItemOp
     }
 
     .items {
-        display: none;
         /* TODO: adaptive typography https://github.com/microsoft/fast/issues/2432 */
         font-size: calc(1em + (${designUnit} + 16) * 1px);
     }
@@ -210,7 +218,9 @@ export const treeItemStyles: FoundationElementTemplate<ElementStyles, TreeItemOp
     }
 
     :host([expanded]) > .items {
-        display: block;
+        animation: treeItemLoading ease-in 10ms;
+        animation-iteration-count: 1;
+        animation-fill-mode: forwards;
     }
 
     :host([disabled]) .content-region {


### PR DESCRIPTION
# Pull Request

## 📖 Description
When expanding groups of tree items, there is a very slight issue where the DOM is conditionally loaded but styles are not fully set. This PR adds a very, very quick animation of opacity to manage the initial load of both DOM and styles which appears to solve the issue.

### 🎫 Issues
closes #5166

## 👩‍💻 Reviewer Notes
If reviewing and curious about the ever so slight, likely imperceptible value being used for the transition - please validate using the screen capture in the issue and validate against the fix.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->