### PR TITLE
fix: warn when host bindings are accidentally applied on non CE views

### DIFF
--- a/change/@microsoft-fast-element-d157c8b1-cdea-49a3-bb5a-48fcd7652f95.json
+++ b/change/@microsoft-fast-element-d157c8b1-cdea-49a3-bb5a-48fcd7652f95.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: warn when host bindings are accidentally applied on non CE views",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-d157c8b1-cdea-49a3-bb5a-48fcd7652f95.json
+++ b/change/@microsoft-fast-element-d157c8b1-cdea-49a3-bb5a-48fcd7652f95.json
@@ -3,5 +3,5 @@
   "comment": "fix: warn when host bindings are accidentally applied on non CE views",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -427,12 +427,12 @@ export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Co
 // @internal
 export interface FASTGlobal {
     addMessages(messages: Record<number, string>): void;
-    error(code: number, ...args: any[]): Error;
+    error(code: number, values?: Record<string, any>): Error;
     getById<T>(id: string | number): T | null;
     // (undocumented)
     getById<T>(id: string | number, initialize: () => T): T;
     readonly versions: string[];
-    warn(code: number, ...args: any[]): void;
+    warn(code: number, values?: Record<string, any>): void;
 }
 
 // @public

--- a/packages/web-components/fast-element/src/debug.spec.ts
+++ b/packages/web-components/fast-element/src/debug.spec.ts
@@ -1,20 +1,42 @@
 import { expect } from "chai";
 import "./debug.js";
-import { FASTGlobal, Message } from "./interfaces.js";
+import type { FASTGlobal } from "./interfaces.js";
 
 declare const FAST: FASTGlobal;
 
