### PR TITLE
remove deprecated item slot on accordion

### DIFF
--- a/change/@microsoft-fast-foundation-d461d7cb-5136-4816-94e9-04b46fa8a11e.json
+++ b/change/@microsoft-fast-foundation-d461d7cb-5136-4816-94e9-04b46fa8a11e.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "remove deprecated item slot name on accordion as it is the default slot",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
@@ -10,9 +10,9 @@ import type { Accordion } from "./accordion.js";
 export const accordionTemplate: FoundationElementTemplate<ViewTemplate<Accordion>> = (
     context,
     definition
-) => /* TODO: deprecate slot name `item` to only support default slot https://github.com/microsoft/fast/issues/5515 */ html`
+) => html`
     <template>
         <slot ${slotted({ property: "accordionItems", filter: elements() })}></slot>
-        <slot name="item" part="item" ${slotted("accordionItems")}></slot>
+        <slot ${slotted("accordionItems")}></slot>
     </template>
 `;

--- a/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
@@ -13,6 +13,5 @@ export const accordionTemplate: FoundationElementTemplate<ViewTemplate<Accordion
 ) => html`
     <template>
         <slot ${slotted({ property: "accordionItems", filter: elements() })}></slot>
-        <slot ${slotted("accordionItems")}></slot>
     </template>
 `;


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR removes the deprecated slot name of item for accordion default items.

### 🎫 Issues
closes #5515 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->