### PR TITLE
feat: add two-way binding

### DIFF
--- a/change/@microsoft-fast-element-812c3a96-4de5-4429-907a-86c354742b82.json
+++ b/change/@microsoft-fast-element-812c3a96-4de5-4429-907a-86c354742b82.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add two-way binding",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -148,6 +148,7 @@ export interface CaptureType<TSource> {
 export class ChangeBinding extends UpdateBinding {
     constructor(directive: HTMLBindingDirective, updateTarget: UpdateTarget);
     bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
+    protected getObserver(target: Node): BindingObserver;
     // @internal (undocumented)
     handleChange(binding: Binding, observer: BindingObserver): void;
     unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -285,6 +285,12 @@ export type DecoratorAttributeConfiguration = Omit<AttributeConfiguration, "prop
 export type DefaultBindingOptions = AddEventListenerOptions;
 
 // @public
+export type DefaultTwoWayBindingOptions = DefaultBindingOptions & {
+    changeEvent?: string;
+    fromView?: (value: any) => any;
+};
+
+// @public
 export const DOM: Readonly<{
     queueUpdate: (callable: Callable) => void;
     nextUpdate: () => Promise<void>;
@@ -812,6 +818,23 @@ export type TrustedTypes = {
 export type TrustedTypesPolicy = {
     createHTML(html: string): string;
 };
+
+// @public
+export const twoWay: BindingConfig<DefaultTwoWayBindingOptions> & BindingConfigResolver<DefaultTwoWayBindingOptions>;
+
+// @public
+export class TwoWayBinding extends ChangeBinding {
+    bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
+    static configure(settings: TwoWaySettings): void;
+    // @internal (undocumented)
+    handleEvent(event: Event): void;
+    unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
+}
+
+// @public
+export interface TwoWaySettings {
+    determineChangeEvent(directive: HTMLBindingDirective, target: HTMLElement): string;
+}
 
 // Warning: (ae-internal-missing-underscore) The name "TypeDefinition" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -540,6 +540,7 @@ export abstract class NodeObservationDirective<T extends NodeBehaviorOptions> ex
     protected computeNodes(target: any): Node[];
     protected abstract disconnect(target: any): void;
     protected abstract getNodes(target: any): Node[];
+    protected getSource(target: Node): any;
     protected abstract observe(target: any): void;
     unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
     protected updateTarget(source: any, value: ReadonlyArray<any>): void;

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -4,6 +4,7 @@ import {
     BindingObserver,
     ExecutionContext,
     Observable,
+    ObservationRecord,
 } from "../observation/observable.js";
 import { FAST } from "../platform.js";
 import { DOM } from "./dom.js";
@@ -594,6 +595,100 @@ export class EventBinding {
 }
 
 /**
+ * The settings required to enable two-way binding.
+ * @public
+ */
+export interface TwoWaySettings {
+    /**
+     * Determines which event to listen to, to detect changes in the view.
+     * @param directive - The directive to determine the change event for.
+     * @param target - The target element to determine the change event for.
+     */
+    determineChangeEvent(directive: HTMLBindingDirective, target: HTMLElement): string;
+}
+
+let twoWaySettings: TwoWaySettings = {
+    determineChangeEvent() {
+        return "change";
+    },
+};
+
+/**
+ * A binding behavior for bindings that update in two directions.
+ * @public
+ */
+export class TwoWayBinding extends ChangeBinding {
+    private changeEvent: string;
+
+    /**
+     * Bind this behavior to the source.
+     * @param source - The source to bind to.
+     * @param context - The execution context that the binding is operating within.
+     * @param targets - The targets that behaviors in a view can attach to.
+     */
+    bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
+        super.bind(source, context, targets);
+
+        const directive = this.directive;
+        const target = targets[directive.nodeId] as HTMLElement;
+
+        if (!this.changeEvent) {
+            this.changeEvent =
+                directive.options.changeEvent ??
+                twoWaySettings.determineChangeEvent(directive, target);
+        }
+
+        target.addEventListener(this.changeEvent, this);
+    }
+
+    /**
+     * Unbinds this behavior from the source.
+     * @param source - The source to unbind from.
+     * @param context - The execution context that the binding is operating within.
+     * @param targets - The targets that behaviors in a view can attach to.
+     */
+    unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
+        super.unbind(source, context, targets);
+        (targets[this.directive.nodeId] as HTMLElement).removeEventListener(
+            this.changeEvent,
+            this
+        );
+    }
+
+    /** @internal */
+    public handleEvent(event: Event): void {
+        const directive = this.directive;
+        const target = event.currentTarget as HTMLElement;
+        const observer: BindingObserver = target[directive.id];
+
+        let value;
+
+        switch (directive.aspectType) {
+            case 1:
+                value = target.getAttribute(directive.targetAspect);
+                break;
+            case 2:
+                value = target.hasAttribute(directive.targetAspect);
+                break;
+            default:
+                value = target[directive.targetAspect];
+                break;
+        }
+
+        const last = (observer as any).last as ObservationRecord; // using internal API!!!
+        last.propertySource[last.propertyName] = directive.options.fromView(value);
+    }
+
+    /**
+     * Configures two-way binding.
+     * @param settings - The settings to use for the two-way binding system.
+     */
+    public static configure(settings: TwoWaySettings) {
+        twoWaySettings = settings;
+    }
+}
+
+/**
  * The default binding options.
  * @public
  */
@@ -607,6 +702,23 @@ export const onChange = BindingConfig.define(
     BindingMode.define(ChangeBinding),
     {} as DefaultBindingOptions
 );
+
+/**
+ * The default twoWay binding options.
+ * @public
+ */
+export type DefaultTwoWayBindingOptions = DefaultBindingOptions & {
+    changeEvent?: string;
+    fromView?: (value: any) => any;
+};
+
+/**
+ * The default twoWay binding configuration.
+ * @public
+ */
+export const twoWay = BindingConfig.define(BindingMode.define(TwoWayBinding), {
+    fromView: v => v,
+} as DefaultTwoWayBindingOptions);
 
 /**
  * The default onTime binding configuration.

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -670,6 +670,9 @@ export class TwoWayBinding extends ChangeBinding {
             case 2:
                 value = target.hasAttribute(directive.targetAspect);
                 break;
+            case 4:
+                value = target.innerText;
+                break;
             default:
                 value = target[directive.targetAspect];
                 break;

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -304,7 +304,7 @@ function updateTokenListTarget(
     value: any
 ): void {
     const directive = this.directive;
-    const lookup = `${directive.id}-token-list`;
+    const lookup = `${directive.id}-t`;
     const state: TokenListState =
         target[lookup] ?? (target[lookup] = { c: 0, v: Object.create(null) });
     const versions = state.v;
@@ -374,6 +374,8 @@ const signals: Record<string, undefined | Function | Function[]> = Object.create
  * @public
  */
 export class SignalBinding extends UpdateBinding {
+    private handlerProperty = `${this.directive.id}-h`;
+
     /**
      * Bind this behavior to the source.
      * @param source - The source to bind to.
@@ -384,7 +386,7 @@ export class SignalBinding extends UpdateBinding {
         const directive = this.directive;
         const target = targets[directive.nodeId];
         const signal = this.getSignal(source, context);
-        const handler = (target[directive.id] = () => {
+        const handler = (target[this.handlerProperty] = () => {
             this.updateTarget(
                 target,
                 directive.targetAspect!,
@@ -420,7 +422,7 @@ export class SignalBinding extends UpdateBinding {
         if (found && Array.isArray(found)) {
             const directive = this.directive;
             const target = targets[directive.nodeId];
-            const handler = target[directive.id];
+            const handler = target[this.handlerProperty];
             const index = found.indexOf(handler);
             if (index !== -1) {
                 found.splice(index, 1);

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -591,6 +591,10 @@ export class EventBinding {
         if (result !== true) {
             event.preventDefault();
         }
+
+        if (this.directive.options.once) {
+            target.$fastSource = target.$fastContext = null;
+        }
     }
 }
 

--- a/packages/web-components/fast-element/src/templating/children.ts
+++ b/packages/web-components/fast-element/src/templating/children.ts
@@ -45,6 +45,8 @@ export type ChildrenDirectiveOptions<T = any> =
 export class ChildrenDirective extends NodeObservationDirective<
     ChildrenDirectiveOptions
 > {
+    private observerProperty = `${this.id}-o`;
+
     /**
      * Creates an instance of ChildrenDirective.
      * @param options - The options to use in configuring the child observation behavior.
@@ -60,8 +62,9 @@ export class ChildrenDirective extends NodeObservationDirective<
      */
     observe(target: any): void {
         const observer =
-            target[this.id] ?? (target[this.id] = new MutationObserver(this.handleEvent));
-        observer.$fastTarget = target;
+            target[this.observerProperty] ??
+            (target[this.observerProperty] = new MutationObserver(this.handleEvent));
+        observer.target = target;
         observer.observe(target, this.options);
     }
 
@@ -70,8 +73,8 @@ export class ChildrenDirective extends NodeObservationDirective<
      * @param target - The target to unobserve.
      */
     disconnect(target: any): void {
-        const observer = target[this.id];
-        observer.$fastTarget = null;
+        const observer = target[this.observerProperty];
+        observer.target = null;
         observer.disconnect();
     }
 
@@ -88,9 +91,8 @@ export class ChildrenDirective extends NodeObservationDirective<
     }
 
     private handleEvent = (mutations: MutationRecord[], observer: any): void => {
-        const target = observer.$fastTarget;
-        const source = target.$fastSource;
-        this.updateTarget(source, this.computeNodes(target));
+        const target = observer.target;
+        this.updateTarget(this.getSource(target), this.computeNodes(target));
     };
 }
 

