### PR TITLE
update to trigger build on color explorer only on path change

### DIFF
--- a/.github/workflows/cd-deploy-color-staging.yml
+++ b/.github/workflows/cd-deploy-color-staging.yml
@@ -13,11 +13,13 @@ on:
     branches:
       - master
     paths:
-      - ${{ env.AZURE_WEBAPP_DIST_PATH }}/**
+      - ${{ env.AZURE_WEBAPP_BUILD_PATH }}/**
   pull_request:
     types: [opened, synchronize, reopened, closed]
     branches:
       - master
+    paths:
+      - ${{ env.AZURE_WEBAPP_BUILD_PATH }}/**
 
 jobs:
   build:

--- a/.github/workflows/cd-deploy-color-staging.yml
+++ b/.github/workflows/cd-deploy-color-staging.yml
@@ -1,14 +1,5 @@
 name: Deploy Color Explorer
 
-on:
-  push:
-    branches:
-    - master
-  pull_request:
-    types: [opened, synchronize, reopened, closed]
-    branches:
-      - master
-
 env:
   AZURE_WEBAPP_ACTIVE_STAGE_NAME: color-west-app
   AZURE_WEBAPP_PASSIVE_STAGE_NAME: color-east-app
@@ -16,6 +7,17 @@ env:
   AZURE_WEBAPP_DIST_PATH: sites/fast-color-explorer/www
   AZURE_WEBAPP_SLOT_NAME: stage
   ARTIFACT_NAME: color-explorer-site
+
+on:
+  push:
+    branches:
+      - master
+    paths:
+      - ${{ env.AZURE_WEBAPP_DIST_PATH }}/**
+  pull_request:
+    types: [opened, synchronize, reopened, closed]
+    branches:
+      - master
 
 jobs:
   build:

--- a/sites/fast-color-explorer/README.md
+++ b/sites/fast-color-explorer/README.md
@@ -1,5 +1,5 @@
 # Introduction 
-Application for testing UI color system.
+FAST Color Explorer is an application used for testing UI color system.
 
 ## Getting Started
 Follow setup instructions in (https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md)(https://github.com/Microsoft/fast/blob/master/CONTRIBUTING.md)


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
Color Explorer has stopped pushing builds to Static Web Apps due to the limitation of 10 builds per Static Web App.  To work around this limitation, this change will only build the website when `sites/fast-color-explorer` source code has changed. 

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
* Static Web Apps in PRs used to conveniently and quickly test websites has stopped working.
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
Two tests are required to be done during this PR.
1. Test pushing a change outside this package
2. Test pushing a change inside this package

* I may be required to manually delete deployments on Azure to get under the 10 limit in order to test.
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps
Upon completion this same pattern will be implemented across websites deployed from FAST.
<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->