### PR TITLE
feat: trim unnecessary nodes from start end

### DIFF
--- a/change/@microsoft-fast-foundation-3296c3df-4043-46e8-a1f0-9a7f4e33e1c3.json
+++ b/change/@microsoft-fast-foundation-3296c3df-4043-46e8-a1f0-9a7f4e33e1c3.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "remove unnecessary DOM nodes from start/end slot templates",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1090,9 +1090,6 @@ export type EndOptions = {
 // @public
 export const endSlotTemplate: (context: ElementDefinitionContext, definition: EndOptions) => ViewTemplate<StartEnd>;
 
-// @public @deprecated
-export const endTemplate: ViewTemplate<StartEnd>;
-
 // @public
 export interface Factory<T extends Constructable = any> {
     construct(container: Container, dynamicDependencies?: Key[]): Resolved<T>;
@@ -2349,15 +2346,7 @@ export class StartEnd {
     // (undocumented)
     end: HTMLSlotElement;
     // (undocumented)
-    endContainer: HTMLSpanElement;
-    // (undocumented)
-    handleEndContentChange(): void;
-    // (undocumented)
-    handleStartContentChange(): void;
-    // (undocumented)
     start: HTMLSlotElement;
-    // (undocumented)
-    startContainer: HTMLSpanElement;
 }
 
 // @public
@@ -2370,9 +2359,6 @@ export type StartOptions = {
 
 // @public
 export const startSlotTemplate: (context: ElementDefinitionContext, definition: StartOptions) => ViewTemplate<StartEnd>;
-
-// @public @deprecated
-export const startTemplate: ViewTemplate<StartEnd>;
 
 // @public
 export type StaticDesignTokenValue<T> = T extends Function ? never : T;

--- a/packages/web-components/fast-foundation/src/calendar/calendar.template.ts
+++ b/packages/web-components/fast-foundation/src/calendar/calendar.template.ts
@@ -8,7 +8,7 @@ import {
     when,
 } from "@microsoft/fast-element";
 import type { ViewTemplate } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "../patterns/start-end.js";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/start-end.js";
 import { DataGrid, DataGridCell, DataGridRow } from "../data-grid/index.js";
 import type { FoundationElementTemplate } from "../foundation-element/foundation-element.js";
 import type { ElementDefinitionContext } from "../design-system/registration-context.js";
@@ -252,7 +252,7 @@ export const calendarTemplate: FoundationElementTemplate<
     }-${today.getDate()}-${today.getFullYear()}`;
     return html<Calendar>`
         <template>
-            ${startTemplate}
+            ${startSlotTemplate(context, definition)}
             ${definition.title instanceof Function
                 ? definition.title(context, definition)
                 : definition.title ?? ""}
@@ -262,7 +262,7 @@ export const calendarTemplate: FoundationElementTemplate<
                 interactiveCalendarGridTemplate(context, todayString)
             )}
             ${when(x => x.readonly === true, noninteractiveCalendarTemplate(todayString))}
-            ${endTemplate}
+            ${endSlotTemplate(context, definition)}
         </template>
     `;
 };

--- a/packages/web-components/fast-foundation/src/patterns/start-end.ts
+++ b/packages/web-components/fast-foundation/src/patterns/start-end.ts
@@ -25,29 +25,18 @@ export type EndOptions = {
 export type StartEndOptions = StartOptions & EndOptions;
 
 /**
- * A mixin class implementing start and end elements.
+ * A mixin class implementing start and end slots.
  * These are generally used to decorate text elements with icons or other visual indicators.
  * @public
  */
 export class StartEnd {
     public start: HTMLSlotElement;
-    public startContainer: HTMLSpanElement;
-    public handleStartContentChange(): void {
-        this.startContainer.classList.toggle(
-            "start",
-            this.start.assignedNodes().length > 0
-        );
-    }
 
     public end: HTMLSlotElement;
-    public endContainer: HTMLSpanElement;
-    public handleEndContentChange(): void {
-        this.endContainer.classList.toggle("end", this.end.assignedNodes().length > 0);
-    }
 }
 
 /**
- * The template for the end element.
+ * The template for the end slot.
  * For use with {@link StartEnd}
  *
  * @public
@@ -59,19 +48,11 @@ export const endSlotTemplate: (
     context: ElementDefinitionContext,
     definition: EndOptions
 ) => html`
