### PR TITLE
adaptive-ui: Initial support for opacity in neutral recipes

### DIFF
--- a/change/@microsoft-adaptive-ui-2c911859-fa07-4cfb-898e-9cea4af0ac67.json
+++ b/change/@microsoft-adaptive-ui-2c911859-fa07-4cfb-898e-9cea4af0ac67.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Initial support for opacity in neutral recipes",
+  "packageName": "@microsoft/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/utilities/adaptive-ui/docs/api-report.md
+++ b/packages/utilities/adaptive-ui/docs/api-report.md
@@ -4,6 +4,7 @@
 
 ```ts
 
+import { ColorRGBA64 } from '@microsoft/fast-colors';
 import { CSSDesignToken } from '@microsoft/fast-foundation';
 import { CSSDirective } from '@microsoft/fast-element';
 import { DesignToken } from '@microsoft/fast-foundation';
@@ -251,6 +252,9 @@ export interface InteractiveSwatchSet {
 }
 
 // @public
+export function interactiveSwatchSetAsOverlay(set: InteractiveSwatchSet, reference: Swatch, asOverlay: boolean): InteractiveSwatchSet;
+
+// @public
 export function isDark(color: RelativeLuminance): boolean;
 
 // @public (undocumented)
@@ -258,6 +262,9 @@ export const layerCornerRadius: CSSDesignToken<number>;
 
 // @public
 export function luminanceSwatch(luminance: number): Swatch;
+
+// @public (undocumented)
+export const neutralAsOverlay: DesignToken<boolean>;
 
 // @public (undocumented)
 export const neutralBaseColor: CSSDesignToken<string>;
@@ -600,9 +607,14 @@ export interface Swatch extends RelativeLuminance {
 }
 
 // @public
+export function swatchAsOverlay(swatch: Swatch, reference: Swatch, asOverlay: boolean): Swatch;
+
+// @public
 export class SwatchRGB implements Swatch {
-    constructor(red: number, green: number, blue: number);
+    constructor(red: number, green: number, blue: number, alpha?: number, intendedColor?: SwatchRGB);
+    static asOverlay(intendedColor: SwatchRGB, reference: SwatchRGB): SwatchRGB;
     readonly b: number;
+    readonly color: ColorRGBA64;
     contrast: any;
     createCSS: () => string;
     static from(obj: {
@@ -611,6 +623,7 @@ export class SwatchRGB implements Swatch {
         b: number;
     }): SwatchRGB;
     readonly g: number;
+    readonly intendedColor?: SwatchRGB;
     readonly r: number;
     readonly relativeLuminance: number;
     toColorString(): string;

--- a/packages/utilities/adaptive-ui/src/color/recipes/contrast-swatch.ts
+++ b/packages/utilities/adaptive-ui/src/color/recipes/contrast-swatch.ts
@@ -8,6 +8,7 @@ import { directionByIsDark } from "../utilities/direction-by-is-dark.js";
  * @param palette - The Palette used to find the Swatch
  * @param reference - The reference color
  * @param minContrast - The desired minimum contrast
+ * @param direction - The direction the delta moves on the `palette`, defaults to {@link directionByIsDark} based on `reference`
  * @returns The Swatch
  *
  * @public

--- a/packages/utilities/adaptive-ui/src/color/utilities/index.ts
+++ b/packages/utilities/adaptive-ui/src/color/utilities/index.ts
@@ -2,4 +2,5 @@ export * from "./color-constants.js";
 export * from "./direction-by-is-dark.js";
 export * from "./is-dark.js";
 export * from "./luminance-swatch.js";
+export * from "./opacity.js";
 export * from "./relative-luminance.js";

--- a/packages/utilities/adaptive-ui/src/color/utilities/opacity.ts
+++ b/packages/utilities/adaptive-ui/src/color/utilities/opacity.ts
@@ -1,0 +1,46 @@
+import { InteractiveSwatchSet } from "../recipe.js";
+import { Swatch, SwatchRGB } from "../swatch.js";
+
+/**
+ * Returns an opaque {@link Swatch} or a {@link Swatch} with opacity relative to the reference color.
+ *
+ * @param swatch The opaque intended swatch color
+ * @param reference The reference color for a semitransparent swatch
+ * @param asOverlay True to return a semitransparent representation of `swatch` relative to `reference`.
+ * @returns The requested representation of `swatch`
+ *
+ * @public
+ */
+export function swatchAsOverlay(
+    swatch: Swatch,
+    reference: Swatch,
+    asOverlay: boolean
+): Swatch {
+    return swatch instanceof SwatchRGB && asOverlay
+        ? SwatchRGB.asOverlay(swatch as SwatchRGB, reference as SwatchRGB)
+        : swatch;
+}
+
+/**
+ * Returns an interactive set of opaque {@link Swatch}es or {@link Swatch}es with opacity relative to the reference color.
+ *
+ * @param set
+ * @param reference The reference color for a semitransparent swatch
+ * @param asOverlay True to return a semitransparent representation of `swatch` relative to `reference`.
+ * @returns The requested representation of a `swatch` set
+ */
+export function interactiveSwatchSetAsOverlay(
+    set: InteractiveSwatchSet,
+    reference: Swatch,
+    asOverlay: boolean
+): InteractiveSwatchSet {
+    if (asOverlay) {
+        return {
+            rest: swatchAsOverlay(set.rest, reference, asOverlay),
+            hover: swatchAsOverlay(set.hover, reference, asOverlay),
+            active: swatchAsOverlay(set.active, reference, asOverlay),
+            focus: swatchAsOverlay(set.focus, reference, asOverlay),
+        };
+    }
+    return set;
+}

--- a/packages/utilities/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/utilities/adaptive-ui/src/design-tokens/color.ts
@@ -1,6 +1,10 @@
 import { parseColorHexRGB } from "@microsoft/fast-colors";
 import { DesignTokenResolver } from "@microsoft/fast-foundation";
-import { blackOrWhiteByContrast } from "../color/index.js";
+import {
+    blackOrWhiteByContrast,
+    interactiveSwatchSetAsOverlay,
+    swatchAsOverlay,
+} from "../color/index.js";
 import {
     ColorRecipe,
     InteractiveColorRecipe,
@@ -35,6 +39,11 @@ export const ContrastTarget = Object.freeze({
 /** @public */
 export const fillColor = create<Swatch>("fill-color").withDefault(
     SwatchRGB.from(parseColorHexRGB("#FFFFFF")!)
+);
+
+/** @public */
+export const neutralAsOverlay = createNonCss<boolean>("neutral-as-overlay").withDefault(
+    true
 );
 
 // Accent Fill
@@ -262,14 +271,18 @@ export const neutralForegroundRecipe = createNonCss<InteractiveColorRecipe>(
     "neutral-foreground-recipe"
 ).withDefault({
     evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        contrastAndDeltaSwatchSet(
-            resolve(neutralPalette),
+        interactiveSwatchSetAsOverlay(
+            contrastAndDeltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralForegroundMinContrast),
+                resolve(neutralForegroundRestDelta),
+                resolve(neutralForegroundHoverDelta),
+                resolve(neutralForegroundActiveDelta),
+                resolve(neutralForegroundFocusDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralForegroundMinContrast),
-            resolve(neutralForegroundRestDelta),
-            resolve(neutralForegroundHoverDelta),
-            resolve(neutralForegroundActiveDelta),
-            resolve(neutralForegroundFocusDelta)
+            resolve(neutralAsOverlay)
         ),
 });
 
@@ -312,10 +325,14 @@ export const neutralForegroundHintRecipe = createNonCss<ColorRecipe>(
     "neutral-foreground-hint-recipe"
 ).withDefault({
     evaluate: (resolve: DesignTokenResolver, reference?: Swatch): Swatch =>
-        contrastSwatch(
-            resolve(neutralPalette),
+        swatchAsOverlay(
+            contrastSwatch(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                ContrastTarget.NormalText
+            ),
             reference || resolve(fillColor),
-            ContrastTarget.NormalText
+            resolve(neutralAsOverlay)
         ),
 });
 
@@ -353,13 +370,17 @@ export const neutralFillRecipe = createNonCss<InteractiveColorRecipe>(
     "neutral-fill-recipe"
 ).withDefault({
     evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        deltaSwatchSet(
-            resolve(neutralPalette),
+        interactiveSwatchSetAsOverlay(
+            deltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralFillRestDelta),
+                resolve(neutralFillHoverDelta),
+                resolve(neutralFillActiveDelta),
+                resolve(neutralFillFocusDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralFillRestDelta),
-            resolve(neutralFillHoverDelta),
-            resolve(neutralFillActiveDelta),
-            resolve(neutralFillFocusDelta)
+            resolve(neutralAsOverlay)
         ),
 });
 
@@ -410,13 +431,17 @@ export const neutralFillInputRecipe = createNonCss<InteractiveColorRecipe>(
     "neutral-fill-input-recipe"
 ).withDefault({
     evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        deltaSwatchSet(
-            resolve(neutralPalette),
+        interactiveSwatchSetAsOverlay(
+            deltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralFillInputRestDelta),
+                resolve(neutralFillInputHoverDelta),
+                resolve(neutralFillInputActiveDelta),
+                resolve(neutralFillInputFocusDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralFillInputRestDelta),
-            resolve(neutralFillInputHoverDelta),
-            resolve(neutralFillInputActiveDelta),
-            resolve(neutralFillInputFocusDelta)
+            resolve(neutralAsOverlay)
         ),
 });
 
@@ -477,13 +502,17 @@ export const neutralFillSecondaryRecipe = createNonCss<InteractiveColorRecipe>(
     "neutral-fill-secondary-recipe"
 ).withDefault({
     evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        deltaSwatchSet(
-            resolve(neutralPalette),
+        interactiveSwatchSetAsOverlay(
+            deltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralFillSecondaryRestDelta),
+                resolve(neutralFillSecondaryHoverDelta),
+                resolve(neutralFillSecondaryActiveDelta),
+                resolve(neutralFillSecondaryFocusDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralFillSecondaryRestDelta),
-            resolve(neutralFillSecondaryHoverDelta),
-            resolve(neutralFillSecondaryActiveDelta),
-            resolve(neutralFillSecondaryFocusDelta)
+            resolve(neutralAsOverlay)
         ),
 });
 
@@ -546,13 +575,17 @@ export const neutralFillStealthRecipe = createNonCss<InteractiveColorRecipe>(
     "neutral-fill-stealth-recipe"
 ).withDefault({
     evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        deltaSwatchSet(
-            resolve(neutralPalette),
+        interactiveSwatchSetAsOverlay(
+            deltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralFillStealthRestDelta),
+                resolve(neutralFillStealthHoverDelta),
+                resolve(neutralFillStealthActiveDelta),
+                resolve(neutralFillStealthFocusDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralFillStealthRestDelta),
-            resolve(neutralFillStealthHoverDelta),
-            resolve(neutralFillStealthActiveDelta),
-            resolve(neutralFillStealthFocusDelta)
+            resolve(neutralAsOverlay)
         ),
 });
 
@@ -620,14 +653,18 @@ export const neutralFillStrongRecipe = createNonCss<InteractiveColorRecipe>(
     "neutral-fill-strong-recipe"
 ).withDefault({
     evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        contrastAndDeltaSwatchSet(
-            resolve(neutralPalette),
+        interactiveSwatchSetAsOverlay(
+            contrastAndDeltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralFillStrongMinContrast),
+                resolve(neutralFillStrongRestDelta),
+                resolve(neutralFillStrongHoverDelta),
+                resolve(neutralFillStrongActiveDelta),
+                resolve(neutralFillStrongFocusDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralFillStrongMinContrast),
-            resolve(neutralFillStrongRestDelta),
-            resolve(neutralFillStrongHoverDelta),
-            resolve(neutralFillStrongActiveDelta),
-            resolve(neutralFillStrongFocusDelta)
+            resolve(neutralAsOverlay)
         ),
 });
 
@@ -689,19 +726,19 @@ export const neutralStrokeFocusDelta = createNonCss<number>(
 export const neutralStrokeRecipe = createNonCss<InteractiveColorRecipe>(
     "neutral-stroke-recipe"
 ).withDefault({
-    evaluate: (
-        resolve: DesignTokenResolver,
-        reference?: Swatch
-    ): InteractiveSwatchSet => {
-        return deltaSwatchSet(
-            resolve(neutralPalette),
+    evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
+        interactiveSwatchSetAsOverlay(
+            deltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralStrokeRestDelta),
+                resolve(neutralStrokeHoverDelta),
+                resolve(neutralStrokeActiveDelta),
+                resolve(neutralStrokeFocusDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralStrokeRestDelta),
-            resolve(neutralStrokeHoverDelta),
-            resolve(neutralStrokeActiveDelta),
-            resolve(neutralStrokeFocusDelta)
-        );
-    },
+            resolve(neutralAsOverlay)
+        ),
 });
 
 /** @public */
@@ -737,10 +774,14 @@ export const neutralStrokeDividerRecipe = createNonCss<ColorRecipe>(
     "neutral-stroke-divider-recipe"
 ).withDefault({
     evaluate: (resolve: DesignTokenResolver, reference?: Swatch): Swatch =>
-        deltaSwatch(
-            resolve(neutralPalette),
+        swatchAsOverlay(
+            deltaSwatch(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralStrokeDividerRestDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralStrokeDividerRestDelta)
+            resolve(neutralAsOverlay)
         ),
 });
 
@@ -775,19 +816,19 @@ export const neutralStrokeInputFocusDelta = createNonCss<number>(
 export const neutralStrokeInputRecipe = createNonCss<InteractiveColorRecipe>(
     "neutral-stroke-input-recipe"
 ).withDefault({
-    evaluate: (
-        resolve: DesignTokenResolver,
-        reference?: Swatch
-    ): InteractiveSwatchSet => {
-        return deltaSwatchSet(
-            resolve(neutralPalette),
+    evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
+        interactiveSwatchSetAsOverlay(
+            deltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralStrokeInputRestDelta),
+                resolve(neutralStrokeInputHoverDelta),
+                resolve(neutralStrokeInputActiveDelta),
+                resolve(neutralStrokeInputFocusDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralStrokeInputRestDelta),
-            resolve(neutralStrokeInputHoverDelta),
-            resolve(neutralStrokeInputActiveDelta),
-            resolve(neutralStrokeInputFocusDelta)
-        );
-    },
+            resolve(neutralAsOverlay)
+        ),
 });
 
 /** @public */
@@ -854,14 +895,18 @@ export const neutralStrokeStrongRecipe = createNonCss<InteractiveColorRecipe>(
     "neutral-stroke-strong-recipe"
 ).withDefault({
     evaluate: (resolve: DesignTokenResolver, reference?: Swatch): InteractiveSwatchSet =>
-        contrastAndDeltaSwatchSet(
-            resolve(neutralPalette),
+        interactiveSwatchSetAsOverlay(
+            contrastAndDeltaSwatchSet(
+                resolve(neutralPalette),
+                reference || resolve(fillColor),
+                resolve(neutralStrokeStrongMinContrast),
+                resolve(neutralStrokeStrongRestDelta),
+                resolve(neutralStrokeStrongHoverDelta),
+                resolve(neutralStrokeStrongActiveDelta),
+                resolve(neutralStrokeStrongFocusDelta)
+            ),
             reference || resolve(fillColor),
-            resolve(neutralStrokeStrongMinContrast),
-            resolve(neutralStrokeStrongRestDelta),
-            resolve(neutralStrokeStrongHoverDelta),
-            resolve(neutralStrokeStrongActiveDelta),
-            resolve(neutralStrokeStrongFocusDelta)
+            resolve(neutralAsOverlay)
         ),
 });
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds support for rendering neutral recipe colors as an overlay. This supports UI over the Windows 11 mica effect or contrast-safe scenarios over images or gradients.

The feature is applied to the neutral palette only for now, as it produces either a white or black semitransparent overlay instead of a fixed color. This works perfect with a non-tinted grey neutral palette, and it works well for low-saturated colors which might be more common for a tinted-neutral setup. It may not produce the expected colors for an accent color, which is typically more saturated and intended to stand out. Interested in thoughts for future updates in this regard though.

## 👩‍💻 Reviewer Notes

This needs to be applied to components to be tested. Working on getting this into the CLI now.

## 📑 Test Plan

See above.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.