### PR TITLE
Color explorer: Added banner to direct to Fluent UI version

### DIFF
--- a/sites/fast-color-explorer/app/app.ts
+++ b/sites/fast-color-explorer/app/app.ts
@@ -85,6 +85,17 @@ const colorBlockTemplate = html<App>`
 
 const template = html<App>`
     <div class="container fill">
+        <div class="row banner">
+            <p>
+                <a
+                    href="https://aka.ms/fluentwebcomponents/?path=/docs/design-system-color-explorer--page"
+                >
+                    Fluent UI Web Components color explorer
+                </a>
+                has moved to the Fluent UI Storybook site. This site now represents the
+                latest version of @microsoft/fast-components.
+            </p>
+        </div>
         <div class="row fill">
             <div class="canvas" ${ref("canvasElement")}>
                 <div class="container fill">
@@ -161,6 +172,15 @@ const styles = css`
     .row.fill {
         flex: 1;
         overflow: hidden;
+    }
+
+    .banner {
+        background-color: #80deea;
+        padding: 20px;
+    }
+
+    .banner p {
+        margin: 0;
     }
 
     .canvas {

--- a/sites/fast-color-explorer/app/app.ts
+++ b/sites/fast-color-explorer/app/app.ts
@@ -30,8 +30,10 @@ import { DesignToken } from "@microsoft/fast-foundation";
 import { AppColorBlock } from "./components/color-block";
 import { AppControlPane } from "./components/control-pane";
 import { AppGradient } from "./components/gradient";
+import { AppLayerBackground } from "./components/layer-background";
 import { AppSampleApp } from "./components/sample-app";
 
+AppLayerBackground;
 AppColorBlock;
 AppControlPane;
 AppGradient;

--- a/sites/fast-color-explorer/app/components/control-pane/control-pane.template.ts
+++ b/sites/fast-color-explorer/app/components/control-pane/control-pane.template.ts
@@ -1,7 +1,7 @@
 import { Checkbox, RadioGroup } from "@microsoft/fast-components";
 import { html, repeat } from "@microsoft/fast-element";
-import { ColorPicker } from "@microsoft/fast-tooling/dist/dts/web-components/color-picker/color-picker";
 import { ComponentTypes } from "../../app";
+import { ColorPicker } from "../color-picker/color-picker";
 import { ControlPane } from "./control-pane";
 
 function titleCase(str: string): string {

--- a/sites/fast-color-explorer/app/components/layer-background/index.ts
+++ b/sites/fast-color-explorer/app/components/layer-background/index.ts
@@ -9,13 +9,30 @@ import {
     neutralPalette,
     Swatch,
 } from "@microsoft/fast-components";
-import { attr, css, html, nullableNumberConverter } from "@microsoft/fast-element";
+import {
+    attr,
+    css,
+    customElement,
+    html,
+    nullableNumberConverter,
+} from "@microsoft/fast-element";
 import {
     DesignToken,
     DesignTokenChangeRecord,
     display,
     FoundationElement,
 } from "@microsoft/fast-foundation";
+
+export const layerBackgroundTemplate = html`
+    <slot></slot>
+`;
+
+export const layerBackgroundStyles = css`
+    ${display("block")} :host {
+        background: ${fillColor};
+        color: ${neutralForegroundRest};
+    }
+`;
 
 export class LayerBackground extends FoundationElement {
     @attr({ attribute: "base-layer-luminance", converter: nullableNumberConverter })
@@ -74,19 +91,9 @@ export class LayerBackground extends FoundationElement {
     }
 }
 
-export const layerBackgroundTemplate = html`
-    <slot></slot>
-`;
-
-export const layerBackgroundStyles = css`
-    ${display("block")} :host {
-        background: ${fillColor};
-        color: ${neutralForegroundRest};
-    }
-`;
-
-export const layerBackground = LayerBackground.compose({
-    baseName: "layer-background",
+@customElement({
+    name: "app-layer-background",
     template: layerBackgroundTemplate,
     styles: layerBackgroundStyles,
-});
+})
+export class AppLayerBackground extends LayerBackground {}

--- a/sites/fast-color-explorer/app/custom-elements.ts
+++ b/sites/fast-color-explorer/app/custom-elements.ts
@@ -1,5 +1,1 @@
-import { layerBackground } from "./components/layer-background";
-
-export { layerBackground };
-
-export const appComponents = [layerBackground()];
+export const appComponents = [];

--- a/sites/fast-color-explorer/package.json
+++ b/sites/fast-color-explorer/package.json
@@ -6,6 +6,7 @@
   "private": true,
   "scripts": {
     "build": "webpack --progress --mode=production",
+    "build:dev": "webpack --progress",
     "prettier": "prettier --config ../../.prettierrc --write \"**/*.{ts,tsx,html}\"",
     "prettier:diff": "prettier --config ../../.prettierrc \"**/*.{ts,tsx,html}\" --list-different",
     "start": "webpack-dev-server",
@@ -53,7 +54,6 @@
   },
   "dependencies": {
     "@fluentui/svg-icons": "^1.1.0",
-    "@microsoft/fast-tooling": "0.37.9",
     "@microsoft/fast-colors": "^5.3.1",
     "@microsoft/fast-components": "^2.30.6",
     "@microsoft/fast-element": "^1.0.0",


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

The latest Fluent visual update (v2, fall of 2021) introduced a split in the color algorithms previously shared with fast-components. The color explorer site has not represented that shift for Fluent UI. Now the color explorer is bundled into the Storybook site for Fluent UI, so the previous site can be used for the latest algorithms in the fast-components work.

This is mostly temporary as we have recently introduced @microsoft/adaptive-ui which seeks to unify the underlying color recipe infrastrcture.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->