### PR TITLE
fix(fast-element): do not notify splices for changes pre-subscription (v2)

### DIFF
--- a/change/@microsoft-fast-element-65662448-c859-4bfd-b06d-a52379348361.json
+++ b/change/@microsoft-fast-element-65662448-c859-4bfd-b06d-a52379348361.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(fast-element): do not notify splices for changes pre-subscription",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/observation/arrays.spec.ts
+++ b/packages/web-components/fast-element/src/observation/arrays.spec.ts
@@ -336,6 +336,24 @@ describe("The ArrayObserver", () => {
         expect(changeArgs![0].removed).members([]);
         expect(changeArgs![0].index).equal(0);
     });
+
+    it("should not deliver splices for changes prior to subscription", async () => {
+        ArrayObserver.enable();
+        const array = [1,2,3,4,5];
+        const observer = Observable.getNotifier(array);
+        let wasCalled = false;
+
+        array.push(6);
+        observer.subscribe({
+            handleChange() {
+                wasCalled = true;
+            }
+        });
+
+        await Updates.next();
+
+        expect(wasCalled).to.be.false;
+    })
 });
 
 describe("The array length observer", () => {

--- a/packages/web-components/fast-element/src/observation/arrays.ts
+++ b/packages/web-components/fast-element/src/observation/arrays.ts
@@ -423,6 +423,11 @@ class DefaultArrayObserver extends SubscriberSet implements ArrayObserver {
         setNonEnumerable(subject, "$fastController", this);
     }
 
+    public subscribe(subscriber: Subscriber): void {
+        this.flush();
+        super.subscribe(subscriber);
+    }
+
     public addSplice(splice: Splice) {
         if (this.splices === void 0) {
             this.splices = [splice];


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes a bug in array observation that happens when a subscription is added to an already observed array that has splices queued for delivery but not yet delivered. Without this fix, the new subscriber would receive change notification for changes that happened before it subscribed.

### 🎫 Issues

* Fixes #6003 for FAST Element 1.x

## 👩‍💻 Reviewer Notes

The fix involved flushing the changes prior to any subscription being added. However, to enable this, it needed to be possible to override the `subscribe` method of the base class. This was not possible due to some method swizzling in `SubscriberSet`. Therefore, the implementation of `SubscriberSet` was changed to not swizzle and enable method overriding, which is probably a cleaner approach anyway, since the previous implementation could result in surprising behavior (e.g. you override a method and then your override gets swizzled out).

## 📑 Test Plan

I have added a test for the specific bug.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

n/a