### PR TITLE
fix: Enable `createElementTemplate` to work without attributes defined

### DIFF
--- a/change/@microsoft-fast-element-64ffcc23-bbc9-409d-99a7-00a93af07b85.json
+++ b/change/@microsoft-fast-element-64ffcc23-bbc9-409d-99a7-00a93af07b85.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: enable createElementTemplate to have undefined attributes",
+  "packageName": "@microsoft/fast-element",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/templating/render.ts
+++ b/packages/web-components/fast-element/src/templating/render.ts
@@ -330,11 +330,12 @@ function createElementTemplate<TSource = any, TParent = any>(
     attributes?: Record<string, string | TemplateValue<TSource, TParent>>,
     content?: string | ContentTemplate
 ): ViewTemplate<TSource, TParent> {
-    const markup = [`<${tagName}`];
+    const markup: Array<string> = [];
     const values: Array<TemplateValue<TSource, TParent>> = [];
 
     if (attributes) {
         const attrNames = Object.getOwnPropertyNames(attributes);
+        markup.push(`<${tagName}`);
 
         for (let i = 0, ii = attrNames.length; i < ii; ++i) {
             const name = attrNames[i];
@@ -347,14 +348,18 @@ function createElementTemplate<TSource = any, TParent = any>(
 
             values.push(attributes[name]);
         }
+
+        markup.push(`">`);
+    } else {
+        markup.push(`<${tagName}>`);
     }
 
     if (content && isFunction((content as any).create)) {
-        markup.push(`">`);
         values.push(content);
         markup.push(`</${tagName}>`);
     } else {
-        markup.push(`">${content ?? ""}</${tagName}>`);
+        const lastIndex = markup.length - 1;
+        markup[lastIndex] = `${markup[lastIndex]}${content ?? ""}</${tagName}>`;
     }
 
     return html((markup as any) as TemplateStringsArray, ...values);


### PR DESCRIPTION
# Pull Request

## 📖 Description

`createElementTemplate` currently cannot work if the attributes argument is null or undefined. This PR adds the ability for the function to work without attributes passed to it as well as related tests.

### 🎫 Issues

## 👩‍💻 Reviewer Notes
Stackblitz with `createElementTemplate` with the fix running on v1.10.2 of `fast-element`
https://stackblitz.com/edit/typescript-n2mura?file=index.ts

I was having trouble with getting binding sources created using a class and the `@observable` decorator on class properties to work properly in the stackblitz example, however I added a test specifically for this scenario in the spec file that does work, so I think it is a stackblitz specific issue.

## 📑 Test Plan

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps
