### PR TITLE
fix: FASTElementDefinition#isDefined should be true only after define

### DIFF
--- a/change/@microsoft-fast-animation-32d3c5b6-562a-4962-8297-e95d92c3f294.json
+++ b/change/@microsoft-fast-animation-32d3c5b6-562a-4962-8297-e95d92c3f294.json
@@ -1,7 +1,7 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "Updates a security vulnerability on dependency",
   "packageName": "@microsoft/fast-animation",
   "email": "16669785+awentzel@users.noreply.github.com",
-  "dependentChangeType": "prerelease"
+  "dependentChangeType": "patch"
 }

--- a/change/@microsoft-fast-animation-32d3c5b6-562a-4962-8297-e95d92c3f294.json
+++ b/change/@microsoft-fast-animation-32d3c5b6-562a-4962-8297-e95d92c3f294.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "Updates a security vulnerability on dependency",
   "packageName": "@microsoft/fast-animation",
   "email": "16669785+awentzel@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-9ae2db31-9f6d-41c5-a0fa-e056d7b7c029.json
+++ b/change/@microsoft-fast-element-9ae2db31-9f6d-41c5-a0fa-e056d7b7c029.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: FASTElementDefinition#isDefined should be true only after define",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-9ae2db31-9f6d-41c5-a0fa-e056d7b7c029.json
+++ b/change/@microsoft-fast-element-9ae2db31-9f6d-41c5-a0fa-e056d7b7c029.json
@@ -3,5 +3,5 @@
   "comment": "fix: FASTElementDefinition#isDefined should be true only after define",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-router-19cffffd-de42-4d49-820a-93a1d91d1737.json
+++ b/change/@microsoft-fast-router-19cffffd-de42-4d49-820a-93a1d91d1737.json
@@ -3,5 +3,5 @@
   "comment": "refactor: reduce duplication in style normalization code scenarios",
   "packageName": "@microsoft/fast-router",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-router-19cffffd-de42-4d49-820a-93a1d91d1737.json
