### PR TITLE
fix: make SyntheticViewTemplate type a string so it is generally usable

### DIFF
--- a/change/@microsoft-fast-element-5804fe41-9a70-4cc2-ad00-bff57d7fed78.json
+++ b/change/@microsoft-fast-element-5804fe41-9a70-4cc2-ad00-bff57d7fed78.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: make SyntheticViewTemplate type a string so it is generally usable",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-5804fe41-9a70-4cc2-ad00-bff57d7fed78.json
+++ b/change/@microsoft-fast-element-5804fe41-9a70-4cc2-ad00-bff57d7fed78.json
@@ -3,5 +3,5 @@
   "comment": "fix: make SyntheticViewTemplate type a string so it is generally usable",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -197,7 +197,6 @@ export type ChildrenDirectiveOptions<T = any> = ChildListDirectiveOptions<T> | S
 // @public
 export interface ChildViewTemplate<TSource = any, TParent = any> {
     create(): SyntheticView<TSource, TParent, ChildContext<TParent>>;
-    // (undocumented)
     type: "child";
 }
 
@@ -349,7 +348,6 @@ export interface ElementView<TSource = any, TParent = any> extends View<TSource,
 export interface ElementViewTemplate<TSource = any, TParent = any> {
     create(hostBindingTarget: Element): ElementView<TSource, TParent>;
     render(source: TSource, host: Node, hostBindingTarget?: Element): ElementView<TSource, TParent>;
-    // (undocumented)
     type: "element";
 }
 
@@ -512,7 +510,6 @@ export interface ItemContext<TParentSource = any> extends ChildContext<TParentSo
 // @public
 export interface ItemViewTemplate<TSource = any, TParent = any> {
     create(): SyntheticView<TSource, TParent, ItemContext<TParent>>;
-    // (undocumented)
     type: "item";
 }
 
@@ -840,8 +837,7 @@ export interface SyntheticView<TSource = any, TParent = any, TContext extends Ex
 // @public
 export interface SyntheticViewTemplate<TSource = any, TParent = any, TContext extends ExecutionContext<TParent> = ExecutionContext<TParent>> {
     create(): SyntheticView<TSource, TParent, TContext>;
-    // (undocumented)
-    type: "synthetic";
+    type: string;
 }
 
 // @public

--- a/packages/web-components/fast-element/src/templating/template.ts
+++ b/packages/web-components/fast-element/src/templating/template.ts
@@ -23,7 +23,12 @@ import type { ElementView, HTMLView, SyntheticView } from "./view.js";
  * @public
  */
 export interface ElementViewTemplate<TSource = any, TParent = any> {
+    /**
+     * Used for TypeScript purposes only.
+     * Do not use.
+     */
     type: "element";
+
     /**
      * Creates an ElementView instance based on this template definition.
      * @param hostBindingTarget - The element that host behaviors will be bound to.
@@ -53,7 +58,12 @@ export interface SyntheticViewTemplate<
     TParent = any,
     TContext extends ExecutionContext<TParent> = ExecutionContext<TParent>
 > {
-    type: "synthetic";
+    /**
+     * Used for TypeScript purposes only.
+     * Do not use.
+     */
+    type: string;
+
     /**
      * Creates a SyntheticView instance based on this template definition.
      */
@@ -65,6 +75,10 @@ export interface SyntheticViewTemplate<
  * @public
  */
 export interface ChildViewTemplate<TSource = any, TParent = any> {
+    /**
+     * Used for TypeScript purposes only.
+     * Do not use.
+     */
     type: "child";
 
     /**
@@ -78,6 +92,10 @@ export interface ChildViewTemplate<TSource = any, TParent = any> {
  * @public
  */
 export interface ItemViewTemplate<TSource = any, TParent = any> {
+    /**
+     * Used for TypeScript purposes only.
+     * Do not use.
+     */
     type: "item";
 
     /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR corrects the `type` field of `SyntheticViewTemplate` to be properly generic, fixing some typing issues that can occur when using various directives in combination.

### 🎫 Issues

* Closes #6065 

## 👩‍💻 Reviewer Notes

I added a few missing doc comments but the real fix was changing the type of the `type` field of `SyntheticViewTemplate`.

## 📑 Test Plan

All existing tests continue to pass. This was just a type definition fix.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

n/a