### PR TITLE
feat: implement W3C WC community context protocol and integrate with DI

### DIFF
--- a/change/@microsoft-fast-element-c5184ad5-9a98-4cd6-8b58-5d717e43fc6b.json
+++ b/change/@microsoft-fast-element-c5184ad5-9a98-4cd6-8b58-5d717e43fc6b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: implement W3C WC community context protocol and integrate with DI",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-c5184ad5-9a98-4cd6-8b58-5d717e43fc6b.json
+++ b/change/@microsoft-fast-element-c5184ad5-9a98-4cd6-8b58-5d717e43fc6b.json
@@ -3,5 +3,5 @@
   "comment": "feat: implement W3C WC community context protocol and integrate with DI",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-a5bf55a6-6f13-4364-a9cc-8687b7feae18.json
+++ b/change/@microsoft-fast-foundation-a5bf55a6-6f13-4364-a9cc-8687b7feae18.json
@@ -3,5 +3,5 @@
   "comment": "feat: implement W3C WC community context protocol and integrate with DI",
   "packageName": "@microsoft/fast-foundation",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-a5bf55a6-6f13-4364-a9cc-8687b7feae18.json
+++ b/change/@microsoft-fast-foundation-a5bf55a6-6f13-4364-a9cc-8687b7feae18.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: implement W3C WC community context protocol and integrate with DI",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/package.json
+++ b/packages/web-components/fast-element/package.json
@@ -45,6 +45,14 @@
     "./hooks": {
       "types": "./dist/dts/hooks.d.ts",
       "default": "./dist/esm/hooks.js"
+    },
+    "./context": {
+      "types": "./dist/dts/context.d.ts",
+      "default": "./dist/esm/context.js"
+    },
+    "./metadata": {
+      "types": "./dist/dts/metadata.d.ts",
+      "default": "./dist/esm/metadata.js"
     }
   },
   "unpkg": "dist/fast-element.min.js",

--- a/packages/web-components/fast-element/src/context.spec.ts
+++ b/packages/web-components/fast-element/src/context.spec.ts
@@ -1,0 +1,271 @@
+import { expect } from "chai";
+import { Context } from "./context.js";
+import { uniqueElementName } from "./__test__/helpers.js";
+
+describe("Context", () => {
+    describe(`create()`, () => {
+        it(`returns a context that has the specified name`, () => {
+            const TestContext = Context.create("TestContext");
+
+            expect(TestContext.name).equal("TestContext");
+        });
+
+        it(`returns a context that stringifies its name`, () => {
+            const TestContext = Context.create("TestContext");
+            const expected = "Context<TestContext>";
+
+            expect(TestContext.toString()).equal(expected);
+            expect(String(TestContext)).equal(expected);
+            expect(`${TestContext}`).equal(expected);
+        });
+
+        it(`returns a context that gets the initial value if not handled`, () => {
+            const initialValue = "hello world";
+            const TestContext = Context.create("TestContext", initialValue);
+
+            const node = document.createElement("div");
+            const value = TestContext.get(node);
+
+            expect(value).equal(initialValue);
+        });
+
+        it(`returns a context that can be used for a protocol request`, () => {
+            const value = "hello world";
+            const TestContext = Context.create("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            TestContext.handle(parent, event => {
+                if (event.context === TestContext) {
+                    event.stopImmediatePropagation();
+                    event.callback(value);
+                }
+            });
+
+            let capture;
+            TestContext.request(child, response => capture = response);
+
+            expect(capture).equal(value);
+        });
+
+        it(`returns a context that can be used for a get request`, () => {
+            const value = "hello world";
+            const TestContext = Context.create("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            TestContext.handle(parent, event => {
+                if (event.context === TestContext) {
+                    event.stopImmediatePropagation();
+                    event.callback(value);
+                }
+            });
+
+            const capture = TestContext.get(child);
+
+            expect(capture).equal(value);
+        });
+
+        it(`returns a context that can be used as a decorator`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const elementName = uniqueElementName();
+
+            class TestElement extends HTMLElement {
+                @TestContext test: string;
+            }
+
+            customElements.define(elementName, TestElement);
+
+            const parent = document.createElement("div");
+            const child = document.createElement(elementName) as TestElement;
+            parent.append(child);
+
+            TestContext.handle(parent, event => {
+                if (event.context === TestContext) {
+                    event.stopImmediatePropagation();
+                    event.callback(value);
+                }
+            });
+
+            expect(child.test).equal(value);
+        });
+    });
+
+    describe(`get()`, () => {
+        it(`gets the value for a context`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            Context.handle(parent, event => {
+                event.stopImmediatePropagation();
+                event.callback(value);
+            }, TestContext);
+
+            const capture = Context.get(child, TestContext);
+
+            expect(capture).equal(value);
+        });
+    });
+
+    describe(`request()`, () => {
+        it(`makes a protocol request`, () => {
+            const value = "hello world";
+            const TestContext = Context.create("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            Context.handle(parent, event => {
+                event.stopImmediatePropagation();
+                event.callback(value);
+            }, TestContext);
+
+            let capture;
+            Context.request(child, TestContext, response => capture = response);
+
+            expect(capture).equal(value);
+        });
+    });
+
+    describe(`dispatch()`, () => {
+        it(`dispatches an event even when the request strategy has been changed`, () => {
+            const wrongValue = "hello world";
+            const rightValue = "bye bye";
+            const TestContext = Context.create<string>("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            Context.setDefaultRequestStrategy((target, context, callback) => {
+                callback(wrongValue as any);
+            });
+
+            Context.handle(parent, event => {
+                event.stopImmediatePropagation();
+                event.callback(rightValue);
+            }, TestContext);
+
+            let capture;
+
+            Context.dispatch(parent, TestContext, value => {
+                capture = value;
+            });
+
+            expect(capture).equal(rightValue);
+
+            Context.setDefaultRequestStrategy(Context.dispatch);
+        });
+    });
+
+    describe(`defineProperty()`, () => {
+        it(`defines a property on a target that returns the context value`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            Context.defineProperty(child, "test", TestContext);
+
+            TestContext.handle(parent, event => {
+                if (event.context === TestContext) {
+                    event.stopImmediatePropagation();
+                    event.callback(value);
+                }
+            });
+
+            expect((child as any).test).equal(value);
+        });
+    });
+
+    describe(`setDefaultRequestStrategy()`, () => {
+        it(`changes how request() works`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            Context.setDefaultRequestStrategy((target, context, callback) => {
+                callback(value as any);
+            });
+
+            let capture;
+
+            Context.request(parent, TestContext, response => {
+                capture = response;
+            });
+
+            expect(capture).equal(value);
+
+            Context.setDefaultRequestStrategy(Context.dispatch);
+        });
+
+        it(`changes how get() works`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            Context.setDefaultRequestStrategy((target, context, callback) => {
+                callback(value as any);
+            });
+
+            let capture = Context.get(child, TestContext);
+
+            expect(capture).equal(value);
+
+            Context.setDefaultRequestStrategy(Context.dispatch);
+        });
+
+        it(`changes how defineProperty() works`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            Context.setDefaultRequestStrategy((target, context, callback) => {
+                callback(value as any);
+            });
+
+            Context.defineProperty(child, "test", TestContext);
+
+            expect((child as any).test).equal(value);
+
+            Context.setDefaultRequestStrategy(Context.dispatch);
+        });
+
+        it(`changes how context decorators work`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const elementName = uniqueElementName();
+
+            class TestElement extends HTMLElement {
+                @TestContext test: string;
+            }
+
+            customElements.define(elementName, TestElement);
+
+            const parent = document.createElement("div");
+            const child = document.createElement(elementName) as TestElement;
+            parent.append(child);
+
+            Context.setDefaultRequestStrategy((target, context, callback) => {
+                callback(value as any);
+            });
+
+            expect(child.test).equal(value);
+
+            Context.setDefaultRequestStrategy(Context.dispatch);
+        });
+    });
+});

--- a/packages/web-components/fast-element/src/context.ts
+++ b/packages/web-components/fast-element/src/context.ts
@@ -9,15 +9,6 @@ export type Context<T> = {
     initialValue?: T;
 };
 
-export type FASTContext<T> = Context<T> & {
-    request(
-        node: Node,
-        callback: ContextCallback<FASTContext<T>>,
-        multiple?: boolean
-    ): void;
-    handle(node: Node, callback: (event: ContextEvent<FASTContext<T>>) => void);
-};
-
 /**
  * A constant key that can be used to represent an interface to a dependency.
  * The key can be used for context or DI but also doubles as a decorator for
@@ -25,8 +16,21 @@ export type FASTContext<T> = Context<T> & {
  * @public
  */
 /* eslint-disable-next-line @typescript-eslint/no-unused-vars */