+++ b/change/@microsoft-fast-router-19cffffd-de42-4d49-820a-93a1d91d1737.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "refactor: reduce duplication in style normalization code scenarios",
+  "packageName": "@microsoft/fast-router",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -319,6 +319,7 @@ export class ElementStyles {
     readonly behaviors: ReadonlyArray<Behavior<HTMLElement>> | null;
     // @internal (undocumented)
     isAttachedTo(target: StyleTarget): boolean;
+    static normalize(styles: ComposableStyles | ComposableStyles[] | undefined): ElementStyles | undefined;
     // @internal (undocumented)
     removeStylesFrom(target: StyleTarget): void;
     static setDefaultStrategy(Strategy: ConstructibleStyleStrategy): void;

--- a/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
@@ -1,6 +1,7 @@
 import { expect } from "chai";
 import { FASTElementDefinition } from "./fast-definitions.js";
 import { ElementStyles } from "../styles/element-styles.js";
+import { uniqueElementName } from "../testing/fixture.js";
 
 describe("FASTElementDefinition", () => {
     class MyElement extends HTMLElement {}
@@ -111,5 +112,17 @@ describe("FASTElementDefinition", () => {
                 expect(def.styles!.styles).to.contain(styleSheet3);
             });
         }
+    });
+
+    context("instance", () => {
+        it("reports not defined until after define is called", () => {
+            const def = FASTElementDefinition.compose(MyElement, uniqueElementName());
+
+            expect(def.isDefined).to.be.false;
+
+            def.define();
+
+            expect(def.isDefined).to.be.true;
+        });
     });
 });

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -56,6 +56,8 @@ export interface PartialFASTElementDefinition {
 export class FASTElementDefinition<
     TType extends Constructable<HTMLElement> = Constructable<HTMLElement>
 > {
+    private platformDefined = false;
+
     /**
      * The type this element definition describes.
      */
@@ -65,7 +67,7 @@ export class FASTElementDefinition<
      * Indicates if this element has been defined in at least one registry.
      */
     public get isDefined(): boolean {
-        return !!fastElementRegistry.getByType(this.type);
+        return this.platformDefined;
     }
 
     /**
@@ -155,14 +157,7 @@ export class FASTElementDefinition<
                 ? defaultElementOptions
                 : { ...defaultElementOptions, ...nameOrConfig.elementOptions };
 
-        this.styles =
-            nameOrConfig.styles === void 0
-                ? void 0
-                : Array.isArray(nameOrConfig.styles)
-                ? new ElementStyles(nameOrConfig.styles)
-                : nameOrConfig.styles instanceof ElementStyles
-                ? nameOrConfig.styles
-                : new ElementStyles([nameOrConfig.styles]);
+        this.styles = ElementStyles.normalize(nameOrConfig.styles);
 
         fastElementRegistry.register(this);
     }
@@ -177,6 +172,7 @@ export class FASTElementDefinition<
         const type = this.type;
 
         if (!registry.get(this.name)) {
+            this.platformDefined = true;
             registry.define(this.name, type as any, this.elementOptions);
         }
 

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -132,7 +132,6 @@ export const enum KernelServiceId {
     contextEvent = 3,
     elementRegistry = 4,
     styleSheetStrategy = 5,
-    developerChannel = 6,
 }
 
 /**

--- a/packages/web-components/fast-element/src/styles/element-styles.ts
+++ b/packages/web-components/fast-element/src/styles/element-styles.ts
@@ -121,6 +121,23 @@ export class ElementStyles {
     }
 
     /**
+     * Normalizes a set of composable style options.
+     * @param styles - The style options to normalize.
+     * @returns A singular ElementStyles instance or undefined.
+     */
+    public static normalize(
+        styles: ComposableStyles | ComposableStyles[] | undefined
+    ): ElementStyles | undefined {
+        return styles === void 0
+            ? void 0
+            : Array.isArray(styles)
+            ? new ElementStyles(styles)
+            : styles instanceof ElementStyles
+            ? styles
+            : new ElementStyles([styles]);
+    }
+
+    /**
      * Indicates whether the DOM supports the adoptedStyleSheets feature.
      */
     public static readonly supportsAdoptedStyleSheets =

--- a/packages/web-components/fast-router/docs/api-report.md
+++ b/packages/web-components/fast-router/docs/api-report.md
@@ -152,7 +152,7 @@ export type FASTElementConstructor = new () => FASTElement;
 
 // @beta (undocumented)
 export class FASTElementLayout implements Layout {
-    constructor(template?: ViewTemplate | null, styles?: ComposableStyles | ComposableStyles[] | null, runBeforeCommit?: boolean);
+    constructor(template?: ViewTemplate | null, styles?: ComposableStyles | ComposableStyles[] | undefined, runBeforeCommit?: boolean);
     // (undocumented)
     afterCommit(routerElement: HTMLElement): Promise<void>;
     // (undocumented)

--- a/packages/web-components/fast-router/src/view.ts
+++ b/packages/web-components/fast-router/src/view.ts
@@ -87,17 +87,10 @@ export class FASTElementLayout implements Layout {
 
     constructor(
         private readonly template: ViewTemplate | null = null,
-        styles: ComposableStyles | ComposableStyles[] | null = null,
+        styles: ComposableStyles | ComposableStyles[] | undefined = undefined,
         private runBeforeCommit = true
     ) {
-        this.styles =
-            styles === void 0 || styles === null
-                ? null
-                : Array.isArray(styles)
-                ? new ElementStyles(styles)
-                : styles instanceof ElementStyles
-                ? styles
-                : new ElementStyles([styles]);
+        this.styles = ElementStyles.normalize(styles) ?? null;
     }
 
     async beforeCommit(routerElement: HTMLElement) {


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR fixes a bug in `FASTElementDefinition` where the `isDefined` property reported true when the element had not yet been defined with the platform.

### 🎫 Issues

* Closes #6199 

## 👩‍💻 Reviewer Notes

While reading through the `FASTElementDefinition` code I realized there was some style normalization code in there that really should be part of `ElementStyles` so I made the minor refactoring. I discovered that the router had previously duplicated this code, so I removed the duplication and switched the router to using the new API.

## 📑 Test Plan

I have added a test related to the bug. All tests pass.

## ✅ Checklist

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

None at this time.