### PR TITLE
feat: enable render, repeat, and when template helpers to handle static data

### DIFF
--- a/change/@microsoft-fast-element-64ffcc23-bbc9-409d-99a7-00a93af07b85.json
+++ b/change/@microsoft-fast-element-64ffcc23-bbc9-409d-99a7-00a93af07b85.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "fix: enable createElementTemplate to have undefined attributes",
   "packageName": "@microsoft/fast-element",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-6f2b6b24-e285-4faa-b0a8-5acdedaede8d.json
+++ b/change/@microsoft-fast-element-6f2b6b24-e285-4faa-b0a8-5acdedaede8d.json
@@ -1,7 +1,7 @@
 {
-  "type": "minor",
+  "type": "prerelease",
   "comment": "use index to track reusable views",
   "packageName": "@microsoft/fast-element",
   "email": "prudepixie@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-7e339741-a763-4313-b23e-4b5644e6ebe2.json
+++ b/change/@microsoft-fast-element-7e339741-a763-4313-b23e-4b5644e6ebe2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: enable render, repeat, and when template helpers to handle static data in addition to the already supported dynamic bindings",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-7e339741-a763-4313-b23e-4b5644e6ebe2.json
+++ b/change/@microsoft-fast-element-7e339741-a763-4313-b23e-4b5644e6ebe2.json
@@ -3,5 +3,5 @@
   "comment": "feat: enable render, repeat, and when template helpers to handle static data in addition to the already supported dynamic bindings",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-c0150ae1-d206-45b8-8c0e-f0873bc3602e.json
+++ b/change/@microsoft-fast-foundation-c0150ae1-d206-45b8-8c0e-f0873bc3602e.json
@@ -3,5 +3,5 @@
   "comment": "Removed the `fill` and `color` attributes and styling from Badge",
   "packageName": "@microsoft/fast-foundation",
   "email": "47367562+bheston@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-c8e72081-257f-474b-803b-0ae63fc25a83.json
+++ b/change/@microsoft-fast-foundation-c8e72081-257f-474b-803b-0ae63fc25a83.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "accordion verifies change events",
   "packageName": "@microsoft/fast-foundation",
   "email": "stephcomeau@msn.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-ssr-d5fb6092-d576-4983-a2f0-8a7cfb88138a.json
+++ b/change/@microsoft-fast-ssr-d5fb6092-d576-4983-a2f0-8a7cfb88138a.json
@@ -3,5 +3,5 @@
   "comment": "fix: update server-side-rendering of the repeat directive to use the renamed dataBinding property of the repeat directive",
   "packageName": "@microsoft/fast-ssr",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-ssr-d5fb6092-d576-4983-a2f0-8a7cfb88138a.json
+++ b/change/@microsoft-fast-ssr-d5fb6092-d576-4983-a2f0-8a7cfb88138a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: update server-side-rendering of the repeat directive to use the renamed dataBinding property of the repeat directive",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -619,7 +619,7 @@ export class RefDirective extends StatelessAttachedAttributeDirective<string> {
 }
 
 // @public
-export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>, templateOrTemplateBinding: ViewTemplate | Binding<TSource, ViewTemplate>, options?: RepeatOptions): CaptureType<TSource>;
+export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(items: Binding<TSource, TArray, ExecutionContext<TSource>> | ReadonlyArray<any>, templateOrTemplateBinding: ViewTemplate | Binding<TSource, ViewTemplate>, options?: RepeatOptions): CaptureType<TSource>;
 
 // @public
 export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -878,7 +878,7 @@ export class ViewTemplate<TSource = any, TParent = any> implements ElementViewTe
 export function volatile(target: {}, name: string | Accessor, descriptor: PropertyDescriptor): PropertyDescriptor;
 
 // @public
