### PR TITLE
chore: strip internals from package d.ts files

### DIFF
--- a/change/@microsoft-fast-element-ec659aa5-28ef-47e2-99e0-cd5859520900.json
+++ b/change/@microsoft-fast-element-ec659aa5-28ef-47e2-99e0-cd5859520900.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "chore: configure fast-element for internal stripping",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-57e2a77a-2351-4de9-9f09-232296e06ccd.json
+++ b/change/@microsoft-fast-foundation-57e2a77a-2351-4de9-9f09-232296e06ccd.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "chore: configure fast-foundation for internals stripping",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-react-wrapper-814d8db1-9182-494f-a347-89ef6840cbc2.json
+++ b/change/@microsoft-fast-react-wrapper-814d8db1-9182-494f-a347-89ef6840cbc2.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "chore: update fast-react-wrapper to latest core APIs",
+  "packageName": "@microsoft/fast-react-wrapper",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-router-62ff5dee-3371-44cd-afe8-e319157c0d3e.json
+++ b/change/@microsoft-fast-router-62ff5dee-3371-44cd-afe8-e319157c0d3e.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "chore: configure fast-router for internals stripping",
+  "packageName": "@microsoft/fast-router",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-ssr-74c43e3e-f32e-4823-8e84-215a21f9f333.json
+++ b/change/@microsoft-fast-ssr-74c43e3e-f32e-4823-8e84-215a21f9f333.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "chore: configure fast-ssr for internals stripping",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/fast-react-wrapper/src/index.spec.tsx
+++ b/packages/utilities/fast-react-wrapper/src/index.spec.tsx
@@ -1,7 +1,7 @@
 import { attr, customElement, DOM, FASTElement, html, nullableNumberConverter, observable, Updates } from '@microsoft/fast-element';
 import React from "react";
 import ReactDOM from "react-dom";
-import { uniqueElementName } from '@microsoft/fast-foundation/testing';
+import { uniqueElementName } from '@microsoft/fast-foundation/testing.js';
 import { expect } from "chai";
 import { DesignSystem, FoundationElement } from "@microsoft/fast-foundation";
 import { provideReactWrapper } from './index.js';

--- a/packages/web-components/fast-element/api-extractor.json
+++ b/packages/web-components/fast-element/api-extractor.json
@@ -1,4 +1,10 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
-  "extends": "../../../api-extractor.json"
+  "extends": "../../../api-extractor.json",
+  "mainEntryPointFilePath": "./dist/dts/index.d.ts",
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "./dist/fast-element.untrimmed.d.ts",
+    "betaTrimmedFilePath": "./dist/fast-element.d.ts"
+  }
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -350,9 +350,7 @@ export interface ElementViewTemplate<TSource = any, TParent = any> {
     type: "element";
 }
 
