### PR TITLE
fix: accordion item should not collapse on unrelated change events

### DIFF
--- a/change/@microsoft-fast-foundation-c8e72081-257f-474b-803b-0ae63fc25a83.json
+++ b/change/@microsoft-fast-foundation-c8e72081-257f-474b-803b-0ae63fc25a83.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "accordion verifies change events",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/accordion/accordion.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { FASTAccordion, accordionTemplate, AccordionExpandMode } from "./index.js";
 import { FASTAccordionItem, accordionItemTemplate } from "../accordion-item/index.js";
 import { fixture, uniqueElementName } from "../testing/fixture.js";
+import { FASTCheckbox, checkboxTemplate } from "../checkbox/index.js";
 import { Updates } from "@microsoft/fast-element";
 
 const Accordion = FASTAccordion.define({
@@ -12,6 +13,11 @@ const Accordion = FASTAccordion.define({
 const AccordionItem = FASTAccordionItem.define({
     name: uniqueElementName("accordion-item"),
     template: accordionItemTemplate()
+});
+
+const Checkbox = FASTCheckbox.define({
+    name: uniqueElementName("checkbox"),
+    template: checkboxTemplate()
 });
 
 async function setup() {
@@ -66,4 +72,93 @@ describe("Accordion", () => {
 
         await disconnect();
     });
+
+    it("should expand/collapse items when clicked in multi mode", async () => {
+        const { element, connect, disconnect, item1, item2, item3 } = await setup();
+
+        element.expandmode = AccordionExpandMode.multi;
+
+        await connect();
+        await Updates.next();
+
+        expect(item1.expanded).to.equal(false);
+        expect(item2.expanded).to.equal(false);
+        expect(item3.expanded).to.equal(false);
+
+        item1.expandbutton.click();
+        item2.expandbutton.click();
+        item3.expandbutton.click();
+
+        await Updates.next();
+
+        expect(item1.expanded).to.equal(true);
+        expect(item2.expanded).to.equal(true);
+        expect(item3.expanded).to.equal(true);
+
+        item1.expandbutton.click();
+        item2.expandbutton.click();
+        item3.expandbutton.click();
+
+        await Updates.next();
+
+        expect(item1.expanded).to.equal(false);
+        expect(item2.expanded).to.equal(false);
+        expect(item3.expanded).to.equal(false);
+
+        await disconnect();
+    });
+
+    it("should always be one item expanded in single mode", async () => {
+        const { element, connect, disconnect, item1, item2, item3 } = await setup();
+
+        element.expandmode = AccordionExpandMode.single;
+
+        await connect();
+        await Updates.next();
+
+        expect(item1.expanded).to.equal(true);
+        expect(item2.expanded).to.equal(false);
+        expect(item3.expanded).to.equal(false);
+
+        item2.expandbutton.click();
+
+        await Updates.next();
+
+        expect(item1.expanded).to.equal(false);
+        expect(item2.expanded).to.equal(true);
+        expect(item3.expanded).to.equal(false);
+
+        item2.expandbutton.click();
+
+        await Updates.next();
+
+        expect(item1.expanded).to.equal(false);
+        expect(item2.expanded).to.equal(true);
+        expect(item3.expanded).to.equal(false);
+
+        await disconnect();
+    });
+
+    it("should ignore 'change' events from components other than accordion items", async () => {
+        const { element, connect, disconnect, item1, item2, item3 } = await setup();
+
+        element.expandmode = AccordionExpandMode.multi;
+        const checkbox = new Checkbox();
+        item1.appendChild(checkbox);
+
+        await connect();
+        await Updates.next();
+        expect(item1.expanded).to.equal(false);
+
+        item1.expandbutton.click();
+        await Updates.next();
+        expect(item1.expanded).to.equal(true);
+
+        checkbox.click();
+        await Updates.next();
+        expect(item1.expanded).to.equal(true);
+
+        await disconnect();
+    });
+
 });

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -131,10 +131,7 @@ export class FASTAccordion extends FASTElement {
     };
 
     private activeItemChange = (event: Event): void => {
-        if (
-            event.defaultPrevented ||
-            event.target !== event.currentTarget
-        ) {
+        if (event.defaultPrevented || event.target !== event.currentTarget) {
             return;
         }
 

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -131,6 +131,15 @@ export class FASTAccordion extends FASTElement {
     };
 
     private activeItemChange = (event: Event): void => {
+        if (
+            event.defaultPrevented ||
+            event.target === null ||
+            this.accordionItems.indexOf(event.target as HTMLElement) === -1
+        ) {
+            return;
+        }
+
+        event.preventDefault();
         const selectedItem = event.target as FASTAccordionItem;
         this.activeid = selectedItem.getAttribute("id");
         if (this.isSingleExpandMode()) {

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -133,8 +133,7 @@ export class FASTAccordion extends FASTElement {
     private activeItemChange = (event: Event): void => {
         if (
             event.defaultPrevented ||
-            event.target === null ||
-            this.accordionItems.indexOf(event.target as HTMLElement) === -1
+            event.target !== event.currentTarget
         ) {
             return;
         }

--- a/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
+++ b/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
@@ -22,7 +22,7 @@ export default {
             </fast-accordion-item>
             <fast-accordion-item>
                 <div slot="heading">Accordion Item 2 Heading</div>
-                Accordion Item 2 Content
+                <fast-checkbox>A checkbox as content</fast-checkbox
             </fast-accordion-item>
         `,
     },


### PR DESCRIPTION
# Pull Request

## 📖 Description

Accordion was listening for `change` events to determine when to open/close items, but was not differentiating between change events generated by the accordion items and those of the children of these items.  This change adds checks to ensure that accordion ignores `change` events from other elements and does not react to events that have been defaultPrevented, 

### 🎫 Issues
closes https://github.com/microsoft/fast/issues/6144

## 📑 Test Plan
We should add some functional accordion tests when we move to playright.  The current set is limited.  Added an issue to track.
https://github.com/microsoft/fast/issues/6157

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
