### PR TITLE
trim extra spaces from text in listbox-option

### DIFF
--- a/change/@microsoft-fast-foundation-d054ea11-441a-4531-8134-f43dc6d07b8b.json
+++ b/change/@microsoft-fast-foundation-d054ea11-441a-4531-8134-f43dc6d07b8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "trim extra spaces from the text property for listbox-option",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "john.kreitlow@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.spec.ts
@@ -1,8 +1,8 @@
 import { DOM } from "@microsoft/fast-element";
 import { expect } from "chai";
-import { listboxOptionTemplate } from "../listbox-option/listbox-option.template";
-import { fixture } from "../test-utilities/fixture";
-import { ListboxOption } from "./listbox-option";
+import { listboxOptionTemplate } from "../listbox-option/listbox-option.template.js";
+import { fixture } from "../test-utilities/fixture.js";
+import { ListboxOption } from "./listbox-option.js";
 
 describe("ListboxOption", () => {
     const FASTOption = ListboxOption.compose({
@@ -115,6 +115,21 @@ describe("ListboxOption", () => {
         expect(element.text).to.equal("hello");
 
         expect(element.value).to.equal("hello");
+
+        await disconnect();
+    });
+
+    it("should return the trimmed text content with the `text` property", async () => {
+        const { connect, element, disconnect } = await setup();
+
+        await connect();
+
+        element.textContent = `
+            hello
+            world
+        `;
+
+        expect(element.text).to.equal("hello world");
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.ts
@@ -1,10 +1,10 @@
 import { attr, observable, Observable } from "@microsoft/fast-element";
 import { isHTMLElement } from "@microsoft/fast-web-utilities";
-import { FoundationElement } from "../foundation-element/foundation-element.js";
 import type { FoundationElementDefinition } from "../foundation-element/foundation-element.js";
+import { FoundationElement } from "../foundation-element/foundation-element.js";
 import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global.js";
-import { StartEnd } from "../patterns/start-end.js";
 import type { StartEndOptions } from "../patterns/start-end.js";
+import { StartEnd } from "../patterns/start-end.js";
 import { applyMixins } from "../utilities/apply-mixins.js";
 
 /**
@@ -192,11 +192,11 @@ export class ListboxOption extends FoundationElement {
     }
 
     public get label() {
-        return this.value ?? this.textContent ?? "";
+        return this.value ?? this.text;
     }
 
     public get text(): string {
-        return this.textContent as string;
+        return this.textContent?.replace(/\s+/g, " ").trim() ?? "";
     }
 
     public set value(next: string) {
@@ -213,7 +213,7 @@ export class ListboxOption extends FoundationElement {
 
     public get value(): string {
         Observable.track(this, "value");
-        return this._value ?? this.textContent ?? "";
+        return this._value ?? this.text;
     }
 
     public get form(): HTMLFormElement | null {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Modifies the listbox-option `text` property to trim out excess spaces.

### 🎫 Issues

Fixes #4664.

## 📑 Test Plan

All tests should pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
