### PR TITLE
Fixed a cyclical reference

### DIFF
--- a/change/@microsoft-adaptive-ui-c2b6a755-6dc3-4265-8bfd-8431ff8cf8d0.json
+++ b/change/@microsoft-adaptive-ui-c2b6a755-6dc3-4265-8bfd-8431ff8cf8d0.json
@@ -3,5 +3,5 @@
   "comment": "Fixed a cyclical reference",
   "packageName": "@microsoft/adaptive-ui",
   "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-adaptive-ui-c2b6a755-6dc3-4265-8bfd-8431ff8cf8d0.json
+++ b/change/@microsoft-adaptive-ui-c2b6a755-6dc3-4265-8bfd-8431ff8cf8d0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed a cyclical reference",
+  "packageName": "@microsoft/adaptive-ui",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/adaptive-ui/src/design-tokens/type.ts
+++ b/packages/utilities/adaptive-ui/src/design-tokens/type.ts
@@ -1,6 +1,22 @@
 import { DesignToken } from "@microsoft/fast-foundation";
-import { StandardFontWeight } from "../type/type-ramp.js";
 import { create } from "./create.js";
+
+/**
+ * Standard font wights.
+ *
+ * @public
+ */
+export const StandardFontWeight = {
+    Thin: 100,
+    ExtraLight: 200,
+    Light: 300,
+    Normal: 400,
+    Medium: 500,
+    SemiBold: 600,
+    Bold: 700,
+    ExtraBold: 800,
+    Black: 900,
+} as const;
 
 /** @public */
 export const bodyFont = create<string>("body-font").withDefault(

--- a/packages/utilities/adaptive-ui/src/type/type-ramp.ts
+++ b/packages/utilities/adaptive-ui/src/type/type-ramp.ts
@@ -30,23 +30,6 @@ import {
     typeRampPlus6LineHeight,
 } from "../design-tokens/type.js";
 
-/**
- * Standard font wights.
- *
- * @public
- */
-export const StandardFontWeight = {
-    Thin: 100,
-    ExtraLight: 200,
-    Light: 300,
-    Normal: 400,
-    Medium: 500,
-    SemiBold: 600,
-    Bold: 700,
-    ExtraBold: 800,
-    Black: 900,
-} as const;
-
 /** @public */
 export const typeRampBase = cssPartial`
     font-family: ${bodyFont};


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
This change fixes a reference where the `design-tokens/type.ts` file imported an interface from `type/type-ramp.ts` while the `type/type-ramp.ts` is also importing various type ramp exports from `design-tokens/type.ts`. Since this interface is only used in `design-tokens/type.ts` it has been moved there.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Another change has been made to the eslint config to catch this issue in the future, see #6138 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.