### PR TITLE
fix: fast-disclosure break

### DIFF
--- a/change/@microsoft-fast-components-2fd58c1a-a158-410b-8690-fe64e28f8440.json
+++ b/change/@microsoft-fast-components-2fd58c1a-a158-410b-8690-fe64e28f8440.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix broken disclosure",
+  "comment": "fix disclosure connected callback not invoked",
   "packageName": "@microsoft/fast-components",
   "email": "scomea@microsoft.com",
   "dependentChangeType": "patch"

--- a/change/@microsoft-fast-components-2fd58c1a-a158-410b-8690-fe64e28f8440.json
+++ b/change/@microsoft-fast-components-2fd58c1a-a158-410b-8690-fe64e28f8440.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix broken disclosure",
+  "packageName": "@microsoft/fast-components",
+  "email": "scomea@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-components/src/disclosure/index.ts
+++ b/packages/web-components/fast-components/src/disclosure/index.ts
@@ -24,6 +24,7 @@ export class Disclosure extends FoundationDisclosure {
     private totalHeight: number = 0;
 
     public connectedCallback(): void {
+        super.connectedCallback();
         if (!this.appearance) {
             this.appearance = "accent";
         }


### PR DESCRIPTION
## 📖 Description
fast-disclosure was not initializing properly because the base class connected callback was not being invoked.

### 🎫 Issues
ad hoc

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
