### PR TITLE
feat: anchored-region checks local shadow dom for anchor id

### DIFF
--- a/change/@microsoft-fast-foundation-5dacab8f-7ec9-4469-9853-e99b87b243c4.json
+++ b/change/@microsoft-fast-foundation-5dacab8f-7ec9-4469-9853-e99b87b243c4.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "anchored-region checks local shadow dom",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-5dacab8f-7ec9-4469-9853-e99b87b243c4.json
+++ b/change/@microsoft-fast-foundation-5dacab8f-7ec9-4469-9853-e99b87b243c4.json
@@ -1,7 +1,7 @@
 {
-  "type": "minor",
+  "type": "prerelease",
   "comment": "anchored-region checks local shadow dom",
   "packageName": "@microsoft/fast-foundation",
   "email": "stephcomeau@msn.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/.storybook/preview-head.html
+++ b/packages/web-components/fast-foundation/.storybook/preview-head.html
@@ -107,6 +107,7 @@
     body,
     #root {
         width: 100%;
+        height: 100%;
     }
 
     @media (prefers-color-scheme: dark) {

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.spec.md
@@ -182,7 +182,7 @@ NOTE: this component api will not be exposed outside of the fast-components pack
 - `fast-anchored-region`
 
 *Attributes:*
-- anchor - The html id of the HTMLElement used as the anchor around which the positioning region is placed.  This must be set for the component's positioning logic to be active.
+- anchor - The html id of the HTMLElement used as the anchor around which the positioning region is placed.  This must be set for the component's positioning logic to be active. The component will first check for the element id in the local shadow DOM followed by the document light DOM.
 
 - viewport - The ID of the HTMLElement to be used as the viewport used to determine available layout space around the anchor element.  If unset the parent element of the anchored region is used.
 

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -610,6 +610,12 @@ export class FASTAnchoredRegion extends FASTElement {
      *  Gets the anchor element by id
      */
     private getAnchor = (): HTMLElement | null => {
+        const rootNode = this.getRootNode();
+
+        if (rootNode instanceof ShadowRoot) {
+            return rootNode.getElementById(this.anchor);
+        }
+
         return document.getElementById(this.anchor);
     };
 

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.ts
@@ -603,6 +603,12 @@ export class FASTAnchoredRegion extends FASTElement {
             return document.documentElement;
         }
 
+        const rootNode = this.getRootNode();
+
+        if (rootNode instanceof ShadowRoot) {
+            return rootNode.getElementById(this.viewport);
+        }
+
         return document.getElementById(this.viewport);
     };
 

--- a/packages/web-components/fast-foundation/src/anchored-region/stories/anchored-region.stories.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/stories/anchored-region.stories.ts
@@ -6,32 +6,30 @@ type AnchoredRegionArgs = Args & FASTAnchoredRegion;
 type AnchoredRegionMeta = Meta<AnchoredRegionArgs>;
 
 const storyTemplate = html<AnchoredRegionArgs>`
-    <div id="viewport" style="height: 100%; width: 100%;">
-        <div
+    <div style="height: 300%; width: 300%;">
+        <fast-button
             id="anchor"
             class="anchor"
             style="
-                transform: translate(120px, 120px);
-                height: 60px;
-                width: 60px;
-                background: yellow;"
+                    transform: translate(400px, 400px);"
         >
             Anchor
-        </div>
+        </fast-button>
         <fast-anchored-region
             class="region"
             id="region"
             anchor="anchor"
-            viewport="viewport"
             fixed-placement="${x => x.fixedPlacement}"
             vertical-positioning-mode="${x => x.verticalPositioningMode}"
             vertical-default-position="${x => x.verticalDefaultPosition}"
             vertical-inset="${x => x.verticalInset}"
             vertical-scaling="${x => x.verticalScaling}"
+            vertical-viewport-lock="${x => x.verticalViewportLock}"
             horizontal-positioning-mode="${x => x.horizontalPositioningMode}"
             horizontal-default-position="${x => x.horizontalDefaultPosition}"
             horizontal-scaling="${x => x.horizontalScaling}"
             horizontal-inset="${x => x.horizontalInset}"
+            horizontal-viewport-lock="${x => x.horizontalViewportLock}"
             auto-update-mode="${x => x.autoUpdateMode}"
         >
             ${x => x?.content}
@@ -42,12 +40,13 @@ const storyTemplate = html<AnchoredRegionArgs>`
 export default {
     title: "Anchored Region",
     args: {
+        autoUpdateMode: "auto",
         verticalPositioningMode: "locktodefault",
         horizontalPositioningMode: "locktodefault",
         verticalDefaultPosition: "top",
         horizontalDefaultPosition: "left",
         content: html`
-            <div style="background: green">
+            <div style="background: white; padding: 20px">
                 anchored-region
             </div>
         `,
@@ -67,6 +66,7 @@ export default {
             options: ["anchor", "fill", "content"],
             control: { type: "select" },
         },
+        verticalViewportLock: { control: { type: "boolean" } },
         horizontalPositioningMode: {
             options: ["uncontrolled", "locktodefault", "dynamic"],
             control: { type: "select" },
@@ -80,7 +80,8 @@ export default {
             control: { type: "select" },
         },
         horizontalInset: { control: { type: "boolean" } },
-        autoupdateMode: {
+        horizontalViewportLock: { control: { type: "boolean" } },
+        autoUpdateMode: {
             options: ["anchor", "auto"],
             control: { type: "select" },
         },


### PR DESCRIPTION
# Pull Request

## 📖 Description
Anchored region defaulted to checking the light dom to find the anchor element by id.  With this change it will check the local shadow dom for a matching id before checking the light dom.  Matches a behavior we already have in tooltip and should make it easier to use.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
