### PR TITLE
fix incorrect and non-semantic slot names for search

### DIFF
--- a/change/@microsoft-fast-foundation-119dceba-853f-4809-8a2b-169352ebe125.json
+++ b/change/@microsoft-fast-foundation-119dceba-853f-4809-8a2b-169352ebe125.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "fix incorrect and unsemantic slot names for search",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/search/README.md
+++ b/packages/web-components/fast-foundation/src/search/README.md
@@ -132,8 +132,8 @@ This component is built with the expectation that focus is delegated to the inpu
 | `start`        | Content which can be provided before the search input       |
 | `end`          | Content which can be provided after the search clear button |
 |                | The default slot for the label                              |
-| `close-button` | The clear button                                            |
-| `close-glyph`  | The clear glyph                                             |
+| `clear-button` | The clear button                                            |
+| `clear-glyph`  | The clear glyph                                             |
 
 <hr/>
 

--- a/packages/web-components/fast-foundation/src/search/search.template.ts
+++ b/packages/web-components/fast-foundation/src/search/search.template.ts
@@ -73,7 +73,7 @@ export const searchTemplate: FoundationElementTemplate<
                     aria-roledescription="${x => x.ariaRoledescription}"
                     ${ref("control")}
                 />
-                <slot name="close-button">
+                <slot name="clear-button">
                     <button
                         class="clear-button ${x =>
                             x.value ? "" : "clear-button__hidden"}"
@@ -81,7 +81,7 @@ export const searchTemplate: FoundationElementTemplate<
                         tabindex="-1"
                         @click=${x => x.handleClearInput()}
                     >
-                        <slot name="close-glyph">
+                        <slot name="clear-glyph">
                             <svg
                                 width="9"
                                 height="9"

--- a/packages/web-components/fast-foundation/src/search/search.ts
+++ b/packages/web-components/fast-foundation/src/search/search.ts
@@ -25,8 +25,8 @@ export type SearchOptions = FoundationElementDefinition & StartEndOptions;
  * @slot start - Content which can be provided before the search input
  * @slot end - Content which can be provided after the search clear button
  * @slot - The default slot for the label
- * @slot close-button - The clear button
- * @slot close-glyph - The clear glyph
+ * @slot clear-button - The clear button
+ * @slot clear-glyph - The clear glyph
  * @csspart label - The label
  * @csspart root - The element wrapping the control, including start and end slots
  * @csspart control - The element representing the input


### PR DESCRIPTION
# Pull Request

## 📖 Description
While adding tsdoc comments for slots I found an issue with the slot names for the clear button. This PR fixes the slot names to be `clear-button` instead of `close-button`.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->