### PR TITLE
adaptive-ui: Added tokens for elevation and shadow treatment

### DIFF
--- a/change/@microsoft-adaptive-ui-2e49e17b-a6eb-4ff8-9428-41ecda134255.json
+++ b/change/@microsoft-adaptive-ui-2e49e17b-a6eb-4ff8-9428-41ecda134255.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Added elevation design tokens",
+  "packageName": "@microsoft/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/adaptive-ui/docs/api-report.md
+++ b/packages/utilities/adaptive-ui/docs/api-report.md
@@ -134,6 +134,56 @@ export const direction: CSSDesignToken<Direction>;
 export function directionByIsDark(color: RelativeLuminance): PaletteDirectionValue;
 
 // @public (undocumented)
+export const elevationCardActive: CSSDesignToken<string>;
+
+// @public (undocumented)
+export const elevationCardActiveSize: DesignToken<number>;
+
+// @public (undocumented)
+export const elevationCardFocus: CSSDesignToken<string>;
+
+// @public (undocumented)
+export const elevationCardFocusSize: DesignToken<number>;
+
+// @public (undocumented)
+export const elevationCardHover: CSSDesignToken<string>;
+
+// @public (undocumented)
+export const elevationCardHoverSize: DesignToken<number>;
+
+// @public (undocumented)
+export const elevationCardRest: CSSDesignToken<string>;
+
+// @public (undocumented)
+export const elevationCardRestSize: DesignToken<number>;
+
+// @public (undocumented)
+export const elevationDialog: CSSDesignToken<string>;
+
+// @public (undocumented)
+export const elevationDialogSize: DesignToken<number>;
+
+// @public (undocumented)
+export const elevationFlyout: CSSDesignToken<string>;
+
+// @public (undocumented)
+export const elevationFlyoutSize: DesignToken<number>;
+
+// @public
+export interface ElevationRecipe {
+    evaluate(element: HTMLElement, size: number): string;
+}
+
+// @public (undocumented)
+export const elevationRecipe: DesignToken<ElevationRecipe>;
+
+// @public (undocumented)
+export const elevationTooltip: CSSDesignToken<string>;
+
+// @public (undocumented)
+export const elevationTooltipSize: DesignToken<number>;
+
+// @public (undocumented)
 export const fillColor: CSSDesignToken<Swatch>;
 
 // @public (undocumented)

--- a/packages/utilities/adaptive-ui/src/design-tokens/elevation.ts
+++ b/packages/utilities/adaptive-ui/src/design-tokens/elevation.ts
@@ -1,0 +1,135 @@
+import { create, createNonCss } from "./create.js";
+
+/**
+ * A recipe that evaluates to an elevation treatment, commonly, but not limited to, a box .
+ *
+ * @public
+ */
+export interface ElevationRecipe {
+    /**
+     * Evaluate an elevation treatment.
+     *
+     * @param element - The element for which to evaluate the recipe
+     * @param size - The size of the elevation
+     */
+    evaluate(element: HTMLElement, size: number): string;
+}
+
+/**
+ * @public
+ */
+export const elevationRecipe = createNonCss<ElevationRecipe>(
+    "elevation-recipe"
+).withDefault({
+    evaluate: (element: HTMLElement, size: number): string => {
+        let ambientOpacity = 0.12;
+        let directionalOpacity = 0.14;
+
+        if (size > 16) {
+            ambientOpacity = 0.2;
+            directionalOpacity = 0.24;
+        }
+
+        const ambient = `0 0 2px rgba(0, 0, 0, ${ambientOpacity})`;
+        const directional = `0 calc(${size} * 0.5px) calc((${size} * 1px)) rgba(0, 0, 0, ${directionalOpacity})`;
+        return `${ambient}, ${directional}`;
+    },
+});
+
+/** @public */
+export const elevationCardRestSize = createNonCss<number>(
+    "elevation-card-rest-size"
+).withDefault(4);
+
+/** @public */
+export const elevationCardHoverSize = createNonCss<number>(
+    "elevation-card-hover-size"
+).withDefault(8);
+
+/** @public */
+export const elevationCardActiveSize = createNonCss<number>(
+    "elevation-card-active-size"
+).withDefault(2);
+
+/** @public */
+export const elevationCardFocusSize = createNonCss<number>(
+    "elevation-card-focus-size"
+).withDefault(4);
+
+/** @public */
+export const elevationCardRest = create<string>(
+    "elevation-card-rest"
+).withDefault((element: HTMLElement) =>
+    elevationRecipe
+        .getValueFor(element)
+        .evaluate(element, elevationCardRestSize.getValueFor(element))
+);
+
+/** @public */
+export const elevationCardHover = create<string>(
+    "elevation-card-hover"
+).withDefault((element: HTMLElement) =>
+    elevationRecipe
+        .getValueFor(element)
+        .evaluate(element, elevationCardHoverSize.getValueFor(element))
+);
+
+/** @public */
+export const elevationCardActive = create<string>(
+    "elevation-card-active"
+).withDefault((element: HTMLElement) =>
+    elevationRecipe
+        .getValueFor(element)
+        .evaluate(element, elevationCardActiveSize.getValueFor(element))
+);
+
+/** @public */
+export const elevationCardFocus = create<string>(
+    "elevation-card-focus"
+).withDefault((element: HTMLElement) =>
+    elevationRecipe
+        .getValueFor(element)
+        .evaluate(element, elevationCardFocusSize.getValueFor(element))
+);
+
+/** @public */
+export const elevationTooltipSize = createNonCss<number>(
+    "elevation-tooltip-size"
+).withDefault(16);
+
+/** @public */
+export const elevationTooltip = create<string>(
+    "elevation-tooltip"
+).withDefault((element: HTMLElement) =>
+    elevationRecipe
+        .getValueFor(element)
+        .evaluate(element, elevationTooltipSize.getValueFor(element))
+);
+
+/** @public */
+export const elevationFlyoutSize = createNonCss<number>(
+    "elevation-flyout-size"
+).withDefault(32);
+
+/** @public */
+export const elevationFlyout = create<string>(
+    "elevation-flyout"
+).withDefault((element: HTMLElement) =>
+    elevationRecipe
+        .getValueFor(element)
+        .evaluate(element, elevationFlyoutSize.getValueFor(element))
+);
+
+/** @public */
+export const elevationDialogSize = createNonCss<number>(
+    "elevation-dialog-size"
+).withDefault(128);
+
+/** @public */
+export const elevationDialog = create<string>(
+    "elevation-dialog"
+).withDefault((element: HTMLElement) =>
+    elevationRecipe
+        .getValueFor(element)
+        .evaluate(element, elevationDialogSize.getValueFor(element))
+);

