### PR TITLE
feat: add export for custom-elements manifest

### DIFF
--- a/change/@microsoft-fast-foundation-33f8e31d-364c-4ef8-985a-3b16ac9716e6.json
+++ b/change/@microsoft-fast-foundation-33f8e31d-364c-4ef8-985a-3b16ac9716e6.json
@@ -1,7 +1,7 @@
 {
-  "type": "none",
+  "type": "prerelease",
   "comment": "add export for custom elements manifest",
   "packageName": "@microsoft/fast-foundation",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "none"
+  "dependentChangeType": "patch"
 }

--- a/change/@microsoft-fast-foundation-33f8e31d-364c-4ef8-985a-3b16ac9716e6.json
+++ b/change/@microsoft-fast-foundation-33f8e31d-364c-4ef8-985a-3b16ac9716e6.json
@@ -1,5 +1,5 @@
 {
-  "type": "prerelease",
+  "type": "patch",
   "comment": "add export for custom elements manifest",
   "packageName": "@microsoft/fast-foundation",
   "email": "32497422+KingOfTac@users.noreply.github.com",

--- a/change/@microsoft-fast-foundation-33f8e31d-364c-4ef8-985a-3b16ac9716e6.json
+++ b/change/@microsoft-fast-foundation-33f8e31d-364c-4ef8-985a-3b16ac9716e6.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "add export for custom elements manifest",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-foundation-33f8e31d-364c-4ef8-985a-3b16ac9716e6.json
+++ b/change/@microsoft-fast-foundation-33f8e31d-364c-4ef8-985a-3b16ac9716e6.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "add export for custom elements manifest",
   "packageName": "@microsoft/fast-foundation",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -25,7 +25,8 @@
     ".": {
       "types": "./dist/dts/index.d.ts",
       "default": "./dist/esm/index.js"
-    }
+    },
+    "./custom-elements": "./dist/custom-elements.json"
   },
   "scripts": {
     "clean:dist": "node ../../../build/clean.js dist",

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -26,7 +26,7 @@
       "types": "./dist/dts/index.d.ts",
       "default": "./dist/esm/index.js"
     },
-    "./custom-elements": "./dist/custom-elements.json"
+    "./custom-elements.json": "./dist/custom-elements.json"
   },
   "scripts": {
     "clean:dist": "node ../../../build/clean.js dist",


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds an export path for the custom elements manifest, allowing it to be imported and consumed by tooling, and applications.

### 🎫 Issues

closes #6217 

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.