-export type InterfaceSymbol<T = any> = Readonly<Context<T>> &
+export type ContextDecorator<T = any> = Readonly<Context<T>> &
     ((target: Constructable, property: string, index?: number) => void);
+
+/**
+ * A Context object defines an optional initial value for a Context, as well as a name identifier for debugging purposes.
+ * The FASTContext can also be used as a decorator to declare context dependencies or as a key for DI.
+ */
+export type FASTContext<T> = ContextDecorator<T> & {
+    request(
+        node: Node,
+        callback: ContextCallback<FASTContext<T>>,
+        multiple?: boolean
+    ): void;
+    handle(node: Node, callback: (event: ContextEvent<FASTContext<T>>) => void);
+};
 
 const contextEventName = "context-request";
 
@@ -41,10 +45,7 @@ export const Context = Object.freeze({
      * Creates a W3C Community Protocol-based Context object to use in requesting/providing
      * context through the DOM.
      */
-    create<T = unknown>(
-        name: string,
-        initialValue?: T
-    ): InterfaceSymbol<T> & Readonly<FASTContext<T>> {
+    create<T = unknown>(name: string, initialValue?: T): FASTContext<T> {
         const Interface = function (
             target: Constructable<Node>,
             property: string,
@@ -84,7 +85,7 @@ export const Context = Object.freeze({
         };
 
         Interface.toString = function toString(): string {
-            return `ContextInterfaceSymbol<${Interface.name}>`;
+            return `Context<${Interface.name}>`;
         };
 
         return Interface;

--- a/packages/web-components/fast-element/src/context.ts
+++ b/packages/web-components/fast-element/src/context.ts
@@ -6,17 +6,16 @@ import { Metadata } from "./metadata.js";
  * @public
  */
 export type Context<T> = {
-    name: string;
-    initialValue?: T;
+    readonly name: string;
+    readonly initialValue?: T;
 };
 
 /**
- * A constant key that can be used to represent an interface to a dependency.
+ * A constant key that can be used to represent a Context dependency.
  * The key can be used for context or DI but also doubles as a decorator for
  * resolving the associated dependency.
  * @beta
  */
-/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
 export type ContextDecorator<T = any> = Readonly<Context<T>> &
     ((target: Constructable, property: string, index?: number) => void);
 
@@ -26,8 +25,9 @@ export type ContextDecorator<T = any> = Readonly<Context<T>> &
  * @beta
  */
 export type FASTContext<T> = ContextDecorator<T> & {
-    request(node: Node, callback: ContextCallback<T>, multiple?: boolean): void;
-    handle(node: Node, callback: (event: ContextEvent<FASTContext<T>>) => void);
+    get(target: EventTarget): T;
+    request(target: EventTarget, callback: ContextCallback<T>, multiple?: boolean): void;
+    handle(target: EventTarget, callback: (event: ContextEvent<FASTContext<T>>) => void);
 };
 
 /**
@@ -59,6 +59,8 @@ export const Context = Object.freeze({
     /**
      * Creates a W3C Community Protocol-based Context object to use in requesting/providing
      * context through the DOM.
+     * @param name - The name to use for the connext. Useful in debugging.
+     * @param initialValue - An optional initial value to use if a context handler isn't found.
      */
     create<T = unknown>(name: string, initialValue?: T): FASTContext<T> {
         const Interface = function (
@@ -73,10 +75,8 @@ export const Context = Object.freeze({
             if (property) {
                 Context.defineProperty(target, property, Interface);
             } else {
-                const annotationParamtypes = Metadata.getOrCreateAnnotationParamTypes(
-                    target
-                );
-                annotationParamtypes[index] = Interface;
+                const types = Metadata.getOrCreateAnnotationParamTypes(target);
+                types[index] = Interface;
             }
         } as FASTContext<T>;
 
@@ -84,41 +84,79 @@ export const Context = Object.freeze({
         (Interface as any).initialValue = initialValue;
         Reflect.defineProperty(Interface, "name", { value: name });
 
-        Interface.handle = function (
-            node: Node,
+        Interface.handle = (
+            target: EventTarget,
             callback: (event: ContextEvent<FASTContext<T>>) => void
-        ) {
-            Context.handle(node, callback, Interface);
-        };
+        ) => Context.handle(target, callback, Interface);
 
-        Interface.request = function (
-            node: Node,
+        Interface.get = (target: EventTarget) => Context.get(target, Interface);
+
+        Interface.request = (
+            target: EventTarget,
             callback: ContextCallback<T>,
             multiple?: boolean
-        ) {
-            Context.request(node, Interface, callback, multiple);
-        };
+        ) => Context.request(target, Interface, callback, multiple);
 
-        Interface.toString = function toString(): string {
-            return `Context<${Interface.name}>`;
-        };
+        Interface.toString = () => `Context<${Interface.name}>`;
 
         return Interface;
     },
 
+    /**
+     * Sets the strategy used by all FAST-specific context requests made through the
+     * Context.request, Context.get, Context.defineProperty, and ContextDecorator APIs.
+     * @param strategy - The strategy to use. By default, the strategy is Context.dispatch.
+     */
     setDefaultRequestStrategy(strategy: FASTContextRequestStrategy) {
         requestStrategy = strategy;
     },
 
+    /**
+     * Gets the context value for the target node or returns the initial value if
+     * a context handler is not found.
+     * @param target - The target to get the context for.
+     * @param context - The context to locate.
+     * @returns The context value.
+     * @remarks
+     * Uses the default request strategy to locate the context. If no context is found
+     * then the initial value of the context is returned.
+     */
+    get<T extends UnknownContext>(target: EventTarget, context: T): ContextType<T> {
+        let value: ContextType<T>;
+        requestStrategy(target, context, found => (value = found), false);
+        return value! ?? (context.initialValue as ContextType<T>);
+    },
+
+    /**
+     * Requests the context value for the target node.
+     * @param target - The target to request the context for.
+     * @param context - The context to locate.
+     * @param callback - A callback to invoke with the context value.
+     * @param multiple - Whether the context requestor expects to handle updates
+     * to the context value after the initial request.
+     * @remarks
+     * Uses the default request strategy to locate the context.
+     */
     request<T extends UnknownContext>(
         target: EventTarget,
         context: T,
         callback: ContextCallback<ContextType<T>>,
         multiple = false
-    ) {
+    ): void {
         requestStrategy(target, context, callback, multiple);
     },
 
+    /**
+     *
+     * @param target - The target to dispatch the context event on.
+     * @param context - The context to locate.
+     * @param callback - The callback to invoke with the context value.
+     * @param multiple - Whether the context requestor expects to handle updates
+     * to the context value after the initial request.
+     * @remarks
+     * This API does NOT use the default request strategy. It always dispatches
+     * an event through the DOM.
+     */
     dispatch<T extends UnknownContext>(
         target: EventTarget,
         context: T,
@@ -128,6 +166,15 @@ export const Context = Object.freeze({
         target.dispatchEvent(new ContextEvent(context, callback, multiple));
     },
 
+    /**
+     *
+     * @param target - The target on which to handle context requests.
+     * @param callback - The callback to invoke when a context request is received.
+     * @param context - The context to handle requests for.
+     * @remarks
+     * If a context is not provided then the callback will be invoked for all context
+     * requests that are received on the target.
+     */
     handle<T extends UnknownContext>(
         target: EventTarget,
         callback: (event: ContextEvent<T>) => void,
@@ -144,22 +191,26 @@ export const Context = Object.freeze({
         }
     },
 
+    /**
+     * Defines a getter-only property on the target that will return the context
+     * value for the target.
+     * @param target The target to define the property on.
+     * @param propertyName The name of the property to define.
+     * @param context The context that will be used to retrieve the property value.
+     * @remarks
+     * Uses the default request strategy to locate the context and will return the
+     * initialValue if the context isn't handled.
+     */
     defineProperty<T extends UnknownContext>(
-        target: Constructable<Node> | Node,
+        target: Constructable<EventTarget> | EventTarget,
         propertyName: string,
         context: T
     ) {
         const field = `$di_${propertyName}`;
 
         Reflect.defineProperty(target, propertyName, {
-            get: function (this: Node) {
-                let value = this[field];
-
-                if (value === void 0) {
-                    Context.request(this, context, found => (value = found));
-                }
-
-                return value ?? context.initialValue;
+            get: function (this: EventTarget) {
+                return this[field] ?? (this[field] = Context.get(this, context));
             },
         });
     },

--- a/packages/web-components/fast-element/src/context.ts
+++ b/packages/web-components/fast-element/src/context.ts
@@ -1,0 +1,182 @@
+import type { Constructable } from "./interfaces.js";
+import { Metadata } from "./metadata.js";
+
+/**
+ * A Context object defines an optional initial value for a Context, as well as a name identifier for debugging purposes.
+ */
+export type Context<T> = {
+    name: string;
+    initialValue?: T;
+};
+
+export type FASTContext<T> = Context<T> & {
+    request(
+        node: Node,
+        callback: ContextCallback<FASTContext<T>>,
+        multiple?: boolean
+    ): void;
+    handle(node: Node, callback: (event: ContextEvent<FASTContext<T>>) => void);
+};
+
+/**
+ * A constant key that can be used to represent an interface to a dependency.
+ * The key can be used for context or DI but also doubles as a decorator for
+ * resolving the associated dependency.
+ * @public
+ */
+/* eslint-disable-next-line @typescript-eslint/no-unused-vars */
+export type InterfaceSymbol<T = any> = Readonly<Context<T>> &
+    ((target: Constructable, property: string, index?: number) => void);
+
+const contextEventName = "context-request";
+
+let getValueForInjectedProperty = function <T>(object: Node, context: Context<T>) {
+    let value;
+    Context.request(object, context, found => (value = found));
+    return value;
+};
+
+export const Context = Object.freeze({
+    /**
+     * Creates a W3C Community Protocol-based Context object to use in requesting/providing
+     * context through the DOM.
+     */
+    create<T = unknown>(
+        name: string,
+        initialValue?: T
+    ): InterfaceSymbol<T> & Readonly<FASTContext<T>> {
+        const Interface = function (
+            target: Constructable<Node>,
+            property: string,
+            index: number
+        ): void {
+            if (target == null || new.target !== undefined) {
+                throw new Error(`No registration for interface: '${Interface.name}'`);
+            }
+
+            if (property) {
+                Context.defineProperty(target, property, Interface);
+            } else {
+                const annotationParamtypes = Metadata.getOrCreateAnnotationParamTypes(
+                    target
+                );
+                annotationParamtypes[index] = Interface;
+            }
+        };
+
+        Interface.$isInterface = true;
+        Interface.initialValue = initialValue;
+        Reflect.defineProperty(Interface, "name", { value: name });
+
+        Interface.handle = function (
+            node: Node,
+            callback: (event: ContextEvent<FASTContext<T>>) => void
+        ) {
+            Context.handle(node, callback);
+        };
+
+        Interface.request = function (
+            node: Node,
+            callback: ContextCallback<FASTContext<T>>,
+            multiple?: boolean
+        ) {
+            Context.request(node, this, callback, multiple);
+        };
+
+        Interface.toString = function toString(): string {
+            return `ContextInterfaceSymbol<${Interface.name}>`;
+        };
+
+        return Interface;
+    },
+
+    request<T extends UnknownContext>(
+        node: Node,
+        context: T,
+        callback: ContextCallback<ContextType<T>>,
+        multiple = false
+    ) {
+        node.dispatchEvent(new ContextEvent(context, callback, multiple));
+    },
+
+    handle<T extends UnknownContext>(
+        node: Node,
+        callback: (event: ContextEvent<T>) => void
+    ) {
+        node.addEventListener(contextEventName, callback);
+    },
+
+    defineProperty<T extends UnknownContext>(
+        target: Constructable<Node> | Node,
+        propertyName: string,
+        context: T
+    ) {
+        const field = `$di_${propertyName}`;
+
+        Reflect.defineProperty(target, propertyName, {
+            get: function (this: Node) {
+                let value = this[field];
+
+                if (value === void 0) {
+                    value = getValueForInjectedProperty(this, context);
+                }
+
+                return value ?? context.initialValue;
+            },
+        });
+    },
+
+    setDefaultPropertyInjectionStrategy(
+        strategy: <T = unknown>(object: Node, context: Context<T>) => T
+    ) {
+        getValueForInjectedProperty = strategy;
+    },
+});
+
+/**
+ * An unknown context typeU
+ */
+export type UnknownContext = Context<unknown>;
+
+/**
+ * A helper type which can extract a Context value type from a Context type
+ */
+export type ContextType<T extends UnknownContext> = T extends Context<infer Y>
+    ? Y
+    : never;
+
+/**
+ * A callback which is provided by a context requester and is called with the value satisfying the request.
+ * This callback can be called multiple times by context providers as the requested value is changed.
+ */
+export type ContextCallback<ValueType> = (value: ValueType, dispose?: () => void) => void;
+
+/**
+ * An event fired by a context requester to signal it desires a named context.
+ *
+ * A provider should inspect the `context` property of the event to determine if it has a value that can
+ * satisfy the request, calling the `callback` with the requested value if so.
+ *
+ * If the requested context event contains a truthy `multiple` value, then a provider can call the callback
+ * multiple times if the value is changed, if this is the case the provider should pass a `dispose`
+ * method to the callback which requesters can invoke to indicate they no longer wish to receive these updates.
+ */
+export class ContextEvent<T extends UnknownContext> extends Event {
+    public constructor(
+        public readonly context: T,
+        public readonly callback: ContextCallback<ContextType<T>>,
+        public readonly multiple?: boolean
+    ) {
+        super(contextEventName, { bubbles: true, composed: true });
+    }
+}
+
+declare global {
+    interface HTMLElementEventMap {
+        /**
+         * A 'context-request' event can be emitted by any element which desires
+         * a context value to be injected by an external provider.
+         */
+        [contextEventName]: ContextEvent<UnknownContext>;
+    }
+}

--- a/packages/web-components/fast-element/src/context.ts
+++ b/packages/web-components/fast-element/src/context.ts
@@ -48,7 +48,7 @@ const contextEventType = "context-request";
 let requestStrategy: FASTContextRequestStrategy;
 
 /**
- * Enables using the W3C Community Context protocol.
+ * Enables using the {@link https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/context.md | W3C Community Context protocol.}
  * @beta
  */
 export const Context = Object.freeze({

--- a/packages/web-components/fast-element/src/context.ts
+++ b/packages/web-components/fast-element/src/context.ts
@@ -17,7 +17,8 @@ export type Context<T> = {
  * @beta
  */
 export type ContextDecorator<T = any> = Readonly<Context<T>> &
-    ((target: Constructable, property: string, index?: number) => void);
+    PropertyDecorator &
+    ParameterDecorator;
 
 /**
  * A Context object defines an optional initial value for a Context, as well as a name identifier for debugging purposes.

--- a/packages/web-components/fast-element/src/metadata.spec.ts
+++ b/packages/web-components/fast-element/src/metadata.spec.ts
@@ -1,0 +1,183 @@
+import { expect } from "chai";
+import { Metadata } from "./metadata.js";
+import { emptyArray } from "./platform.js";
+
+function decorator(): ClassDecorator { return (target: any) => target; }
+
+describe("Metadata", () => {
+    describe(`getDesignParamTypes()`, () => {
+        it(`returns emptyArray if the class has no constructor or decorators`, () => {
+            class Foo {}
+
+            const actual = Metadata.getDesignParamTypes(Foo);
+
+            expect(actual).equal(emptyArray);
+        });
+
+        it(`returns emptyArray if the class has a decorator but no constructor`, () => {
+            @decorator()
+            class Foo {}
+
+            const actual = Metadata.getDesignParamTypes(Foo);
+
+            expect(actual).equal(emptyArray);
+        });
+
+        it(`returns emptyArray if the class has no constructor args or decorators`, () => {
+            class Foo { constructor() { return; } }
+
+            const actual = Metadata.getDesignParamTypes(Foo);
+
+            expect(actual).equal(emptyArray);
+        });
+
+        it(`returns emptyArray if the class has constructor args but no decorators`, () => {
+            class Bar {}
+            class Foo { constructor(public bar: Bar) {} }
+
+            const actual = Metadata.getDesignParamTypes(Foo);
+
+            expect(actual).equal(emptyArray);
+        });
+
+        it(`returns emptyArray if the class has constructor args and the decorator is applied via a function call`, () => {
+            class Bar {}
+            class Foo { constructor(public bar: Bar) {} }
+
+            decorator()(Foo);
+            const actual = Metadata.getDesignParamTypes(Foo);
+
+            expect(actual).equal(emptyArray);
+        });
+
+        it(`returns an empty mutable array if the class has a decorator but no constructor args`, () => {
+            @decorator()
+            class Foo { constructor() { return; } }
+
+            const actual = Metadata.getDesignParamTypes(Foo);
+
+            expect(actual).not.equal(emptyArray);
+            expect(actual).length(0);
+        });
+
+        describe(`falls back to Object for declarations that cannot be statically analyzed`, () => {
+            interface ArgCtor {}
+
+            for (const argCtor of [
+                class Bar {},
+                function () { return; },
+                () => { return; },
+                class {},
+                {},
+                Error,
+                Array,
+                (class Bar {}).prototype,
+                (class Bar {}).prototype.constructor
+            ] as any[]) {
+                @decorator()
+                class FooDecoratorInvocation { constructor(public arg: ArgCtor) {} }
+
+                it(`FooDecoratorInvocation { constructor(${argCtor.name}) }`, () => {
+                    const actual = Metadata.getDesignParamTypes(FooDecoratorInvocation);
+                    expect(actual).length(1);
+                    expect(actual[0]).equal(Object);
+                });
+
+                @(decorator as any)
+                class FooDecoratorNonInvocation { constructor(public arg: ArgCtor) {} }
+
+                it(`FooDecoratorNonInvocation { constructor(${argCtor.name}) }`, () => {
+                    const actual = Metadata.getDesignParamTypes(FooDecoratorInvocation);
+                    expect(actual).length(1);
+                    expect(actual[0]).equal(Object);
+                });
+            }
+        });
+
+        describe(`returns the correct types for valid declarations`, () =>  {
+            class Bar {}
+            class Foo {}
+            class Baz {}
+
+            describe(`decorator invocation`, () =>  {
+                it(`Class { constructor(public arg: Bar) }`, () =>  {
+                    @decorator()
+                    class FooBar { constructor(public arg: Bar) {} }
+
+                    const actual = Metadata.getDesignParamTypes(FooBar);
+
+                    expect(actual).length(1);
+                    expect(actual[0]).equal(Bar);
+                });
+
+                it(`Class { constructor(public arg1: Bar, public arg2: Foo) }`, () =>  {
+                    @decorator()
+                    class FooBar { constructor(public arg1: Bar, public arg2: Foo) {} }
+
+                    const actual = Metadata.getDesignParamTypes(FooBar);
+
+                    expect(actual).length(2);
+                    expect(actual[0]).equal(Bar);
+                    expect(actual[1]).equal(Foo);
+                });
+
+                it(`Class { constructor(public arg1: Bar, public arg2: Foo, public arg3: Baz) }`, () => {
+                    @decorator()
+                    class FooBar { constructor(public arg1: Bar, public arg2: Foo, public arg3: Baz) {} }
+
+                    const actual = Metadata.getDesignParamTypes(FooBar);
+
+                    expect(actual).length(3);
+                    expect(actual[0]).equal(Bar);
+                    expect(actual[1]).equal(Foo);
+                    expect(actual[2]).equal(Baz);
+                });
+            });
+        });
+    });
+
+    describe(`getAnnotationParamTypes()`, () => {
+        it("returns emptyArray if the class has no annotations", () => {
+            class Foo {}
+
+            const actual = Metadata.getAnnotationParamTypes(Foo);
+
+            expect(actual).equal(emptyArray);
+        });
+
+        it("returns added annotations", () => {
+            class Foo {}
+
+            const a = Metadata.getOrCreateAnnotationParamTypes(Foo);
+            a.push("test");
+
+            const actual = Metadata.getAnnotationParamTypes(Foo);
+
+            expect(actual).length(1);
+            expect(actual[0]).equal("test");
+        });
+    });
+
+    describe(`getOrCreateAnnotationParamTypes()`, () => {
+        it("returns an empty mutable array if the class has no annotations", () => {
+            class Foo {}
+
+            const actual = Metadata.getOrCreateAnnotationParamTypes(Foo);
+
+            expect(actual).not.equal(emptyArray);
+            expect(actual).length(0);
+        });
+
+        it("returns added annotations", () => {
+            class Foo {}
+
+            const a = Metadata.getOrCreateAnnotationParamTypes(Foo);
+            a.push("test");
+
+            const actual = Metadata.getOrCreateAnnotationParamTypes(Foo);
+
+            expect(actual).length(1);
+            expect(actual[0]).equal("test");
+        });
+    });
+});

--- a/packages/web-components/fast-element/src/metadata.ts
+++ b/packages/web-components/fast-element/src/metadata.ts
@@ -32,6 +32,9 @@ if (!("metadata" in Reflect)) {
     };
 }
 
+/**
+ * Provides basic metadata capabilities used by Context and Dependency Injection.
+ */
 export const Metadata = Object.freeze({
     /**
      * Gets the "design:paramtypes" metadata for the specified type.

--- a/packages/web-components/fast-element/src/metadata.ts
+++ b/packages/web-components/fast-element/src/metadata.ts
@@ -1,4 +1,5 @@
 import type { Constructable } from "./interfaces.js";
+import { emptyArray } from "./platform.js";
 
 // Tiny polyfill for TypeScript's Reflect metadata API.
 const metadataByTarget = new Map<any, Map<any, any>>();
@@ -31,44 +32,38 @@ if (!("metadata" in Reflect)) {
     };
 }
 
-function getParamTypes(key: string): (Type) => readonly any[] | undefined {
-    return Type => {
-        return (Reflect as any).getOwnMetadata(key, Type);
-    };
-}
-
 export const Metadata = Object.freeze({
     /**
      * Gets the "design:paramtypes" metadata for the specified type.
      * @param Type - The type to get the metadata for.
-     * @returns The metadata array or undefined if no metadata is found.
+     * @returns The metadata array or a frozen empty array if no metadata is found.
      */
-    getDesignParamtypes: getParamTypes("design:paramtypes"),
+    getDesignParamTypes: Type =>
+        (Reflect as any).getOwnMetadata("design:paramtypes", Type) ??
+        (emptyArray as readonly any[]),
 
     /**
-     * Gets the "di:paramtypes" metadata for the specified type.
+     * Gets the "annotation:paramtypes" metadata for the specified type.
      * @param Type - The type to get the metadata for.
-     * @returns The metadata array or undefined if no metadata is found.
+     * @returns The metadata array or a frozen empty array if no metadata is found.
      */
-    getAnnotationParamtypes: getParamTypes("di:paramtypes"),
+    getAnnotationParamTypes: Type =>
+        (Reflect as any).getOwnMetadata("annotation:paramtypes", Type) ??
+        (emptyArray as readonly any[]),
 
     /**
      *
-     * @param Type - Gets the "di:paramtypes" metadata for the specified type. If none is found,
-     * an empty metadata array is created and added.
+     * @param Type - Gets the "annotation:paramtypes" metadata for the specified type. If none is found,
+     * an empty, mutable metadata array is created and added.
      * @returns The metadata array.
      */
     getOrCreateAnnotationParamTypes(Type: Constructable): any[] {
-        let annotationParamtypes = this.getAnnotationParamtypes(Type);
+        let types = this.getAnnotationParamTypes(Type);
 
-        if (annotationParamtypes === void 0) {
-            (Reflect as any).defineMetadata(
-                "di:paramtypes",
-                (annotationParamtypes = []),
-                Type
-            );
+        if (types === emptyArray) {
+            (Reflect as any).defineMetadata("annotation:paramtypes", (types = []), Type);
         }
 
-        return annotationParamtypes;
+        return types;
     },
 });

--- a/packages/web-components/fast-element/src/metadata.ts
+++ b/packages/web-components/fast-element/src/metadata.ts
@@ -1,0 +1,74 @@
+import type { Constructable } from "./interfaces.js";
+
+// Tiny polyfill for TypeScript's Reflect metadata API.
+const metadataByTarget = new Map<any, Map<any, any>>();
+
+if (!("metadata" in Reflect)) {
+    (Reflect as any).metadata = function (key: any, value: any) {
+        return function (target: any) {
+            (Reflect as any).defineMetadata(key, value, target);
+        };
+    };
+
+    (Reflect as any).defineMetadata = function (key: any, value: any, target: any) {
+        let metadata = metadataByTarget.get(target);
+
+        if (metadata === void 0) {
+            metadataByTarget.set(target, (metadata = new Map()));
+        }
+
+        metadata.set(key, value);
+    };
+
+    (Reflect as any).getOwnMetadata = function (key: any, target: any): any {
+        const metadata = metadataByTarget.get(target);
+
+        if (metadata !== void 0) {
+            return metadata.get(key);
+        }
+
+        return void 0;
+    };
+}
+
+function getParamTypes(key: string): (Type) => readonly any[] | undefined {
+    return Type => {
+        return (Reflect as any).getOwnMetadata(key, Type);
+    };
+}
+
+export const Metadata = Object.freeze({
+    /**
+     * Gets the "design:paramtypes" metadata for the specified type.
+     * @param Type - The type to get the metadata for.
+     * @returns The metadata array or undefined if no metadata is found.
+     */
+    getDesignParamtypes: getParamTypes("design:paramtypes"),
+
+    /**
+     * Gets the "di:paramtypes" metadata for the specified type.
+     * @param Type - The type to get the metadata for.
+     * @returns The metadata array or undefined if no metadata is found.
+     */
+    getAnnotationParamtypes: getParamTypes("di:paramtypes"),
+
+    /**
+     *
+     * @param Type - Gets the "di:paramtypes" metadata for the specified type. If none is found,
+     * an empty metadata array is created and added.
+     * @returns The metadata array.
+     */
+    getOrCreateAnnotationParamTypes(Type: Constructable): any[] {
+        let annotationParamtypes = this.getAnnotationParamtypes(Type);
+
+        if (annotationParamtypes === void 0) {
+            (Reflect as any).defineMetadata(
+                "di:paramtypes",
+                (annotationParamtypes = []),
+                Type
+            );
+        }
+
+        return annotationParamtypes;
+    },
+});

--- a/packages/web-components/fast-element/tsconfig.json
+++ b/packages/web-components/fast-element/tsconfig.json
@@ -5,6 +5,7 @@
         "outDir": "dist/esm",
         "importsNotUsedAsValues": "error",
         "experimentalDecorators": true,
+        "emitDecoratorMetadata": true,
         "noImplicitAny": false,
         "strictPropertyInitialization": false,
         "target": "es2015",

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -12,7 +12,7 @@ import { ComposableStyles } from '@microsoft/fast-element';
 import { composedContains } from '@microsoft/fast-element/utilities';
 import { composedParent } from '@microsoft/fast-element/utilities';
 import { Constructable } from '@microsoft/fast-element';
-import { Context } from '@microsoft/fast-element/context';
+import { ContextDecorator } from '@microsoft/fast-element/context';
 import { CSSDirective } from '@microsoft/fast-element';
 import { Direction } from '@microsoft/fast-web-utilities';
 import { ElementStyles } from '@microsoft/fast-element';
@@ -617,7 +617,7 @@ export interface Container extends ServiceLocator {
 }
 
 // @public
-export const Container: InterfaceSymbol<Container>;
+export const Container: ContextDecorator<Container>;
 
 // @public
 export interface ContainerConfiguration {
@@ -1060,7 +1060,8 @@ export const DI: Readonly<{
     getOrCreateDOMContainer(node?: Node, config?: Partial<Omit<ContainerConfiguration, "parentLocator">>): Container;
     getDependencies(Type: Constructable | Injectable): Key[];
     defineProperty(target: {}, propertyName: string, key: Key, respectConnection?: boolean): void;
-    createInterface<K extends Key>(nameConfigOrCallback?: string | InterfaceConfiguration | ((builder: ResolverBuilder<K>) => Resolver<K>) | undefined, configuror?: ((builder: ResolverBuilder<K>) => Resolver<K>) | undefined): InterfaceSymbol<K>;
+    createContext: typeof createContext;
+    createInterface: typeof createContext;
     inject(...dependencies: Key[]): (target: any, key?: string | number, descriptor?: PropertyDescriptor | number) => void;
     transient<T extends Constructable<{}>>(target: T & Partial<RegisterSelf<T>>): T & RegisterSelf<T>;
     singleton<T_1 extends Constructable<{}>>(target: T_1 & Partial<RegisterSelf<T_1>>, options?: SingletonOptions): T_1 & RegisterSelf<T_1>;
@@ -1440,16 +1441,13 @@ export interface InterfaceConfiguration {
 }
 
 // @public
-export type InterfaceSymbol<T = any> = Readonly<Context<T>> & ((target: Constructable, property: string, index?: number) => void);
-
-// @public
 export function isListboxOption(el: Element): el is ListboxOption;
 
 // @public
 export function isTreeItemElement(el: Element): el is HTMLElement;
 
 // @public
-export type Key = PropertyKey | object | InterfaceSymbol | Constructable | Resolver;
+export type Key = PropertyKey | object | ContextDecorator | Constructable | Resolver;
 
 // @public
 export const lazy: (key: any) => any;
@@ -2155,7 +2153,7 @@ export type ResolveCallback<T = any> = (handler: Container, requestor: Container
 // Warning: (ae-forgotten-export) The symbol "ResolverLike" needs to be exported by the entry point index.d.ts
 //
 // @public
-export type Resolved<K> = K extends InterfaceSymbol<infer T> ? T : K extends Constructable ? InstanceType<K> : K extends ResolverLike<any, infer T1> ? T1 extends Constructable ? InstanceType<T1> : T1 : K;
+export type Resolved<K> = K extends ContextDecorator<infer T> ? T : K extends Constructable ? InstanceType<K> : K extends ResolverLike<any, infer T1> ? T1 extends Constructable ? InstanceType<T1> : T1 : K;
 
 // @public
 export interface Resolver<K = any> extends ResolverLike<Container, K> {
@@ -2370,7 +2368,7 @@ export interface ServiceLocator {
 }
 
 // @public
-export const ServiceLocator: InterfaceSymbol<ServiceLocator>;
+export const ServiceLocator: ContextDecorator<ServiceLocator>;
 
 // Warning: (ae-forgotten-export) The symbol "singletonDecorator" needs to be exported by the entry point index.d.ts
 //
@@ -2991,7 +2989,8 @@ export type YearFormat = "2-digit" | "numeric";
 // Warnings were encountered during analysis:
 //
 // dist/dts/design-token/design-token.d.ts:91:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
-// dist/dts/di/di.d.ts:500:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
+// dist/dts/di/di.d.ts:433:5 - (ae-forgotten-export) The symbol "createContext" needs to be exported by the entry point index.d.ts
+// dist/dts/di/di.d.ts:499:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -12,6 +12,7 @@ import { ComposableStyles } from '@microsoft/fast-element';
 import { composedContains } from '@microsoft/fast-element/utilities';
 import { composedParent } from '@microsoft/fast-element/utilities';
 import { Constructable } from '@microsoft/fast-element';
+import { Context } from '@microsoft/fast-element/context';
 import { CSSDirective } from '@microsoft/fast-element';
 import { Direction } from '@microsoft/fast-web-utilities';
 import { ElementStyles } from '@microsoft/fast-element';
@@ -1052,13 +1053,11 @@ export type DesignTokenValue<T> = StaticDesignTokenValue<T> | DerivedDesignToken
 
 // @public
 export const DI: Readonly<{
+    handlePropertyInjectionContextRequests(): void;
     createContainer(config?: Partial<ContainerConfiguration>): Container;
     findResponsibleContainer(node: Node): Container;
     findParentContainer(node: Node): Container;
     getOrCreateDOMContainer(node?: Node, config?: Partial<Omit<ContainerConfiguration, "parentLocator">>): Container;
-    getDesignParamtypes: (Type: Constructable | Injectable) => readonly Key[] | undefined;
-    getAnnotationParamtypes: (Type: Constructable | Injectable) => readonly Key[] | undefined;
-    getOrCreateAnnotationParamTypes(Type: Constructable | Injectable): Key[];
     getDependencies(Type: Constructable | Injectable): Key[];
     defineProperty(target: {}, propertyName: string, key: Key, respectConnection?: boolean): void;
     createInterface<K extends Key>(nameConfigOrCallback?: string | InterfaceConfiguration | ((builder: ResolverBuilder<K>) => Resolver<K>) | undefined, configuror?: ((builder: ResolverBuilder<K>) => Resolver<K>) | undefined): InterfaceSymbol<K>;
@@ -1441,7 +1440,7 @@ export interface InterfaceConfiguration {
 }
 
 // @public
-export type InterfaceSymbol<K = any> = (target: any, property: string, index?: number) => void;
+export type InterfaceSymbol<T = any> = Readonly<Context<T>> & ((target: Constructable, property: string, index?: number) => void);
 
 // @public
 export function isListboxOption(el: Element): el is ListboxOption;
@@ -2992,7 +2991,7 @@ export type YearFormat = "2-digit" | "numeric";
 // Warnings were encountered during analysis:
 //
 // dist/dts/design-token/design-token.d.ts:91:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
-// dist/dts/di/di.d.ts:513:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
+// dist/dts/di/di.d.ts:500:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -635,7 +635,7 @@ export const ContainerConfiguration: Readonly<{
 //
 // @internal (undocumented)
 export class ContainerImpl implements DOMContainer {
-    constructor(owner: EventTarget | null, config: ContainerConfiguration);
+    constructor(owner: any, config: ContainerConfiguration);
     // (undocumented)
     protected config: ContainerConfiguration;
     // (undocumented)
@@ -655,7 +655,7 @@ export class ContainerImpl implements DOMContainer {
     // (undocumented)
     has<K extends Key>(key: K, searchAncestors?: boolean): boolean;
     // (undocumented)
-    protected owner: EventTarget | null;
+    protected owner: any;
     // (undocumented)
     get parent(): ContainerImpl | null;
     // (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -634,8 +634,8 @@ export const ContainerConfiguration: Readonly<{
 // Warning: (ae-internal-missing-underscore) The name "ContainerImpl" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal (undocumented)
-export class ContainerImpl implements Container {
-    constructor(owner: any, config: ContainerConfiguration);
+export class ContainerImpl implements DOMContainer {
+    constructor(owner: EventTarget | null, config: ContainerConfiguration);
     // (undocumented)
     protected config: ContainerConfiguration;
     // (undocumented)
@@ -651,9 +651,11 @@ export class ContainerImpl implements Container {
     // (undocumented)
     getResolver<K extends Key, T = K>(key: K | Key, autoRegister?: boolean): Resolver<T> | null;
     // (undocumented)
+    handleContextRequests(enable: boolean): void;
+    // (undocumented)
     has<K extends Key>(key: K, searchAncestors?: boolean): boolean;
     // (undocumented)
-    protected owner: any;
+    protected owner: EventTarget | null;
     // (undocumented)
     get parent(): ContainerImpl | null;
     // (undocumented)
@@ -1053,11 +1055,11 @@ export type DesignTokenValue<T> = StaticDesignTokenValue<T> | DerivedDesignToken
 
 // @public
 export const DI: Readonly<{
-    handlePropertyInjectionContextRequests(): void;
+    installAsContextRequestStrategy(): void;
     createContainer(config?: Partial<ContainerConfiguration>): Container;
-    findResponsibleContainer(node: Node): Container;
-    findParentContainer(node: Node): Container;
-    getOrCreateDOMContainer(node?: Node, config?: Partial<Omit<ContainerConfiguration, "parentLocator">>): Container;
+    findResponsibleContainer(target: EventTarget): DOMContainer;
+    findParentContainer(target: EventTarget): DOMContainer;
+    getOrCreateDOMContainer(target?: EventTarget, config?: Partial<Omit<ContainerConfiguration, "parentLocator">>): DOMContainer;
     getDependencies(Type: Constructable | Injectable): Key[];
     defineProperty(target: {}, propertyName: string, key: Key, respectConnection?: boolean): void;
     createContext: typeof createContext;
@@ -1135,6 +1137,15 @@ export type DividerRole = typeof DividerRole[keyof typeof DividerRole];
 
 // @public
 export const dividerTemplate: FoundationElementTemplate<ViewTemplate<Divider>>;
+
+// @public
+export interface DOMContainer extends Container {
+    // @beta
+    handleContextRequests(enable: boolean): void;
+}
+
+// @public
+export const DOMContainer: ContextDecorator<DOMContainer>;
 
 // @public
 export type ElementDefinitionCallback = (ctx: ElementDefinitionContext) => void;
@@ -2989,8 +3000,8 @@ export type YearFormat = "2-digit" | "numeric";
 // Warnings were encountered during analysis:
 //
 // dist/dts/design-token/design-token.d.ts:91:5 - (ae-forgotten-export) The symbol "create" needs to be exported by the entry point index.d.ts
-// dist/dts/di/di.d.ts:433:5 - (ae-forgotten-export) The symbol "createContext" needs to be exported by the entry point index.d.ts
-// dist/dts/di/di.d.ts:499:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
+// dist/dts/di/di.d.ts:446:5 - (ae-forgotten-export) The symbol "createContext" needs to be exported by the entry point index.d.ts
+// dist/dts/di/di.d.ts:512:5 - (ae-forgotten-export) The symbol "SingletonOptions" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-system/design-system.spec.ts
@@ -371,7 +371,7 @@ describe("DesignSystem", () => {
         class DefaultTest implements Test {}
         class AltTest implements Test {}
 
-        const Test = DI.createInterface<Test>(x => x.singleton(DefaultTest));
+        const Test = DI.createContext<Test>(x => x.singleton(DefaultTest));
 
         const host = document.createElement("div");
         DesignSystem.getOrCreate(host)

--- a/packages/web-components/fast-foundation/src/design-system/design-system.ts
+++ b/packages/web-components/fast-foundation/src/design-system/design-system.ts
@@ -106,7 +106,7 @@ export interface DesignSystem {
 
 let rootDesignSystem: DesignSystem | null = null;
 
-const designSystemKey = DI.createInterface<DesignSystem>(x =>
+const designSystemKey = DI.createContext<DesignSystem>(x =>
     x.cachedCallback(handler => {
         if (rootDesignSystem === null) {
             rootDesignSystem = new DefaultDesignSystem(null, handler);

--- a/packages/web-components/fast-foundation/src/di/di.exception.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.exception.spec.ts
@@ -7,7 +7,7 @@ describe("DI Exception", function () {
 
         interface Foo {}
 
-        const Foo = DI.createInterface<Foo>("Foo");
+        const Foo = DI.createContext<Foo>("Foo");
 
         class Bar {
             public constructor(@Foo public readonly foo: Foo) {}
@@ -24,7 +24,7 @@ describe("DI Exception", function () {
             parent: Foo | null;
         }
 
-        const Foo = DI.createInterface<Foo>("IFoo", x => x.singleton(FooImpl));
+        const Foo = DI.createContext<Foo>("IFoo", x => x.singleton(FooImpl));
 
         class FooImpl {
             public constructor(@optional(Foo) public parent: Foo) {}

--- a/packages/web-components/fast-foundation/src/di/di.get.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.get.spec.ts
@@ -182,7 +182,7 @@ describe("DI.get", function () {
         });
 
         it("interface with default", function () {
-            const Strings = DI.createInterface<string[]>(x => x.instance([]));
+            const Strings = DI.createContext<string[]>(x => x.instance([]));
             class Foo {
                 public constructor(@optional(Strings) public readonly test: string[]) {}
             }
@@ -191,7 +191,7 @@ describe("DI.get", function () {
         });
 
         it("interface with default and default in constructor", function () {
-            const MyStr = DI.createInterface<string>(x => x.instance("hello"));
+            const MyStr = DI.createContext<string>(x => x.instance("hello"));
             class Foo {
                 public constructor(
                     @optional(MyStr) public readonly test: string = "test"
@@ -202,7 +202,7 @@ describe("DI.get", function () {
         });
 
         it("interface with default registered and default in constructor", function () {
-            const MyStr = DI.createInterface<string>(x => x.instance("hello"));
+            const MyStr = DI.createContext<string>(x => x.instance("hello"));
             container.register(MyStr);
             class Foo {
                 public constructor(

--- a/packages/web-components/fast-foundation/src/di/di.getAll.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.getAll.spec.ts
@@ -43,7 +43,7 @@ describe("Container#.getAll", function () {
             id: number;
         }
 
-        const IAttrPattern = DI.createInterface<IAttrPattern>("IAttrPattern");
+        const IAttrPattern = DI.createContext<IAttrPattern>("IAttrPattern");
         // eslint-disable
         for (const searchAncestors of [true, false])
             for (const regInChild of [true, false])

--- a/packages/web-components/fast-foundation/src/di/di.integration.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.integration.spec.ts
@@ -1,4 +1,5 @@
-import { DI, Container, inject, InterfaceSymbol, Registration, singleton } from "./di.js";
+import { DI, Container, inject, Registration, singleton } from "./di.js";
+import type { ContextDecorator } from "@microsoft/fast-element/context";
 import chai, { expect } from "chai";
 import spies from "chai-spies";
 
@@ -53,29 +54,29 @@ describe("DI.getDependencies", function () {
     });
 });
 
-describe("DI.createInterface() -> container.get()", function () {
+describe("DI.createContext() -> container.get()", function () {
     let container: Container;
 
     interface ITransient {}
     class Transient implements ITransient {}
-    let ITransient: InterfaceSymbol<ITransient>;
+    let ITransient: ContextDecorator<ITransient>;
 
     interface ISingleton {}
     class Singleton implements ISingleton {}
-    let ISingleton: InterfaceSymbol<ISingleton>;
+    let ISingleton: ContextDecorator<ISingleton>;
 
     interface IInstance {}
     class Instance implements IInstance {}
-    let IInstance: InterfaceSymbol<IInstance>;
+    let IInstance: ContextDecorator<IInstance>;
     let instance: Instance;
 
     interface ICallback {}
     class Callback implements ICallback {}
-    let ICallback: InterfaceSymbol<ICallback>;
+    let ICallback: ContextDecorator<ICallback>;
 
     interface ICachedCallback {}
     class CachedCallback implements ICachedCallback {}
-    let ICachedCallback: InterfaceSymbol<ICachedCallback>;
+    let ICachedCallback: ContextDecorator<ICachedCallback>;
     const cachedCallback = "cachedCallBack";
     let callbackCount = 0;
     function callbackToCache() {
@@ -89,17 +90,17 @@ describe("DI.createInterface() -> container.get()", function () {
     beforeEach(function () {
         callbackCount = 0;
         container = DI.createContainer();
-        ITransient = DI.createInterface<ITransient>("ITransient", x =>
+        ITransient = DI.createContext<ITransient>("ITransient", x =>
             x.transient(Transient)
         );
-        ISingleton = DI.createInterface<ISingleton>("ISingleton", x =>
+        ISingleton = DI.createContext<ISingleton>("ISingleton", x =>
             x.singleton(Singleton)
         );
         instance = new Instance();
-        IInstance = DI.createInterface<IInstance>("IInstance", x => x.instance(instance));
+        IInstance = DI.createContext<IInstance>("IInstance", x => x.instance(instance));
         callback = chai.spy(() => new Callback());
-        ICallback = DI.createInterface<ICallback>("ICallback", x => x.callback(callback));
-        ICachedCallback = DI.createInterface<ICachedCallback>("ICachedCallback", x =>
+        ICallback = DI.createContext<ICallback>("ICallback", x => x.callback(callback));
+        ICachedCallback = DI.createContext<ICachedCallback>("ICachedCallback", x =>
             x.cachedCallback(callbackToCache)
         );
         chai.spy.on(container, "get");
@@ -255,9 +256,9 @@ describe("DI.createInterface() -> container.get()", function () {
             expect(actual21).equal(actual22);
         });
 
-        it(`InterfaceSymbol alias to transient registration returns a new instance each time`, function () {
+        it(`ContextDecorator alias to transient registration returns a new instance each time`, function () {
             interface IAlias {}
-            const IAlias = DI.createInterface<IAlias>("IAlias", x =>
+            const IAlias = DI.createContext<IAlias>("IAlias", x =>
                 x.aliasTo(ITransient)
             );
 
@@ -275,9 +276,9 @@ describe("DI.createInterface() -> container.get()", function () {
             expect(container.get).to.have.been.nth(4).called.with(ITransient);
         });
 
-        it(`InterfaceSymbol alias to singleton registration returns the same instance each time`, function () {
+        it(`ContextDecorator alias to singleton registration returns the same instance each time`, function () {
             interface IAlias {}
-            const IAlias = DI.createInterface<IAlias>("IAlias", x =>
+            const IAlias = DI.createContext<IAlias>("IAlias", x =>
                 x.aliasTo(ISingleton)
             );
 
@@ -295,9 +296,9 @@ describe("DI.createInterface() -> container.get()", function () {
             expect(container.get).to.have.been.nth(4).called.with(ISingleton);
         });
 
-        it(`InterfaceSymbol alias to instance registration returns the same instance each time`, function () {
+        it(`ContextDecorator alias to instance registration returns the same instance each time`, function () {
             interface IAlias {}
-            const IAlias = DI.createInterface<IAlias>("IAlias", x =>
+            const IAlias = DI.createContext<IAlias>("IAlias", x =>
                 x.aliasTo(IInstance)
             );
 
@@ -317,9 +318,9 @@ describe("DI.createInterface() -> container.get()", function () {
         });
 
         // TODO: make test work
-        it(`InterfaceSymbol alias to callback registration is invoked each time`, function () {
+        it(`ContextDecorator alias to callback registration is invoked each time`, function () {
             interface IAlias {}
-            const IAlias = DI.createInterface<IAlias>("IAlias", x =>
+            const IAlias = DI.createContext<IAlias>("IAlias", x =>
                 x.aliasTo(ICallback)
             );
 
@@ -433,10 +434,10 @@ describe("DI.createInterface() -> container.get()", function () {
         interface ITransientParent {
             dep: any;
         }
-        let ITransientParent: InterfaceSymbol<ITransientParent>;
+        let ITransientParent: ContextDecorator<ITransientParent>;
 
         function register(cls: any) {
-            ITransientParent = DI.createInterface<ITransientParent>(
+            ITransientParent = DI.createContext<ITransientParent>(
                 "ITransientParent",
                 x => x.transient(cls)
             );
@@ -557,10 +558,10 @@ describe("DI.createInterface() -> container.get()", function () {
         interface ISingletonParent {
             dep: any;
         }
-        let ISingletonParent: InterfaceSymbol<ISingletonParent>;
+        let ISingletonParent: ContextDecorator<ISingletonParent>;
 
         function register(cls: any) {
-            ISingletonParent = DI.createInterface<ISingletonParent>(
+            ISingletonParent = DI.createContext<ISingletonParent>(
                 "ISingletonParent",
                 x => x.singleton(cls)
             );
@@ -672,12 +673,12 @@ describe("DI.createInterface() -> container.get()", function () {
         interface IInstanceParent {
             dep: any;
         }
-        let IInstanceParent: InterfaceSymbol<IInstanceParent>;
+        let IInstanceParent: ContextDecorator<IInstanceParent>;
         let instanceParent: IInstanceParent;
 
         function register(cls: any) {
             instanceParent = container.get(cls);
-            IInstanceParent = DI.createInterface<IInstanceParent>("IInstanceParent", x =>
+            IInstanceParent = DI.createContext<IInstanceParent>("IInstanceParent", x =>
                 x.instance(instanceParent)
             );
         }

--- a/packages/web-components/fast-foundation/src/di/di.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.spec.ts
@@ -168,7 +168,7 @@ describe(`The DI object`, function () {
     describe(`createInterface()`, function () {
         it(`returns a function that stringifies its default friendly name`, function () {
             const sut = DI.createInterface();
-            const expected = "InterfaceSymbol<(anonymous)>";
+            const expected = "DIInterfaceSymbol<(anonymous)>";
             expect(sut.toString()).equal(expected, `sut.toString() === '${expected}'`);
             expect(String(sut)).equal(expected, `String(sut) === '${expected}'`);
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
@@ -177,7 +177,7 @@ describe(`The DI object`, function () {
 
         it(`returns a function that stringifies its configured friendly name`, function () {
             const sut = DI.createInterface("IFoo");
-            const expected = "InterfaceSymbol<IFoo>";
+            const expected = "DIInterfaceSymbol<IFoo>";
             expect(sut.toString()).equal(expected, `sut.toString() === '${expected}'`);
             expect(String(sut)).equal(expected, `String(sut) === '${expected}'`);
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/packages/web-components/fast-foundation/src/di/di.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.spec.ts
@@ -165,10 +165,10 @@ describe(`The DI object`, function () {
         }
     });
 
-    describe(`createInterface()`, function () {
+    describe(`createContext()`, function () {
         it(`returns a function that stringifies its default friendly name`, function () {
-            const sut = DI.createInterface();
-            const expected = "DIInterfaceSymbol<(anonymous)>";
+            const sut = DI.createContext();
+            const expected = "DIContext<(anonymous)>";
             expect(sut.toString()).equal(expected, `sut.toString() === '${expected}'`);
             expect(String(sut)).equal(expected, `String(sut) === '${expected}'`);
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions
@@ -176,8 +176,8 @@ describe(`The DI object`, function () {
         });
 
         it(`returns a function that stringifies its configured friendly name`, function () {
-            const sut = DI.createInterface("IFoo");
-            const expected = "DIInterfaceSymbol<IFoo>";
+            const sut = DI.createContext("IFoo");
+            const expected = "DIContext<IFoo>";
             expect(sut.toString()).equal(expected, `sut.toString() === '${expected}'`);
             expect(String(sut)).equal(expected, `String(sut) === '${expected}'`);
             // eslint-disable-next-line @typescript-eslint/restrict-template-expressions

--- a/packages/web-components/fast-foundation/src/di/di.spec.ts
+++ b/packages/web-components/fast-foundation/src/di/di.spec.ts
@@ -13,6 +13,8 @@ import {
 import chai, { expect } from "chai";
 import spies from "chai-spies";
 import { customElement, FASTElement, html, ref } from "@microsoft/fast-element";
+import { Context } from "@microsoft/fast-element/context";
+import { uniqueElementName } from "../testing/exports.js";
 
 chai.use(spies);
 
@@ -36,6 +38,94 @@ describe(`The DI object`, function () {
                 DI.createContainer(),
                 `DI.createContainer()`
             );
+        });
+    });
+
+    describe("installAsContextRequestStrategy", () => {
+        it(`causes DI to handle Context.request`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            DI.installAsContextRequestStrategy();
+            DI.getOrCreateDOMContainer().register(
+                Registration.instance(TestContext, value)
+            );
+
+            let capture;
+
+            Context.request(parent, TestContext, response => {
+                capture = response;
+            });
+
+            expect(capture).equal(value);
+
+            Context.setDefaultRequestStrategy(Context.dispatch);
+        });
+
+        it(`causes DI to handle Context.get`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            DI.installAsContextRequestStrategy();
+            DI.getOrCreateDOMContainer().register(
+                Registration.instance(TestContext, value)
+            );
+
+            let capture = Context.get(child, TestContext);
+
+            expect(capture).equal(value);
+
+            Context.setDefaultRequestStrategy(Context.dispatch);
+        });
+
+        it(`causes DI to handle Context.defineProperty`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const parent = document.createElement("div");
+            const child = document.createElement("div");
+            parent.append(child);
+
+            DI.installAsContextRequestStrategy();
+            DI.getOrCreateDOMContainer().register(
+                Registration.instance(TestContext, value)
+            );
+
+            Context.defineProperty(child, "test", TestContext);
+
+            expect((child as any).test).equal(value);
+
+            Context.setDefaultRequestStrategy(Context.dispatch);
+        });
+
+        it(`causes DI to handle Context decorators`, () => {
+            const value = "hello world";
+            const TestContext = Context.create<string>("TestContext");
+            const elementName = uniqueElementName();
+
+            class TestElement extends HTMLElement {
+                @TestContext test: string;
+            }
+
+            customElements.define(elementName, TestElement);
+
+            const parent = document.createElement("div");
+            const child = document.createElement(elementName) as TestElement;
+            parent.append(child);
+
+            DI.installAsContextRequestStrategy();
+            DI.getOrCreateDOMContainer().register(
+                Registration.instance(TestContext, value)
+            );
+
+            expect(child.test).equal(value);
+
+            Context.setDefaultRequestStrategy(Context.dispatch);
         });
     });
 

--- a/packages/web-components/fast-foundation/src/di/di.ts
+++ b/packages/web-components/fast-foundation/src/di/di.ts
@@ -671,11 +671,11 @@ export const DI = Object.freeze({
 
             if (inject === void 0) {
                 // design:paramtypes is set by tsc when emitDecoratorMetadata is enabled.
-                const designParamtypes = Metadata.getDesignParamtypes(Type);
+                const designParamtypes = Metadata.getDesignParamTypes(Type);
                 // di:paramtypes is set by the parameter decorator from DI.createInterface or by @inject
-                const annotationParamtypes = Metadata.getAnnotationParamtypes(Type);
-                if (designParamtypes === void 0) {
-                    if (annotationParamtypes === void 0) {
+                const annotationParamtypes = Metadata.getAnnotationParamTypes(Type);
+                if (designParamtypes === emptyArray) {
+                    if (annotationParamtypes === emptyArray) {
                         // Only go up the prototype if neither static inject nor any of the paramtypes is defined, as
                         // there is no sound way to merge a type's deps with its prototype's deps
                         const Proto = Object.getPrototypeOf(Type);
@@ -690,7 +690,7 @@ export const DI = Object.freeze({
                         // No design:paramtypes so just use the di:paramtypes
                         dependencies = cloneArrayWithPossibleProps(annotationParamtypes);
                     }
-                } else if (annotationParamtypes === void 0) {
+                } else if (annotationParamtypes === emptyArray) {
                     // No di:paramtypes so just use the design:paramtypes
                     dependencies = cloneArrayWithPossibleProps(designParamtypes);
                 } else {
@@ -805,7 +805,7 @@ export const DI = Object.freeze({
      * @returns The decorator to be applied to the target class.
      * @remarks
      * The decorator can be used to decorate a class, listing all of the classes dependencies.
-     * Or it can be used to decorate a constructor paramter, indicating what to inject for that
+     * Or it can be used to decorate a constructor parameter, indicating what to inject for that
      * parameter.
      * Or it can be used for a web component property, indicating what that property should resolve to.
      */

--- a/packages/web-components/fast-foundation/src/di/di.ts
+++ b/packages/web-components/fast-foundation/src/di/di.ts
@@ -1503,7 +1503,7 @@ export class ContainerImpl implements DOMContainer {
                         } catch {
                             // Container failed to find the context, so we need to
                             // let the event propagate.
-                            // TODO: Introduce a tryGet API to Container.
+                            // TODO: Introduce a tryGet API to Container. Issue #4582
                         }
                     } else if (
                         e.context === Container &&

--- a/packages/web-components/fast-foundation/src/di/di.ts
+++ b/packages/web-components/fast-foundation/src/di/di.ts
@@ -524,15 +524,18 @@ function createContext<K extends Key>(
             const annotationParamtypes = Metadata.getOrCreateAnnotationParamTypes(target);
             annotationParamtypes[index] = Interface;
         }
-    };
+    } as ContextDecorator<K>;
 
-    Interface.$isInterface = true;
+    (Interface as any).$isInterface = true;
     Reflect.defineProperty(Interface, "name", {
         value: friendlyName ?? defaultFriendlyName,
     });
 
     if (configure != null) {
-        Interface.register = function (container: Container, key?: Key): Resolver<K> {
+        (Interface as any).register = function (
+            container: Container,
+            key?: Key
+        ): Resolver<K> {
             return configure(new ResolverBuilder(container, key ?? Interface));
         };
     }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds support for the W3C Web Components Community Protocol for Context to FAST 🎉 

The core `Context` features are added to `@microsoft/fast-element` as a special package export named `context`. Basic `Metadata` has also been added in a similar way. The `fast-foundation` DI was then fixed up to both use `Context` events to locate containers as well as be able to plug itself in to handle `Context` requests. This means that someone building components with just `fast-element` can use the `Context` APIs to declare dependencies with decorators on their components, and then the consumer of those components could choose to satisfy those dependencies either by using `Context` APIs or plugging in `DI`.

### Examples

#### Create Context

```ts
export interface AuthService {
  login(username: string, password: string): Promise<LoginResponse>;
}

export const AuthService = Context.create<AuthService>("AuthService");
```

#### Get the Context Value for a Target Using the Context Itself

```ts
const node = document.getElementById("someElementId");
const authService = AuthService.get(node);
```

#### Get the Context Value for a Target Using the Context Gateway

```ts
const node = document.getElementById("someElementId");
const authService = Context.get(node, AuthService);
```

#### Request the Context Value for a Target Using the Context Itself

```ts
const node = document.getElementById("someElementId");
AuthService.request(node, value => {
  // use the value
});
```

#### Request the Context Value for a Target Using the Context Gateway

```ts
const node = document.getElementById("someElementId");
Context.request(node, AuthService, value => {
  // use the value
});
```

#### Use the Context As a Decorator on a Custom Element

```ts
class LoginScreen extends HTMLElement {
  @AuthService authService: AuthService;
  @observable username: string;
  @observable password: string;

  login() {
    const response = await this.authService.login(this.username, this.password);
  }
}

customElements.define("login-screen", LoginScreen);
```

#### Handle the Context Event Using the Context Itself

```ts
AuthService.handle(parentNode, event => {
  event.stopImmediatePropagation();
  event.callback(new AuthServiceImplementation());
});
```

#### Handle the Context Event Using the Context Gateway

```ts
Context.handle(parentNode, event => {
  event.stopImmediatePropagation();
  event.callback(new AuthServiceImplementation());
}, AuthService);
```

#### Handle All Context Requests Through the Gateway

```ts
Context.handle(parentNode, event => {
  // check event.context to see which context to supply
});
```

#### Instruct DI to Handle all Context.request, Context.get, Context.defineProperty, and Context Decorators

```ts
DI.installAsContextRequestStrategy();
DI.getOrCreateDOMContainer().register(
  Registration.singleton(AuthService, AuthServiceImplementation)
);
```

#### Instruct a Specific DI Container to Handle All Context Events for its Associated DOM Tree

```ts
container.handleContextRequests();
```

### 🎫 Issues

* Closes #4948 

## 👩‍💻 Reviewer Notes

The `Metadata` API from DI was moved to `fast-element` so that it could be leveraged by the Context APIs for decorators, allowing better integration of `Context` and `DI`. The core `Context` types along with a couple of `DI` types were added to the `Context` exports for standardization and unification purposes. After implementing `Context` APIs, those were then used in `DI` for container location and to enable plugging `DI` into `Context` if desired.

An additional performance optimization was made to `DI` so that it can skip using events when a DOM Container or Context request is made and the system knows there is only one container at the root.

## 📑 Test Plan

All existing `DI` tests continue to pass. Additional tests have been added for `Metadata` and `Context`, as well as `DI` handling of `Context`.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

In the future I'd like to explore whether we can move the entire `DI` system into `fast-element` as a special export. Before we do this I'd like to decouple a bunch of things in `fast-foundation` so that hopefully nothing in `fast-foundation` has any dependency on `DI`.

Assuming the `DI` code is able to be moved to `fast-element` I think we could probably also move `testing` there too, which would be an improvement for the platform. That will definitely be dependent on us removing the old registration code from `fast-foundation`.