### PR TITLE
Users/bheston/remove avatar styling model

### DIFF
--- a/change/@microsoft-fast-foundation-414e6985-df17-48a9-a519-accb0f492635.json
+++ b/change/@microsoft-fast-foundation-414e6985-df17-48a9-a519-accb0f492635.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Removed the `fill`, `color`, and `shape` attributes and styling from Avatar",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -662,12 +662,7 @@ export class FASTAnchoredRegion extends FASTElement {
 
 // @public
 export class FASTAvatar extends FASTElement {
-    color: string;
-    connectedCallback(): void;
-    fill: string;
     link: string;
-    // Warning: (ae-forgotten-export) The symbol "AvatarShape" needs to be exported by the entry point index.d.ts
-    shape: AvatarShape;
 }
 
 // @public

--- a/packages/web-components/fast-foundation/src/avatar/README.md
+++ b/packages/web-components/fast-foundation/src/avatar/README.md
@@ -68,32 +68,6 @@ provideFASTDesignSystem()
 </fast-avatar>
 ```
 
-### Filled, Colored, and Shaped
-
-The `fill` and `color` attributes of the *avatar* create CSS custom properties which can be used to style the control.
-
-```css
-fast-avatar {
-    --avatar-fill-primary: #00FF00;
-    --avatar-fill-danger: #FF0000;
-    --avatar-color-light: #FFFFFF;
-    --avatar-color-dark: #000000;
-}
-```
-
-While the `shape` attribute lets you choose between `circle` (default) or `square`:
-
-```html
-<fast-avatar 
-  src="..."
-  alt="..."
-  link="..."
-  fill="primary"
-  color="dark"
-  shape="square">
-</fast-avatar>
-```
-
 ## Create your own design
 
 ```ts
@@ -133,21 +107,15 @@ This component is built with the expectation that focus is delegated to the anch
 
 #### Fields
 
-| Name    | Privacy | Type          | Default | Description                                                                  | Inherited From |
-| ------- | ------- | ------------- | ------- | ---------------------------------------------------------------------------- | -------------- |
-| `fill`  | public  | `string`      |         | Indicates the Avatar should have a color fill.                               |                |
-| `color` | public  | `string`      |         | Indicates the Avatar should have a text color.                               |                |
-| `link`  | public  | `string`      |         | Indicates the Avatar should have url link                                    |                |
-| `shape` | public  | `AvatarShape` |         | Indicates the Avatar shape should be. By default it will be set to "circle". |                |
+| Name   | Privacy | Type     | Default | Description                               | Inherited From |
+| ------ | ------- | -------- | ------- | ----------------------------------------- | -------------- |
+| `link` | public  | `string` |         | Indicates the Avatar should have url link |                |
 
 #### Attributes
 
-| Name    | Field | Inherited From |
-| ------- | ----- | -------------- |
-| `fill`  | fill  |                |
-| `color` | color |                |
-| `link`  | link  |                |
-| `shape` | shape |                |
+| Name   | Field | Inherited From |
+| ------ | ----- | -------------- |
+| `link` | link  |                |
 
 #### CSS Parts
 

--- a/packages/web-components/fast-foundation/src/avatar/avatar.spec.md
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.spec.md
@@ -12,8 +12,6 @@ A common use case would be to display an image or text (usually initials) of a u
 - A URL for an image can be passed to the component to be displayed in the backplate
 - Badge slot: Able to slot in a badge component
 - Media slot: Accepts an `img` or an `svg`
-- `shape`, a circle or square shape can be chosen. Any border radius for square shaped backplates should be determined by the users design system values or stylesheet
-- `color`, a hexadecimal color can be provided to determine the backplate background color
 - When a `link` is provided an `aria-link` attribute is added
 
 ### Prior Art/Examples
@@ -33,12 +31,9 @@ A common use case would be to display an image or text (usually initials) of a u
 #### Attributes
 |   Name    | Description                                                 | Type                                |
 |-----------|-------------------------------------------------------------|-------------------------------------|
-| `src` | Accepts URL string of image to be displayed                 | `string`                            |
-| `alt`| Accepts alt text for image                                  | `string`                            |
+| `src`     | Accepts URL string of image to be displayed                 | `string`                            |
+| `alt`     | Accepts alt text for image                                  | `string`                            |
 | `link`    | Accepts a URL for the anchor source                         | `string`                            |
-| `shape`   | Determines the avatar backplate shape. Default will be a circle. | `string: default | circle | square` |
-| `fill`    | Accepts a string that defines the `avatar-fill-*` post-fix for custom variable mapping.                | `string`                 |
-| `color`   | Accepts a string that defines the `avatar-color-*` post-fix for custom variable mapping.                    | `string`                |
 
 #### Slots
 
@@ -52,16 +47,13 @@ A common use case would be to display an image or text (usually initials) of a u
 *Template*
 ```js
 <div
-    class="backplate ${x => x.shape}"
+    class="backplate"
     part="backplate"
-    style="${x =>
-        x.fill ? `background-color: var(--avatar-fill-${x.fill});` : void 0}"
 >
     <a
         class="link"
         part="link"
         href="${x => (x.link ? x.link : void 0)}"
-        style="${x => (x.color ? `color: var(--avatar-color-${x.color});` : void 0)}"
     >
         <slot name="media" part="media">${definition.media || ""}</slot>
         <slot class="content" part="content"></slot>

--- a/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
@@ -10,16 +10,13 @@ export function avatarTemplate(
 ): ElementViewTemplate<FASTAvatar> {
     return html<FASTAvatar>`
     <div