--- a/packages/web-components/fast-element/src/templating/node-observation.ts
+++ b/packages/web-components/fast-element/src/templating/node-observation.ts
@@ -51,6 +51,8 @@ export const elements = (selector?: string): ElementsFilter =>
 export abstract class NodeObservationDirective<
     T extends NodeBehaviorOptions
 > extends StatelessAttachedAttributeDirective<T> {
+    private sourceProperty = `${this.id}-s`;
+
     /**
      * Bind this behavior to the source.
      * @param source - The source to bind to.
@@ -59,7 +61,7 @@ export abstract class NodeObservationDirective<
      */
     bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
         const target = targets[this.nodeId] as any;
-        target.$fastSource = source;
+        target[this.sourceProperty] = source;
         this.updateTarget(source, this.computeNodes(target));
         this.observe(target);
     }
@@ -74,7 +76,16 @@ export abstract class NodeObservationDirective<
         const target = targets[this.nodeId] as any;
         this.updateTarget(source, emptyArray);
         this.disconnect(target);
-        target.$fastSource = null;
+        target[this.sourceProperty] = null;
+    }
+
+    /**
+     * Gets the data source for the target.
+     * @param target - The target to get the source for.
+     * @returns The source.
+     */
+    protected getSource(target: Node) {
+        return target[this.sourceProperty];
     }
 
     /**

--- a/packages/web-components/fast-element/src/templating/slotted.ts
+++ b/packages/web-components/fast-element/src/templating/slotted.ts
@@ -45,8 +45,7 @@ export class SlottedDirective extends NodeObservationDirective<SlottedDirectiveO
     /** @internal */
     handleEvent(event: Event): void {
         const target = event.currentTarget as any;
-        const source = target.$fastSource;
-        this.updateTarget(source, this.computeNodes(target));
+        this.updateTarget(this.getSource(target), this.computeNodes(target));
     }
 }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds a new `twoWay` binding mode/config for use with `fast-element` templates. The new mode is completely tree-shakeable, just like the new `signal` mode.

