### PR TITLE
 fix: RadioGroup does not check correct Radio when Radio value set through property

### DIFF
--- a/change/@microsoft-fast-foundation-95a55f8c-bf15-4eba-b928-5da6e11497f8.json
+++ b/change/@microsoft-fast-foundation-95a55f8c-bf15-4eba-b928-5da6e11497f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Compare radio value property instead of attribute when value changes",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "sknoslo@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.spec.ts
@@ -299,6 +299,44 @@ describe("Radio Group", () => {
         await disconnect();
     });
 
+    it("should set a child radio with a matching `value` to `checked` when value changes", async () => {
+        const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
+
+        element.value = "baz";
+
+        const radio1 = document.createElement("fast-radio") as Radio;
+        const radio2 = document.createElement("fast-radio") as Radio;
+        const radio3 = document.createElement("fast-radio") as Radio;
+
+        radio1.className = "one";
+        radio2.className = "two";
+        radio3.className = "three";
+
+        radio1.value = "foo";
+        radio2.value = "bar";
+        radio3.value = "baz";
+
+        element.appendChild(radio1);
+        element.appendChild(radio2);
+        element.appendChild(radio3);
+
+        await connect();
+        await DOM.nextUpdate();
+
+        element.value = "foo";
+
+        await DOM.nextUpdate();
+
+        expect((element.querySelectorAll("fast-radio")[0] as Radio).checked).to.equal(
+            true
+        );
+        expect(
+            element.querySelectorAll("fast-radio")[0].getAttribute("aria-checked")
+        ).to.equal("true");
+
+        await disconnect();
+    });
+
     it("should mark the last radio defaulted to checked as checked, the rest should not be checked", async () => {
         const { element, connect, disconnect, parent } = await fixture([FASTRadioGroup(), FASTRadio()]);
 

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -95,7 +95,7 @@ export class RadioGroup extends FoundationElement {
     protected valueChanged(): void {
         if (this.slottedRadioButtons) {
             this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
-                if (radio.getAttribute("value") === this.value) {
+                if (radio.value === this.value) {
                     radio.checked = true;
                     this.selectedRadio = radio;
                 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Updates the FormGroup `valueChanged` callback to compare the new value with the Radio's value property, rather than the value attribute. This brings it inline with how the comparison is done when the component is first connected.

### 🎫 Issues

#6050 

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps