### PR TITLE
fix(fast-element): do not notify splices for changes pre-subscription

### DIFF
--- a/change/@microsoft-fast-element-4d2683a2-b3a2-4c92-b401-abede39da9b2.json
+++ b/change/@microsoft-fast-element-4d2683a2-b3a2-4c92-b401-abede39da9b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(fast-element): do not notify splices for changes pre-subscription",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/observation/array-observer.ts
+++ b/packages/web-components/fast-element/src/observation/array-observer.ts
@@ -1,7 +1,7 @@
 import { DOM } from "../dom.js";
 import { calcSplices, newSplice, projectArraySplices } from "./array-change-records.js";
 import type { Splice } from "./array-change-records.js";
-import { SubscriberSet } from "./notifier.js";
+import { Subscriber, SubscriberSet } from "./notifier.js";
 import type { Notifier } from "./notifier.js";
 import { Observable } from "./observable.js";
 
@@ -39,6 +39,11 @@ class ArrayObserver extends SubscriberSet {
             value: this,
             enumerable: false,
         });
+    }
+
+    public subscribe(subscriber: Subscriber): void {
+        this.flush();
+        super.subscribe(subscriber);
     }
 
     public addSplice(splice: Splice): void {

--- a/packages/web-components/fast-element/src/observation/notifier.spec.ts
+++ b/packages/web-components/fast-element/src/observation/notifier.spec.ts
@@ -1,5 +1,8 @@
 import { expect } from "chai";
+import { DOM } from "../dom";
+import { enableArrayObservation } from "./array-observer";
 import { PropertyChangeNotifier, Subscriber, SubscriberSet } from "./notifier";
+import { Observable } from "./observable";
 
 describe(`A SubscriberSet`, () => {
     const oneThroughTen = [1, 2, 3, 4, 5, 6, 7, 8, 9, 10];
@@ -248,4 +251,24 @@ describe(`A PropertyChangeNotifier`, () => {
             });
         });
     });
+});
+
+describe(`An array observer`, () => {
+    it("should not deliver splices for changes prior to subscription", async () => {
+        enableArrayObservation();
+        const array = [1,2,3,4,5];
+        const observer = Observable.getNotifier(array);
+        let wasCalled = false;
+
+        array.push(6);
+        observer.subscribe({
+            handleChange() {
+                wasCalled = true;
+            }
+        });
+
+        await DOM.nextUpdate();
+
+        expect(wasCalled).to.be.false;
+    })
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes a bug in array observation that happens when a subscription is added to an already observed array that has splices queued for delivery but not yet delivered. Without this fix, the new subscriber would receive change notification for changes that happened before it subscribed.

### 🎫 Issues

* Fixes #6003 for FAST Element 1.x

## 👩‍💻 Reviewer Notes

The fix involved flushing the changes prior to any subscription being added. However, to enable this, it needed to be possible to override the `subscribe` method of the base class. This was not possible due to some method swizzling in `SubscriberSet`. Therefore, the implementation of `SubscriberSet` was changed to not swizzle and enable method overriding, which is probably a cleaner approach anyway, since the previous implementation could result in surprising behavior (e.g. you override a method and then your override gets swizzled out).

## 📑 Test Plan

I have added a test for the specific bug.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

There will be a follow-up PR for FAST Element 2.0 as well.