### PR TITLE
feat: update tabs bool attr defaulting to true

### DIFF
--- a/change/@microsoft-fast-foundation-70646681-8dcc-4511-92e1-0062ddbdda8f.json
+++ b/change/@microsoft-fast-foundation-70646681-8dcc-4511-92e1-0062ddbdda8f.json
@@ -1,0 +1,7 @@
+{
+  "type": "major",
+  "comment": "change activeindicator attribute in tabs to hide-active-indicator to better support boolean attribute behavior",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2586,13 +2586,13 @@ export class Tabs extends FoundationElement {
     activeid: string;
     // @internal (undocumented)
     activeidChanged(oldValue: string, newValue: string): void;
-    activeindicator: boolean;
     // @internal (undocumented)
     activeIndicatorRef: HTMLElement;
     activetab: HTMLElement;
     adjust(adjustment: number): void;
     // @internal (undocumented)
     connectedCallback(): void;
+    hideActiveIndicator: boolean;
     orientation: TabsOrientation;
     // @internal (undocumented)
     orientationChanged(): void;

--- a/packages/web-components/fast-foundation/src/tabs/README.md
+++ b/packages/web-components/fast-foundation/src/tabs/README.md
@@ -116,15 +116,15 @@ export const myTabs = Tabs.compose({
 
 #### Fields
 
-| Name              | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
-| ----------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
-| `orientation`     | public  | `TabsOrientation`                     |         | The orientation                                                                                                                                                                     |                   |
-| `activeid`        | public  | `string`                              |         | The id of the active tab                                                                                                                                                            |                   |
-| `activeindicator` | public  | `boolean`                             | `true`  | Whether or not to show the active indicator                                                                                                                                         |                   |
-| `activetab`       | public  | `HTMLElement`                         |         | A reference to the active tab                                                                                                                                                       |                   |
-| `$presentation`   | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
-| `template`        | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
-| `styles`          | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
+| Name                  | Privacy | Type                                  | Default | Description                                                                                                                                                                         | Inherited From    |
+| --------------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ----------------- |
+| `orientation`         | public  | `TabsOrientation`                     |         | The orientation                                                                                                                                                                     |                   |
+| `activeid`            | public  | `string`                              |         | The id of the active tab                                                                                                                                                            |                   |
+| `hideActiveIndicator` | public  | `boolean`                             | `false` | Whether or not to show the active indicator                                                                                                                                         |                   |
+| `activetab`           | public  | `HTMLElement`                         |         | A reference to the active tab                                                                                                                                                       |                   |
+| `$presentation`       | public  | `ComponentPresentation or null`       |         | A property which resolves the ComponentPresentation instance for the current component.                                                                                             | FoundationElement |
+| `template`            | public  | `ElementViewTemplate or void or null` |         | Sets the template of the element instance. When undefined, the element will attempt to resolve the template from the associated presentation or custom element definition.          | FoundationElement |
+| `styles`              | public  | `ElementStyles or void or null`       |         | Sets the default styles for the element instance. When undefined, the element will attempt to resolve default styles from the associated presentation or custom element definition. | FoundationElement |
 
 #### Methods
 
@@ -142,11 +142,11 @@ export const myTabs = Tabs.compose({
 
 #### Attributes
 
-| Name          | Field           | Inherited From |
-| ------------- | --------------- | -------------- |
-| `orientation` | orientation     |                |
-| `activeid`    | activeid        |                |
-|               | activeindicator |                |
+| Name                    | Field               | Inherited From |
+| ----------------------- | ------------------- | -------------- |
+| `orientation`           | orientation         |                |
+| `activeid`              | activeid            |                |
+| `hide-active-indicator` | hideActiveIndicator |                |
 
 #### CSS Parts
 

--- a/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
@@ -95,22 +95,32 @@ describe("Tabs", () => {
         await disconnect();
     });
 
-    it("should set a property equal to activeIndicator when `activeIndicator` property is true", async () => {
+    it("should set a property equal to hideActiveIndicator when `hideActiveIndicator` property is true", async () => {
         const { element, connect, disconnect } = await setup();
-        element.setAttribute("activeIndicator", "false");
+        element.setAttribute("hide-active-indicator", "true");
 
         await connect();
 
-        expect(element.activeindicator).to.equal(false);
+        expect(element.hideActiveIndicator).to.equal(true);
 
         await disconnect();
     });
 
-    it("should render an internal element with a class of 'activeIndicator' when `activeIndicator` is true", async () => {
+    it("should set a default value of `hideActiveIndicator` to false", async () => {
         const { element, connect, disconnect } = await setup();
         await connect();
 
-        expect(element.shadowRoot?.querySelector(".activeIndicator")).to.exist;
+        expect(element.hideActiveIndicator).to.equal(false);
+        expect(element.hasAttribute("hide-active-indicator")).to.equal(false);
+
+        await disconnect();
+    });
+
+    it("should render an internal element with a class of 'active-indicator' when `hide-active-indicator` is false", async () => {
+        const { element, connect, disconnect } = await setup();
+        await connect();
+
+        expect(element.shadowRoot?.querySelector(".active-indicator")).to.exist;
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
@@ -22,8 +22,8 @@ export const tabsTemplate: FoundationElementTemplate<ViewTemplate<Tabs>, TabsOpt
                 html<Tabs>`
                     <div
                         ${ref("activeIndicatorRef")}
-                        class="activeIndicator"
-                        part="activeIndicator"
+                        class="active-indicator"
+                        part="active-indicator"
                     ></div>
                 `
             )}

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -146,8 +146,8 @@ export class Tabs extends FoundationElement {
      * @remarks
      * HTML Attribute: activeindicator
      */
-    @attr({ mode: "boolean" })
-    public activeindicator = true;
+    @attr({ attribute: "hide-active-indicator", mode: "boolean" })
+    public hideActiveIndicator = false;
 
     /**
      * @internal
@@ -209,7 +209,7 @@ export class Tabs extends FoundationElement {
             if (tab.slot === "tab") {
                 const isActiveTab =
                     this.activeTabIndex === index && this.isFocusableElement(tab);
-                if (this.activeindicator && this.isFocusableElement(tab)) {
+                if (!this.hideActiveIndicator && this.isFocusableElement(tab)) {
                     this.showActiveIndicator = true;
                 }
                 const tabId: string = this.tabIds[index];
@@ -321,7 +321,7 @@ export class Tabs extends FoundationElement {
         // Ignore if we click twice on the same tab
         if (
             this.showActiveIndicator &&
-            this.activeindicator &&
+            !this.hideActiveIndicator &&
             this.activeTabIndex !== this.prevActiveTabIndex
         ) {
             if (this.ticking) {


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR changes the boolean attribute of `activeindicator` to `hide-active-indicator` to support a default value of false.

### 🎫 Issues
related to #5320 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->