### PR TITLE
feat: enable array length observation

### DIFF
--- a/change/@microsoft-fast-element-b447782c-22f3-4f6a-96f5-b7afc160af0b.json
+++ b/change/@microsoft-fast-element-b447782c-22f3-4f6a-96f5-b7afc160af0b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: enable array length observation",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -117,7 +117,7 @@ export type BindingMode = Record<number, BindingType>;
 // @public
 export interface BindingObserver<TSource = any, TReturn = any, TParent = any> extends Notifier {
     disconnect(): void;
-    observe(source: TSource, context: ExecutionContext<TParent>): TReturn;
+    observe(source: TSource, context?: ExecutionContext<TParent>): TReturn;
     records(): IterableIterator<ObservationRecord>;
 }
 
@@ -460,6 +460,10 @@ export interface ItemViewTemplate<TSource = any, TParent = any> {
 }
 
 // @public
+function length_2<T>(array: readonly T[]): number;
+export { length_2 as length }
+
+// @public
 export const Markup: Readonly<{
     interpolation: (id: string) => string;
     attribute: (id: string) => string;
@@ -506,7 +510,7 @@ export const nullableNumberConverter: ValueConverter;
 // @public
 export const Observable: Readonly<{
     setArrayObserverFactory(factory: (collection: any[]) => Notifier): void;
-    getNotifier: (source: any) => Notifier;
+    getNotifier: <T extends Notifier = Notifier>(source: any) => T;
     track(source: unknown, propertyName: string): void;
     trackVolatile(): void;
     notify(source: unknown, args: any): void;

--- a/packages/web-components/fast-element/src/observation/array-observer.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.ts
@@ -1,6 +1,6 @@
 import { DOM } from "../dom.js";
 import { Splice } from "./array-change-records.js";
-import { SubscriberSet } from "./notifier.js";
+import { Subscriber, SubscriberSet } from "./notifier.js";
 import type { Notifier } from "./notifier.js";
 import { Observable } from "./observable.js";
 
@@ -11,10 +11,18 @@ function setNonEnumerable(target: any, property: string, value: any): void {
     });
 }
 
+interface LengthSubscriber extends Subscriber {
+    length: number;
+}
+
 class ArrayObserver extends SubscriberSet {
     private oldCollection: any[] | undefined = void 0;
     private splices: Splice[] | undefined = void 0;
     private needsQueue: boolean = true;
+
+    /** @internal */
+    public lengthSubscriber: LengthSubscriber | undefined = void 0;
+
     call: () => void = this.flush;
 
     constructor(subject: any[]) {
@@ -222,4 +230,40 @@ export function enableArrayObservation(): void {
             },
         });
     }
+}
+
+/**
+ * Enables observing the length of an array.
+ * @param array - The array to observe the length of.
+ * @returns The length of the array.
+ * @public
+ */
+export function length<T>(array: readonly T[]): number {
+    if (!array) {
+        return 0;
+    }
+
+    let arrayObserver = (array as any).$fastController as ArrayObserver;
+    if (arrayObserver === void 0) {
+        enableArrayObservation();
+        arrayObserver = Observable.getNotifier<ArrayObserver>(array);
+    }
+
+    let lengthSubscriber = arrayObserver.lengthSubscriber;
+    if (lengthSubscriber === void 0) {
+        arrayObserver.lengthSubscriber = lengthSubscriber = {
+            length: array.length,
+            handleChange() {
+                if (this.length !== array.length) {
+                    this.length = array.length;
+                    Observable.notify(lengthSubscriber, "length");
+                }
+            },
+        };
+
+        arrayObserver.subscribe(lengthSubscriber);
+    }
+
+    Observable.track(lengthSubscriber, "length");
+    return array.length;
 }

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -72,7 +72,7 @@ export interface BindingObserver<TSource = any, TReturn = any, TParent = any>
      * @param context - The execution context to execute the binding within.
      * @returns The value of the binding.
      */
-    observe(source: TSource, context: ExecutionContext<TParent>): TReturn;
+    observe(source: TSource, context?: ExecutionContext<TParent>): TReturn;
 
     /**
      * Unsubscribe from all dependent observables of the binding.
@@ -100,7 +100,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         throw FAST.error(Message.needsArrayObservation);
     };
 
-    function getNotifier(source: any): Notifier {
+    function getNotifier<T extends Notifier = Notifier>(source: any): T {
         let found = source.$fastController ?? notifierLookup.get(source);
 
         if (found === void 0) {
@@ -191,7 +191,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
             super(binding, initialSubscriber);
         }
 
-        public observe(source: TSource, context: ExecutionContext): TReturn {
+        public observe(source: TSource, context?: ExecutionContext): TReturn {
             if (this.needsRefresh && this.last !== null) {
                 this.disconnect();
             }
@@ -199,7 +199,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
             const previousWatcher = watcher;
             watcher = this.needsRefresh ? this : void 0;
             this.needsRefresh = this.isVolatileBinding;
-            const result = this.binding(source, context);
+            const result = this.binding(source, context ?? ExecutionContext.default);
             watcher = previousWatcher;
 
             return result;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds a new helper to `fast-element` that enables observing the length of an array in a binding expression.

### 🎫 Issues

* Closes #5962 

## 👩‍💻 Reviewer Notes

A new `length` function will return the length of the provided array. Before doing so, it will connect an observer to the array (if one is not present), and then subscribe to that for `length` checks (if it isn't already setup). Then, when the array changes, if the new length is different from the old length, a notification will be raised. The helper function also serves to track the access of the `length` itself.

## 📑 Test Plan

New tests were added to test the helper function in bindings.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

No further steps relates to this functionality at this time.