--- a/packages/utilities/adaptive-ui/src/design-tokens/elevation.ts
+++ b/packages/utilities/adaptive-ui/src/design-tokens/elevation.ts
@@ -1,19 +1,5 @@
+import { ElevationRecipe } from "../elevation/recipe.js";
 import { create, createNonCss } from "./create.js";
-
-/**
- * A recipe that evaluates to an elevation treatment, commonly, but not limited to, a box .
- *
- * @public
- */
-export interface ElevationRecipe {
-    /**
-     * Evaluate an elevation treatment.
-     *
-     * @param element - The element for which to evaluate the recipe
-     * @param size - The size of the elevation
-     */
-    evaluate(element: HTMLElement, size: number): string;
-}
 
 /**
  * @public

--- a/packages/utilities/adaptive-ui/src/design-tokens/index.ts
+++ b/packages/utilities/adaptive-ui/src/design-tokens/index.ts
@@ -1,5 +1,6 @@
 export * from "./appearance.js";
 export * from "./color.js";
+export * from "./elevation.js";
 export * from "./general.js";
 export * from "./palette.js";
 export * from "./type.js";

--- a/packages/utilities/adaptive-ui/src/elevation/index.ts
+++ b/packages/utilities/adaptive-ui/src/elevation/index.ts
@@ -1,0 +1,1 @@
+export * from "./recipe.js";

--- a/packages/utilities/adaptive-ui/src/elevation/recipe.ts
+++ b/packages/utilities/adaptive-ui/src/elevation/recipe.ts
@@ -1,0 +1,14 @@
+/**
+ * A recipe that evaluates to an elevation treatment, commonly, but not limited to, a box .
+ *
+ * @public
+ */
+export interface ElevationRecipe {
+    /**
+     * Evaluate an elevation treatment.
+     *
+     * @param element - The element for which to evaluate the recipe
+     * @param size - The size of the elevation
+     */
+    evaluate(element: HTMLElement, size: number): string;
+}

--- a/packages/utilities/adaptive-ui/src/index.ts
+++ b/packages/utilities/adaptive-ui/src/index.ts
@@ -1,3 +1,4 @@
 export * from "./color/index.js";
 export * from "./design-tokens/index.js";
+export * from "./elevation/index.js";
 export * from "./type/index.js";


### PR DESCRIPTION
# Pull Request

## 📖 Description

Bringing over support for elevation tokens and a default shadow implementation.

All tokens have been renamed to remove "Shadow" as there are other elevation treatments that may not be a box-shadow that can benefit from the same semantic recipes.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.