-    <span
-        part="end"
-        ${ref("endContainer")}
-        class=${x => (definition.end ? "end" : void 0)}
-    >
-        <slot name="end" ${ref("end")} @slotchange="${x => x.handleEndContentChange()}">
-            ${definition.end || ""}
-        </slot>
-    </span>
+    <slot name="end" ${ref("end")}>${definition.end || ""}</slot>
 `;
 
 /**
- * The template for the start element.
+ * The template for the start slots.
  * For use with {@link StartEnd}
  *
  * @public
@@ -82,52 +63,7 @@ export const startSlotTemplate: (
 ) => ViewTemplate<StartEnd> = (
     context: ElementDefinitionContext,
     definition: StartOptions
-) => html`
-    <span
-        part="start"
-        ${ref("startContainer")}
-        class="${x => (definition.start ? "start" : void 0)}"
-    >
-        <slot
-            name="start"
-            ${ref("start")}
-            @slotchange="${x => x.handleStartContentChange()}"
-        >
-            ${definition.start || ""}
-        </slot>
-    </span>
-`;
-
-/**
- * The template for the end element.
- * For use with {@link StartEnd}
- *
- * @public
- * @deprecated - use endSlotTemplate
- */
-export const endTemplate: ViewTemplate<StartEnd> = html`
-    <span part="end" ${ref("endContainer")}>
-        <slot
-            name="end"
-            ${ref("end")}
-            @slotchange="${x => x.handleEndContentChange()}"
-        ></slot>
-    </span>
-`;
-
-/**
- * The template for the start element.
- * For use with {@link StartEnd}
- *
- * @public
- * @deprecated - use startSlotTemplate
- */
-export const startTemplate: ViewTemplate<StartEnd> = html`
-    <span part="start" ${ref("startContainer")}>
-        <slot
-            name="start"
-            ${ref("start")}
-            @slotchange="${x => x.handleStartContentChange()}"
-        ></slot>
-    </span>
-`;
+) =>
+    html`
+        <slot name="start" ${ref("start")}>${definition.start || ""}</slot>
+    `;

--- a/sites/fast-website/src/app/components/navigation/navigation.template.ts
+++ b/sites/fast-website/src/app/components/navigation/navigation.template.ts
@@ -1,5 +1,5 @@
 import { html, when, elements, slotted } from "@microsoft/fast-element";
-import { endTemplate, startTemplate } from "@microsoft/fast-foundation";
+import { endSlotTemplate, startSlotTemplate } from "@microsoft/fast-foundation";
 import CloseIcon from "svg/icon-close.svg";
 import MenuIcon from "svg/icon-menu.svg";
 import { Navigation } from "./navigation";
@@ -10,7 +10,7 @@ export const NavigationTemplate = html<Navigation>`
         ${x => (x.debounce ? "debounce" : "")}"
         @focusout=${(x, c) => x.handleFocusOut(c.event as FocusEvent)}
     >
-        ${startTemplate}
+        ${startSlotTemplate}
         <fast-button
             class="nav-button"
             part="nav-button"
@@ -36,7 +36,7 @@ export const NavigationTemplate = html<Navigation>`
                     ${slotted({ property: "slottedNavigationItems", filter: elements() })}
                 ></slot>
             </ul>
-            ${endTemplate}
+            ${endSlotTemplate}
         </nav>
     </template>
 `;


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR removes the wrapping DOM nodes from the start and end slots. This PR keeps the refs on the slots as those are required by certain classes (such as toolbar). Once we have the next version of Foundation template support in, we can look to customize that as-needed if we like, but for now, I think keeping references to those slots without needing to take any action is a solid baseline of support for extensibility.

### 🎫 Issues
Part of #5806 

## 👩‍💻 Reviewer Notes
N/A

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->