### PR TITLE
Figma plugin: Added support for custom "Dark mode" components

### DIFF
--- a/packages/tooling/fast-figma-plugin-msft/src/core/controller.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/core/controller.ts
@@ -111,6 +111,7 @@ export abstract class Controller {
         nodes.forEach(node => {
             const pluginNode = this.getNode(node.id);
             if (pluginNode) {
+                pluginNode.handleManualDarkMode();
                 pluginNode.setDesignTokens(node.designTokens);
                 pluginNode.setRecipes(node.recipes);
                 pluginNode.setRecipeEvaluations(node.recipeEvaluations);

--- a/packages/tooling/fast-figma-plugin-msft/src/core/node.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/core/node.ts
@@ -163,6 +163,11 @@ export abstract class PluginNode {
     public abstract getEffectiveFillColor(): ColorRGBA64 | null;
 
     /**
+     * Handle components that have custom dark mode configuration, like logos or illustration.
+     */
+    public abstract handleManualDarkMode(): boolean;
+
+    /**
      * Setup special handling for fill color. It should either be a recipe or a fixed color applied in the design tool.
      * Must be called after design tokens and recipe evaluations are loaded.
      */

--- a/packages/tooling/fast-figma-plugin-msft/src/figma/node.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/figma/node.ts
@@ -1,3 +1,4 @@
+import { isDark, SwatchRGB } from "@fluentui/web-components";
 import { ColorRGBA64, parseColor } from "@microsoft/fast-colors";
 import {
     AppliedDesignTokens,
@@ -307,6 +308,52 @@ export class FigmaPluginNode extends PluginNode {
         }
 
         return null;
+    }
+
+    public handleManualDarkMode(): boolean {
+        if (isInstanceNode(this.node)) {
+            if (this.node.variantProperties) {
+                const currentDarkMode = this.node.variantProperties["Dark mode"];
+                if (currentDarkMode) {
+                    const color = this.getEffectiveFillColor();
+                    if (color) {
+                        let trueString = "Yes";
+                        let falseString = "No";
+                        // Thanks Figma for supporting "true", "True", "yes", and "Yes", but not doing the work to interpret it. Assume it's paired.
+                        switch (currentDarkMode) {
+                            case "yes":
+                            case "no":
+                                trueString = "yes";
+                                falseString = "no";
+                                break;
+                            case "Yes":
+                            case "No":
+                                trueString = "Yes";
+                                falseString = "No";
+                                break;
+                            case "true":
+                            case "false":
+                                trueString = "true";
+                                falseString = "false";
+                                break;
+                            case "True":
+                            case "False":
+                                trueString = "True";
+                                falseString = "False";
+                                break;
+                        }
+                        const containerIsDark = isDark(SwatchRGB.from(color));
+                        // console.log("handleManualDarkMode", this.node.variantProperties['Dark mode'], "color", color.toStringHexRGB(), "dark", containerIsDark);
+                        this.node.setProperties({
+                            "Dark mode": containerIsDark ? trueString : falseString,
+                        });
+                        return true;
+                    }
+                }
+            }
+        }
+
+        return false;
     }
 
     protected getPluginData<K extends keyof PluginNodeData>(key: K): string | undefined {

--- a/packages/tooling/fast-figma-plugin-msft/src/figma/node.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/figma/node.ts
@@ -8,6 +8,7 @@ import {
 } from "../core/model";
 import { PluginNode } from "../core/node";
 import { DesignTokenType } from "../core/ui/design-token-registry";
+import { variantBooleanHelper } from "./utility";
 
 function isNodeType<T extends BaseNode>(type: NodeType): (node: BaseNode) => node is T {
     return (node: BaseNode): node is T => node.type === type;
@@ -317,35 +318,12 @@ export class FigmaPluginNode extends PluginNode {
                 if (currentDarkMode) {
                     const color = this.getEffectiveFillColor();
                     if (color) {
-                        let trueString = "Yes";
-                        let falseString = "No";
-                        // Thanks Figma for supporting "true", "True", "yes", and "Yes", but not doing the work to interpret it. Assume it's paired.
-                        switch (currentDarkMode) {
-                            case "yes":
-                            case "no":
-                                trueString = "yes";
-                                falseString = "no";
-                                break;
-                            case "Yes":
-                            case "No":
-                                trueString = "Yes";
-                                falseString = "No";
-                                break;
-                            case "true":
-                            case "false":
-                                trueString = "true";
-                                falseString = "false";
-                                break;
-                            case "True":
-                            case "False":
-                                trueString = "True";
-                                falseString = "False";
-                                break;
-                        }
                         const containerIsDark = isDark(SwatchRGB.from(color));
                         // console.log("handleManualDarkMode", this.node.variantProperties['Dark mode'], "color", color.toStringHexRGB(), "dark", containerIsDark);
                         this.node.setProperties({
-                            "Dark mode": containerIsDark ? trueString : falseString,
+                            "Dark mode": variantBooleanHelper(currentDarkMode)(
+                                containerIsDark
+                            ),
                         });
                         return true;
                     }

--- a/packages/tooling/fast-figma-plugin-msft/src/figma/utility.ts
+++ b/packages/tooling/fast-figma-plugin-msft/src/figma/utility.ts
@@ -1,0 +1,18 @@
+/**
+ * Gets a string representation of `isTrue` based on the format of `booleanString`.
+ *
+ * Figma supports component properties like "true", "True", "yes", and "Yes", but doesn't doi the work to interpret it.
+ *
+ * Assumes the value is paired with the same case and set (i.e. "Yes" / "No", "true" / "false", etc.).
+ */
+// eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+export const variantBooleanHelper = (booleanString: string) => (isTrue: boolean) =>
+    [
+        ["No", "Yes"],
+        ["False", "True"],
+    ]
+        // eslint-disable-next-line @typescript-eslint/no-non-null-assertion
+        .find(bools => bools.find(b => b.toLowerCase() === booleanString.toLowerCase())!)!
+        .map(b => (booleanString.match(/^[nytf]/) ? b.toLowerCase() : b))[
+        !isTrue ? 0 : 1
+    ];


### PR DESCRIPTION
# Pull Request

## 📖 Description

Some designs call for custom treatment in dark mode. Ideally everything could be a system, but the primary case this comes up is illustration.

This change adds support for Figma components with a "Dark mode" variant property, which will be set according to the context luminosity.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.