### PR TITLE
rename title attribute on disclosure to summary

### DIFF
--- a/change/@microsoft-fast-foundation-f39a8fc1-be44-49f9-bc63-8259f3d18932.json
+++ b/change/@microsoft-fast-foundation-f39a8fc1-be44-49f9-bc63-8259f3d18932.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "rename title attribute on disclosure to summary",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1024,7 +1024,7 @@ export class Disclosure extends FoundationElement {
     protected onToggle(): void;
     protected setup(): void;
     show(): void;
-    title: string;
+    summary: string;
     toggle(): void;
 }
 

--- a/packages/web-components/fast-foundation/src/disclosure/README.md
+++ b/packages/web-components/fast-foundation/src/disclosure/README.md
@@ -66,8 +66,8 @@ export const myDisclosure = Disclosure.compose({
 
 | Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
 | --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `expanded`      | public  | `boolean`                             |         | Determines if the element should show the extra content or not.                                                                                                                     |                   |
-| `title`         | public  | `string`                              |         | Invoker title                                                                                                                                                                       |                   |
+| `expanded`      | public  | `boolean`                             | `false` | Determines if the element should show the extra content or not.                                                                                                                     |                   |
+| `summary`       | public  | `string`                              |         | Invoker title                                                                                                                                                                       |                   |
 | `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
 | `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
 | `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
@@ -86,10 +86,10 @@ export const myDisclosure = Disclosure.compose({
 
 #### Attributes
 
-| Name    | Field    | Inherited From |
-| ------- | -------- | -------------- |
-|         | expanded |                |
-| `title` | title    |                |
+| Name      | Field    | Inherited From |
+| --------- | -------- | -------------- |
+|           | expanded |                |
+| `summary` | summary  |                |
 
 <hr/>
 

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.spec.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.spec.ts
@@ -1,6 +1,6 @@
+import { DOM } from "@microsoft/fast-element";
 import { expect } from "chai";
 import { fixture } from "../test-utilities/fixture";
-import { DOM } from "@microsoft/fast-element";
 import { Disclosure, disclosureTemplate as template } from "./index";
 
 const FastDisclosure = Disclosure.compose({
@@ -14,34 +14,93 @@ async function createDisclosure() {
     return { element, connect, disconnect };
 }
 
-async function macrotask() {
-    return new Promise((resolve, reject) => {
-        window.setTimeout(() => {
-            resolve(void 0);
-        })
-    })
-}
-
 describe("Disclosure", () => {
+    it("should set the expanded attribute to false when no value is provided", async () => {
+        const { element, connect, disconnect } = await createDisclosure();
+        await connect();
+
+        await DOM.nextUpdate();
+
+        expect(element.expanded).to.equal(false);
+
+        await disconnect();
+    });
+
+    it("should set the expanded attribute to true when set to true", async () => {
+        const { element, connect, disconnect } = await createDisclosure();
+
+        await connect();
+
+        element.expanded = true;
+
+        await DOM.nextUpdate();
+
+        expect(element.expanded).to.equal(true);
+
+        await disconnect();
+    });
+
+    it("should set the expanded attribute to false when set to false", async () => {
+        const { element, connect, disconnect } = await createDisclosure();
+
+        await connect();
+
+        element.expanded = false;
+
+        await DOM.nextUpdate();
+
+        expect(element.expanded).to.equal(false);
+
+        await disconnect();
+    });
+
+    it("should set summary slot content to the value of the summary attribute", async () => {
+        const { element, connect, disconnect } = await createDisclosure();
+
+        const summary: string = "Should set the summary slot content to the value of the summary attribute";
+
+        await connect();
+
+        element.summary = summary;
+
+        await DOM.nextUpdate();
+
+        expect(element.shadowRoot?.querySelector("slot[name='summary']")?.innerHTML).to.equal(summary);
+
+        await disconnect();
+    });
     describe("User interaction", () => {
         it("should toggle the content using `toggle()`", async () => {
             const { element, connect, disconnect } = await createDisclosure();
+
             await connect();
+
             element.toggle();
-            await macrotask();
+
+            await DOM.nextUpdate();
+
             expect(element.expanded).to.equal(true);
+
             await disconnect();
         });
 
         it("should expand and collapse the content using `show()` and `hide()`", async () => {
             const { element, connect, disconnect } = await createDisclosure();
+
             await connect();
+
             element.show();
-            await macrotask();
+
+            await DOM.nextUpdate();
+
             expect(element.expanded).to.equal(true);
+
             element.hide();
-            await macrotask();
+
+            await DOM.nextUpdate();
+
             expect(element.expanded).to.equal(false);
+
             await disconnect();
         });
     });

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.template.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.template.ts
@@ -19,7 +19,7 @@ export const disclosureTemplate: FoundationElementTemplate<ViewTemplate<Disclosu
             aria-expanded="${x => x.expanded}"
         >
             <slot name="start"></slot>
-            <slot name="title">${x => x.title}</slot>
+            <slot name="summary">${x => x.summary}</slot>
             <slot name="end"></slot>
         </summary>
         <div id="disclosure-content"><slot></slot></div>

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.ts
@@ -13,7 +13,7 @@ export class Disclosure extends FoundationElement {
      * @public
      */
     @attr({ mode: "boolean" })
-    public expanded: boolean;
+    public expanded: boolean = false;
 
     /**
      * Invoker title
@@ -21,7 +21,7 @@ export class Disclosure extends FoundationElement {
      * @public
      */
     @attr
-    public title: string;
+    public summary: string;
 
     /**
      * @internal


### PR DESCRIPTION
# Pull Request

## 📖 Description
The disclosure component hijacked the host element's title attribute. To resolve this, updating the attribute name to `summary`, which is more semantic as well for this scenario.

Part of the Foundation vNext breaking changes we're doing in coordination with FE2.

### 🎫 Issues
closes #5568

## 👩‍💻 Reviewer Notes


## 📑 Test Plan
Added tests to ensure attributes are accurate, which were previously missing.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://www.fast.design/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/Microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->