### PR TITLE
fix: enable safer type inference on the repeat helper

### DIFF
--- a/change/@microsoft-fast-element-230be6d2-2fd7-4d50-938b-fd03e18f362f.json
+++ b/change/@microsoft-fast-element-230be6d2-2fd7-4d50-938b-fd03e18f362f.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: enable safer type inference on the repeat helper",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -571,10 +571,8 @@ export class RefDirective extends StatelessAttachedAttributeDirective<string> {
     unbind(): void;
 }
 
-// Warning: (ae-forgotten-export) The symbol "ArrayItem" needs to be exported by the entry point index.d.ts
-//
 // @public
-export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>, templateOrTemplateBinding: SyntheticViewTemplate<ArrayItem<TArray>, TSource, RootContext> | Binding<TSource, SyntheticViewTemplate<ArrayItem<TArray>, TSource, RootContext>>, options?: {
+export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>, templateOrTemplateBinding: ViewTemplate | Binding<TSource, ViewTemplate, RootContext>, options?: {
     positioning: false;
 } | {
     recycle: true;
@@ -587,7 +585,7 @@ export function repeat<TSource = any, TArray extends ReadonlyArray<any> = Readon
 }): CaptureType<TSource>;
 
 // @public
-export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>, templateOrTemplateBinding: ChildViewTemplate<ArrayItem<TArray>, TSource> | Binding<TSource, ChildViewTemplate<ArrayItem<TArray>, TSource>>, options?: {
+export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>, templateOrTemplateBinding: ChildViewTemplate | Binding<TSource, ChildViewTemplate, ChildContext>, options?: {
     positioning: false;
 } | {
     recycle: true;
@@ -600,7 +598,7 @@ export function repeat<TSource = any, TArray extends ReadonlyArray<any> = Readon
 }): CaptureType<TSource>;
 
 // @public
-export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>, templateOrTemplateBinding: ItemViewTemplate<ArrayItem<TArray>, TSource> | Binding<TSource, ItemViewTemplate<ArrayItem<TArray>, TSource>>, options: {
+export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>, templateOrTemplateBinding: ItemViewTemplate | Binding<TSource, ItemViewTemplate, ItemContext>, options: {
     positioning: true;
 } | {
     positioning: true;

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -22,16 +22,6 @@ export type Mutable<T> = {
 };
 
 /**
- * Extracts the item type from an array.
- * @public
- */
-export type ArrayItem<T> = T extends ReadonlyArray<infer TItem>
-    ? TItem
-    : T extends Array<infer TItem>
-    ? TItem
-    : any;
-
-/**
  * A policy for use with the standard trustedTypes platform API.
  * @public
  */

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -1,4 +1,4 @@
-import { ArrayItem, isFunction } from "../interfaces.js";
+import { isFunction } from "../interfaces.js";
 import type { Splice } from "../observation/array-change-records.js";
 import { enableArrayObservation } from "../observation/array-observer.js";
 import type { Behavior } from "../observation/behavior.js";
@@ -25,6 +25,7 @@ import type {
     ChildViewTemplate,
     ItemViewTemplate,
     SyntheticViewTemplate,
+    ViewTemplate,
 } from "./template.js";
 import { HTMLView, SyntheticView } from "./view.js";
 
@@ -369,12 +370,7 @@ export function repeat<
     TArray extends ReadonlyArray<any> = ReadonlyArray<any>
 >(
     itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>,
-    templateOrTemplateBinding:
-        | SyntheticViewTemplate<ArrayItem<TArray>, TSource, RootContext>
-        | Binding<
-              TSource,
-              SyntheticViewTemplate<ArrayItem<TArray>, TSource, RootContext>
-          >,
+    templateOrTemplateBinding: ViewTemplate | Binding<TSource, ViewTemplate, RootContext>,
     options?:
         | { positioning: false }
         | { recycle: true }
@@ -395,8 +391,8 @@ export function repeat<
 >(
     itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>,
     templateOrTemplateBinding:
-        | ChildViewTemplate<ArrayItem<TArray>, TSource>
-        | Binding<TSource, ChildViewTemplate<ArrayItem<TArray>, TSource>>,
+        | ChildViewTemplate
+        | Binding<TSource, ChildViewTemplate, ChildContext>,
     options?:
         | { positioning: false }
         | { recycle: true }
@@ -417,8 +413,8 @@ export function repeat<
 >(
     itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>,
     templateOrTemplateBinding:
-        | ItemViewTemplate<ArrayItem<TArray>, TSource>
-        | Binding<TSource, ItemViewTemplate<ArrayItem<TArray>, TSource>>,
+        | ItemViewTemplate
+        | Binding<TSource, ItemViewTemplate, ItemContext>,
     options:
         | { positioning: true }
         | { positioning: true; recycle: true }

--- a/packages/web-components/fast-element/src/templating/template.ts
+++ b/packages/web-components/fast-element/src/templating/template.ts
@@ -122,7 +122,7 @@ export class ViewTemplate<
 
     /**
      * Used for TypeScript purposes only.
-     * Do not sure.
+     * Do not use.
      */
     type: any;
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adjusts the types of the `repeat` helper function so that type inference isn't lost on the parent type in certain situations, and so that the `html` helper can still be used with the `repeat` when no child-context-specific functionality is needed.

### 🎫 Issues

* Fixes #5974 

## 👩‍💻 Reviewer Notes

A basic PR that just removes some of the generics. Turns out that TS isn't powerful enough to infer some things, given the extra type info. It actually breaks things. Removing it enables it to function better.

## 📑 Test Plan

All tests continue to pass. Some manual testing of type inference was done as well.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Some more polish PRs coming after this one but this should settle the template and repeat types.