-// Warning: (ae-internal-missing-underscore) The name "emptyArray" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
+// @public
 export const emptyArray: readonly never[];
 
 // @public

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -318,11 +318,9 @@ export type ElementsFilter = (value: Node, index: number, array: Node[]) => bool
 
 // @public
 export class ElementStyles {
-    constructor(
-    styles: ReadonlyArray<ComposableStyles>);
+    constructor(styles: ReadonlyArray<ComposableStyles>);
     // @internal (undocumented)
     addStylesTo(target: StyleTarget): void;
-    // @internal (undocumented)
     readonly behaviors: ReadonlyArray<Behavior<HTMLElement>> | null;
     // @internal (undocumented)
     isAttachedTo(target: StyleTarget): boolean;
@@ -330,7 +328,7 @@ export class ElementStyles {
     removeStylesFrom(target: StyleTarget): void;
     static setDefaultStrategy(Strategy: ConstructibleStyleStrategy): void;
     get strategy(): StyleStrategy;
-    // @internal (undocumented)
+    // (undocumented)
     readonly styles: ReadonlyArray<ComposableStyles>;
     static readonly supportsAdoptedStyleSheets: boolean;
     withBehaviors(...behaviors: Behavior<HTMLElement>[]): this;

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -183,8 +183,6 @@ export interface ChildListDirectiveOptions<T = any> extends NodeBehaviorOptions<
 // @public
 export function children<T = any>(propertyOrOptions: (keyof T & string) | ChildListDirectiveOptions<keyof T & string>): CaptureType<T>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "ChildrenDirective" is marked as @public, but its signature references "NodeObservationDirective" which is marked as @internal
-//
 // @public
 export class ChildrenDirective extends NodeObservationDirective<ChildrenDirectiveOptions> {
     constructor(options: ChildrenDirectiveOptions);
@@ -546,9 +544,7 @@ export interface NodeBehaviorOptions<T = any> {
     property: T;
 }
 
-// Warning: (ae-internal-missing-underscore) The name "NodeObservationDirective" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
+// @public
 export abstract class NodeObservationDirective<T extends NodeBehaviorOptions> extends StatelessAttachedAttributeDirective<T> {
     bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
     protected computeNodes(target: any): Node[];
@@ -683,7 +679,6 @@ export function repeat<TSource = any, TArray extends ReadonlyArray<any> = Readon
 export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
     constructor(location: Node, itemsBinding: Binding<TSource, any[]>, isItemsBindingVolatile: boolean, templateBinding: Binding<TSource, SyntheticViewTemplate>, isTemplateBindingVolatile: boolean, options: RepeatOptions);
     bind(source: TSource, context: ExecutionContext): void;
-    // @internal (undocumented)
     handleChange(source: any, args: Splice[]): void;
     unbind(): void;
 }
@@ -730,8 +725,6 @@ export class SignalBinding extends UpdateBinding {
 // @public
 export function slotted<T = any>(propertyOrOptions: (keyof T & string) | SlottedDirectiveOptions<keyof T & string>): CaptureType<T>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "SlottedDirective" is marked as @public, but its signature references "NodeObservationDirective" which is marked as @internal
-//
 // @public
 export class SlottedDirective extends NodeObservationDirective<SlottedDirectiveOptions> {
     disconnect(target: EventSource): void;

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -52,7 +52,7 @@ if (FAST.error === void 0) {
  * @remarks
  * Typically returned by APIs that return arrays when there are
  * no actual items to return.
- * @internal
+ * @public
  */
 export const emptyArray = Object.freeze([]);
 

--- a/packages/web-components/fast-element/src/styles/element-styles.ts
+++ b/packages/web-components/fast-element/src/styles/element-styles.ts
@@ -41,7 +41,9 @@ export class ElementStyles {
     private targets: WeakSet<StyleTarget> = new WeakSet();
     private _strategy: StyleStrategy | null = null;
 
-    /** @internal */
+    /**
+     * The behaviors associated with this set of styles.
+     */
     public readonly behaviors: ReadonlyArray<Behavior<HTMLElement>> | null;
 
     /**
@@ -59,10 +61,7 @@ export class ElementStyles {
      * Creates an instance of ElementStyles.
      * @param styles - The styles that will be associated with elements.
      */
-    public constructor(
-        /** @internal */
-        public readonly styles: ReadonlyArray<ComposableStyles>
-    ) {
+    public constructor(public readonly styles: ReadonlyArray<ComposableStyles>) {
         this.behaviors = styles
             .map((x: ComposableStyles) =>
                 x instanceof ElementStyles ? x.behaviors : null

--- a/packages/web-components/fast-element/src/templating/node-observation.ts
+++ b/packages/web-components/fast-element/src/templating/node-observation.ts
@@ -46,7 +46,9 @@ export const elements = (selector?: string): ElementsFilter =>
 
 /**
  * A base class for node observation.
- * @internal
+ * @public
+ * @remarks
+ * Internally used by the SlottedDirective and the ChildrenDirective.
  */
 export abstract class NodeObservationDirective<
     T extends NodeBehaviorOptions

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -149,7 +149,11 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
         this.templateBindingObserver.disconnect();
     }
 
-    /** @internal */
+    /**
+     * Handles changes in the array, its items, and the repeat template.
+     * @param source The source of the change.
+     * @param args The details about what was changed.
+     */
     public handleChange(source: any, args: Splice[]): void {
         if (source === this.itemsBinding) {
             this.items = this.itemsBindingObserver.observe(this.source!, this.context!);

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -151,8 +151,8 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
 
     /**
      * Handles changes in the array, its items, and the repeat template.
-     * @param source The source of the change.
-     * @param args The details about what was changed.
+     * @param source - The source of the change.
+     * @param args - The details about what was changed.
      */
     public handleChange(source: any, args: Splice[]): void {
         if (source === this.itemsBinding) {

--- a/packages/web-components/fast-foundation/api-extractor.json
+++ b/packages/web-components/fast-foundation/api-extractor.json
@@ -1,12 +1,18 @@
 {
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "../../../api-extractor.json",
+  "mainEntryPointFilePath": "./dist/dts/index.d.ts",
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "./dist/fast-foundation.untrimmed.d.ts",
+    "betaTrimmedFilePath": "./dist/fast-foundation.d.ts"
+  },
   "messages": {
-      "extractorMessageReporting": {
-        "ae-different-release-tags": {
-            "logLevel": "none",
-            "addToApiReportFile": true
-        }
+    "extractorMessageReporting": {
+      "ae-different-release-tags": {
+        "logLevel": "none",
+        "addToApiReportFile": true
       }
     }
+  }
 }

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2058,7 +2058,7 @@ export type ProxyElement = HTMLSelectElement | HTMLTextAreaElement | HTMLInputEl
 // @public
 export class Radio extends FormAssociatedRadio implements RadioControl {
     constructor();
-    // @internal (undocumented)
+    // @beta
     clickHandler(e: MouseEvent): boolean | void;
     // @internal (undocumented)
     connectedCallback(): void;
@@ -2068,8 +2068,8 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     defaultSlottedNodes: Node[];
     // @internal
     initialValue: string;
-    // @internal (undocumented)
-    keypressHandler: (e: KeyboardEvent) => boolean | void;
+    // @beta
+    keypressHandler(e: KeyboardEvent): boolean | void;
     name: string;
     readOnly: boolean;
     // (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -430,10 +430,10 @@ export class Card extends FoundationElement {
 // @public
 export const cardTemplate: FoundationElementTemplate<ViewTemplate<Card>>;
 
-// @alpha (undocumented)
+// @beta
 export function CheckableFormAssociated<T extends ConstructableFormAssociated>(BaseCtor: T): T;
 
-// @alpha
+// @beta
 export interface CheckableFormAssociated extends FormAssociated {
     // (undocumented)
     checked: boolean;
@@ -451,7 +451,7 @@ export interface CheckableFormAssociated extends FormAssociated {
     dirtyChecked: boolean;
 }
 
-// @alpha
+// @beta
 export type CheckableFormAssociatedElement = FormAssociatedElement & CheckableFormAssociated & {
     proxy: HTMLInputElement;
 };
@@ -600,7 +600,7 @@ export function composedContains(reference: HTMLElement, test: HTMLElement): boo
 // @public
 export function composedParent<T extends HTMLElement>(element: T): HTMLElement | null;
 
-// @alpha
+// @beta
 export type ConstructableFormAssociated = Constructable<HTMLElement & FASTElement>;
 
 // @public
@@ -1249,12 +1249,12 @@ export const focusVisible: string;
 // @public
 export const forcedColorsStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
-// @alpha
+// @beta
 export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: T): T;
 
 // Warning: (ae-forgotten-export) The symbol "ElementInternals" needs to be exported by the entry point index.d.ts
 //
-// @alpha
+// @beta
 export interface FormAssociated extends Omit<ElementInternals_2, "labels"> {
     // (undocumented)
     attachProxy(): void;
@@ -1300,10 +1300,10 @@ export interface FormAssociated extends Omit<ElementInternals_2, "labels"> {
     valueChanged(previous: string, next: string): void;
 }
 
-// @alpha
+// @beta
 export type FormAssociatedElement = FormAssociated & FASTElement & HTMLElement & FormAssociatedProxy;
 
-// @alpha
+// @beta
 export interface FormAssociatedProxy {
     // (undocumented)
     disabledChanged?(previous: boolean, next: boolean): void;
@@ -1324,7 +1324,6 @@ export interface FormAssociatedProxy {
 // @public
 export class FoundationElement extends FASTElement {
     protected get $presentation(): ComponentPresentation | null;
-    // Warning: (ae-incompatible-release-tags) The symbol "compose" is marked as @public, but its signature references "FoundationElementRegistry" which is marked as @internal
     static compose<T extends FoundationElementDefinition = FoundationElementDefinition, K extends Constructable<FoundationElement> = Constructable<FoundationElement>>(this: K, elementDefinition: T): (overrideDefinition?: OverrideFoundationElementDefinition<T>) => FoundationElementRegistry<T, K>;
     connectedCallback(): void;
     styles: ElementStyles | void | null;
@@ -1347,9 +1346,7 @@ export interface FoundationElementDefinition {
     readonly template?: EagerOrLazyFoundationOption<ElementViewTemplate, this>;
 }
 
-// Warning: (ae-internal-missing-underscore) The name "FoundationElementRegistry" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
+// @public
 export class FoundationElementRegistry<TDefinition extends FoundationElementDefinition, TType> implements Registry {
     constructor(type: Constructable<FoundationElement>, elementDefinition: TDefinition, overrideDefinition: OverrideFoundationElementDefinition<TDefinition>);
     // (undocumented)
@@ -1661,7 +1658,6 @@ export abstract class MatchMediaBehavior implements Behavior {
 // @public
 export class MatchMediaStyleSheetBehavior extends MatchMediaBehavior {
     constructor(query: MediaQueryList, styles: ElementStyles);
-    // @internal
     protected constructListener(source: typeof FASTElement): MediaQueryListListener;
     readonly query: MediaQueryList;
     readonly styles: ElementStyles;
@@ -1857,7 +1853,7 @@ export type ParentLocator = (owner: any) => Container | null;
 
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedPicker" needs to be exported by the entry point index.d.ts
 //
-// @alpha
+// @beta
 export class Picker extends FormAssociatedPicker {
     // @internal
     activeListItemTemplate?: ViewTemplate;
@@ -1950,11 +1946,11 @@ export class Picker extends FormAssociatedPicker {
     suggestionsAvailableText: string;
 }
 
-// @alpha
+// @beta
 export class PickerList extends FoundationElement {
 }
 
-// @alpha
+// @beta
 export class PickerListItem extends FoundationElement {
     // @internal (undocumented)
     connectedCallback(): void;
@@ -1970,17 +1966,17 @@ export class PickerListItem extends FoundationElement {
     value: string;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "pickerListItemTemplate" is marked as @public, but its signature references "PickerListItem" which is marked as @alpha
+// Warning: (ae-incompatible-release-tags) The symbol "pickerListItemTemplate" is marked as @public, but its signature references "PickerListItem" which is marked as @beta
 //
 // @public (undocumented)
 export const pickerListItemTemplate: FoundationElementTemplate<ViewTemplate<PickerListItem>>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "pickerListTemplate" is marked as @public, but its signature references "PickerList" which is marked as @alpha
+// Warning: (ae-incompatible-release-tags) The symbol "pickerListTemplate" is marked as @public, but its signature references "PickerList" which is marked as @beta
 //
 // @public (undocumented)
 export const pickerListTemplate: FoundationElementTemplate<ViewTemplate<PickerList>>;
 
-// @alpha
+// @beta
 export class PickerMenu extends FoundationElement {
     // @internal
     footerElements: HTMLElement[];
@@ -1999,7 +1995,7 @@ export class PickerMenu extends FoundationElement {
     suggestionsAvailableText: string;
 }
 
-// @alpha
+// @beta
 export class PickerMenuOption extends FoundationElement {
     // @internal (undocumented)
     connectedCallback(): void;
@@ -2013,17 +2009,17 @@ export class PickerMenuOption extends FoundationElement {
     value: string;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "pickerMenuOptionTemplate" is marked as @public, but its signature references "PickerMenuOption" which is marked as @alpha
+// Warning: (ae-incompatible-release-tags) The symbol "pickerMenuOptionTemplate" is marked as @public, but its signature references "PickerMenuOption" which is marked as @beta
 //
 // @public (undocumented)
 export const pickerMenuOptionTemplate: FoundationElementTemplate<ViewTemplate<PickerMenuOption>>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "pickerMenuTemplate" is marked as @public, but its signature references "PickerMenu" which is marked as @alpha
+// Warning: (ae-incompatible-release-tags) The symbol "pickerMenuTemplate" is marked as @public, but its signature references "PickerMenu" which is marked as @beta
 //
 // @public
 export const pickerMenuTemplate: FoundationElementTemplate<ViewTemplate<PickerMenu>>;
 
-// Warning: (ae-incompatible-release-tags) The symbol "pickerTemplate" is marked as @public, but its signature references "Picker" which is marked as @alpha
+// Warning: (ae-incompatible-release-tags) The symbol "pickerTemplate" is marked as @public, but its signature references "Picker" which is marked as @beta
 //
 // @public
 export const pickerTemplate: FoundationElementTemplate<ViewTemplate<Picker>>;
@@ -2051,11 +2047,10 @@ export class PropertyStyleSheetBehavior implements Behavior {
     bind(elementInstance: FASTElement): void;
     // @internal
     handleChange(source: FASTElement, key: string): void;
-    // @internal
     unbind(source: typeof FASTElement & HTMLElement): void;
 }
 
-// @alpha
+// @beta
 export type ProxyElement = HTMLSelectElement | HTMLTextAreaElement | HTMLInputElement;
 
 // Warning: (ae-forgotten-export) The symbol "FormAssociatedRadio" needs to be exported by the entry point index.d.ts

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -26,7 +26,7 @@
       "types": "./dist/fast-foundation.d.ts",
       "default": "./dist/esm/index.js"
     },
-    "./testing": {
+    "./testing.js": {
       "types": "./dist/dts/testing/exports.d.ts",
       "default": "./dist/esm/testing/exports.js"
     }

--- a/packages/web-components/fast-foundation/src/button/README.md
+++ b/packages/web-components/fast-foundation/src/button/README.md
@@ -59,6 +59,40 @@ This component is built with the expectation that focus is delegated to the butt
 
 
 
+### class: `FormAssociatedButton`
+
+#### Superclass
+
+| Name      | Module                               | Package |
+| --------- | ------------------------------------ | ------- |
+| `_Button` | src/button/button.form-associated.ts |         |
+
+#### Mixins
+
+| Name             | Module                                  | Package |
+| ---------------- | --------------------------------------- | ------- |
+| `FormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### class: `Button`
 
 #### Superclass

--- a/packages/web-components/fast-foundation/src/button/button.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/button/button.form-associated.ts
@@ -7,7 +7,7 @@ interface _Button extends FormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(Button:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedButton extends FormAssociated(_Button) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/checkbox/README.md
+++ b/packages/web-components/fast-foundation/src/checkbox/README.md
@@ -76,6 +76,40 @@ export const myCheckbox = Checkbox.compose<CheckboxOptions>({
 
 
 
+### class: `FormAssociatedCheckbox`
+
+#### Superclass
+
+| Name        | Module                                   | Package |
+| ----------- | ---------------------------------------- | ------- |
+| `_Checkbox` | src/checkbox/checkbox.form-associated.ts |         |
+
+#### Mixins
+
+| Name                      | Module                                  | Package |
+| ------------------------- | --------------------------------------- | ------- |
+| `CheckableFormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### class: `Checkbox`
 
 #### Superclass

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.form-associated.ts
@@ -7,7 +7,7 @@ interface _Checkbox extends CheckableFormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(Checkbox:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedCheckbox extends CheckableFormAssociated(_Checkbox) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/combobox/README.md
+++ b/packages/web-components/fast-foundation/src/combobox/README.md
@@ -88,6 +88,60 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 
 
+### class: `FormAssociatedCombobox`
+
+#### Superclass
+
+| Name        | Module                                   | Package |
+| ----------- | ---------------------------------------- | ------- |
+| `_Combobox` | src/combobox/combobox.form-associated.ts |         |
+
+#### Mixins
+
+| Name             | Module                                  | Package |
+| ---------------- | --------------------------------------- | ------- |
+| `FormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Static Fields
+
+| Name                  | Privacy | Type | Default | Description                                         | Inherited From |
+| --------------------- | ------- | ---- | ------- | --------------------------------------------------- | -------------- |
+| `slottedOptionFilter` | public  |      |         | A static filter to include only selectable options. | Listbox        |
+
+#### Fields
+
+| Name               | Privacy   | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| ------------------ | --------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`            |           |                                       |         |                                                                                                                                                                                     |                   |
+| `length`           | public    | `number`                              |         | The number of options.                                                                                                                                                              | Listbox           |
+| `options`          | public    | `ListboxOption[]`                     |         | The list of options.                                                                                                                                                                | Listbox           |
+| `typeAheadExpired` | protected |                                       |         |                                                                                                                                                                                     | Listbox           |
+| `disabled`         | public    | `boolean`                             |         | The disabled state of the listbox.                                                                                                                                                  | Listbox           |
+| `selectedIndex`    | public    | `number`                              | `-1`    | The index of the selected option.                                                                                                                                                   | Listbox           |
+| `selectedOptions`  | public    | `ListboxOption[]`                     | `[]`    | A collection of the selected options.                                                                                                                                               | Listbox           |
+| `$presentation`    | public    | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`         | public    | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`           | public    | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name                 | Privacy   | Description                                    | Parameters | Return | Inherited From    |
+| -------------------- | --------- | ---------------------------------------------- | ---------- | ------ | ----------------- |
+| `selectFirstOption`  | public    | Moves focus to the first selectable option.    |            | `void` | Listbox           |
+| `setSelectedOptions` | public    | Sets an option as selected and gives it focus. |            |        | Listbox           |
+| `templateChanged`    | protected |                                                |            | `void` | FoundationElement |
+| `stylesChanged`      | protected |                                                |            | `void` | FoundationElement |
+
+#### Attributes
+
+| Name | Field    | Inherited From |
+| ---- | -------- | -------------- |
+|      | disabled | Listbox        |
+
+<hr/>
+
+
+
 ### Variables
 
 | Name                   | Description                       | Type                                                              |

--- a/packages/web-components/fast-foundation/src/combobox/combobox.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.form-associated.ts
@@ -7,7 +7,7 @@ interface _Combobox extends FormAssociated {}
 /**
  * A form-associated base class for the {@link (Combobox:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedCombobox extends FormAssociated(_Combobox) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/form-associated/README.md
+++ b/packages/web-components/fast-foundation/src/form-associated/README.md
@@ -21,7 +21,7 @@ For more information view the [specification](https://github.com/microsoft/fast/
 | Name                      | Description                                                  | Parameters    | Return |
 | ------------------------- | ------------------------------------------------------------ | ------------- | ------ |
 | `FormAssociated`          | Base function for providing Custom Element Form Association. | `BaseCtor: T` | `T`    |
-| `CheckableFormAssociated` |                                                              | `BaseCtor: T` | `T`    |
+| `CheckableFormAssociated` | Creates a checkable form associated component.               | `BaseCtor: T` | `T`    |
 
 <hr/>
 

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -103,7 +103,7 @@ const InternalsMap = new WeakMap();
 /**
  * Base class for providing Custom Element Form Association.
  *
- * @alpha
+ * @beta
  */
 export interface FormAssociated extends Omit<ElementInternals, "labels"> {
     dirtyValue: boolean;
@@ -132,7 +132,7 @@ export interface FormAssociated extends Omit<ElementInternals, "labels"> {
 /**
  * Base class for providing Custom Element Form Association with checkable features.
  *
- * @alpha
+ * @beta
  */
 export interface CheckableFormAssociated extends FormAssociated {
     currentChecked: boolean;
@@ -146,7 +146,7 @@ export interface CheckableFormAssociated extends FormAssociated {
 
 /**
  * Avaiable types for the `proxy` property.
- * @alpha
+ * @beta
  */
 export type ProxyElement = HTMLSelectElement | HTMLTextAreaElement | HTMLInputElement;
 
@@ -154,7 +154,7 @@ export type ProxyElement = HTMLSelectElement | HTMLTextAreaElement | HTMLInputEl
  * Identifies a class as having a proxy element and optional submethods related
  * to the proxy element.
  *
- * @alpha
+ * @beta
  */
 export interface FormAssociatedProxy {
     proxy: ProxyElement;
@@ -169,7 +169,7 @@ export interface FormAssociatedProxy {
 /**
  * Combined type to describe a Form-associated element.
  *
- * @alpha
+ * @beta
  */
 export type FormAssociatedElement = FormAssociated &
     FASTElement &
@@ -179,7 +179,7 @@ export type FormAssociatedElement = FormAssociated &
 /**
  * Combined type to describe a checkable Form-associated element.
  *
- * @alpha
+ * @beta
  */
 export type CheckableFormAssociatedElement = FormAssociatedElement &
     CheckableFormAssociated & { proxy: HTMLInputElement };
@@ -187,14 +187,14 @@ export type CheckableFormAssociatedElement = FormAssociatedElement &
 /**
  * Combined type to describe a Constructable Form-Associated type.
  *
- * @alpha
+ * @beta
  */
 export type ConstructableFormAssociated = Constructable<HTMLElement & FASTElement>;
 
 /**
  * Base function for providing Custom Element Form Association.
  *
- * @alpha
+ * @beta
  */
 export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: T): T {
     const C = class extends BaseCtor {
@@ -202,7 +202,7 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
          * The proxy element - this element serves as the communication layer with the parent form
          * when form association is not supported by the browser.
          *
-         * @alpha
+         * @beta
          */
         public proxy: ProxyElement;
 
@@ -219,7 +219,7 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
         /**
          * Returns the validity state of the element
          *
-         * @alpha
+         * @beta
          */
         public get validity(): ValidityState {
             return this.elementInternals
@@ -231,7 +231,7 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
          * Retrieve a reference to the associated form.
          * Returns null if not associated to any form.
          *
-         * @alpha
+         * @beta
          */
         public get form(): HTMLFormElement | null {
             return this.elementInternals ? this.elementInternals.form : this.proxy.form;
@@ -241,7 +241,7 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
          * Retrieve the localized validation message,
          * or custom validation message if set.
          *
-         * @alpha
+         * @beta
          */
         public get validationMessage(): string {
             return this.elementInternals
@@ -683,7 +683,8 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
 }
 
 /**
- * @alpha
+ * Creates a checkable form associated component.
+ * @beta
  */
 export function CheckableFormAssociated<T extends ConstructableFormAssociated>(
     BaseCtor: T

--- a/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
+++ b/packages/web-components/fast-foundation/src/foundation-element/foundation-element.ts
@@ -205,8 +205,7 @@ function resolveOption<T, K extends FoundationElementDefinition>(
 
 /**
  * Registry capable of defining presentation properties for a DOM Container hierarchy.
- *
- * @internal
+ * @public
  */
 /* eslint-disable @typescript-eslint/no-unused-vars */
 export class FoundationElementRegistry<

--- a/packages/web-components/fast-foundation/src/number-field/README.md
+++ b/packages/web-components/fast-foundation/src/number-field/README.md
@@ -77,6 +77,40 @@ This component is built with the expectation that focus is delegated to the inpu
 
 
 
+### class: `FormAssociatedNumberField`
+
+#### Superclass
+
+| Name           | Module                                           | Package |
+| -------------- | ------------------------------------------------ | ------- |
+| `_NumberField` | src/number-field/number-field.form-associated.ts |         |
+
+#### Mixins
+
+| Name             | Module                                  | Package |
+| ---------------- | --------------------------------------- | ------- |
+| `FormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### class: `NumberField`
 
 #### Superclass

--- a/packages/web-components/fast-foundation/src/number-field/number-field.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.form-associated.ts
@@ -7,7 +7,7 @@ interface _NumberField extends FormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(NumberField:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedNumberField extends FormAssociated(_NumberField) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/picker/README.md
+++ b/packages/web-components/fast-foundation/src/picker/README.md
@@ -175,6 +175,40 @@ export class FASTTextField extends TextField {}
 
 
 
+### class: `FormAssociatedPicker`
+
+#### Superclass
+
+| Name      | Module                               | Package |
+| --------- | ------------------------------------ | ------- |
+| `_Picker` | src/picker/picker.form-associated.ts |         |
+
+#### Mixins
+
+| Name             | Module                                  | Package |
+| ---------------- | --------------------------------------- | ------- |
+| `FormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### class: `Picker`
 
 #### Superclass

--- a/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
@@ -11,13 +11,12 @@ const defaultContentsTemplate: ViewTemplate<PickerListItem> = html`
 /**
  * A picker list item Custom HTML Element.
  *
- * @alpha
+ * @beta
  */
 export class PickerListItem extends FoundationElement {
     /**
      * The underlying string value of the item
      *
-     * @alpha
      * @remarks
      * HTML Attribute: value
      */
@@ -27,7 +26,6 @@ export class PickerListItem extends FoundationElement {
     /**
      *  The template used to render the contents of the list item
      *
-     * @alpha
      */
     @observable
     public contentsTemplate: ViewTemplate;

--- a/packages/web-components/fast-foundation/src/picker/picker-list.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list.ts
@@ -3,6 +3,6 @@ import { FoundationElement } from "../foundation-element/foundation-element.js";
 /**
  * A List Picker Menu Custom HTML Element.
  *
- * @alpha
+ * @beta
  */
 export class PickerList extends FoundationElement {}

--- a/packages/web-components/fast-foundation/src/picker/picker-menu-option.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-menu-option.ts
@@ -10,13 +10,12 @@ const defaultContentsTemplate: ViewTemplate<PickerMenuOption> = html`
 /**
  * A picker list item Custom HTML Element.
  *
- * @alpha
+ * @beta
  */
 export class PickerMenuOption extends FoundationElement {
     /**
      * The underlying string value of the item
      *
-     * @alpha
      * @remarks
      * HTML Attribute: value
      */
@@ -25,8 +24,6 @@ export class PickerMenuOption extends FoundationElement {
 
     /**
      *  The template used to render the contents of the list item
-     *
-     * @alpha
      */
     @observable
     public contentsTemplate: ViewTemplate;

--- a/packages/web-components/fast-foundation/src/picker/picker-menu.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-menu.ts
@@ -5,7 +5,7 @@ import { FoundationElement } from "../foundation-element/foundation-element.js";
 /**
  * A List Picker Menu Custom HTML Element.
  *
- * @alpha
+ * @beta
  */
 export class PickerMenu extends FoundationElement {
     /**
@@ -47,7 +47,6 @@ export class PickerMenu extends FoundationElement {
      * Text to display to assistive technology when
      * suggestions are available
      *
-     * @alpha
      */
     @observable
     public suggestionsAvailableText: string;

--- a/packages/web-components/fast-foundation/src/picker/picker.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.form-associated.ts
@@ -7,7 +7,7 @@ interface _Picker extends FormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(Picker:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedPicker extends FormAssociated(_Picker) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -68,13 +68,12 @@ export type menuConfigs =
  * A Picker Custom HTML Element.  This is an early "alpha" version of the component.
  * Developers should expect the api to evolve, breaking changes are possible.
  *
- * @alpha
+ * @beta
  */
 export class Picker extends FormAssociatedPicker {
     /**
      * Currently selected items. Comma delineated string ie. "apples,oranges".
      *
-     * @alpha
      * @remarks
      * HTML Attribute: selection
      */
@@ -93,7 +92,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * Currently available options. Comma delineated string ie. "apples,oranges".
      *
-     * @alpha
      * @remarks
      * HTML Attribute: options
      */
@@ -109,7 +107,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * Whether the component should remove an option from the list when it is in the selection
      *
-     * @alpha
      * @remarks
      * HTML Attribute: filter-selected
      */
@@ -119,7 +116,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * Whether the component should remove options based on the current query
      *
-     * @alpha
      * @remarks
      * HTML Attribute: filter-query
      */
@@ -129,7 +125,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * The maximum number of items that can be selected.
      *
-     * @alpha
      * @remarks
      * HTML Attribute: max-selected
      */
@@ -139,7 +134,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * The text to present to assistive technolgies when no suggestions are available.
      *
-     * @alpha
      * @remarks
      * HTML Attribute: no-suggestions-text
      */
@@ -149,7 +143,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      *  The text to present to assistive technolgies when suggestions are available.
      *
-     * @alpha
      * @remarks
      * HTML Attribute: suggestions-available-text
      */
@@ -159,7 +152,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * The text to present to assistive technologies when suggestions are loading.
      *
-     * @alpha
      * @remarks
      * HTML Attribute: loading-text
      */
@@ -169,7 +161,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * Applied to the aria-label attribute of the input element
      *
-     * @alpha
      * @remarks
      * HTML Attribute: label
      */
@@ -179,7 +170,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * Applied to the aria-labelledby attribute of the input element
      *
-     * @alpha
      * @remarks
      * HTML Attribute: labelledby
      */
@@ -189,7 +179,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * Applied to the placeholder attribute of the input element
      *
-     * @alpha
      * @remarks
      * HTML Attribute: placholder
      */
@@ -199,7 +188,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * Controls menu placement
      *
-     * @alpha
      * @remarks
      * HTML Attribute: menu-placement
      */
@@ -214,7 +202,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * Whether to display a loading state if the menu is opened.
      *
-     * @alpha
      */
     @observable
     public showLoading: boolean = false;
@@ -230,7 +217,6 @@ export class Picker extends FormAssociatedPicker {
      * Template used to generate selected items.
      * This is used in a repeat directive.
      *
-     * @alpha
      */
     @observable
     public listItemTemplate: ViewTemplate;
@@ -242,7 +228,6 @@ export class Picker extends FormAssociatedPicker {
      * Default template to use for selected items (usually specified in the component template).
      * This is used in a repeat directive.
      *
-     * @alpha
      */
     @observable
     public defaultListItemTemplate?: ViewTemplate;
@@ -262,7 +247,6 @@ export class Picker extends FormAssociatedPicker {
      * Template to use for available options.
      * This is used in a repeat directive.
      *
-     * @alpha
      */
     @observable
     public menuOptionTemplate: ViewTemplate;
@@ -274,7 +258,6 @@ export class Picker extends FormAssociatedPicker {
      * Default template to use for available options (usually specified in the template).
      * This is used in a repeat directive.
      *
-     * @alpha
      */
     @observable
     public defaultMenuOptionTemplate?: ViewTemplate;
@@ -293,7 +276,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      *  Template to use for the contents of a selected list item
      *
-     * @alpha
      */
     @observable
     public listItemContentsTemplate: ViewTemplate;
@@ -301,7 +283,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      *  Template to use for the contents of menu options
      *
-     * @alpha
      */
     @observable
     public menuOptionContentsTemplate: ViewTemplate;
@@ -309,7 +290,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      *  Current list of options in array form
      *
-     * @alpha
      */
     @observable
     public optionsList: string[] = [];
@@ -320,7 +300,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      * The text value currently in the input field
      *
-     * @alpha
      */
     @observable
     public query: string;
@@ -432,7 +411,6 @@ export class Picker extends FormAssociatedPicker {
     /**
      *  Reference to the placeholder element for the repeat directive
      *
-     * @alpha
      */
     public itemsPlaceholderElement: Node;
 

--- a/packages/web-components/fast-foundation/src/radio/README.md
+++ b/packages/web-components/fast-foundation/src/radio/README.md
@@ -134,11 +134,13 @@ export const myRadio = Radio.compose<RadioOptions>({
 
 #### Methods
 
-| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
-| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
-| `readOnlyChanged` | protected |             |            | `void` |                   |
-| `templateChanged` | protected |             |            | `void` | FoundationElement |
-| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+| Name              | Privacy   | Description                       | Parameters         | Return            | Inherited From    |
+| ----------------- | --------- | --------------------------------- | ------------------ | ----------------- | ----------------- |
+| `readOnlyChanged` | protected |                                   |                    | `void`            |                   |
+| `keypressHandler` | public    | Handles key presses on the radio. | `e: KeyboardEvent` | `boolean or void` |                   |
+| `clickHandler`    | public    | Handles clicks on the radio.      | `e: MouseEvent`    | `boolean or void` |                   |
+| `templateChanged` | protected |                                   |                    | `void`            | FoundationElement |
+| `stylesChanged`   | protected |                                   |                    | `void`            | FoundationElement |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/radio/README.md
+++ b/packages/web-components/fast-foundation/src/radio/README.md
@@ -79,6 +79,40 @@ export const myRadio = Radio.compose<RadioOptions>({
 
 
 
+### class: `FormAssociatedRadio`
+
+#### Superclass
+
+| Name     | Module                             | Package |
+| -------- | ---------------------------------- | ------- |
+| `_Radio` | src/radio/radio.form-associated.ts |         |
+
+#### Mixins
+
+| Name                      | Module                                  | Package |
+| ------------------------- | --------------------------------------- | ------- |
+| `CheckableFormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### class: `Radio`
 
 #### Superclass

--- a/packages/web-components/fast-foundation/src/radio/radio.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.form-associated.ts
@@ -7,7 +7,7 @@ interface _Radio extends CheckableFormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(Radio:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedRadio extends CheckableFormAssociated(_Radio) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -124,9 +124,10 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
     }
 
     /**
-     * @internal
+     * Handles key presses on the radio.
+     * @beta
      */
-    public keypressHandler = (e: KeyboardEvent): boolean | void => {
+    public keypressHandler(e: KeyboardEvent): boolean | void {
         switch (e.key) {
             case keySpace:
                 if (!this.checked && !this.readOnly) {
@@ -136,10 +137,11 @@ export class Radio extends FormAssociatedRadio implements RadioControl {
         }
 
         return true;
-    };
+    }
 
     /**
-     * @internal
+     * Handles clicks on the radio.
+     * @beta
      */
     public clickHandler(e: MouseEvent): boolean | void {
         if (!this.disabled && !this.readOnly && !this.checked) {

--- a/packages/web-components/fast-foundation/src/search/README.md
+++ b/packages/web-components/fast-foundation/src/search/README.md
@@ -59,6 +59,40 @@ This component is built with the expectation that focus is delegated to the inpu
 
 
 
+### class: `FormAssociatedSearch`
+
+#### Superclass
+
+| Name      | Module                               | Package |
+| --------- | ------------------------------------ | ------- |
+| `_Search` | src/search/search.form-associated.ts |         |
+
+#### Mixins
+
+| Name             | Module                                  | Package |
+| ---------------- | --------------------------------------- | ------- |
+| `FormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### class: `Search`
 
 #### Superclass

--- a/packages/web-components/fast-foundation/src/search/search.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/search/search.form-associated.ts
@@ -7,7 +7,7 @@ interface _Search extends FormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(Search:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedSearch extends FormAssociated(_Search) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/select/README.md
+++ b/packages/web-components/fast-foundation/src/select/README.md
@@ -78,6 +78,62 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 
 
+### class: `FormAssociatedSelect`
+
+#### Superclass
+
+| Name      | Module                               | Package |
+| --------- | ------------------------------------ | ------- |
+| `_Select` | src/select/select.form-associated.ts |         |
+
+#### Mixins
+
+| Name             | Module                                  | Package |
+| ---------------- | --------------------------------------- | ------- |
+| `FormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Static Fields
+
+| Name                  | Privacy | Type | Default | Description                                         | Inherited From |
+| --------------------- | ------- | ---- | ------- | --------------------------------------------------- | -------------- |
+| `slottedOptionFilter` | public  |      |         | A static filter to include only selectable options. | Listbox        |
+
+#### Fields
+
+| Name               | Privacy   | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| ------------------ | --------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`            |           |                                       |         |                                                                                                                                                                                     |                   |
+| `multiple`         | public    | `boolean`                             |         | Indicates if the listbox is in multi-selection mode.                                                                                                                                | ListboxElement    |
+| `size`             | public    | `number`                              |         | The maximum number of options to display.                                                                                                                                           | ListboxElement    |
+| `length`           | public    | `number`                              |         | The number of options.                                                                                                                                                              | Listbox           |
+| `options`          | public    | `ListboxOption[]`                     |         | The list of options.                                                                                                                                                                | Listbox           |
+| `typeAheadExpired` | protected |                                       |         |                                                                                                                                                                                     | Listbox           |
+| `disabled`         | public    | `boolean`                             |         | The disabled state of the listbox.                                                                                                                                                  | Listbox           |
+| `selectedIndex`    | public    | `number`                              | `-1`    | The index of the selected option.                                                                                                                                                   | Listbox           |
+| `selectedOptions`  | public    | `ListboxOption[]`                     | `[]`    | A collection of the selected options.                                                                                                                                               | Listbox           |
+| `$presentation`    | public    | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`         | public    | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`           | public    | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name                 | Privacy   | Description                                    | Parameters | Return | Inherited From    |
+| -------------------- | --------- | ---------------------------------------------- | ---------- | ------ | ----------------- |
+| `setSelectedOptions` | public    | Sets an option as selected and gives it focus. |            |        | Listbox           |
+| `selectFirstOption`  | public    | Moves focus to the first selectable option.    |            | `void` | Listbox           |
+| `templateChanged`    | protected |                                                |            | `void` | FoundationElement |
+| `stylesChanged`      | protected |                                                |            | `void` | FoundationElement |
+
+#### Attributes
+
+| Name | Field    | Inherited From |
+| ---- | -------- | -------------- |
+|      | multiple | Listbox        |
+
+<hr/>
+
+
+
 ### Variables
 
 | Name             | Description                                                   | Type                                  |

--- a/packages/web-components/fast-foundation/src/select/select.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/select/select.form-associated.ts
@@ -7,7 +7,7 @@ interface _Select extends FormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(Select:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedSelect extends FormAssociated(_Select) {
     proxy = document.createElement("select");

--- a/packages/web-components/fast-foundation/src/slider/README.md
+++ b/packages/web-components/fast-foundation/src/slider/README.md
@@ -121,6 +121,40 @@ export const mySliderLabel = SliderLabel.compose({
 
 
 
+### class: `FormAssociatedSlider`
+
+#### Superclass
+
+| Name      | Module                               | Package |
+| --------- | ------------------------------------ | ------- |
+| `_Slider` | src/slider/slider.form-associated.ts |         |
+
+#### Mixins
+
+| Name             | Module                                  | Package |
+| ---------------- | --------------------------------------- | ------- |
+| `FormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### class: `Slider`
 
 #### Superclass

--- a/packages/web-components/fast-foundation/src/slider/slider.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.form-associated.ts
@@ -7,7 +7,7 @@ interface _Slider extends FormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(Slider:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedSlider extends FormAssociated(_Slider) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/switch/README.md
+++ b/packages/web-components/fast-foundation/src/switch/README.md
@@ -72,6 +72,40 @@ export const mySwitch = Switch.compose<SwitchOptions>({
 
 
 
+### class: `FormAssociatedSwitch`
+
+#### Superclass
+
+| Name      | Module                               | Package |
+| --------- | ------------------------------------ | ------- |
+| `_Switch` | src/switch/switch.form-associated.ts |         |
+
+#### Mixins
+
+| Name                      | Module                                  | Package |
+| ------------------------- | --------------------------------------- | ------- |
+| `CheckableFormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### class: `Switch`
 
 #### Superclass

--- a/packages/web-components/fast-foundation/src/switch/switch.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.form-associated.ts
@@ -7,7 +7,7 @@ interface _Switch extends CheckableFormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(Switch:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedSwitch extends CheckableFormAssociated(_Switch) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/text-area/README.md
+++ b/packages/web-components/fast-foundation/src/text-area/README.md
@@ -55,6 +55,40 @@ This component is built with the expectation that focus is delegated to the inpu
 
 
 
+### class: `FormAssociatedTextArea`
+
+#### Superclass
+
+| Name        | Module                                     | Package |
+| ----------- | ------------------------------------------ | ------- |
+| `_TextArea` | src/text-area/text-area.form-associated.ts |         |
+
+#### Mixins
+
+| Name             | Module                                  | Package |
+| ---------------- | --------------------------------------- | ------- |
+| `FormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### Variables
 
 | Name             | Description                | Type                                                                              |

--- a/packages/web-components/fast-foundation/src/text-area/text-area.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.form-associated.ts
@@ -7,7 +7,7 @@ interface _TextArea extends FormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(TextArea:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedTextArea extends FormAssociated(_TextArea) {
     proxy = document.createElement("textarea");

--- a/packages/web-components/fast-foundation/src/text-field/README.md
+++ b/packages/web-components/fast-foundation/src/text-field/README.md
@@ -60,6 +60,40 @@ This component is built with the expectation that focus is delegated to the inpu
 
 
 
+### class: `FormAssociatedTextField`
+
+#### Superclass
+
+| Name         | Module                                       | Package |
+| ------------ | -------------------------------------------- | ------- |
+| `_TextField` | src/text-field/text-field.form-associated.ts |         |
+
+#### Mixins
+
+| Name             | Module                                  | Package |
+| ---------------- | --------------------------------------- | ------- |
+| `FormAssociated` | /src/form-associated/form-associated.js |         |
+
+#### Fields
+
+| Name            | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `proxy`         |         |                                       |         |                                                                                                                                                                                     |                   |
+| `$presentation` | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`      | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`        | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+
+#### Methods
+
+| Name              | Privacy   | Description | Parameters | Return | Inherited From    |
+| ----------------- | --------- | ----------- | ---------- | ------ | ----------------- |
+| `templateChanged` | protected |             |            | `void` | FoundationElement |
+| `stylesChanged`   | protected |             |            | `void` | FoundationElement |
+
+<hr/>
+
+
+
 ### Variables
 
 | Name            | Description          | Type                                                                              |

--- a/packages/web-components/fast-foundation/src/text-field/text-field.form-associated.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.form-associated.ts
@@ -7,7 +7,7 @@ interface _TextField extends FormAssociated {}
 /**
  * A form-associated base class for the {@link @microsoft/fast-foundation#(TextField:class)} component.
  *
- * @internal
+ * @beta
  */
 export class FormAssociatedTextField extends FormAssociated(_TextField) {
     proxy = document.createElement("input");

--- a/packages/web-components/fast-foundation/src/utilities/match-media-stylesheet-behavior.ts
+++ b/packages/web-components/fast-foundation/src/utilities/match-media-stylesheet-behavior.ts
@@ -139,7 +139,6 @@ export class MatchMediaStyleSheetBehavior extends MatchMediaBehavior {
     /**
      * Constructs a match-media listener for a provided element.
      * @param source - the element for which to attach or detach styles.
-     * @internal
      */
     protected constructListener(source: typeof FASTElement): MediaQueryListListener {
         let attached = false;

--- a/packages/web-components/fast-foundation/src/utilities/property-stylesheet-behavior.ts
+++ b/packages/web-components/fast-foundation/src/utilities/property-stylesheet-behavior.ts
@@ -37,7 +37,6 @@ export class PropertyStyleSheetBehavior implements Behavior {
     /**
      * Unbinds the behavior from the element.
      * @param source - The element for which the behavior is unbinding.
-     * @internal
      */
     public unbind(source: typeof FASTElement & HTMLElement) {
         Observable.getNotifier(source).unsubscribe(this, this.propertyName);

--- a/packages/web-components/fast-router/api-extractor.json
+++ b/packages/web-components/fast-router/api-extractor.json
@@ -2,6 +2,11 @@
   "$schema": "https://developer.microsoft.com/json-schemas/api-extractor/v7/api-extractor.schema.json",
   "extends": "../../../api-extractor.json",
   "mainEntryPointFilePath": "dist/dts/index.d.ts",
+  "dtsRollup": {
+    "enabled": true,
+    "untrimmedFilePath": "./dist/fast-router.untrimmed.d.ts",
+    "betaTrimmedFilePath": "./dist/fast-router.d.ts"
+  },
   "messages": {
       "extractorMessageReporting": {
         "ae-different-release-tags": {

--- a/packages/web-components/fast-router/docs/api-report.md
+++ b/packages/web-components/fast-router/docs/api-report.md
@@ -19,13 +19,13 @@ import { ViewTemplate } from '@microsoft/fast-element';
 // @internal (undocumented)
 export const childRouteParameter = "fast-child-route";
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type CommandFallbackRouteDefinition<TSettings = any> = HasCommand & SupportsSettings<TSettings> & HasTitle;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type CommandRouteDefinition<TSettings = any> = PathedRouteDefinition<TSettings> & HasCommand & HasTitle;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class ConfigurableRoute implements Route {
     constructor(path: string, name: string, caseSensitive: boolean);
     // (undocumented)
@@ -36,18 +36,18 @@ export class ConfigurableRoute implements Route {
     readonly path: string;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type ContributorOptions = {
     lifecycle?: boolean;
     parameters?: boolean;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type ConverterObject = {
     convert: RouteParameterConverter;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class DefaultLinkHandler implements LinkHandler {
     // (undocumented)
     connect(): void;
@@ -55,7 +55,7 @@ export class DefaultLinkHandler implements LinkHandler {
     disconnect(): void;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class DefaultNavigationProcess<TSettings> {
     // Warning: (ae-forgotten-export) The symbol "NavigationPhaseImpl" needs to be exported by the entry point index.d.ts
     //
@@ -65,7 +65,7 @@ export class DefaultNavigationProcess<TSettings> {
     run(router: Router, message: NavigationMessage): Promise<void>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class DefaultNavigationQueue implements NavigationQueue, NavigationHandler {
     // (undocumented)
     connect(): void;
@@ -79,7 +79,7 @@ export class DefaultNavigationQueue implements NavigationQueue, NavigationHandle
     receive(): Promise<NavigationMessage>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class DefaultRouter implements Router {
     constructor(host: HTMLElement);
     // (undocumented)
@@ -110,7 +110,7 @@ export class DefaultRouter implements Router {
     shouldRender(route: RecognizedRoute): boolean;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class DefaultRouteRecognizer<TSettings> implements RouteRecognizer<TSettings> {
     // (undocumented)
     add(routeOrRoutes: Route | readonly Route[], settings?: TSettings): void;
@@ -120,16 +120,16 @@ export class DefaultRouteRecognizer<TSettings> implements RouteRecognizer<TSetti
     recognize(path: string, converters?: Readonly<Record<string, RouteParameterConverter>>): Promise<RecognizedRoute<TSettings> | null>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type DefinitionCallback = () => Promise<FallbackRouteDefinition> | FallbackRouteDefinition;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type ElementFallbackRouteDefinition<TSettings = any> = LayoutAndTransitionRouteDefinition & HasElement & SupportsSettings<TSettings> & HasTitle;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type ElementRouteDefinition<TSettings = any> = NavigableRouteDefinition<TSettings> & HasElement;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class Endpoint<TSettings = any> {
     constructor(route: ConfigurableRoute, paramNames: readonly string[], paramTypes: readonly string[], settings: TSettings | null);
     // (undocumented)
@@ -144,13 +144,13 @@ export class Endpoint<TSettings = any> {
     readonly settings: TSettings | null;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type FallbackRouteDefinition<TSettings = any> = ElementFallbackRouteDefinition<TSettings> | TemplateFallbackRouteDefinition<TSettings> | Pick<RedirectRouteDefinition<TSettings>, "redirect"> | CommandFallbackRouteDefinition<TSettings>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type FASTElementConstructor = new () => FASTElement;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class FASTElementLayout implements Layout {
     constructor(template?: ViewTemplate | null, styles?: ComposableStyles | ComposableStyles[] | null, runBeforeCommit?: boolean);
     // (undocumented)
@@ -161,34 +161,34 @@ export class FASTElementLayout implements Layout {
 
 // Warning: (ae-forgotten-export) The symbol "FASTRouter_base" needs to be exported by the entry point index.d.ts
 //
-// @alpha (undocumented)
+// @beta (undocumented)
 export class FASTRouter extends FASTRouter_base {
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type HasCommand = {
     command: NavigationCommand;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type HasElement = {
     element: string | FASTElementConstructor | HTMLElement | (() => Promise<string | FASTElementConstructor | HTMLElement>);
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type HasTemplate = {
     template: ViewTemplate | (() => Promise<ViewTemplate>);
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type HasTitle = {
     title?: string;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type IgnorableRouteDefinition<TSettings = any> = PathedRouteDefinition<TSettings>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class Ignore implements NavigationCommand {
     // (undocumented)
     createContributor(): Promise<{
@@ -196,13 +196,13 @@ export class Ignore implements NavigationCommand {
     }>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export function isFASTElementHost(host: HTMLElement): host is HTMLElement & FASTElement;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export function isNavigationPhaseContributor<T extends NavigationPhaseName>(object: any, phase: T): object is Record<T, NavigationPhaseHook>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface Layout {
     // (undocumented)
     afterCommit(routerElement: HTMLElement): Promise<void>;
@@ -210,18 +210,18 @@ export interface Layout {
     beforeCommit(routerElement: HTMLElement): Promise<void>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export const Layout: Readonly<{
     default: Readonly<Layout>;
 }>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type LayoutAndTransitionRouteDefinition = {
     layout?: Layout | ViewTemplate;
     transition?: Transition;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface LinkHandler {
     // (undocumented)
     connect(): void;
@@ -229,59 +229,59 @@ export interface LinkHandler {
     disconnect(): void;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type MappableRouteDefinition<TSettings = any> = RenderableRouteDefinition<TSettings> | RedirectRouteDefinition<TSettings> | CommandRouteDefinition<TSettings> | ParentRouteDefinition<TSettings>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type NavigableRouteDefinition<TSettings = any> = PathedRouteDefinition<TSettings> & LayoutAndTransitionRouteDefinition & HasTitle & {
     childRouters?: boolean;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface NavigationCommand {
     // (undocumented)
     createContributor(router: Router, route: RecognizedRoute): Promise<NavigationContributor>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface NavigationCommitPhase<TSettings = any> extends Omit<NavigationPhase<TSettings>, "cancel" | "canceled" | "onCancel"> {
     // (undocumented)
     setTitle(title: string): any;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type NavigationCommitPhaseHook<TSettings = any> = (phase: NavigationCommitPhase<TSettings>) => Promise<any> | any;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type NavigationContributor<TSettings = any> = Partial<Record<Exclude<NavigationPhaseName, "commit">, NavigationPhaseHook<TSettings>>> & {
     commit?: NavigationCommitPhaseHook<TSettings>;
 };
 
 // Warning: (ae-forgotten-export) The symbol "NavigationContributorDirective" needs to be exported by the entry point index.d.ts
 //
-// @alpha (undocumented)
+// @beta (undocumented)
 export function navigationContributor(options?: ContributorOptions): NavigationContributorDirective;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface NavigationHandler {
     // (undocumented)
     enqueue(msg: NavigationMessage): void;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export const NavigationHandler: Readonly<{
     register(handler: NavigationHandler): void;
     unregister(handler: NavigationHandler): void;
 }>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class NavigationMessage {
     constructor(path: string);
     // (undocumented)
     path: string;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface NavigationPhase<TSettings = any> {
     // (undocumented)
     cancel(callback?: NavigationPhaseFollowupAction): void;
@@ -301,22 +301,22 @@ export interface NavigationPhase<TSettings = any> {
     readonly router: Router<TSettings>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type NavigationPhaseFollowupAction = () => Promise<any> | any;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type NavigationPhaseHook<TSettings = any> = (phase: NavigationPhase<TSettings>) => Promise<any> | any;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type NavigationPhaseName = "navigate" | "leave" | "construct" | "enter" | "commit";
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface NavigationProcess {
     // (undocumented)
     run(router: Router, message: NavigationMessage): Promise<void>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface NavigationQueue {
     // (undocumented)
     connect(): void;
@@ -326,18 +326,18 @@ export interface NavigationQueue {
     receive(): Promise<NavigationMessage>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type ParameterConverter = RouteParameterConverter | ConverterObject | Constructable<ConverterObject>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type ParentRouteDefinition<TSettings = any> = PathedRouteDefinition<TSettings> & LayoutAndTransitionRouteDefinition & {
     children: MappableRouteDefinition<TSettings>[];
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type PathedRouteDefinition<TSettings = any> = SupportsSettings<TSettings> & Route;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export const QueryString: Readonly<{
     readonly current: string;
     build(params: Object, traditional?: boolean): string;
@@ -348,7 +348,7 @@ export const QueryString: Readonly<{
     parse(queryString: string): Readonly<Record<string, string>>;
 }>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class RecognizedRoute<TSettings = any> {
     constructor(endpoint: Endpoint<TSettings>, params: Readonly<Record<string, string | undefined>>, typedParams: Readonly<Record<string, any>>, queryParams: Readonly<Record<string, string>>);
     // (undocumented)
@@ -367,7 +367,7 @@ export class RecognizedRoute<TSettings = any> {
     readonly typedParams: Readonly<Record<string, any>>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class Redirect implements NavigationCommand {
     constructor(redirect: string);
     // (undocumented)
@@ -376,12 +376,12 @@ export class Redirect implements NavigationCommand {
     }>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type RedirectRouteDefinition<TSettings = any> = PathedRouteDefinition<TSettings> & {
     redirect: string;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class Render implements RenderCommand {
     constructor(owner: RouterConfiguration, createView: () => Promise<RouteView>);
     // Warning: (ae-forgotten-export) The symbol "RenderContributor" needs to be exported by the entry point index.d.ts
@@ -402,10 +402,10 @@ export class Render implements RenderCommand {
     set transition(value: Transition);
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type RenderableRouteDefinition<TSettings = any> = ElementRouteDefinition<TSettings> | TemplateRouteDefinition<TSettings>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface RenderCommand extends NavigationCommand {
     // (undocumented)
     createView(): Promise<RouteView>;
@@ -415,7 +415,7 @@ export interface RenderCommand extends NavigationCommand {
     transition: Transition;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface RenderOperation {
     // (undocumented)
     commit(): Promise<void>;
@@ -423,7 +423,7 @@ export interface RenderOperation {
     rollback(): Promise<void>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface Route {
     // (undocumented)
     readonly caseSensitive?: boolean;
@@ -433,7 +433,7 @@ export interface Route {
     readonly path: string;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export const Route: Readonly<{
     path: Readonly<{
         readonly current: string;
@@ -450,7 +450,7 @@ export const Route: Readonly<{
     }>;
 }>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export class RouteCollection<TSettings = any> {
     constructor(owner: RouterConfiguration);
     // (undocumented)
@@ -467,16 +467,16 @@ export class RouteCollection<TSettings = any> {
     recognize(path: string): Promise<RouteMatch<TSettings> | null>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type RouteMatch<TSettings = any> = {
     route: RecognizedRoute<TSettings>;
     command: NavigationCommand;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type RouteParameterConverter = (value: string | undefined) => any | Promise<any>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface Router<TSettings = any> {
     // (undocumented)
     addContributor(contributor: NavigationContributor): void;
@@ -500,7 +500,7 @@ export interface Router<TSettings = any> {
     shouldRender(route: RecognizedRoute<TSettings>): boolean;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export const Router: Readonly<{
     getOrCreateFor(element: HTMLElement): Router<any> | DefaultRouter;
     find(element: HTMLElement): Router | null;
@@ -510,7 +510,7 @@ export const Router: Readonly<{
     }>(BaseType: TBase): new () => InstanceType<TBase> & RouterElement;
 }>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export abstract class RouterConfiguration<TSettings = any> {
     // (undocumented)
     protected cached(ElementType: new () => HTMLElement): () => Promise<HTMLElement>;
@@ -554,7 +554,7 @@ export abstract class RouterConfiguration<TSettings = any> {
     title: string;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface RouteRecognizer<TSettings> {
     // (undocumented)
     add(routeOrRoutes: Route | readonly Route[], settings?: TSettings): void;
@@ -566,7 +566,7 @@ export interface RouteRecognizer<TSettings> {
     recognize(path: string, converters?: Readonly<Record<string, RouteParameterConverter>>): Promise<RecognizedRoute<TSettings> | null>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface RouterElement extends HTMLElement {
     // Warning: (ae-forgotten-export) The symbol "routerProperty" needs to be exported by the entry point index.d.ts
     //
@@ -580,17 +580,17 @@ export interface RouterElement extends HTMLElement {
     disconnectedCallback(): any;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type RouterExecutionContext = ExecutionContext & {
     router: Router;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export const RouterExecutionContext: Readonly<{
     create(router: Router): any;
 }>;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface RouteView {
     // (undocumented)
     appendTo(host: HTMLElement): void;
@@ -600,18 +600,18 @@ export interface RouteView {
     dispose(): void;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type SupportsSettings<TSettings = any> = {
     settings?: TSettings;
 };
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type TemplateFallbackRouteDefinition<TSettings = any> = LayoutAndTransitionRouteDefinition & HasTemplate & SupportsSettings<TSettings> & HasTitle;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export type TemplateRouteDefinition<TSettings = any> = NavigableRouteDefinition<TSettings> & HasTemplate;
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export interface Transition {
     // (undocumented)
     begin(host: HTMLElement, prev: RouteView | null, next: RouteView): Promise<void>;
@@ -621,7 +621,7 @@ export interface Transition {
     rollback(host: HTMLElement, prev: RouteView | null, next: RouteView): Promise<void>;
 }
 
-// @alpha (undocumented)
+// @beta (undocumented)
 export const Transition: Readonly<{
     default: Readonly<Transition>;
 }>;

--- a/packages/web-components/fast-router/src/commands.ts
+++ b/packages/web-components/fast-router/src/commands.ts
@@ -19,7 +19,7 @@ import { navigationContributor, NavigationContributor } from "./contributors.js"
 import { NavigationCommitPhase, NavigationPhase } from "./phases.js";
 
 /**
- * @alpha
+ * @beta
  */
 export interface NavigationCommand {
     createContributor(
@@ -29,7 +29,7 @@ export interface NavigationCommand {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export interface RenderCommand extends NavigationCommand {
     layout: Layout;
@@ -38,7 +38,7 @@ export interface RenderCommand extends NavigationCommand {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class Ignore implements NavigationCommand {
     public async createContributor() {
@@ -51,7 +51,7 @@ export class Ignore implements NavigationCommand {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class Redirect implements NavigationCommand {
     constructor(private redirect: string) {}
@@ -133,7 +133,7 @@ class RenderContributor {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class Render implements RenderCommand {
     private _layout: Layout | null = null;

--- a/packages/web-components/fast-router/src/configuration.ts
+++ b/packages/web-components/fast-router/src/configuration.ts
@@ -11,7 +11,7 @@ import { NavigationPhaseHook, NavigationPhaseName } from "./phases.js";
 import { DefaultRouteRecognizer, RouteRecognizer } from "./recognizer.js";
 
 /**
- * @alpha
+ * @beta
  */
 export abstract class RouterConfiguration<TSettings = any> {
     private isConfigured = false;

--- a/packages/web-components/fast-router/src/contributors.ts
+++ b/packages/web-components/fast-router/src/contributors.ts
@@ -14,7 +14,7 @@ import { Router } from "./router.js";
 import { RouterExecutionContext } from "./view.js";
 
 /**
- * @alpha
+ * @beta
  */
 export type NavigationContributor<TSettings = any> = Partial<
     Record<Exclude<NavigationPhaseName, "commit">, NavigationPhaseHook<TSettings>>
@@ -23,7 +23,7 @@ export type NavigationContributor<TSettings = any> = Partial<
 };
 
 /**
- * @alpha
+ * @beta
  */
 export function isNavigationPhaseContributor<T extends NavigationPhaseName>(
     object: any,
@@ -33,7 +33,7 @@ export function isNavigationPhaseContributor<T extends NavigationPhaseName>(
 }
 
 /**
- * @alpha
+ * @beta
  */
 export type ContributorOptions = {
     lifecycle?: boolean;
@@ -97,7 +97,7 @@ class NavigationContributorBehavior implements Behavior {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export function navigationContributor(
     options?: ContributorOptions

--- a/packages/web-components/fast-router/src/events.ts
+++ b/packages/web-components/fast-router/src/events.ts
@@ -5,7 +5,7 @@ import { RecognizedRoute } from "./recognizer.js";
 import { Router } from "./router.js";
 
 /**
- * @alpha
+ * @beta
  */
 export interface RoutingEventSink {
     onUnhandledNavigationMessage(router: Router, message: NavigationMessage): void;
@@ -24,7 +24,7 @@ export interface RoutingEventSink {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class DefaultRoutingEventSink implements RoutingEventSink {
     onUnhandledNavigationMessage(router: Router, message: NavigationMessage): void {}

--- a/packages/web-components/fast-router/src/fast-router.ts
+++ b/packages/web-components/fast-router/src/fast-router.ts
@@ -2,7 +2,7 @@ import { customElement, FASTElement } from "@microsoft/fast-element";
 import { Router, RouterElement } from "./router.js";
 
 /**
- * @alpha
+ * @beta
  */
 @customElement("fast-router")
 export class FASTRouter extends (Router.from(FASTElement) as {

--- a/packages/web-components/fast-router/src/links.ts
+++ b/packages/web-components/fast-router/src/links.ts
@@ -7,7 +7,7 @@ interface AnchorEventInfo {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export interface LinkHandler {
     connect(): void;
@@ -15,7 +15,7 @@ export interface LinkHandler {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class DefaultLinkHandler implements LinkHandler {
     private handler = (e: MouseEvent) => {

--- a/packages/web-components/fast-router/src/navigation.ts
+++ b/packages/web-components/fast-router/src/navigation.ts
@@ -1,7 +1,7 @@
 import { Router } from "./router.js";
 
 /**
- * @alpha
+ * @beta
  */
 export interface Route {
     readonly path: string;
@@ -10,14 +10,14 @@ export interface Route {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class NavigationMessage {
     constructor(public path: string) {}
 }
 
 /**
- * @alpha
+ * @beta
  */
 export interface NavigationHandler {
     enqueue(msg: NavigationMessage): void;
@@ -26,7 +26,7 @@ export interface NavigationHandler {
 const handlers = new Set<NavigationHandler>();
 
 /**
- * @alpha
+ * @beta
  */
 export const NavigationHandler = Object.freeze({
     register(handler: NavigationHandler) {
@@ -39,7 +39,7 @@ export const NavigationHandler = Object.freeze({
 });
 
 /**
- * @alpha
+ * @beta
  */
 export interface NavigationQueue {
     connect(): void;
@@ -53,7 +53,7 @@ export interface NavigationQueue {
 const absoluteUrl = /^([a-z][a-z0-9+\-.]*:)?\/\//i;
 
 /**
- * @alpha
+ * @beta
  */
 export const Route = Object.freeze({
     path: Object.freeze({
@@ -178,7 +178,7 @@ export const Route = Object.freeze({
 });
 
 /**
- * @alpha
+ * @beta
  */
 export class DefaultNavigationQueue implements NavigationQueue, NavigationHandler {
     private queue: NavigationMessage[] = [];

--- a/packages/web-components/fast-router/src/phases.ts
+++ b/packages/web-components/fast-router/src/phases.ts
@@ -2,31 +2,31 @@ import { RecognizedRoute } from "./recognizer.js";
 import { Router } from "./router.js";
 
 /**
- * @alpha
+ * @beta
  */
 export type NavigationPhaseName = "navigate" | "leave" | "construct" | "enter" | "commit";
 
 /**
- * @alpha
+ * @beta
  */
 export type NavigationPhaseHook<TSettings = any> = (
     phase: NavigationPhase<TSettings>
 ) => Promise<any> | any;
 
 /**
- * @alpha
+ * @beta
  */
 export type NavigationCommitPhaseHook<TSettings = any> = (
     phase: NavigationCommitPhase<TSettings>
 ) => Promise<any> | any;
 
 /**
- * @alpha
+ * @beta
  */
 export type NavigationPhaseFollowupAction = () => Promise<any> | any;
 
 /**
- * @alpha
+ * @beta
  */
 export interface NavigationPhase<TSettings = any> {
     readonly name: NavigationPhaseName;
@@ -46,7 +46,7 @@ export interface NavigationPhase<TSettings = any> {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export interface NavigationCommitPhase<TSettings = any>
     extends Omit<NavigationPhase<TSettings>, "cancel" | "canceled" | "onCancel"> {

--- a/packages/web-components/fast-router/src/process.ts
+++ b/packages/web-components/fast-router/src/process.ts
@@ -75,14 +75,14 @@ class NavigationPhaseImpl<TSettings = any> implements NavigationCommitPhase<TSet
 }
 
 /**
- * @alpha
+ * @beta
  */
 export interface NavigationProcess {
     run(router: Router, message: NavigationMessage): Promise<void>;
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class DefaultNavigationProcess<TSettings> {
     private phases: NavigationPhaseName[] = [

--- a/packages/web-components/fast-router/src/query-string.ts
+++ b/packages/web-components/fast-router/src/query-string.ts
@@ -73,7 +73,7 @@ function parseComplexParam(queryParams: Object, keys: string[], value: any): voi
 }
 
 /**
- * @alpha
+ * @beta
  */
 export const QueryString = Object.freeze({
     get current() {

--- a/packages/web-components/fast-router/src/recognizer.ts
+++ b/packages/web-components/fast-router/src/recognizer.ts
@@ -2,14 +2,14 @@ import { Route } from "./navigation.js";
 import { QueryString } from "./query-string.js";
 
 /**
- * @alpha
+ * @beta
  */
 export type RouteParameterConverter = (value: string | undefined) => any | Promise<any>;
 const defaultParameterConverter: RouteParameterConverter = (value: string | undefined) =>
     value;
 
 /**
- * @alpha
+ * @beta
  */
 export class ConfigurableRoute implements Route {
     public constructor(
@@ -20,7 +20,7 @@ export class ConfigurableRoute implements Route {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class Endpoint<TSettings = any> {
     public constructor(
@@ -36,7 +36,7 @@ export class Endpoint<TSettings = any> {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class RecognizedRoute<TSettings = any> {
     public readonly allParams: Readonly<Record<string, string | undefined>>;
@@ -364,7 +364,7 @@ class RecognizeResult<T> {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export interface RouteRecognizer<TSettings> {
     add(routeOrRoutes: Route | readonly Route[], settings?: TSettings): void;
@@ -377,7 +377,7 @@ export interface RouteRecognizer<TSettings> {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class DefaultRouteRecognizer<TSettings> implements RouteRecognizer<TSettings> {
     private names = new Map<string, AnySegment<any>[]>();

--- a/packages/web-components/fast-router/src/router.ts
+++ b/packages/web-components/fast-router/src/router.ts
@@ -10,7 +10,7 @@ import { childRouteParameter } from "./routes.js";
 import { Layout, RouterExecutionContext, RouteView, Transition } from "./view.js";
 
 /**
- * @alpha
+ * @beta
  */
 export interface RenderOperation {
     commit(): Promise<void>;
@@ -18,7 +18,7 @@ export interface RenderOperation {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export interface Router<TSettings = any> {
     readonly level: number;
@@ -73,7 +73,7 @@ function findParentRouterForElement(element: HTMLElement) {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export interface RouterElement extends HTMLElement {
     readonly [routerProperty]: Router;
@@ -83,7 +83,7 @@ export interface RouterElement extends HTMLElement {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export const Router = Object.freeze({
     getOrCreateFor(element: HTMLElement) {
@@ -151,14 +151,14 @@ export const Router = Object.freeze({
 });
 
 /**
- * @alpha
+ * @beta
  */
 export function isFASTElementHost(host: HTMLElement): host is HTMLElement & FASTElement {
     return host instanceof FASTElement;
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class DefaultRouter implements Router {
     private parentRouter: Router | null | undefined = void 0;

--- a/packages/web-components/fast-router/src/routes.ts
+++ b/packages/web-components/fast-router/src/routes.ts
@@ -19,24 +19,24 @@ import { Route } from "./navigation.js";
 export const childRouteParameter = "fast-child-route";
 
 /**
- * @alpha
+ * @beta
  */
 export type SupportsSettings<TSettings = any> = {
     settings?: TSettings;
 };
 
 /**
- * @alpha
+ * @beta
  */
 export type PathedRouteDefinition<TSettings = any> = SupportsSettings<TSettings> & Route;
 
 /**
- * @alpha
+ * @beta
  */
 export type IgnorableRouteDefinition<TSettings = any> = PathedRouteDefinition<TSettings>;
 
 /**
- * @alpha
+ * @beta
  */
 export type LayoutAndTransitionRouteDefinition = {
     layout?: Layout | ViewTemplate;
@@ -44,7 +44,7 @@ export type LayoutAndTransitionRouteDefinition = {
 };
 
 /**
- * @alpha
+ * @beta
  */
 export type RedirectRouteDefinition<TSettings = any> = PathedRouteDefinition<
     TSettings
@@ -53,14 +53,14 @@ export type RedirectRouteDefinition<TSettings = any> = PathedRouteDefinition<
 };
 
 /**
- * @alpha
+ * @beta
  */
 export type HasTitle = {
     title?: string;
 };
 
 /**
- * @alpha
+ * @beta
  */
 export type NavigableRouteDefinition<TSettings = any> = PathedRouteDefinition<TSettings> &
     LayoutAndTransitionRouteDefinition &
@@ -69,12 +69,12 @@ export type NavigableRouteDefinition<TSettings = any> = PathedRouteDefinition<TS
     };
 
 /**
- * @alpha
+ * @beta
  */
 export type FASTElementConstructor = new () => FASTElement;
 
 /**
- * @alpha
+ * @beta
  */
 export type HasElement = {
     element:
@@ -85,7 +85,7 @@ export type HasElement = {
 };
 
 /**
- * @alpha
+ * @beta
  */
 export type ElementFallbackRouteDefinition<
     TSettings = any
@@ -95,7 +95,7 @@ export type ElementFallbackRouteDefinition<
     HasTitle;
 
 /**
- * @alpha
+ * @beta
  */
 export type ElementRouteDefinition<TSettings = any> = NavigableRouteDefinition<
     TSettings
@@ -103,14 +103,14 @@ export type ElementRouteDefinition<TSettings = any> = NavigableRouteDefinition<
     HasElement;
 
 /**
- * @alpha
+ * @beta
  */
 export type HasTemplate = {
     template: ViewTemplate | (() => Promise<ViewTemplate>);
 };
 
 /**
- * @alpha
+ * @beta
  */
 export type TemplateFallbackRouteDefinition<
     TSettings = any
@@ -120,7 +120,7 @@ export type TemplateFallbackRouteDefinition<
     HasTitle;
 
 /**
- * @alpha
+ * @beta
  */
 export type TemplateRouteDefinition<TSettings = any> = NavigableRouteDefinition<
     TSettings
@@ -128,28 +128,28 @@ export type TemplateRouteDefinition<TSettings = any> = NavigableRouteDefinition<
     HasTemplate;
 
 /**
- * @alpha
+ * @beta
  */
 export type HasCommand = {
     command: NavigationCommand;
 };
 
 /**
- * @alpha
+ * @beta
  */
 export type CommandRouteDefinition<TSettings = any> = PathedRouteDefinition<TSettings> &
     HasCommand &
     HasTitle;
 
 /**
- * @alpha
+ * @beta
  */
 export type CommandFallbackRouteDefinition<TSettings = any> = HasCommand &
     SupportsSettings<TSettings> &
     HasTitle;
 
 /**
- * @alpha
+ * @beta
  */
 export type FallbackRouteDefinition<TSettings = any> =
     | ElementFallbackRouteDefinition<TSettings>
@@ -158,21 +158,21 @@ export type FallbackRouteDefinition<TSettings = any> =
     | CommandFallbackRouteDefinition<TSettings>;
 
 /**
- * @alpha
+ * @beta
  */
 export type DefinitionCallback = () =>
     | Promise<FallbackRouteDefinition>
     | FallbackRouteDefinition;
 
 /**
- * @alpha
+ * @beta
  */
 export type RenderableRouteDefinition<TSettings = any> =
     | ElementRouteDefinition<TSettings>
     | TemplateRouteDefinition<TSettings>;
 
 /**
- * @alpha
+ * @beta
  */
 export type MappableRouteDefinition<TSettings = any> =
     | RenderableRouteDefinition<TSettings>
@@ -181,7 +181,7 @@ export type MappableRouteDefinition<TSettings = any> =
     | ParentRouteDefinition<TSettings>;
 
 /**
- * @alpha
+ * @beta
  */
 export type ParentRouteDefinition<TSettings = any> = PathedRouteDefinition<TSettings> &
     LayoutAndTransitionRouteDefinition & {
@@ -189,7 +189,7 @@ export type ParentRouteDefinition<TSettings = any> = PathedRouteDefinition<TSett
     };
 
 /**
- * @alpha
+ * @beta
  */
 export type RouteMatch<TSettings = any> = {
     route: RecognizedRoute<TSettings>;
@@ -210,14 +210,14 @@ function getFallbackCommand(
 }
 
 /**
- * @alpha
+ * @beta
  */
 export type ConverterObject = {
     convert: RouteParameterConverter;
 };
 
 /**
- * @alpha
+ * @beta
  */
 export type ParameterConverter =
     | RouteParameterConverter
@@ -250,7 +250,7 @@ const defaultConverters = {
 };
 
 /**
- * @alpha
+ * @beta
  */
 export class RouteCollection<TSettings = any> {
     private _recognizer: RouteRecognizer<TSettings> | null = null;

--- a/packages/web-components/fast-router/src/titles.ts
+++ b/packages/web-components/fast-router/src/titles.ts
@@ -1,5 +1,5 @@
 /**
- * @alpha
+ * @beta
  */
 export interface TitleBuilder {
     joinTitles(parentTitle: string, childTitle: string): string;
@@ -7,7 +7,7 @@ export interface TitleBuilder {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class DefaultTitleBuilder implements TitleBuilder {
     public constructor(

--- a/packages/web-components/fast-router/src/view.ts
+++ b/packages/web-components/fast-router/src/view.ts
@@ -8,14 +8,14 @@ import {
 import { isFASTElementHost, Router } from "./router.js";
 
 /**
- * @alpha
+ * @beta
  */
 export type RouterExecutionContext = ExecutionContext & {
     router: Router;
 };
 
 /**
- * @alpha
+ * @beta
  */
 export const RouterExecutionContext = Object.freeze({
     create(router: Router) {
@@ -28,7 +28,7 @@ export const RouterExecutionContext = Object.freeze({
 });
 
 /**
- * @alpha
+ * @beta
  */
 export interface RouteView {
     bind(
@@ -40,7 +40,7 @@ export interface RouteView {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export interface Transition {
     begin(host: HTMLElement, prev: RouteView | null, next: RouteView): Promise<void>;
@@ -49,7 +49,7 @@ export interface Transition {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export const Transition = Object.freeze({
     default: Object.freeze({
@@ -72,7 +72,7 @@ export const Transition = Object.freeze({
 });
 
 /**
- * @alpha
+ * @beta
  */
 export interface Layout {
     beforeCommit(routerElement: HTMLElement): Promise<void>;
@@ -80,7 +80,7 @@ export interface Layout {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export class FASTElementLayout implements Layout {
     private styles: ElementStyles | null;
@@ -126,7 +126,7 @@ export class FASTElementLayout implements Layout {
 }
 
 /**
- * @alpha
+ * @beta
  */
 export const Layout = Object.freeze({
     default: new FASTElementLayout(

--- a/packages/web-components/fast-ssr/api-extractor.json
+++ b/packages/web-components/fast-ssr/api-extractor.json
@@ -4,6 +4,7 @@
   "mainEntryPointFilePath": "./dist/dts/exports.d.ts",
   "dtsRollup": {
     "enabled": true,
+    "untrimmedFilePath": "./dist/fast-ssr.untrimmed.d.ts",
     "betaTrimmedFilePath": "./dist/fast-ssr.d.ts"
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR updates the API Extractor configuration to strip out APIs marked as internal. Some APIs that were previously internal were made public or beta. Some APIs that were alpha were made beta.

### 🎫 Issues

* Fixes #5937 

## 👩‍💻 Reviewer Notes

Mostly changes to release tags on APIs.

## 📑 Test Plan

All existing tests pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

We also need to fix up our readme files. I'll review those soon.