### PR TITLE
fix document element bindings in SSR template rendering

### DIFF
--- a/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
@@ -4,6 +4,7 @@ import { expect, test } from '@playwright/test';
 import { FASTElementRenderer } from "./element-renderer.js";
 import fastSSR from "../exports.js";
 import { consolidate } from "../test-utils.js";
+import { timeStamp } from "console";
 
 
 @customElement({
@@ -11,7 +12,15 @@ import { consolidate } from "../test-utils.js";
     styles: css`:host { display: block; }${css`:host { color: red; }`}
     `
 })
-class StyledElement extends FASTElement {}
+export class StyledElement extends FASTElement {}
+
+@customElement({
+    name: "host-binding-element",
+    template: html`
+        <template attr="attr" ?bool-attr="${() => true}"></template>
+    `
+})
+export class HostBindingElement extends FASTElement {}
 test.describe("FASTElementRenderer", () => {
     test.describe("should have a 'matchesClass' method", () => {
         test("that returns true when invoked with a class that extends FASTElement ",  () => {
@@ -36,4 +45,14 @@ test.describe("FASTElementRenderer", () => {
             expect(result).toBe(`<styled-element><template shadowroot=\"open\"><fast-style style-id="fast-style-0" css=":host { display: block; }\"></fast-style><fast-style style-id=\"fast-style-1\" css=\":host { color: red; }"></fast-style></template></styled-element>`);
         });
     });
+
+    test("should render attributes on the root of a template element to the host element", () => {
+        const { templateRenderer, defaultRenderInfo} = fastSSR();
+        const result = consolidate(templateRenderer.render(html`
+            <host-binding-element></host-binding-element>
+        `, defaultRenderInfo));
+        expect(result).toBe(`
+            <host-binding-element attr="attr" bool-attr><template shadowroot=\"open\"></template></host-binding-element>
+        `);
+    })
 });

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
@@ -179,6 +179,26 @@ test.describe("TemplateRenderer", () => {
         expect(result).toBe(`<input type="checkbox"  />`);
     });
 
+    test("should evaluate bindings for html element", () => {
+        const { templateRenderer, defaultRenderInfo} = fastSSR();
+        const result = consolidate(templateRenderer.render(html`<html attr=${x => "value"}></html>`, defaultRenderInfo));
+
+        expect(result).toBe(`<html attr="value"></html>`);
+    });
+    test("should evaluate bindings for head element", () => {
+        const { templateRenderer, defaultRenderInfo} = fastSSR();
+        const result = consolidate(templateRenderer.render(html`<head attr=${x => "value"}></head>`, defaultRenderInfo));
+
+        expect(result).toBe(`<head attr="value"></head>`);
+    });
+
+    test("should evaluate bindings for body element", () => {
+        const { templateRenderer, defaultRenderInfo} = fastSSR();
+        const result = consolidate(templateRenderer.render(html`<body attr=${x => "value"}></body>`, defaultRenderInfo));
+
+        expect(result).toBe(`<body attr="value"></body>`);
+    });
+
     test("should emit embedded templates", () =>{
         const { templateRenderer, defaultRenderInfo} = fastSSR();
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR adjusts the way templates are parsed to allow correctly parsing full document templates. `parseFragment()` was parsing templates as document fragments, which don't contain document elements like `html`, `head`, and `body` causing bindings on those elements to not be evaluated. By using full document parsing (`parse()`, we can ensure bindings on those elements get evaluated.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
fixes https://github.com/microsoft/fast/issues/5897
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->