-export function when<TSource = any, TReturn = any>(binding: Binding<TSource, TReturn>, templateOrTemplateBinding: SyntheticViewTemplate | Binding<TSource, SyntheticViewTemplate>): CaptureType<TSource>;
+export function when<TSource = any, TReturn = any>(condition: Binding<TSource, TReturn> | boolean, templateOrTemplateBinding: SyntheticViewTemplate | Binding<TSource, SyntheticViewTemplate>): CaptureType<TSource>;
 
 // Warnings were encountered during analysis:
 //

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -623,7 +623,7 @@ export function repeat<TSource = any, TArray extends ReadonlyArray<any> = Readon
 
 // @public
 export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
-    constructor(location: Node, itemsBinding: Binding<TSource, any[]>, isItemsBindingVolatile: boolean, templateBinding: Binding<TSource, SyntheticViewTemplate>, isTemplateBindingVolatile: boolean, options: RepeatOptions);
+    constructor(location: Node, dataBinding: Binding<TSource, any[]>, isItemsBindingVolatile: boolean, templateBinding: Binding<TSource, SyntheticViewTemplate>, isTemplateBindingVolatile: boolean, options: RepeatOptions);
     bind(source: TSource, context: ExecutionContext): void;
     handleChange(source: any, args: Splice[]): void;
     unbind(): void;
