### PR TITLE
feat: enable the render directive to work in SSR

### DIFF
--- a/change/@microsoft-fast-ssr-9a72ce54-68fa-4fde-8d84-59c8cfd9d157.json
+++ b/change/@microsoft-fast-ssr-9a72ce54-68fa-4fde-8d84-59c8cfd9d157.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: enable the render directive to work in SSR",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-ssr-9a72ce54-68fa-4fde-8d84-59c8cfd9d157.json
+++ b/change/@microsoft-fast-ssr-9a72ce54-68fa-4fde-8d84-59c8cfd9d157.json
@@ -3,5 +3,5 @@
   "comment": "feat: enable the render directive to work in SSR",
   "packageName": "@microsoft/fast-ssr",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-ssr/src/template-renderer/directives.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/directives.ts
@@ -8,6 +8,7 @@ import {
     ViewBehaviorFactory,
     ViewTemplate,
 } from "@microsoft/fast-element";
+import { RenderDirective } from "@microsoft/fast-element/render";
 import { RenderInfo } from "../render-info.js";
 import { TemplateRenderer } from "./template-renderer.js";
 
@@ -80,9 +81,33 @@ export const RepeatDirectiveRenderer: ViewBehaviorFactoryRenderer<RepeatDirectiv
     }
 );
 
+export const RenderDirectiveRenderer: ViewBehaviorFactoryRenderer<RenderDirective> = Object.freeze(
+    {
+        matcher: RenderDirective,
+        *render(
+            directive: RenderDirective,
+            renderInfo: RenderInfo,
+            source: any,
+            renderer: TemplateRenderer,
+            context: ExecutionContext
+        ): IterableIterator<string> {
+            const data = directive.dataBinding(source, context);
+            const template = directive.templateBinding(source, context);
+            const childContext = context.createChildContext(source);
+
+            if (template instanceof ViewTemplate) {
+                yield* renderer.render(template, renderInfo, data, childContext);
+            } else {
+                throw new Error("Unable to render Render Directive template");
+            }
+        },
+    }
+);
+
 function* noop() {
     yield "";
 }
+
 export const ChildrenDirectiveRenderer: ViewBehaviorFactoryRenderer<ChildrenDirective> = Object.freeze(
     {
         matcher: ChildrenDirective,
@@ -96,6 +121,7 @@ export const RefDirectiveRenderer: ViewBehaviorFactoryRenderer<RefDirective> = O
         render: noop,
     }
 );
+
 export const SlottedDirectiveRenderer: ViewBehaviorFactoryRenderer<SlottedDirective> = Object.freeze(
     {
         matcher: SlottedDirective,
@@ -105,6 +131,7 @@ export const SlottedDirectiveRenderer: ViewBehaviorFactoryRenderer<SlottedDirect
 
 export const defaultViewBehaviorFactoryRenderers: ViewBehaviorFactoryRenderer<any>[] = [
     RepeatDirectiveRenderer,
+    RenderDirectiveRenderer,
     ChildrenDirectiveRenderer,
     RefDirectiveRenderer,
     SlottedDirectiveRenderer,


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds an SSR implementation for the `render` directive.

### 🎫 Issues

* Closes #6200 

## 👩‍💻 Reviewer Notes

This PR adds code to the SSR package to support the `render` directive. The approach is based on the implementation of the `repeat` directive, which is very similar.

## 📑 Test Plan

New tests were added based on the pattern that the `repeat` tests used.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

n/a