### PR TITLE
Revert switch a11y changes

### DIFF
--- a/change/@microsoft-fast-foundation-20d429c9-afc3-4daf-b3db-0ea73fb37daa.json
+++ b/change/@microsoft-fast-foundation-20d429c9-afc3-4daf-b3db-0ea73fb37daa.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Revert \"fix: add missing required attribute binding to switch template (#6014)\"",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "burtonsmith@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/switch/switch.spec.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.spec.ts
@@ -122,24 +122,6 @@ describe("Switch", () => {
         await disconnect();
     });
 
-    it("should set the `aria-required` attribute equal to the `required` value", async () => {
-        const { element, connect, disconnect } = await setup();
-
-        element.required = true;
-
-        await connect();
-
-        expect(element.getAttribute("aria-required")).to.equal("true");
-
-        element.required = false;
-
-        await DOM.nextUpdate();
-
-        expect(element.getAttribute("aria-required")).to.equal("false");
-
-        await disconnect();
-    });
-
     it("should set a tabindex of 0 on the element", async () => {
         const { element, connect, disconnect } = await setup();
 

--- a/packages/web-components/fast-foundation/src/switch/switch.template.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.template.ts
@@ -16,7 +16,6 @@ export const switchTemplate: FoundationElementTemplate<
         aria-checked="${x => x.checked}"
         aria-disabled="${x => x.disabled}"
         aria-readonly="${x => x.readOnly}"
-        aria-required="${x => x.required}"
         tabindex="${x => (x.disabled ? null : 0)}"
         @keypress="${(x, c) => x.keypressHandler(c.event as KeyboardEvent)}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

This is to revert the change of adding `aria-required` to switches. Elements with `role="switch"` do not support validation and throw accessibility errors from audit tools when it is present. 

### 🎫 Issues

https://github.com/microsoft/fast/issues/6013

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->