Here's an example of binding the `value` of an `input` bidirectionally, such that the element's `value` updates on changes to the model's `myProperty` property and the `myProperty` value updates when the element's `change` event fires:

```ts
const template = html`
  <input type=text :value=${bind(x => x.myProperty, twoWay)} />
`;
```

If we want to update the model on `input`, we can do this:

```ts
const template = html`
  <input type=text :value=${bind(x => x.myProperty, twoWay({ changeEvent: 'input' }))} />
`;
```

If we need to convert the value provided by the element before assigning it back to our model, we can provide a custom converter function:

```ts
const fromView = viewValue => "converted output";
const template = html`
  <input type=text :value=${bind(x => x.myProperty, twoWay({ fromView }))} />
`;
```

By default, the two-way system always uses the `change` event but you can configure the system in a way that let's you automatically pick which events to use on a per-element, per-aspect basis. You just configure it up front like this:

```ts
TwoWayBinding.configure({
  determineChangeEvent(directive: HTMLBindingDirective, target: HTMLElement): string {
    // inspect the target element and use the directive settings to determine the event to use
    return "change";
  }
});
```

### 🎫 Issues

* Closes #5992 

## 👩‍💻 Reviewer Notes

Most of the code is part of the new `TwoWayBinding` class, which inherits from `ChangeBinding` and also adds its own binding mode/config for convenience. This is all built on top of the new extensible binding APIs for v2.

## 📑 Test Plan

50+ new tests were added to test the various bindings modes: `onChange`, `oneTime`, `signal`, and `twoWay`.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

I think this concludes the core work on the binding engine for v2. I may look into event delegation as well, depending on time. The next set of work is going to be revisiting the array observation code to see if we can factor out different pluggable strategies that would simplify the code for most folks and reduce the package size.