@@ -631,12 +631,12 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
 
 // @public
 export class RepeatDirective<TSource = any> implements HTMLDirective, ViewBehaviorFactory {
-    constructor(itemsBinding: Binding, templateBinding: Binding<TSource, SyntheticViewTemplate>, options: RepeatOptions);
+    constructor(dataBinding: Binding, templateBinding: Binding<TSource, SyntheticViewTemplate>, options: RepeatOptions);
     createBehavior(targets: ViewBehaviorTargets): RepeatBehavior<TSource>;
     createHTML(add: AddViewBehaviorFactory): string;
-    id: string;
     // (undocumented)
-    readonly itemsBinding: Binding;
+    readonly dataBinding: Binding;
+    id: string;
     nodeId: string;
     // (undocumented)
     readonly options: RepeatOptions;

--- a/packages/web-components/fast-element/src/templating/render.spec.ts
+++ b/packages/web-components/fast-element/src/templating/render.spec.ts
@@ -73,6 +73,16 @@ describe("The render", () => {
             expect(data).to.equal(node);
         });
 
+        it("creates a data binding that evaluates to a provided object", () => {
+            const source = new TestParent();
+            const obj = {};
+            const directive = render(obj) as RenderDirective;
+
+            const data = directive.dataBinding(source, ExecutionContext.default);
+
+            expect(data).to.equal(obj);
+        });
+
         it("creates a template binding when a template is provided", () => {
             const source = new TestParent();
             const directive = render<TestParent>(x => x.child, childEditTemplate) as RenderDirective;

--- a/packages/web-components/fast-element/src/templating/render.ts
+++ b/packages/web-components/fast-element/src/templating/render.ts
@@ -569,7 +569,7 @@ export class NodeTemplate implements ContentTemplate, ContentView {
 
 /**
  * Creates a RenderDirective for use in advanced rendering scenarios.
- * @param binding - The binding expression that returns the data to be rendered. The expression
+ * @param data - The binding expression that returns the data to be rendered. The expression
  * can also return a Node to render directly.
  * @param templateOrTemplateBindingOrViewName - A template to render the data with
  * or a string to indicate which RenderInstruction to use when looking up a RenderInstruction.
@@ -584,7 +584,7 @@ export class NodeTemplate implements ContentTemplate, ContentView {
  * @public
  */
 export function render<TSource = any, TItem = any>(
-    binding?: Binding<TSource, TItem> | Node,
+    data?: Binding<TSource, TItem> | {},
     templateOrTemplateBindingOrViewName?:
         | ContentTemplate
         | string
@@ -592,12 +592,12 @@ export function render<TSource = any, TItem = any>(
 ): CaptureType<TSource> {
     let dataBinding: Binding<TSource>;
 
-    if (binding === void 0) {
+    if (data === void 0) {
         dataBinding = (source: TSource) => source;
-    } else if (binding instanceof Node) {
-        dataBinding = () => binding;
+    } else if (isFunction(data)) {
+        dataBinding = data;
     } else {
-        dataBinding = binding;
+        dataBinding = () => data;
     }
 
     let templateBinding;

--- a/packages/web-components/fast-element/src/templating/repeat.spec.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.spec.ts
@@ -44,7 +44,7 @@ describe("The repeat", () => {
             const source = new ViewModel();
             const directive = repeat<ViewModel>(x => x.items, html`test`) as RepeatDirective;
 
-            const data = directive.itemsBinding(source, ExecutionContext.default);
+            const data = directive.dataBinding(source, ExecutionContext.default);
 
             expect(data).to.equal(source.items);
         });
@@ -54,7 +54,7 @@ describe("The repeat", () => {
             const itemTemplate = html`test`;
             const directive = repeat(array, itemTemplate) as RepeatDirective;
 
-            const data = directive.itemsBinding({}, ExecutionContext.default);
+            const data = directive.dataBinding({}, ExecutionContext.default);
 
             expect(data).to.equal(array);
         });

--- a/packages/web-components/fast-element/src/templating/repeat.spec.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.spec.ts
@@ -18,6 +18,10 @@ describe("The repeat", () => {
     }
 
     context("template function", () => {
+        class ViewModel {
+            items = ["a", "b", "c"]
+        }
+
         it("returns a RepeatDirective", () => {
             const directive = repeat(
                 () => [],
@@ -25,6 +29,7 @@ describe("The repeat", () => {
             );
             expect(directive).to.be.instanceOf(RepeatDirective);
         });
+
         it("returns a RepeatDirective with optional properties set to different values", () => {
             const directive = repeat(
                 () => [],
@@ -33,6 +38,41 @@ describe("The repeat", () => {
             ) as RepeatDirective;
             expect(directive).to.be.instanceOf(RepeatDirective);
             expect(directive.options).to.deep.equal({positioning: true, recycle: false})
+        });
+
+        it("creates a data binding that evaluates the provided binding", () => {
+            const source = new ViewModel();
+            const directive = repeat<ViewModel>(x => x.items, html`test`) as RepeatDirective;
+
+            const data = directive.itemsBinding(source, ExecutionContext.default);
+
+            expect(data).to.equal(source.items);
+        });
+
+        it("creates a data binding that evaluates to a provided array", () => {
+            const array = ["a", "b", "c"];
+            const itemTemplate = html`test`;
+            const directive = repeat(array, itemTemplate) as RepeatDirective;
+
+            const data = directive.itemsBinding({}, ExecutionContext.default);
+
+            expect(data).to.equal(array);
+        });
+
+        it("creates a template binding when a template is provided", () => {
+            const source = new ViewModel();
+            const itemTemplate = html`test`;
+            const directive = repeat<ViewModel>(x => x.items, itemTemplate) as RepeatDirective;
+            const template = directive.templateBinding(source, ExecutionContext.default);
+            expect(template).to.equal(itemTemplate);
+        });
+
+        it("creates a template binding when a function is provided", () => {
+            const source = new ViewModel();
+            const itemTemplate = html`test`;
+            const directive = repeat<ViewModel>(x => x.items, () => itemTemplate) as RepeatDirective;
+            const template = directive.templateBinding(source, ExecutionContext.default);
+            expect(template).equal(itemTemplate);
         });
     });
 

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -378,11 +378,11 @@ export function repeat<
     templateOrTemplateBinding: ViewTemplate | Binding<TSource, ViewTemplate>,
     options: RepeatOptions = defaultRepeatOptions
 ): CaptureType<TSource> {
-    const itemsBinding = isFunction(items) ? items : () => items;
+    const dataBinding = isFunction(items) ? items : () => items;
 
     const templateBinding = isFunction(templateOrTemplateBinding)
         ? templateOrTemplateBinding
         : (): SyntheticViewTemplate => templateOrTemplateBinding;
 
-    return new RepeatDirective(itemsBinding, templateBinding, options) as any;
+    return new RepeatDirective(dataBinding, templateBinding, options) as any;
 }

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -364,7 +364,7 @@ HTMLDirective.define(RepeatDirective);
 
 /**
  * A directive that enables list rendering.
- * @param itemsBinding - The array to render.
+ * @param items - The array to render.
  * @param templateOrTemplateBinding - The template or a template binding used obtain a template
  * to render for each item in the array.
  * @param options - Options used to turn on special repeat features.
@@ -374,10 +374,12 @@ export function repeat<
     TSource = any,
     TArray extends ReadonlyArray<any> = ReadonlyArray<any>
 >(
-    itemsBinding: Binding<TSource, TArray, ExecutionContext<TSource>>,
+    items: Binding<TSource, TArray, ExecutionContext<TSource>> | ReadonlyArray<any>,
     templateOrTemplateBinding: ViewTemplate | Binding<TSource, ViewTemplate>,
     options: RepeatOptions = defaultRepeatOptions
 ): CaptureType<TSource> {
+    const itemsBinding = isFunction(items) ? items : () => items;
+
     const templateBinding = isFunction(templateOrTemplateBinding)
         ? templateOrTemplateBinding
         : (): SyntheticViewTemplate => templateOrTemplateBinding;

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -77,7 +77,7 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
     /**
      * Creates an instance of RepeatBehavior.
      * @param location - The location in the DOM to render the repeat.
-     * @param itemsBinding - The array to render.
+     * @param dataBinding - The array to render.
      * @param isItemsBindingVolatile - Indicates whether the items binding has volatile dependencies.
      * @param templateBinding - The template to render for each item.
      * @param isTemplateBindingVolatile - Indicates whether the template binding has volatile dependencies.
@@ -85,14 +85,14 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
      */
     public constructor(
         private location: Node,
-        private itemsBinding: Binding<TSource, any[]>,
+        private dataBinding: Binding<TSource, any[]>,
         isItemsBindingVolatile: boolean,
         private templateBinding: Binding<TSource, SyntheticViewTemplate>,
         isTemplateBindingVolatile: boolean,
         private options: RepeatOptions
     ) {
         this.itemsBindingObserver = Observable.binding(
-            itemsBinding,
+            dataBinding,
             this,
             isItemsBindingVolatile
         );
@@ -146,7 +146,7 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
      * @param args - The details about what was changed.
      */
     public handleChange(source: any, args: Splice[]): void {
-        if (source === this.itemsBinding) {
+        if (source === this.dataBinding) {
             this.items = this.itemsBindingObserver.observe(this.source!, this.context!);
             this.observeItems();
             this.refreshAllViews();
@@ -330,17 +330,17 @@ export class RepeatDirective<TSource = any>
 
     /**
      * Creates an instance of RepeatDirective.
-     * @param itemsBinding - The binding that provides the array to render.
+     * @param dataBinding - The binding that provides the array to render.
      * @param templateBinding - The template binding used to obtain a template to render for each item in the array.
      * @param options - Options used to turn on special repeat features.
      */
     public constructor(
-        public readonly itemsBinding: Binding,
+        public readonly dataBinding: Binding,
         public readonly templateBinding: Binding<TSource, SyntheticViewTemplate>,
         public readonly options: RepeatOptions
     ) {
         ArrayObserver.enable();
-        this.isItemsBindingVolatile = Observable.isVolatileBinding(itemsBinding);
+        this.isItemsBindingVolatile = Observable.isVolatileBinding(dataBinding);
         this.isTemplateBindingVolatile = Observable.isVolatileBinding(templateBinding);
     }
 
@@ -351,7 +351,7 @@ export class RepeatDirective<TSource = any>
     public createBehavior(targets: ViewBehaviorTargets): RepeatBehavior<TSource> {
         return new RepeatBehavior<TSource>(
             targets[this.nodeId],
-            this.itemsBinding,
+            this.dataBinding,
             this.isItemsBindingVolatile,
             this.templateBinding,
             this.isTemplateBindingVolatile,

--- a/packages/web-components/fast-element/src/templating/when.spec.ts
+++ b/packages/web-components/fast-element/src/templating/when.spec.ts
@@ -13,14 +13,26 @@ describe("The 'when' template function", () => {
         const scope = {};
         const template = html`template1`;
 
-        it("returns a template when the condition is true", () => {
+        it("returns a template when the condition binding is true", () => {
             const expression = when(() => true, template) as Binding;
             const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(template);
         });
 
-        it("returns null when the condition is false", () => {
+        it("returns a template when the condition is statically true", () => {
+            const expression = when(true, template) as Binding;
+            const result = expression(scope, ExecutionContext.default);
+            expect(result).to.equal(template);
+        });
+
+        it("returns null when the condition binding is false", () => {
             const expression = when(() => false, template) as Binding;
+            const result = expression(scope, ExecutionContext.default);
+            expect(result).to.equal(null);
+        });
+
+        it("returns null when the condition is statically false", () => {
+            const expression = when(false, template) as Binding;
             const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(null);
         });

--- a/packages/web-components/fast-element/src/templating/when.ts
+++ b/packages/web-components/fast-element/src/templating/when.ts
@@ -4,21 +4,23 @@ import type { CaptureType, SyntheticViewTemplate } from "./template.js";
 
 /**
  * A directive that enables basic conditional rendering in a template.
- * @param binding - The condition to test for rendering.
+ * @param condition - The condition to test for rendering.
  * @param templateOrTemplateBinding - The template or a binding that gets
  * the template to render when the condition is true.
  * @public
  */
 export function when<TSource = any, TReturn = any>(
-    binding: Binding<TSource, TReturn>,
+    condition: Binding<TSource, TReturn> | boolean,
     templateOrTemplateBinding:
         | SyntheticViewTemplate
         | Binding<TSource, SyntheticViewTemplate>
 ): CaptureType<TSource> {
-    const getTemplate = isFunction(templateOrTemplateBinding)
+    const dataBinding = isFunction(condition) ? condition : () => condition;
+
+    const templateBinding = isFunction(templateOrTemplateBinding)
         ? templateOrTemplateBinding
         : (): SyntheticViewTemplate => templateOrTemplateBinding;
 
     return (source: TSource, context: ExecutionContext): SyntheticViewTemplate | null =>
-        binding(source, context) ? getTemplate(source, context) : null;
+        dataBinding(source, context) ? templateBinding(source, context) : null;
 }

--- a/packages/web-components/fast-ssr/src/template-renderer/directives.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/directives.ts
@@ -49,7 +49,7 @@ export const RepeatDirectiveRenderer: ViewBehaviorFactoryRenderer<RepeatDirectiv
             renderer: TemplateRenderer,
             context: ExecutionContext
         ): IterableIterator<string> {
-            const items = directive.itemsBinding(source, context);
+            const items = directive.dataBinding(source, context);
             const template = directive.templateBinding(source, context);
             const childContext = context.createChildContext(source);
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR enables `render`, `repeat`, and `when` template helper functions to receive static data in addition to the already supported bindings.

### 🎫 Issues

* Closes #6170 

## 👩‍💻 Reviewer Notes

The basic approach has been to simply check the input to the template function and if it's not a function (binding), then to wrap the static value in a binding and pass that along to the directive.

I made a minor breaking change to `repeat` by renaming its `itemsBinding` property to `dataBinding` so that we could have consistent naming across directives. I updated SSR to use this renamed property. I doubt anyone else is directly accessing that in the community.

## 📑 Test Plan

I have added tests for the new inputs and also added additional tests to `repeat` that were missing for already existing scenarios.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Eventually, I'd like to look into a way to enable these static scenarios to use oneTime bindings and maybe enable that generally for directives so that it can be specified by the developer. I'm not sure how to do that just yet. I'll need to think about it a bit more.