-        class="backplate ${x => x.shape}"
+        class="backplate"
         part="backplate"
-        style="${x =>
-            x.fill ? `background-color: var(--avatar-fill-${x.fill});` : void 0}"
     >
         <a
             class="link"
             part="link"
             href="${x => (x.link ? x.link : void 0)}"
-            style="${x => (x.color ? `color: var(--avatar-color-${x.color});` : void 0)}"
         >
             <slot name="media">${options.media || ""}</slot>
             <slot><slot>

--- a/packages/web-components/fast-foundation/src/avatar/avatar.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.ts
@@ -1,7 +1,5 @@
 import { attr, FASTElement, SyntheticViewTemplate } from "@microsoft/fast-element";
 
-type AvatarShape = "circle" | "square";
-
 /**
  * Avatar configuration options
  * @public
@@ -24,24 +22,6 @@ export type AvatarOptions = {
  */
 export class FASTAvatar extends FASTElement {
     /**
-     * Indicates the Avatar should have a color fill.
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: fill
-     */
-    @attr public fill: string;
-
-    /**
-     * Indicates the Avatar should have a text color.
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: color
-     */
-    @attr public color: string;
-
-    /**
      * Indicates the Avatar should have url link
      *
      * @public
@@ -49,23 +29,4 @@ export class FASTAvatar extends FASTElement {
      * HTML Attribute: link
      */
     @attr public link: string;
-
-    /**
-     * Indicates the Avatar shape should be. By default it will be set to "circle".
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: shape
-     */
-    @attr public shape: AvatarShape;
-
-    /**
-     * Internal
-     */
-    public connectedCallback(): void {
-        super.connectedCallback();
-        if (!this.shape) {
-            this.shape = "circle";
-        }
-    }
 }

--- a/packages/web-components/fast-foundation/src/avatar/stories/avatar.register.ts
+++ b/packages/web-components/fast-foundation/src/avatar/stories/avatar.register.ts
@@ -19,7 +19,7 @@ const styles = css`
 
     .link {
         align-items: center;
-        color: var(--neutral-foreground-rest);
+        color: var(--foreground-on-accent-rest);
         display: flex;
         flex-direction: row;
         justify-content: center;
@@ -27,21 +27,13 @@ const styles = css`
         text-decoration: none;
     }
 
-    .square {
-        border-radius: calc(var(--control-corner-radius) * 1px);
-        min-width: 100%;
-        overflow: hidden;
-    }
-
-    .circle {
-        border-radius: 100%;
-        min-width: 100%;
-        overflow: hidden;
-    }
-
     .backplate {
         display: flex;
         position: relative;
+        border-radius: 100%;
+        min-width: 100%;
+        overflow: hidden;
+        background-color: var(--accent-fill-rest);
     }
 
     .media,

--- a/packages/web-components/fast-foundation/src/avatar/stories/avatar.stories.ts
+++ b/packages/web-components/fast-foundation/src/avatar/stories/avatar.stories.ts
@@ -6,13 +6,7 @@ type AvatarStoryArgs = Args & FASTAvatar;
 type AvatarStoryMeta = Meta<AvatarStoryArgs>;
 
 const storyTemplate = html<AvatarStoryArgs>`
-    <fast-avatar
-        alt="${x => x.alt}"
-        link="#"
-        shape="circle"
-        fill="accent-primary"
-        color="bar"
-    >
+    <fast-avatar alt="${x => x.alt}" link="#">
         ${x => x.content}
     </fast-avatar>
 `;
@@ -25,32 +19,12 @@ export default {
         `,
         alt: "Annie's profile image",
         link: "#",
-        shape: "circle",
-        fill: "accent-primary",
-        color: "bar",
-    },
-    argTypes: {
-        shape: {
-            options: ["circle", "square"],
-            control: {
-                type: "select",
-            },
-        },
     },
     decorators: [
         Story => {
             const renderedStory = Story() as FASTAvatar;
 
             const storyStyles = css`
-                :host {
-                    --avatar-fill-accent-primary: #cf4073;
-                    --avatar-fill-accent-secondary: #0078d4;
-                    --avatar-color-foo: hsl(0, 0%, 100%);
-                    --avatar-color-bar: gray;
-                    --avatar-text-ratio: 3;
-                    --badge-fill-primary: var(--accent-fill-rest);
-                }
-
                 ::slotted(fast-badge) {
                     bottom: 0;
                     right: 0;
@@ -86,7 +60,4 @@ CircleWithTextContent.args = {
         CR
     `,
     link: "#",
-    shape: "circle",
-    fill: "accent-primary",
-    color: "foo",
 };


### PR DESCRIPTION
# Pull Request

## 📖 Description

Following #6152 for Badge.

The styling model for Avatar was very specific and didn't allow for flexibility in implementations.

The fill and color attributes required specific css variables to be defined, which isn't easiest with different design system token names.
The separation between the fill and foreground color is not how many design systems are organized, specifically for background colors and "on" colors, and increased the possibility of accessibility contrast issues.
If using adaptive-ui in the implementation, there was no easy way to allow the system to use recipes for both values, for example an "accent" fill with the corresponding foreground recipe that then works in both light and dark mode.
Implementations needing multiple shapes should follow the appearance pattern illustrated in the CLI and Fluent UI, or simply apply a class and style however you need.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

Update the styling in the CLI template.