-describe("The debug module", () => {
+describe.only("The debug module", () => {
+    let keyBase = 1111111111;
+
     context("when sending errors", () => {
         it("expect known error message from known error code", () => {
-            const error = FAST.error(Message.bindingInnerHTMLRequiresTrustedTypes);
-            expect(error.message.length).greaterThan(0);
-            expect(error.message).not.equal("Unknown Error");
+            const key = keyBase++;
+            const message = "Test Message.";
+            const messageLookup = {
+                [key]: message
+            };
+
+            FAST.addMessages(messageLookup);
+
+            const error = FAST.error(key);
+            expect(error.message).equal(message);
         });
 
         it("expect unknown error message from unknown error code", () => {
             const error = FAST.error(10);
             expect(error.message).equal("Unknown Error");
+        });
+
+        it("formats error messages with interpolated values", () => {
+            const key = keyBase++;
+            const message = "${greeting}. ${question} My name is FAST.";
+            const messageLookup = {
+                [key]: message
+            };
+
+            FAST.addMessages(messageLookup);
+
+            const error = FAST.error(key, { greeting: "Hello", question: "What is your name?" });
+            expect(error.message).equal("Hello. What is your name? My name is FAST.");
         });
     });
 });

--- a/packages/web-components/fast-element/src/debug.spec.ts
+++ b/packages/web-components/fast-element/src/debug.spec.ts
@@ -4,7 +4,7 @@ import type { FASTGlobal } from "./interfaces.js";
 
 declare const FAST: FASTGlobal;
 
-describe.only("The debug module", () => {
+describe("The debug module", () => {
     let keyBase = 1111111111;
 
     context("when sending errors", () => {

--- a/packages/web-components/fast-element/src/debug.ts
+++ b/packages/web-components/fast-element/src/debug.ts
@@ -16,6 +16,7 @@ const debugMessages = {
     [1201 /* onlySetHTMLPolicyOnce */]: "The HTML policy can only be set once.",
     [1202 /* bindingInnerHTMLRequiresTrustedTypes */]: "To bind innerHTML, you must use a TrustedTypesPolicy.",
     [1203 /* twoWayBindingRequiresObservables */]: "View=>Model update skipped. To use twoWay binding, the target property must be observable.",
+    [1204 /* hostBindingWithoutHost */]: "No host element is present. Cannot bind host with ${name}.",
     [1401 /* missingElementDefinition */]: "Missing FASTElement definition.",
 };
 
@@ -23,7 +24,7 @@ const allPlaceholders = /(\$\{\w+?})/g;
 const placeholder = /\$\{(\w+?)}/g;
 const noValues: Record<string, string> = Object.freeze({});
 
-function formatMessage(message: string, values: Record<string, string>) {
+function formatMessage(message: string, values: Record<string, any>) {
     return message
         .split(allPlaceholders)
         .map(v => {
@@ -37,11 +38,11 @@ Object.assign(FAST, {
     addMessages(messages: Record<number, string>) {
         Object.assign(debugMessages, messages);
     },
-    warn(code: number, values: Record<string, string> = noValues) {
+    warn(code: number, values: Record<string, any> = noValues) {
         const message = debugMessages[code] ?? "Unknown Warning";
         console.warn(formatMessage(message, values));
     },
-    error(code: number, values: Record<string, string> = noValues) {
+    error(code: number, values: Record<string, any> = noValues) {
         const message = debugMessages[code] ?? "Unknown Error";
         return new Error(formatMessage(message, values));
     },

--- a/packages/web-components/fast-element/src/debug.ts
+++ b/packages/web-components/fast-element/src/debug.ts
@@ -19,14 +19,30 @@ const debugMessages = {
     [1401 /* missingElementDefinition */]: "Missing FASTElement definition.",
 };
 
+const allPlaceholders = /(\$\{\w+?})/g;
+const placeholder = /\$\{(\w+?)}/g;
+const noValues: Record<string, string> = Object.freeze({});
+
+function formatMessage(message: string, values: Record<string, string>) {
+    return message
+        .split(allPlaceholders)
+        .map(v => {
+            const replaced = v.replace(placeholder, "$1");
+            return values[replaced] || v;
+        })
+        .join("");
+}
+
 Object.assign(FAST, {
     addMessages(messages: Record<number, string>) {
         Object.assign(debugMessages, messages);
     },
-    warn(code: number, ...args: any[]) {
-        console.warn(debugMessages[code] ?? "Unknown Warning");
+    warn(code: number, values: Record<string, string> = noValues) {
+        const message = debugMessages[code] ?? "Unknown Warning";
+        console.warn(formatMessage(message, values));
     },
-    error(code: number, ...args: any[]) {
-        return new Error(debugMessages[code] ?? "Unknown Error");
+    error(code: number, values: Record<string, string> = noValues) {
+        const message = debugMessages[code] ?? "Unknown Error";
+        return new Error(formatMessage(message, values));
     },
 });

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -106,20 +106,20 @@ export interface FASTGlobal {
      * @param code - The warning code to send.
      * @param values - Values relevant for the warning message.
      */
-    warn(code: number, values?: Record<string, string>): void;
+    warn(code: number, values?: Record<string, any>): void;
 
     /**
      * Creates an error.
      * @param code - The error code to send.
      * @param values - Values relevant for the error message.
      */
-    error(code: number, values?: Record<string, string>): Error;
+    error(code: number, values?: Record<string, any>): Error;
 
     /**
      * Adds debug messages for errors and warnings.
      * @param messages - The message dictionary to add.
      * @remarks
-     * Message can include placeholders like ${name} which can be
+     * Message can include placeholders like $\{name\} which can be
      * replaced by values passed at runtime.
      */
     addMessages(messages: Record<number, string>): void;
@@ -197,6 +197,7 @@ export const enum Message {
     onlySetHTMLPolicyOnce = 1201,
     bindingInnerHTMLRequiresTrustedTypes = 1202,
     twoWayBindingRequiresObservables = 1203,
+    hostBindingWithoutHost = 1204,
     // 1301 - 1400 Styles
     // 1401 - 1500 Components
     missingElementDefinition = 1401,

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -104,20 +104,23 @@ export interface FASTGlobal {
     /**
      * Sends a warning to the developer.
      * @param code - The warning code to send.
-     * @param args - Args relevant for the warning.
+     * @param values - Values relevant for the warning message.
      */
-    warn(code: number, ...args: any[]): void;
+    warn(code: number, values?: Record<string, string>): void;
 
     /**
      * Creates an error.
      * @param code - The error code to send.
-     * @param args - Args relevant for the error.
+     * @param values - Values relevant for the error message.
      */
-    error(code: number, ...args: any[]): Error;
+    error(code: number, values?: Record<string, string>): Error;
 
     /**
      * Adds debug messages for errors and warnings.
      * @param messages - The message dictionary to add.
+     * @remarks
+     * Message can include placeholders like ${name} which can be
+     * replaced by values passed at runtime.
      */
     addMessages(messages: Record<number, string>): void;
 }

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -41,7 +41,7 @@ if (FAST.error === void 0) {
     Object.assign(FAST, {
         warn() {},
         error(code: number) {
-            return new Error(`Code ${code}`);
+            return new Error(`Error ${code}`);
         },
         addMessages() {},
     });

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -402,7 +402,153 @@ describe("The template compiler", () => {
         });
     });
 
-    context("when compiling hosts", () => {});
+    context("when compiling hosts", () => {
+        const scenarios = [
+            {
+                type: "no",
+                html: `<template></template>`,
+                directives: [],
+                fragment: ``,
+            },
+            {
+                type: "a single",
+                html: `<template class="${inline(0)}"></template>`,
+                directives: [binding()],
+                fragment: ``,
+                result: "result",
+                targetIds: ['h'],
+            },
+            {
+                type: "a single starting",
+                html: `<template class="${inline(0)} end"></template>`,
+                directives: [binding()],
+                fragment: ``,
+                result: "result end",
+                targetIds: ['h'],
+            },
+            {
+                type: "a single middle",
+                html: `<template class="beginning ${inline(0)} end"></template>`,
+                directives: [binding()],
+                fragment: ``,
+                result: "beginning result end",
+                targetIds: ['h'],
+            },
+            {
+                type: "a single ending",
+                html: `<template class="${inline(0)} end"></template>`,
+                directives: [binding()],
+                fragment: ``,
+                result: "result end",
+                targetIds: ['h'],
+            },
+            {
+                type: "back-to-back",
+                html: `<template class="${inline(0)}${inline(1)}"></template>`,
+                directives: [binding(), binding()],
+                fragment: ``,
+                result: "resultresult",
+                targetIds: ['h'],
+            },
+            {
+                type: "back-to-back starting",
+                html: `<template class="${inline(0)}${inline(1)} end"></template>`,
+                directives: [binding(), binding()],
+                fragment: ``,
+                result: "resultresult end",
+                targetIds: ['h'],
+            },
+            {
+                type: "back-to-back middle",
+                html: `<template class="beginning ${inline(0)}${inline(1)} end"></template>`,
+                directives: [binding(), binding()],
+                fragment: ``,
+                result: "beginning resultresult end",
+                targetIds: ['h'],
+            },
+            {
+                type: "back-to-back ending",
+                html: `<template class="start ${inline(0)}${inline(1)}"></template>`,
+                directives: [binding(), binding()],
+                fragment: ``,
+                result: "start resultresult",
+                targetIds: ['h'],
+            },
+            {
+                type: "separated",
+                html: `<template class="${inline(0)}separator${inline(1)}"></template>`,
+                directives: [binding(), binding()],
+                fragment: ``,
+                result: "resultseparatorresult",
+                targetIds: ['h'],
+            },
+            {
+                type: "separated starting",
+                html: `<template class="${inline(0)}separator${inline(1)} end"></template>`,
+                directives: [binding(), binding()],
+                fragment: ``,
+                result: "resultseparatorresult end",
+                targetIds: ['h'],
+            },
+            {
+                type: "separated middle",
+                html: `<template class="beginning ${inline(0)}separator${inline(
+                    1
+                )} end"></template>`,
+                directives: [binding(), binding()],
+                fragment: ``,
+                result: "beginning resultseparatorresult end",
+                targetIds: ['h'],
+            },
+            {
+                type: "separated ending",
+                html: `<template class="beginning ${inline(0)}separator${inline(1)}"></template>`,
+                directives: [binding(), binding()],
+                fragment: ``,
+                result: "beginning resultseparatorresult",
+                targetIds: ['h'],
+            },
+            {
+                type: "multiple attributes on the same element with",
+                html: `<template class="${inline(0)}" role="${inline(1)}"></template>`,
+                directives: [binding(), binding()],
+                fragment: ``,
+                targetIds: ['h', 'h'],
+            }
+        ];
+
+        scenarios.forEach(x => {
+            it(`handles ${x.type} binding expression(s)`, () => {
+                const { fragment, factories } = compile(x.html, x.directives);
+
+                expect(toHTML(fragment)).to.equal(x.fragment);
+                expect(toHTML(fragment.cloneNode(true) as DocumentFragment)).to.equal(
+                    x.fragment
+                );
+
+                if (x.result) {
+                    expect(
+                        (factories[0] as HTMLBindingDirective).binding(
+                            scope,
+                            ExecutionContext.default
+                        )
+                    ).to.equal(x.result);
+                }
+
+                if (x.targetIds) {
+                    const length = factories.length;
+
+                    expect(length).to.equal(x.targetIds.length);
+
+                    for (let i = 0; i < length; ++i) {
+                        expect(factories[i].nodeId).to.equal(
+                            x.targetIds[i]
+                        );
+                    }
+                }
+            });
+        });
+    });
 
     if (ElementStyles.supportsAdoptedStyleSheets) {
         it("handles templates with adoptedStyleSheets", () => {

--- a/packages/web-components/fast-element/src/templating/view.spec.ts
+++ b/packages/web-components/fast-element/src/templating/view.spec.ts
@@ -1,0 +1,115 @@
+import { expect } from "chai";
+import { Message } from "../interfaces.js";
+import { ExecutionContext } from "../observation/observable.js";
+import { FAST } from "../platform.js";
+import { html } from "./template.js";
+
+function startCapturingWarnings() {
+    const currentWarn = FAST.warn;
+    const list: { code: number, values?: Record<string, any> }[] = [];
+
+    FAST.warn = function(code, values) {
+        list.push({ code, values });
+    }
+
+    return {
+        list,
+        dispose() {
+            FAST.warn = currentWarn;
+        }
+    };
+}
+
+describe(`The HTMLView`, () => {
+    context("when binding hosts", () => {
+        it("warns on class bindings when host not present", () => {
+            const template = html`
+                <template class="foo"></template>
+            `;
+
+            const warnings = startCapturingWarnings();
+            const view = template.create();
+            view.bind({}, ExecutionContext.default);
+            warnings.dispose();
+
+            expect(warnings.list.length).equal(1);
+            expect(warnings.list[0].code).equal(Message.hostBindingWithoutHost);
+            expect(warnings.list[0].values!.name).equal("className");
+        });
+
+        it("warns on style bindings when host not present", () => {
+            const template = html`
+                <template style="color: red"></template>
+            `;
+
+            const warnings = startCapturingWarnings();
+            const view = template.create();
+            view.bind({}, ExecutionContext.default);
+            warnings.dispose();
+
+            expect(warnings.list.length).equal(1);
+            expect(warnings.list[0].code).equal(Message.hostBindingWithoutHost);
+            expect(warnings.list[0].values!.name).equal("setAttribute");
+        });
+
+        it("warns on boolean bindings when host not present", () => {
+            const template = html`
+                <template ?disabled="${() => false}"></template>
+            `;
+
+            const warnings = startCapturingWarnings();
+            const view = template.create();
+            view.bind({}, ExecutionContext.default);
+            warnings.dispose();
+
+            expect(warnings.list.length).equal(1);
+            expect(warnings.list[0].code).equal(Message.hostBindingWithoutHost);
+            expect(warnings.list[0].values!.name).equal("removeAttribute");
+        });
+
+        it("warns on property bindings when host not present", () => {
+            const template = html`
+                <template :myProperty="${() => false}"></template>
+            `;
+
+            const warnings = startCapturingWarnings();
+            const view = template.create();
+            view.bind({}, ExecutionContext.default);
+            warnings.dispose();
+
+            expect(warnings.list.length).equal(1);
+            expect(warnings.list[0].code).equal(Message.hostBindingWithoutHost);
+            expect(warnings.list[0].values!.name).equal("myProperty");
+        });
+
+        it("warns on className bindings when host not present", () => {
+            const template = html`
+                <template :className="${() => "test"}"></template>
+            `;
+
+            const warnings = startCapturingWarnings();
+            const view = template.create();
+            view.bind({}, ExecutionContext.default);
+            warnings.dispose();
+
+            expect(warnings.list.length).equal(1);
+            expect(warnings.list[0].code).equal(Message.hostBindingWithoutHost);
+            expect(warnings.list[0].values!.name).equal("className");
+        });
+
+        it("warns on event bindings when host not present", () => {
+            const template = html`
+                <template @click="${() => void 0}"></template>
+            `;
+
+            const warnings = startCapturingWarnings();
+            const view = template.create();
+            view.bind({}, ExecutionContext.default);
+            warnings.dispose();
+
+            expect(warnings.list.length).equal(1);
+            expect(warnings.list[0].code).equal(Message.hostBindingWithoutHost);
+            expect(warnings.list[0].values!.name).equal("addEventListener");
+        });
+    });
+});


### PR DESCRIPTION
# Pull Request

## 📖 Description

If a developer puts attributes on the `template` element at the root of a template, and then tries to create a view without a "host", errors will occur. This PR prevents the errors and outputs warnings to the console instead.

### 🎫 Issues

* Closes #6156

## 👩‍💻 Reviewer Notes

The technique used here is to create a `Proxy` that emits warnings on get/set to the underlying element. The proxy is used as the host whenever one isn't provided.

To make the warnings more meaningful, I implemented the debug warning implementation's ability to interpolate named parameters into messages. 

## 📑 Test Plan

Tests were added for the view host binding scenarios as well as the new debug logging capability. While I was working on this, I realized we didn't have any tests on template host binding, so I added those as well.

## ✅ Checklist

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

We could look at also fixing this on v1 of fast-element. The solution would be different there since the internals changed quite a bit.