### PR TITLE
feat: introduce new binding API

### DIFF
--- a/change/@microsoft-fast-element-28e945ca-f2b8-4602-a76a-8b00f6306542.json
+++ b/change/@microsoft-fast-element-28e945ca-f2b8-4602-a76a-8b00f6306542.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: introduce new binding API",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-28e945ca-f2b8-4602-a76a-8b00f6306542.json
+++ b/change/@microsoft-fast-element-28e945ca-f2b8-4602-a76a-8b00f6306542.json
@@ -3,5 +3,5 @@
   "comment": "feat: introduce new binding API",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-733b00a3-cfa6-4a29-99d7-c47b18acc760.json
+++ b/change/@microsoft-fast-foundation-733b00a3-cfa6-4a29-99d7-c47b18acc760.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: update foundation to new binding APIs",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-733b00a3-cfa6-4a29-99d7-c47b18acc760.json
+++ b/change/@microsoft-fast-foundation-733b00a3-cfa6-4a29-99d7-c47b18acc760.json
@@ -3,5 +3,5 @@
   "comment": "feat: update foundation to new binding APIs",
   "packageName": "@microsoft/fast-foundation",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-ssr-f58d955a-5e7b-4324-931c-b8211a008df9.json
+++ b/change/@microsoft-fast-ssr-f58d955a-5e7b-4324-931c-b8211a008df9.json
@@ -3,5 +3,5 @@
   "comment": "feat: update SSR to new binding APIs",
   "packageName": "@microsoft/fast-ssr",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-ssr-f58d955a-5e7b-4324-931c-b8211a008df9.json
+++ b/change/@microsoft-fast-ssr-f58d955a-5e7b-4324-931c-b8211a008df9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: update SSR to new binding APIs",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/examples/todo-app/src/todo-app.template.ts
+++ b/examples/todo-app/src/todo-app.template.ts
@@ -1,4 +1,4 @@
-import { bind, html, repeat } from "@microsoft/fast-element";
+import { html, repeat } from "@microsoft/fast-element";
 import { twoWay } from "@microsoft/fast-element/binding/two-way";
 import type { TodoApp } from "./todo-app.js";
 import type { Todo } from "./todo-list.js";
@@ -11,11 +11,7 @@ export const template = html<TodoApp>`
 
     <section>
         <label for="filter">Filter:</label>
-        <select
-            name="filter"
-            title="filter"
-            :value=${bind(x => x.todos.activeFilter, twoWay)}
-        >
+        <select name="filter" title="filter" :value=${twoWay(x => x.todos.activeFilter)}>
             <option value="all">All</option>
             <option value="active">Active</option>
             <option value="completed">Completed</option>
@@ -27,7 +23,7 @@ export const template = html<TodoApp>`
             x => x.todos.filtered,
             html<Todo, TodoApp>`
                 <li class="todo">
-                    <input type="checkbox" :checked=${bind(x => x.done, twoWay)} />
+                    <input type="checkbox" :checked=${twoWay(x => x.done)} />
                     <span class="description ${x => (x.done ? "done" : "")}">
                         ${x => x.description}
                     </span>

--- a/examples/todo-app/src/todo-form.template.ts
+++ b/examples/todo-app/src/todo-form.template.ts
@@ -1,13 +1,10 @@
-import { bind, html } from "@microsoft/fast-element";
+import { html } from "@microsoft/fast-element";
 import { twoWay } from "@microsoft/fast-element/binding/two-way";
 import type { TodoForm } from "./todo-form.js";
 
 export const template = html<TodoForm>`
     <form @submit=${x => x.submitTodo()}>
-        <input
-            type="text"
-            :value=${bind(x => x.description, twoWay({ changeEvent: "input" }))}
-        />
+        <input type="text" :value=${twoWay(x => x.description, "input")} />
         <button type="submit" ?disabled=${x => !x.description}>
             Add Todo
         </button>

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -62,7 +62,7 @@ export type Aspect = typeof Aspect[Exclude<keyof typeof Aspect, "assign" | "none
 // @public
 export interface Aspected {
     aspectType: Aspect;
-    binding?: Binding;
+    dataBinding?: BindingConfiguration;
     sourceAspect: string;
     targetAspect: string;
 }
@@ -110,7 +110,7 @@ export interface Behavior<TSource = any, TParent = any> {
 }
 
 // @public
-export function bind<T = any>(binding: Binding<T>, isBindingVolatile?: boolean): BindingConfiguration<T>;
+export function bind<T = any>(binding: Binding<T>, isVolatile?: boolean): BindingConfiguration<T>;
 
 // @public
 export type Binding<TSource = any, TReturn = any, TParent = any> = (source: TSource, context: ExecutionContext<TParent>) => TReturn;
@@ -135,7 +135,9 @@ export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent
     // (undocumented)
     abstract binding: Binding<TSource, TReturn, TParent>;
     // (undocumented)
-    abstract createObserver(directive: HTMLBindingDirective, subscriber: Subscriber): BindingObserver<TSource, TReturn, TParent>;
+    abstract createObserver(directive: HTMLDirective, subscriber: Subscriber): BindingObserver<TSource, TReturn, TParent>;
+    // (undocumented)
+    isVolatile?: boolean;
     // (undocumented)
     options?: any;
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -115,7 +115,7 @@ export function bind<T = any>(binding: Expression<T>, isVolatile?: boolean): Bin
 // @public
 export abstract class Binding<TSource = any, TReturn = any, TParent = any> {
     abstract createObserver(directive: HTMLDirective, subscriber: Subscriber): ExpressionObserver<TSource, TReturn, TParent>;
-    abstract evaluate: Expression<TSource, TReturn, TParent>;
+    evaluate: Expression<TSource, TReturn, TParent>;
     isVolatile?: boolean;
     options?: any;
 }
@@ -190,6 +190,11 @@ export type Constructable<T = {}> = {
 export type ConstructibleStyleStrategy = {
     new (styles: (string | CSSStyleSheet)[]): StyleStrategy;
 };
+
+// @public
+export class ContentBehavior extends BindingBehavior {
+    unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
+}
 
 // @public
 export interface ContentTemplate {
@@ -268,9 +273,6 @@ export function customElement(nameOrDef: string | PartialFASTElementDefinition):
 
 // @public
 export type DecoratorAttributeConfiguration = Omit<AttributeConfiguration, "property">;
-
-// @public
-export function defaultBinding<TSource = any, TReturn = any, TParent = any>(object: Expression<TSource, TReturn, TParent> | Binding<TSource, TReturn, TParent> | any): Binding<TSource, TReturn, TParent>;
 
 // @public
 export interface Disposable {
@@ -530,6 +532,9 @@ export abstract class NodeObservationDirective<T extends NodeBehaviorOptions> ex
     unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void;
     protected updateTarget(source: any, value: ReadonlyArray<any>): void;
 }
+
+// @public
+export function normalizeBinding<TSource = any, TReturn = any, TParent = any>(value: Expression<TSource, TReturn, TParent> | Binding<TSource, TReturn, TParent> | {}): Binding<TSource, TReturn, TParent>;
 
 // @public
 export interface Notifier {

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -611,7 +611,7 @@ export class RefDirective extends StatelessAttachedAttributeDirective<string> {
 }
 
 // @public
-export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(items: Expression<TSource, TArray, ExecutionContext<TSource>> | Binding<TSource, TArray> | ReadonlyArray<any>, templateOrTemplateBinding: Expression<TSource, ViewTemplate> | Binding<TSource, ViewTemplate> | ViewTemplate, options?: RepeatOptions): CaptureType<TSource>;
+export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(items: Expression<TSource, TArray, ExecutionContext<TSource>> | Binding<TSource, TArray> | ReadonlyArray<any>, template: Expression<TSource, ViewTemplate> | Binding<TSource, ViewTemplate> | ViewTemplate, options?: RepeatOptions): CaptureType<TSource>;
 
 // @public
 export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -130,15 +130,11 @@ export class BindingBehavior implements ViewBehavior {
     protected updateTarget: UpdateTarget;
 }
 
-// @public (undocumented)
+// @public
 export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent = any> {
-    // (undocumented)
     abstract binding: Binding<TSource, TReturn, TParent>;
-    // (undocumented)
     abstract createObserver(directive: HTMLDirective, subscriber: Subscriber): BindingObserver<TSource, TReturn, TParent>;
-    // (undocumented)
     isVolatile?: boolean;
-    // (undocumented)
     options?: any;
 }
 
@@ -148,9 +144,8 @@ export interface BindingNotifier<TSource = any, TReturn = any, TParent = any> ex
     setMode(isAsync: boolean): void;
 }
 
-// @public (undocumented)
+// @public
 export interface BindingObserver<TSource = any, TReturn = any, TParent = any> extends Disposable {
-    // (undocumented)
     observe(source: TSource, context?: ExecutionContext<TParent>): TReturn;
 }
 

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -132,8 +132,8 @@ export class BindingBehavior implements ViewBehavior {
 
 // @public
 export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent = any> {
-    abstract binding: Binding<TSource, TReturn, TParent>;
     abstract createObserver(directive: HTMLDirective, subscriber: Subscriber): BindingObserver<TSource, TReturn, TParent>;
+    abstract evaluate: Binding<TSource, TReturn, TParent>;
     isVolatile?: boolean;
     options?: any;
 }
@@ -282,6 +282,9 @@ export function customElement(nameOrDef: string | PartialFASTElementDefinition):
 
 // @public
 export type DecoratorAttributeConfiguration = Omit<AttributeConfiguration, "property">;
+
+// @public
+export function defaultBinding<TSource = any, TReturn = any, TParent = any>(object: Binding<TSource, TReturn, TParent> | BindingConfiguration<TSource, TReturn, TParent> | any): BindingConfiguration<TSource, TReturn, TParent>;
 
 // @public
 export interface Disposable {
@@ -603,11 +606,11 @@ export class RefDirective extends StatelessAttachedAttributeDirective<string> {
 }
 
 // @public
-export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(items: Binding<TSource, TArray, ExecutionContext<TSource>> | ReadonlyArray<any>, templateOrTemplateBinding: ViewTemplate | Binding<TSource, ViewTemplate>, options?: RepeatOptions): CaptureType<TSource>;
+export function repeat<TSource = any, TArray extends ReadonlyArray<any> = ReadonlyArray<any>>(items: Binding<TSource, TArray, ExecutionContext<TSource>> | BindingConfiguration<TSource, TArray> | ReadonlyArray<any>, templateOrTemplateBinding: Binding<TSource, ViewTemplate> | BindingConfiguration<TSource, ViewTemplate> | ViewTemplate, options?: RepeatOptions): CaptureType<TSource>;
 
 // @public
 export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
-    constructor(location: Node, dataBinding: Binding<TSource, any[]>, isItemsBindingVolatile: boolean, templateBinding: Binding<TSource, SyntheticViewTemplate>, isTemplateBindingVolatile: boolean, options: RepeatOptions);
+    constructor(directive: RepeatDirective, location: Node);
     bind(source: TSource, context: ExecutionContext): void;
     handleChange(source: any, args: Splice[]): void;
     unbind(): void;
@@ -615,17 +618,17 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
 
 // @public
 export class RepeatDirective<TSource = any> implements HTMLDirective, ViewBehaviorFactory {
-    constructor(dataBinding: Binding, templateBinding: Binding<TSource, SyntheticViewTemplate>, options: RepeatOptions);
+    constructor(dataBinding: BindingConfiguration<TSource>, templateBinding: BindingConfiguration<TSource, SyntheticViewTemplate>, options: RepeatOptions);
     createBehavior(targets: ViewBehaviorTargets): RepeatBehavior<TSource>;
     createHTML(add: AddViewBehaviorFactory): string;
     // (undocumented)
-    readonly dataBinding: Binding;
+    readonly dataBinding: BindingConfiguration<TSource>;
     id: string;
     nodeId: string;
     // (undocumented)
     readonly options: RepeatOptions;
     // (undocumented)
-    readonly templateBinding: Binding<TSource, SyntheticViewTemplate>;
+    readonly templateBinding: BindingConfiguration<TSource, SyntheticViewTemplate>;
 }
 
 // @public

--- a/packages/web-components/fast-element/src/hooks.ts
+++ b/packages/web-components/fast-element/src/hooks.ts
@@ -1,4 +1,4 @@
-import { BindingObserver, Observable } from "./observation/observable.js";
+import { BindingNotifier, Observable } from "./observation/observable.js";
 import { makeObservable } from "./utilities.js";
 
 /**
@@ -26,9 +26,9 @@ const effectModel = Object.freeze({});
  * @param action An action that is affected by state changes.
  * @returns A BindingObserver which can be used to dispose of the effect.
  */
-export function useEffect(action: () => void): BindingObserver {
+export function useEffect(action: () => void): BindingNotifier {
     /* eslint prefer-const: 0 */
-    let observer: BindingObserver;
+    let observer: BindingNotifier;
 
     const subscriber = {
         handleChange() {

--- a/packages/web-components/fast-element/src/hooks.ts
+++ b/packages/web-components/fast-element/src/hooks.ts
@@ -1,4 +1,4 @@
-import { BindingNotifier, Observable } from "./observation/observable.js";
+import { ExpressionNotifier, Observable } from "./observation/observable.js";
 import { makeObservable } from "./utilities.js";
 
 /**
@@ -26,9 +26,9 @@ const effectModel = Object.freeze({});
  * @param action An action that is affected by state changes.
  * @returns A BindingObserver which can be used to dispose of the effect.
  */
-export function useEffect(action: () => void): BindingNotifier {
+export function useEffect(action: () => void): ExpressionNotifier {
     /* eslint prefer-const: 0 */
-    let observer: BindingNotifier;
+    let observer: ExpressionNotifier;
 
     const subscriber = {
         handleChange() {

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -65,8 +65,18 @@ interface SubscriptionRecord extends ObservationRecord {
     next: SubscriptionRecord | undefined;
 }
 
+/**
+ * Observes a binding for changes.
+ *
+ * @public
+ */
 export interface BindingObserver<TSource = any, TReturn = any, TParent = any>
     extends Disposable {
+    /**
+     * Begins observing the binding.
+     * @param source - The source to pass to the binding.
+     * @param context - The context to pass to the binding.
+     */
     observe(source: TSource, context?: ExecutionContext<TParent>): TReturn;
 }
 

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -65,23 +65,20 @@ interface SubscriptionRecord extends ObservationRecord {
     next: SubscriptionRecord | undefined;
 }
 
+export interface BindingObserver<TSource = any, TReturn = any, TParent = any>
+    extends Disposable {
+    observe(source: TSource, context?: ExecutionContext<TParent>): TReturn;
+}
+
 /**
  * Enables evaluation of and subscription to a binding.
  * @public
  */
-export interface BindingObserver<TSource = any, TReturn = any, TParent = any>
+export interface BindingNotifier<TSource = any, TReturn = any, TParent = any>
     extends Notifier,
-        Disposable {
+        BindingObserver<TSource, TReturn, TParent> {
     /**
-     * Begins observing the binding for the source and returns the current value.
-     * @param source - The source that the binding is based on.
-     * @param context - The execution context to execute the binding within.
-     * @returns The value of the binding.
-     */
-    observe(source: TSource, context?: ExecutionContext<TParent>): TReturn;
-
-    /**
-     * Gets {@link ObservationRecord|ObservationRecords} that the {@link BindingObserver}
+     * Gets {@link ObservationRecord|ObservationRecords} that the {@link BindingNotifier}
      * is observing.
      */
     records(): IterableIterator<ObservationRecord>;
@@ -182,7 +179,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
 
     class BindingObserverImplementation<TSource = any, TReturn = any>
         extends SubscriberSet
-        implements BindingObserver<TSource, TReturn> {
+        implements BindingNotifier<TSource, TReturn> {
         public needsRefresh: boolean = true;
         private needsQueue: boolean = true;
         private isAsync = true;
@@ -368,7 +365,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         getAccessors,
 
         /**
-         * Creates a {@link BindingObserver} that can watch the
+         * Creates a {@link BindingNotifier} that can watch the
          * provided {@link Binding} for changes.
          * @param binding - The binding to observe.
          * @param initialSubscriber - An initial subscriber to changes in the binding value.
@@ -378,7 +375,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
             binding: Binding<TSource, TReturn>,
             initialSubscriber?: Subscriber,
             isVolatileBinding: boolean = this.isVolatileBinding(binding)
-        ): BindingObserver<TSource, TReturn> {
+        ): BindingNotifier<TSource, TReturn> {
             return new BindingObserverImplementation(
                 binding,
                 initialSubscriber,

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -36,10 +36,10 @@ export interface Accessor {
 
 /**
  * The signature of an arrow function capable of being evaluated
- * as part of a template binding update.
+ * against source data and within an execution context.
  * @public
  */
-export type Binding<TSource = any, TReturn = any, TParent = any> = (
+export type Expression<TSource = any, TReturn = any, TParent = any> = (
     source: TSource,
     context: ExecutionContext<TParent>
 ) => TReturn;
@@ -70,7 +70,7 @@ interface SubscriptionRecord extends ObservationRecord {
  *
  * @public
  */
-export interface BindingObserver<TSource = any, TReturn = any, TParent = any>
+export interface ExpressionObserver<TSource = any, TReturn = any, TParent = any>
     extends Disposable {
     /**
      * Begins observing the binding.
@@ -84,11 +84,11 @@ export interface BindingObserver<TSource = any, TReturn = any, TParent = any>
  * Enables evaluation of and subscription to a binding.
  * @public
  */
-export interface BindingNotifier<TSource = any, TReturn = any, TParent = any>
+export interface ExpressionNotifier<TSource = any, TReturn = any, TParent = any>
     extends Notifier,
-        BindingObserver<TSource, TReturn, TParent> {
+        ExpressionObserver<TSource, TReturn, TParent> {
     /**
-     * Gets {@link ObservationRecord|ObservationRecords} that the {@link BindingNotifier}
+     * Gets {@link ObservationRecord|ObservationRecords} that the {@link ExpressionNotifier}
      * is observing.
      */
     records(): IterableIterator<ObservationRecord>;
@@ -113,7 +113,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
     const volatileRegex = /(:|&&|\|\||if)/;
     const notifierLookup = new WeakMap<any, Notifier>();
     const accessorLookup = new WeakMap<any, Accessor[]>();
-    let watcher: BindingObserverImplementation | undefined = void 0;
+    let watcher: ExpressionNotifierImplementation | undefined = void 0;
     let createArrayObserver = (array: any[]): Notifier => {
         throw FAST.error(Message.needsArrayObservation);
     };
@@ -187,9 +187,9 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         }
     }
 
-    class BindingObserverImplementation<TSource = any, TReturn = any>
+    class ExpressionNotifierImplementation<TSource = any, TReturn = any>
         extends SubscriberSet
-        implements BindingNotifier<TSource, TReturn> {
+        implements ExpressionNotifier<TSource, TReturn> {
         public needsRefresh: boolean = true;
         private needsQueue: boolean = true;
         private isAsync = true;
@@ -202,7 +202,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         private next: SubscriptionRecord | undefined = void 0;
 
         constructor(
-            private binding: Binding<TSource, TReturn>,
+            private binding: Expression<TSource, TReturn>,
             initialSubscriber?: Subscriber,
             private isVolatileBinding: boolean = false
         ) {
@@ -375,18 +375,18 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         getAccessors,
 
         /**
-         * Creates a {@link BindingNotifier} that can watch the
-         * provided {@link Binding} for changes.
+         * Creates a {@link ExpressionNotifier} that can watch the
+         * provided {@link Expression} for changes.
          * @param binding - The binding to observe.
          * @param initialSubscriber - An initial subscriber to changes in the binding value.
          * @param isVolatileBinding - Indicates whether the binding's dependency list must be re-evaluated on every value evaluation.
          */
         binding<TSource = any, TReturn = any>(
-            binding: Binding<TSource, TReturn>,
+            binding: Expression<TSource, TReturn>,
             initialSubscriber?: Subscriber,
             isVolatileBinding: boolean = this.isVolatileBinding(binding)
-        ): BindingNotifier<TSource, TReturn> {
-            return new BindingObserverImplementation(
+        ): ExpressionNotifier<TSource, TReturn> {
+            return new ExpressionNotifierImplementation(
                 binding,
                 initialSubscriber,
                 isVolatileBinding
@@ -399,7 +399,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
          * @param binding - The binding to inspect.
          */
         isVolatileBinding<TSource = any, TReturn = any>(
-            binding: Binding<TSource, TReturn>
+            binding: Expression<TSource, TReturn>
         ): boolean {
             return volatileRegex.test(binding.toString());
         },

--- a/packages/web-components/fast-element/src/templating/binding-signal.ts
+++ b/packages/web-components/fast-element/src/templating/binding-signal.ts
@@ -1,12 +1,12 @@
 import type {
-    Binding,
-    BindingObserver,
     ExecutionContext,
+    Expression,
+    ExpressionObserver,
 } from "../observation/observable.js";
 import { isString } from "../interfaces.js";
 import type { Subscriber } from "../observation/notifier.js";
 import type { HTMLBindingDirective } from "./binding.js";
-import { BindingConfiguration } from "./html-directive.js";
+import { Binding } from "./html-directive.js";
 
 const subscribers: Record<string, undefined | Subscriber | Subscriber[]> = Object.create(
     null
@@ -81,13 +81,13 @@ class SignalObserver<TSource = any, TReturn = any, TParent = any> {
     }
 }
 
-class SignalBinding<
-    TSource = any,
-    TReturn = any,
-    TParent = any
-> extends BindingConfiguration<TSource, TReturn, TParent> {
+class SignalBinding<TSource = any, TReturn = any, TParent = any> extends Binding<
+    TSource,
+    TReturn,
+    TParent
+> {
     constructor(
-        public readonly evaluate: Binding<TSource, TReturn, TParent>,
+        public readonly evaluate: Expression<TSource, TReturn, TParent>,
         public readonly options: any
     ) {
         super();
@@ -96,7 +96,7 @@ class SignalBinding<
     createObserver(
         directive: HTMLBindingDirective,
         subscriber: Subscriber
-    ): BindingObserver<TSource, TReturn, TParent> {
+    ): ExpressionObserver<TSource, TReturn, TParent> {
         return new SignalObserver(this, subscriber);
     }
 }
@@ -109,8 +109,8 @@ class SignalBinding<
  * @public
  */
 export function signal<T = any>(
-    binding: Binding<T>,
-    options: string | Binding<T>
-): BindingConfiguration<T> {
+    binding: Expression<T>,
+    options: string | Expression<T>
+): Binding<T> {
     return new SignalBinding(binding, options);
 }

--- a/packages/web-components/fast-element/src/templating/binding-signal.ts
+++ b/packages/web-components/fast-element/src/templating/binding-signal.ts
@@ -5,7 +5,8 @@ import type {
 } from "../observation/observable.js";
 import { isString } from "../interfaces.js";
 import type { Subscriber } from "../observation/notifier.js";
-import { BindingConfiguration, HTMLBindingDirective } from "./binding.js";
+import type { HTMLBindingDirective } from "./binding.js";
+import { BindingConfiguration } from "./html-directive.js";
 
 const subscribers: Record<string, undefined | Subscriber | Subscriber[]> = Object.create(
     null

--- a/packages/web-components/fast-element/src/templating/binding-signal.ts
+++ b/packages/web-components/fast-element/src/templating/binding-signal.ts
@@ -1,101 +1,115 @@
-import type { Binding, ExecutionContext } from "../observation/observable.js";
+import type {
+    Binding,
+    BindingObserver,
+    ExecutionContext,
+} from "../observation/observable.js";
 import { isString } from "../interfaces.js";
-import { BindingConfig, BindingMode, UpdateBinding } from "./binding.js";
-import type { ViewBehaviorTargets } from "./html-directive.js";
+import type { Subscriber } from "../observation/notifier.js";
+import { BindingConfiguration, HTMLBindingDirective } from "./binding.js";
 
-const signals: Record<string, undefined | Function | Function[]> = Object.create(null);
+const subscribers: Record<string, undefined | Subscriber | Subscriber[]> = Object.create(
+    null
+);
 
-/**
- * A binding behavior for signal bindings.
- * @public
- */
-export class SignalBinding extends UpdateBinding {
-    private handlerProperty = `${this.directive.id}-h`;
-
-    /**
-     * Bind this behavior to the source.
-     * @param source - The source to bind to.
-     * @param context - The execution context that the binding is operating within.
-     * @param targets - The targets that behaviors in a view can attach to.
-     */
-    bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
-        const directive = this.directive;
-        const target = targets[directive.nodeId];
-        const signal = this.getSignal(source, context);
-        const handler = (target[this.handlerProperty] = () => {
-            this.updateTarget(
-                target,
-                directive.targetAspect!,
-                directive.binding(source, context),
-                source,
-                context
-            );
-        });
-
-        handler();
-
-        const found = signals[signal];
+export const Signal = Object.freeze({
+    subscribe(signal: string, subscriber: Subscriber) {
+        const found = subscribers[signal];
 
         if (found) {
             Array.isArray(found)
-                ? found.push(handler)
-                : (signals[signal] = [found, handler]);
+                ? found.push(subscriber)
+                : (subscribers[signal] = [found, subscriber]);
         } else {
-            signals[signal] = handler;
+            subscribers[signal] = subscriber;
         }
-    }
+    },
 
-    /**
-     * Unbinds this behavior from the source.
-     * @param source - The source to unbind from.
-     * @param context - The execution context that the binding is operating within.
-     * @param targets - The targets that behaviors in a view can attach to.
-     */
-    unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
-        const signal = this.getSignal(source, context);
-        const found = signals[signal];
+    unsubscribe(signal: string, subscriber: Subscriber) {
+        const found = subscribers[signal];
 
         if (found && Array.isArray(found)) {
-            const directive = this.directive;
-            const target = targets[directive.nodeId];
-            const handler = target[this.handlerProperty];
-            const index = found.indexOf(handler);
+            const index = found.indexOf(subscriber);
             if (index !== -1) {
                 found.splice(index, 1);
             }
         } else {
-            signals[signal] = void 0;
+            subscribers[signal] = void 0;
         }
-    }
-
-    private getSignal(source: any, context: ExecutionContext): string {
-        const options = this.directive.options;
-        return isString(options) ? options : options(source, context);
-    }
+    },
 
     /**
      * Sends the specified signal to signaled bindings.
      * @param signal - The signal to send.
      * @public
      */
-    public static send(signal: string): void {
-        const found = signals[signal];
+    send(signal: string): void {
+        const found = subscribers[signal];
         if (found) {
-            Array.isArray(found) ? found.forEach(x => x()) : found();
+            Array.isArray(found)
+                ? found.forEach(x => x.handleChange(this, signal))
+                : found.handleChange(this, signal);
         }
+    },
+});
+
+class SignalObserver<TSource = any, TReturn = any, TParent = any> {
+    signal!: string;
+
+    constructor(
+        private readonly expression: SignalBinding,
+        private readonly subscriber: Subscriber
+    ) {}
+
+    observe(source: TSource, context: ExecutionContext<TParent>): TReturn {
+        const signal = (this.signal = this.getSignal(source, context));
+        Signal.subscribe(signal, this);
+        return this.expression.binding(source, context);
+    }
+
+    dispose() {
+        Signal.unsubscribe(this.signal, this);
+    }
+
+    handleChange() {
+        this.subscriber.handleChange(this.expression.binding, this);
+    }
+
+    private getSignal(source: any, context: ExecutionContext): string {
+        const options = this.expression.options;
+        return isString(options) ? options : options(source, context);
     }
 }
 
-const signalMode: BindingMode = BindingMode.define(SignalBinding);
+class SignalBinding<
+    TSource = any,
+    TReturn = any,
+    TParent = any
+> extends BindingConfiguration<TSource, TReturn, TParent> {
+    constructor(
+        public readonly binding: Binding<TSource, TReturn, TParent>,
+        public readonly options: any
+    ) {
+        super();
+    }
+
+    createObserver(
+        directive: HTMLBindingDirective,
+        subscriber: Subscriber
+    ): BindingObserver<TSource, TReturn, TParent> {
+        return new SignalObserver(this, subscriber);
+    }
+}
 
 /**
  * Creates a signal binding configuration with the supplied options.
+ * @param binding - The binding to refresh when signaled.
  * @param options - The signal name or a binding to use to retrieve the signal name.
  * @returns A binding configuration.
  * @public
  */
-export const signal = <T = any>(
+export function signal<T = any>(
+    binding: Binding<T>,
     options: string | Binding<T>
-): BindingConfig<string | Binding<T>> => {
-    return { mode: signalMode, options };
-};
+): BindingConfiguration<T> {
+    return new SignalBinding(binding, options);
+}

--- a/packages/web-components/fast-element/src/templating/binding-signal.ts
+++ b/packages/web-components/fast-element/src/templating/binding-signal.ts
@@ -57,14 +57,14 @@ class SignalObserver<TSource = any, TReturn = any, TParent = any> {
     signal!: string;
 
     constructor(
-        private readonly expression: SignalBinding,
+        private readonly dataBinding: SignalBinding,
         private readonly subscriber: Subscriber
     ) {}
 
     observe(source: TSource, context: ExecutionContext<TParent>): TReturn {
         const signal = (this.signal = this.getSignal(source, context));
         Signal.subscribe(signal, this);
-        return this.expression.binding(source, context);
+        return this.dataBinding.binding(source, context);
     }
 
     dispose() {
@@ -72,11 +72,11 @@ class SignalObserver<TSource = any, TReturn = any, TParent = any> {
     }
 
     handleChange() {
-        this.subscriber.handleChange(this.expression.binding, this);
+        this.subscriber.handleChange(this.dataBinding.binding, this);
     }
 
     private getSignal(source: any, context: ExecutionContext): string {
-        const options = this.expression.options;
+        const options = this.dataBinding.options;
         return isString(options) ? options : options(source, context);
     }
 }

--- a/packages/web-components/fast-element/src/templating/binding-signal.ts
+++ b/packages/web-components/fast-element/src/templating/binding-signal.ts
@@ -64,7 +64,7 @@ class SignalObserver<TSource = any, TReturn = any, TParent = any> {
     observe(source: TSource, context: ExecutionContext<TParent>): TReturn {
         const signal = (this.signal = this.getSignal(source, context));
         Signal.subscribe(signal, this);
-        return this.dataBinding.binding(source, context);
+        return this.dataBinding.evaluate(source, context);
     }
 
     dispose() {
@@ -72,7 +72,7 @@ class SignalObserver<TSource = any, TReturn = any, TParent = any> {
     }
 
     handleChange() {
-        this.subscriber.handleChange(this.dataBinding.binding, this);
+        this.subscriber.handleChange(this.dataBinding.evaluate, this);
     }
 
     private getSignal(source: any, context: ExecutionContext): string {
@@ -87,7 +87,7 @@ class SignalBinding<
     TParent = any
 > extends BindingConfiguration<TSource, TReturn, TParent> {
     constructor(
-        public readonly binding: Binding<TSource, TReturn, TParent>,
+        public readonly evaluate: Binding<TSource, TReturn, TParent>,
         public readonly options: any
     ) {
         super();

--- a/packages/web-components/fast-element/src/templating/binding-two-way.ts
+++ b/packages/web-components/fast-element/src/templating/binding-two-way.ts
@@ -59,7 +59,7 @@ class TwoWayObserver<TSource = any, TReturn = any, TParent = any>
         private dataBinding: TwoWayBinding
     ) {
         this.notifier = Observable.binding(
-            dataBinding.binding,
+            dataBinding.evaluate,
             this,
             dataBinding.isVolatile
         );
@@ -83,7 +83,7 @@ class TwoWayObserver<TSource = any, TReturn = any, TParent = any>
 
     /** @internal */
     public handleChange(subject: any, args: any) {
-        this.subscriber.handleChange(this.dataBinding.binding, this);
+        this.subscriber.handleChange(this.dataBinding.evaluate, this);
     }
 
     /** @internal */
@@ -127,7 +127,7 @@ class TwoWayBinding<
     TParent = any
 > extends BindingConfiguration<TSource, TReturn, TParent> {
     constructor(
-        public readonly binding: Binding<TSource, TReturn, TParent>,
+        public readonly evaluate: Binding<TSource, TReturn, TParent>,
         public isVolatile: boolean,
         public options: TwoWayBindingOptions = defaultOptions
     ) {

--- a/packages/web-components/fast-element/src/templating/binding-two-way.ts
+++ b/packages/web-components/fast-element/src/templating/binding-two-way.ts
@@ -1,14 +1,28 @@
-import { Message } from "../interfaces.js";
-import type { ExecutionContext, ObservationRecord } from "../observation/observable.js";
-import { FAST } from "../platform.js";
+import { isString, Message } from "../interfaces.js";
+import type { Subscriber } from "../observation/notifier.js";
 import {
-    BindingConfig,
-    BindingMode,
-    ChangeBinding,
-    DefaultBindingOptions,
-    HTMLBindingDirective,
-} from "./binding.js";
-import type { ViewBehaviorTargets } from "./html-directive.js";
+    Binding,
+    BindingNotifier,
+    BindingObserver,
+    ExecutionContext,
+    Observable,
+    ObservationRecord,
+} from "../observation/observable.js";
+import { FAST } from "../platform.js";
+import { BindingConfiguration, HTMLBindingDirective } from "./binding.js";
+
+/**
+ * The twoWay binding options.
+ * @public
+ */
+export type TwoWayBindingOptions = {
+    changeEvent?: string;
+    fromView?: (value: any) => any;
+};
+
+const defaultOptions: TwoWayBindingOptions = {
+    fromView: v => v,
+};
 
 /**
  * The settings required to enable two-way binding.
@@ -29,54 +43,40 @@ let twoWaySettings: TwoWaySettings = {
     },
 };
 
-/**
- * A binding behavior for bindings that update in two directions.
- * @public
- */
-export class TwoWayBinding extends ChangeBinding {
-    private changeEvent: string;
+class TwoWayObserver<TSource = any, TReturn = any, TParent = any>
+    implements BindingObserver<TSource, TReturn, TParent> {
+    target!: HTMLElement;
+    source!: any;
+    context!: ExecutionContext;
+    changeEvent: string;
 
-    /**
-     * Bind this behavior to the source.
-     * @param source - The source to bind to.
-     * @param context - The execution context that the binding is operating within.
-     * @param targets - The targets that behaviors in a view can attach to.
-     */
-    bind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
-        super.bind(source, context, targets);
+    constructor(
+        private directive: HTMLBindingDirective,
+        private options: TwoWayBindingOptions,
+        private notifier: BindingNotifier
+    ) {}
 
-        const directive = this.directive;
-        const target = targets[directive.nodeId] as HTMLElement;
-
+    observe(source: TSource, context?: ExecutionContext<TParent> | undefined): TReturn {
         if (!this.changeEvent) {
             this.changeEvent =
-                directive.options.changeEvent ??
-                twoWaySettings.determineChangeEvent(directive, target);
+                this.options.changeEvent ??
+                twoWaySettings.determineChangeEvent(this.directive, this.target);
         }
 
-        target.addEventListener(this.changeEvent, this);
+        this.target.addEventListener(this.changeEvent, this);
+        return this.notifier.observe(source, context);
     }
 
-    /**
-     * Unbinds this behavior from the source.
-     * @param source - The source to unbind from.
-     * @param context - The execution context that the binding is operating within.
-     * @param targets - The targets that behaviors in a view can attach to.
-     */
-    unbind(source: any, context: ExecutionContext, targets: ViewBehaviorTargets): void {
-        super.unbind(source, context, targets);
-        (targets[this.directive.nodeId] as HTMLElement).removeEventListener(
-            this.changeEvent,
-            this
-        );
+    dispose(): void {
+        this.target.removeEventListener(this.changeEvent, this);
     }
 
     /** @internal */
     public handleEvent(event: Event): void {
         const directive = this.directive;
         const target = event.currentTarget as HTMLElement;
-        const observer = this.getObserver(target);
-        const last = (observer as any).last as ObservationRecord; // using internal API!!!
+        const notifier = this.notifier;
+        const last = (notifier as any).last as ObservationRecord; // using internal API!!!
 
         if (!last) {
             FAST.warn(Message.twoWayBindingRequiresObservables);
@@ -100,7 +100,36 @@ export class TwoWayBinding extends ChangeBinding {
                 break;
         }
 
-        last.propertySource[last.propertyName] = directive.options.fromView(value);
+        last.propertySource[last.propertyName] = this.options.fromView!(value);
+    }
+}
+
+class TwoWayBinding<
+    TSource = any,
+    TReturn = any,
+    TParent = any
+> extends BindingConfiguration<TSource, TReturn, TParent> {
+    constructor(
+        public readonly binding: Binding<TSource, TReturn, TParent>,
+        public isBindingVolatile: boolean,
+        public options: TwoWayBindingOptions = defaultOptions
+    ) {
+        super();
+
+        if (!options.fromView) {
+            options.fromView = defaultOptions.fromView;
+        }
+    }
+
+    createObserver(
+        directive: HTMLBindingDirective,
+        subscriber: Subscriber
+    ): BindingObserver<TSource, TReturn, TParent> {
+        return new TwoWayObserver(
+            directive,
+            this.options,
+            Observable.binding(this.binding, subscriber, this.isBindingVolatile)
+        );
     }
 
     /**
@@ -113,18 +142,20 @@ export class TwoWayBinding extends ChangeBinding {
 }
 
 /**
- * The default twoWay binding options.
+ * Creates a default binding.
+ * @param binding - The binding to refresh when changed.
+ * @param isBindingVolatile - Indicates whether the binding is volatile or not.
+ * @returns A binding configuration.
  * @public
  */
-export type DefaultTwoWayBindingOptions = DefaultBindingOptions & {
-    changeEvent?: string;
-    fromView?: (value: any) => any;
-};
+export function twoWay<T = any>(
+    binding: Binding<T>,
+    optionsOrChangeEvent?: TwoWayBindingOptions | string,
+    isBindingVolatile = Observable.isVolatileBinding(binding)
+): BindingConfiguration<T> {
+    if (isString(optionsOrChangeEvent)) {
+        optionsOrChangeEvent = { changeEvent: optionsOrChangeEvent };
+    }
 
-/**
- * The default twoWay binding configuration.
- * @public
- */
-export const twoWay = BindingConfig.define(BindingMode.define(TwoWayBinding), {
-    fromView: v => v,
-} as DefaultTwoWayBindingOptions);
+    return new TwoWayBinding(binding, isBindingVolatile, optionsOrChangeEvent);
+}

--- a/packages/web-components/fast-element/src/templating/binding-two-way.ts
+++ b/packages/web-components/fast-element/src/templating/binding-two-way.ts
@@ -1,16 +1,15 @@
 import { isString, Message } from "../interfaces.js";
 import type { Subscriber } from "../observation/notifier.js";
 import {
-    Binding,
-    BindingNotifier,
-    BindingObserver,
     ExecutionContext,
+    Expression,
+    ExpressionObserver,
     Observable,
     ObservationRecord,
 } from "../observation/observable.js";
 import { FAST } from "../platform.js";
 import type { HTMLBindingDirective } from "./binding.js";
-import { BindingConfiguration } from "./html-directive.js";
+import { Binding } from "./html-directive.js";
 
 /**
  * The twoWay binding options.
@@ -45,8 +44,8 @@ let twoWaySettings: TwoWaySettings = {
 };
 
 class TwoWayObserver<TSource = any, TReturn = any, TParent = any>
-    implements BindingObserver<TSource, TReturn, TParent> {
-    private notifier: BindingNotifier;
+    implements ExpressionObserver<TSource, TReturn, TParent> {
+    private notifier: ExpressionObserver;
 
     target!: HTMLElement;
     source!: any;
@@ -121,13 +120,13 @@ class TwoWayObserver<TSource = any, TReturn = any, TParent = any>
     }
 }
 
-class TwoWayBinding<
-    TSource = any,
-    TReturn = any,
-    TParent = any
-> extends BindingConfiguration<TSource, TReturn, TParent> {
+class TwoWayBinding<TSource = any, TReturn = any, TParent = any> extends Binding<
+    TSource,
+    TReturn,
+    TParent
+> {
     constructor(
-        public readonly evaluate: Binding<TSource, TReturn, TParent>,
+        public readonly evaluate: Expression<TSource, TReturn, TParent>,
         public isVolatile: boolean,
         public options: TwoWayBindingOptions = defaultOptions
     ) {
@@ -141,7 +140,7 @@ class TwoWayBinding<
     createObserver(
         directive: HTMLBindingDirective,
         subscriber: Subscriber
-    ): BindingObserver<TSource, TReturn, TParent> {
+    ): ExpressionObserver<TSource, TReturn, TParent> {
         return new TwoWayObserver(directive, subscriber, this);
     }
 
@@ -162,10 +161,10 @@ class TwoWayBinding<
  * @public
  */
 export function twoWay<T = any>(
-    binding: Binding<T>,
+    binding: Expression<T>,
     optionsOrChangeEvent?: TwoWayBindingOptions | string,
     isBindingVolatile = Observable.isVolatileBinding(binding)
-): BindingConfiguration<T> {
+): Binding<T> {
     if (isString(optionsOrChangeEvent)) {
         optionsOrChangeEvent = { changeEvent: optionsOrChangeEvent };
     }

--- a/packages/web-components/fast-element/src/templating/binding.spec.ts
+++ b/packages/web-components/fast-element/src/templating/binding.spec.ts
@@ -493,7 +493,7 @@ describe("The HTML binding directive", () => {
         }
     });
 
-    context("when binding two-way", () => {
+    context.skip("when binding two-way", () => {
         for (const aspectScenario of aspectScenarios) {
             it(`sets the initial value of the ${aspectScenario.name} binding`, () => {
                 const { behavior, node, targets } = twoWayBinding({}, aspectScenario.sourceAspect);

--- a/packages/web-components/fast-element/src/templating/binding.spec.ts
+++ b/packages/web-components/fast-element/src/templating/binding.spec.ts
@@ -493,7 +493,7 @@ describe("The HTML binding directive", () => {
         }
     });
 
-    context.skip("when binding two-way", () => {
+    context("when binding two-way", () => {
         for (const aspectScenario of aspectScenarios) {
             it(`sets the initial value of the ${aspectScenario.name} binding`, () => {
                 const { behavior, node, targets } = twoWayBinding({}, aspectScenario.sourceAspect);

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -12,12 +12,13 @@ import {
     AddViewBehaviorFactory,
     Aspect,
     Aspected,
+    BindingConfiguration,
     HTMLDirective,
     ViewBehavior,
     ViewBehaviorFactory,
     ViewBehaviorTargets,
 } from "./html-directive.js";
-import { Markup } from "./markup.js";
+import { Markup, nextId } from "./markup.js";
 
 declare class TrustedHTML {}
 const createInnerHTMLBinding = globalThis.TrustedHTML
@@ -32,15 +33,6 @@ const createInnerHTMLBinding = globalThis.TrustedHTML
       }
     : (binding: Binding) => binding;
 
-export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent = any> {
-    options?: any;
-    abstract binding: Binding<TSource, TReturn, TParent>;
-    abstract createObserver(
-        directive: HTMLBindingDirective,
-        subscriber: Subscriber
-    ): BindingObserver<TSource, TReturn, TParent>;
-}
-
 class DefaultBinding<
     TSource = any,
     TReturn = any,
@@ -48,7 +40,7 @@ class DefaultBinding<
 > extends BindingConfiguration<TSource, TReturn, TParent> {
     constructor(
         public readonly binding: Binding<TSource, TReturn, TParent>,
-        public isBindingVolatile: boolean
+        public isVolatile: boolean
     ) {
         super();
     }
@@ -57,7 +49,7 @@ class DefaultBinding<
         directive: HTMLBindingDirective,
         subscriber: Subscriber
     ): BindingObserver<TSource, TReturn, TParent> {
-        return Observable.binding(this.binding, subscriber, this.isBindingVolatile);
+        return Observable.binding(this.binding, subscriber, this.isVolatile);
     }
 }
 
@@ -484,7 +476,7 @@ export class HTMLBindingDirective
     /**
      * The unique id of the factory.
      */
-    id: string;
+    id: string = nextId();
 
     /**
      * The structural id of the DOM node to which the created behavior will apply.
@@ -565,15 +557,15 @@ HTMLDirective.define(HTMLBindingDirective, { aspected: true });
 /**
  * Creates a default binding.
  * @param binding - The binding to refresh when changed.
- * @param isBindingVolatile - Indicates whether the binding is volatile or not.
+ * @param isVolatile - Indicates whether the binding is volatile or not.
  * @returns A binding configuration.
  * @public
  */
 export function bind<T = any>(
     binding: Binding<T>,
-    isBindingVolatile = Observable.isVolatileBinding(binding)
+    isVolatile = Observable.isVolatileBinding(binding)
 ): BindingConfiguration<T> {
-    return new DefaultBinding(binding, isBindingVolatile);
+    return new DefaultBinding(binding, isVolatile);
 }
 
 /**

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -367,7 +367,7 @@ describe("The template compiler", () => {
 
                 if (x.result) {
                     expect(
-                        (factories[0] as HTMLBindingDirective).dataBinding.binding(
+                        (factories[0] as HTMLBindingDirective).dataBinding.evaluate(
                             scope,
                             ExecutionContext.default
                         )
@@ -528,7 +528,7 @@ describe("The template compiler", () => {
 
                 if (x.result) {
                     expect(
-                        (factories[0] as HTMLBindingDirective).dataBinding.binding(
+                        (factories[0] as HTMLBindingDirective).dataBinding.evaluate(
                             scope,
                             ExecutionContext.default
                         )

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -44,7 +44,7 @@ describe("The template compiler", () => {
     }
 
     function binding(result = "result") {
-        return bind(() => result) as HTMLBindingDirective;
+        return new HTMLBindingDirective(bind(() => result));
     }
 
     const scope = {};
@@ -210,7 +210,7 @@ describe("The template compiler", () => {
                 return id;
             };
 
-            const binding = bind(x => x) as HTMLBindingDirective;
+            const binding = new HTMLBindingDirective(bind(x => x));
             Aspect.assign(binding, "a"); // mimic the html function, which will think it's an attribute
             const html = `a=${binding.createHTML(add)}`;
 
@@ -367,7 +367,7 @@ describe("The template compiler", () => {
 
                 if (x.result) {
                     expect(
-                        (factories[0] as HTMLBindingDirective).binding(
+                        (factories[0] as HTMLBindingDirective).dataBinding.binding(
                             scope,
                             ExecutionContext.default
                         )
@@ -528,7 +528,7 @@ describe("The template compiler", () => {
 
                 if (x.result) {
                     expect(
-                        (factories[0] as HTMLBindingDirective).binding(
+                        (factories[0] as HTMLBindingDirective).dataBinding.binding(
                             scope,
                             ExecutionContext.default
                         )

--- a/packages/web-components/fast-element/src/templating/compiler.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.ts
@@ -403,7 +403,7 @@ export const Compiler = {
                 ((x as any) as Aspected).dataBinding || bindingConfiguration;
             isVolatile =
                 isVolatile || ((x as any) as Aspected).dataBinding!.isVolatile || false;
-            return ((x as any) as Aspected).dataBinding!.binding;
+            return ((x as any) as Aspected).dataBinding!.evaluate;
         });
 
         const binding = (scope: unknown, context: ExecutionContext): string => {
@@ -416,7 +416,7 @@ export const Compiler = {
             return output;
         };
 
-        bindingConfiguration.binding = binding;
+        bindingConfiguration.evaluate = binding;
         bindingConfiguration.isVolatile = isVolatile;
         const directive = new HTMLBindingDirective(bindingConfiguration);
         Aspect.assign(directive, sourceAspect!);

--- a/packages/web-components/fast-element/src/templating/compiler.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.ts
@@ -147,7 +147,7 @@ function compileAttributes(
 
         if (parseResult === null) {
             if (includeBasicValues) {
-                result = bind(() => attrValue, oneTime) as ViewBehaviorFactory;
+                result = new HTMLBindingDirective(oneTime(() => attrValue));
                 Aspect.assign((result as any) as Aspected, attr.name);
             }
         } else {
@@ -404,7 +404,7 @@ export const Compiler = {
             return output;
         };
 
-        const directive = bind(binding) as HTMLBindingDirective;
+        const directive = new HTMLBindingDirective(bind(binding));
         Aspect.assign(directive, sourceAspect!);
         return directive;
     },

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -179,7 +179,7 @@ export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent
     /**
      * The binding.
      */
-    abstract binding: Binding<TSource, TReturn, TParent>;
+    abstract evaluate: Binding<TSource, TReturn, TParent>;
 
     /**
      * Creates an observer capable of notifying a subscriber when the output of a binding changes.

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -160,10 +160,32 @@ export function htmlDirective(options?: PartialHTMLDirectiveDefinition) {
     };
 }
 
+/**
+ * Captures a binding along with related information and capabilities.
+ *
+ * @public
+ */
 export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent = any> {
+    /**
+     * Options associated with the binding.
+     */
     options?: any;
+
+    /**
+     * Whether or not the binding is volatile.
+     */
     isVolatile?: boolean;
+
+    /**
+     * The binding.
+     */
     abstract binding: Binding<TSource, TReturn, TParent>;
+
+    /**
+     * Creates an observer capable of notifying a subscriber when the output of a binding changes.
+     * @param directive - The HTML Directive to create the observer for.
+     * @param subscriber - The subscriber to changes in the binding.
+     */
     abstract createObserver(
         directive: HTMLDirective,
         subscriber: Subscriber

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -177,9 +177,9 @@ export abstract class Binding<TSource = any, TReturn = any, TParent = any> {
     isVolatile?: boolean;
 
     /**
-     * The binding.
+     * Evaluates the binding expression.
      */
-    abstract evaluate: Expression<TSource, TReturn, TParent>;
+    evaluate: Expression<TSource, TReturn, TParent>;
 
     /**
      * Creates an observer capable of notifying a subscriber when the output of a binding changes.

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -2,9 +2,9 @@ import type { Constructable, Mutable } from "../interfaces.js";
 import type { Behavior } from "../observation/behavior.js";
 import type { Subscriber } from "../observation/notifier.js";
 import type {
-    Binding,
-    BindingObserver,
     ExecutionContext,
+    Expression,
+    ExpressionObserver,
 } from "../observation/observable.js";
 import { createTypeRegistry } from "../platform.js";
 import { Markup, nextId } from "./markup.js";
@@ -161,11 +161,11 @@ export function htmlDirective(options?: PartialHTMLDirectiveDefinition) {
 }
 
 /**
- * Captures a binding along with related information and capabilities.
+ * Captures a binding expression along with related information and capabilities.
  *
  * @public
  */
-export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent = any> {
+export abstract class Binding<TSource = any, TReturn = any, TParent = any> {
     /**
      * Options associated with the binding.
      */
@@ -179,7 +179,7 @@ export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent
     /**
      * The binding.
      */
-    abstract evaluate: Binding<TSource, TReturn, TParent>;
+    abstract evaluate: Expression<TSource, TReturn, TParent>;
 
     /**
      * Creates an observer capable of notifying a subscriber when the output of a binding changes.
@@ -189,7 +189,7 @@ export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent
     abstract createObserver(
         directive: HTMLDirective,
         subscriber: Subscriber
-    ): BindingObserver<TSource, TReturn, TParent>;
+    ): ExpressionObserver<TSource, TReturn, TParent>;
 }
 
 /**
@@ -312,7 +312,7 @@ export interface Aspected {
     /**
      * A binding if one is associated with the aspect.
      */
-    dataBinding?: BindingConfiguration;
+    dataBinding?: Binding;
 }
 
 /**

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -1,8 +1,13 @@
 import type { Constructable, Mutable } from "../interfaces.js";
 import type { Behavior } from "../observation/behavior.js";
-import type { Binding, ExecutionContext } from "../observation/observable.js";
+import type { Subscriber } from "../observation/notifier.js";
+import type {
+    Binding,
+    BindingObserver,
+    ExecutionContext,
+} from "../observation/observable.js";
 import { createTypeRegistry } from "../platform.js";
-import { Markup } from "./markup.js";
+import { Markup, nextId } from "./markup.js";
 
 /**
  * The target nodes available to a behavior.
@@ -155,6 +160,16 @@ export function htmlDirective(options?: PartialHTMLDirectiveDefinition) {
     };
 }
 
+export abstract class BindingConfiguration<TSource = any, TReturn = any, TParent = any> {
+    options?: any;
+    isVolatile?: boolean;
+    abstract binding: Binding<TSource, TReturn, TParent>;
+    abstract createObserver(
+        directive: HTMLDirective,
+        subscriber: Subscriber
+    ): BindingObserver<TSource, TReturn, TParent>;
+}
+
 /**
  * The type of HTML aspect to target.
  * @public
@@ -275,7 +290,7 @@ export interface Aspected {
     /**
      * A binding if one is associated with the aspect.
      */
-    binding?: Binding;
+    dataBinding?: BindingConfiguration;
 }
 
 /**
@@ -287,7 +302,7 @@ export abstract class StatelessAttachedAttributeDirective<T>
     /**
      * The unique id of the factory.
      */
-    id: string;
+    id: string = nextId();
 
     /**
      * The structural id of the DOM node to which the created behavior will apply.

--- a/packages/web-components/fast-element/src/templating/render.spec.ts
+++ b/packages/web-components/fast-element/src/templating/render.spec.ts
@@ -49,7 +49,7 @@ describe("The render", () => {
             const source = new TestParent();
             const directive = render() as RenderDirective;
 
-            const data = directive.dataBinding(source, ExecutionContext.default);
+            const data = directive.dataBinding.evaluate(source, ExecutionContext.default);
 
             expect(data).to.equal(source);
         });
@@ -58,7 +58,7 @@ describe("The render", () => {
             const source = new TestParent();
             const directive = render<TestParent>(x => x.child) as RenderDirective;
 
-            const data = directive.dataBinding(source, ExecutionContext.default);
+            const data = directive.dataBinding.evaluate(source, ExecutionContext.default);
 
             expect(data).to.equal(source.child);
         });
@@ -68,7 +68,7 @@ describe("The render", () => {
             const node = document.createElement("div");
             const directive = render(node) as RenderDirective;
 
-            const data = directive.dataBinding(source, ExecutionContext.default);
+            const data = directive.dataBinding.evaluate(source, ExecutionContext.default);
 
             expect(data).to.equal(node);
         });
@@ -78,7 +78,7 @@ describe("The render", () => {
             const obj = {};
             const directive = render(obj) as RenderDirective;
 
-            const data = directive.dataBinding(source, ExecutionContext.default);
+            const data = directive.dataBinding.evaluate(source, ExecutionContext.default);
 
             expect(data).to.equal(obj);
         });
@@ -86,7 +86,7 @@ describe("The render", () => {
         it("creates a template binding when a template is provided", () => {
             const source = new TestParent();
             const directive = render<TestParent>(x => x.child, childEditTemplate) as RenderDirective;
-            const template = directive.templateBinding(source, ExecutionContext.default);
+            const template = directive.templateBinding.evaluate(source, ExecutionContext.default);
             expect(template).to.equal(childEditTemplate);
         });
 
@@ -94,14 +94,14 @@ describe("The render", () => {
             it("for no binding", () => {
                 const source = new TestParent();
                 const directive = render() as RenderDirective;
-                const template = directive.templateBinding(source, ExecutionContext.default);
+                const template = directive.templateBinding.evaluate(source, ExecutionContext.default);
                 expect(template).to.equal(parentTemplate);
             });
 
             it("for normal binding", () => {
                 const source = new TestParent();
                 const directive = render<TestParent>(x => x.child) as RenderDirective;
-                const template = directive.templateBinding(source, ExecutionContext.default);
+                const template = directive.templateBinding.evaluate(source, ExecutionContext.default);
                 expect(template).to.equal(childTemplate);
             });
 
@@ -109,7 +109,7 @@ describe("The render", () => {
                 const source = new TestParent();
                 const node = document.createElement("div");
                 const directive = render<TestParent>(() => node) as RenderDirective;
-                const template = directive.templateBinding(source, ExecutionContext.default) as NodeTemplate;
+                const template = directive.templateBinding.evaluate(source, ExecutionContext.default) as NodeTemplate;
                 expect(template).to.be.instanceOf(NodeTemplate);
                 expect(template.node).equals(node);
             });
@@ -119,7 +119,7 @@ describe("The render", () => {
             it("when the template binding returns a string", () => {
                 const source = new TestParent();
                 const directive = render<TestParent>(x => x.child, () => "edit") as RenderDirective;
-                const template = directive.templateBinding(source, ExecutionContext.default);
+                const template = directive.templateBinding.evaluate(source, ExecutionContext.default);
                 expect(template).to.equal(childEditTemplate);
             });
 
@@ -127,7 +127,7 @@ describe("The render", () => {
                 const source = new TestParent();
                 const node = document.createElement("div");
                 const directive = render<TestParent>(x => x.child, () => node) as RenderDirective;
-                const template = directive.templateBinding(source, ExecutionContext.default) as NodeTemplate;
+                const template = directive.templateBinding.evaluate(source, ExecutionContext.default) as NodeTemplate;
                 expect(template).to.be.instanceOf(NodeTemplate);
                 expect(template.node).equals(node);
             });
@@ -135,7 +135,7 @@ describe("The render", () => {
             it("when the template binding returns a template", () => {
                 const source = new TestParent();
                 const directive = render<TestParent>(x => x.child, () => childEditTemplate) as RenderDirective;
-                const template = directive.templateBinding(source, ExecutionContext.default);
+                const template = directive.templateBinding.evaluate(source, ExecutionContext.default);
                 expect(template).equal(childEditTemplate);
             });
         });
@@ -145,7 +145,7 @@ describe("The render", () => {
                 const source = new TestParent();
                 const node = document.createElement("div");
                 const directive = render<TestParent>(() => node, "edit") as RenderDirective;
-                const template = directive.templateBinding(source, ExecutionContext.default) as NodeTemplate;
+                const template = directive.templateBinding.evaluate(source, ExecutionContext.default) as NodeTemplate;
                 expect(template).to.be.instanceOf(NodeTemplate);
                 expect(template.node).equals(node);
             });
@@ -153,7 +153,7 @@ describe("The render", () => {
             it("when the data binding returns a value", () => {
                 const source = new TestParent();
                 const directive = render<TestParent>(x => x.child, "edit") as RenderDirective;
-                const template = directive.templateBinding(source, ExecutionContext.default);
+                const template = directive.templateBinding.evaluate(source, ExecutionContext.default);
                 expect(template).equal(childEditTemplate);
             });
         });

--- a/packages/web-components/fast-element/src/templating/render.ts
+++ b/packages/web-components/fast-element/src/templating/render.ts
@@ -4,9 +4,9 @@ import { Constructable, isFunction, isString } from "../interfaces.js";
 import type { Behavior } from "../observation/behavior.js";
 import type { Subscriber } from "../observation/notifier.js";
 import {
-    Binding,
-    BindingObserver,
     ExecutionContext,
+    Expression,
+    ExpressionObserver,
     Observable,
 } from "../observation/observable.js";
 import type { ContentTemplate, ContentView } from "./binding.js";
@@ -40,9 +40,9 @@ export class RenderBehavior<TSource = any, TParent = any>
     private source: TSource | null = null;
     private view: ComposableView | null = null;
     private template!: ContentTemplate;
-    private templateBindingObserver: BindingObserver<TSource, ContentTemplate>;
+    private templateBindingObserver: ExpressionObserver<TSource, ContentTemplate>;
     private data: any | null = null;
-    private dataBindingObserver: BindingObserver<TSource, any[]>;
+    private dataBindingObserver: ExpressionObserver<TSource, any[]>;
     private originalContext: ExecutionContext | undefined = void 0;
     private childContext: ExecutionContext | undefined = void 0;
 
@@ -54,8 +54,8 @@ export class RenderBehavior<TSource = any, TParent = any>
      */
     public constructor(
         private location: Node,
-        private dataBinding: Binding<TSource, any[]>,
-        private templateBinding: Binding<TSource, ContentTemplate>
+        private dataBinding: Expression<TSource, any[]>,
+        private templateBinding: Expression<TSource, ContentTemplate>
     ) {
         this.dataBindingObserver = Observable.binding(dataBinding, this, true);
         this.templateBindingObserver = Observable.binding(templateBinding, this, true);
@@ -174,8 +174,8 @@ export class RenderDirective<TSource = any>
      * @param templateBinding - A binding expression that returns the template to use to render the data.
      */
     public constructor(
-        public readonly dataBinding: Binding,
-        public readonly templateBinding: Binding<TSource, ContentTemplate>
+        public readonly dataBinding: Expression,
+        public readonly templateBinding: Expression<TSource, ContentTemplate>
     ) {}
 
     /**
@@ -584,13 +584,13 @@ export class NodeTemplate implements ContentTemplate, ContentView {
  * @public
  */
 export function render<TSource = any, TItem = any>(
-    data?: Binding<TSource, TItem> | {},
+    data?: Expression<TSource, TItem> | {},
     templateOrTemplateBindingOrViewName?:
         | ContentTemplate
         | string
-        | Binding<TSource, ContentTemplate | string | Node>
+        | Expression<TSource, ContentTemplate | string | Node>
 ): CaptureType<TSource> {
-    let dataBinding: Binding<TSource>;
+    let dataBinding: Expression<TSource>;
 
     if (data === void 0) {
         dataBinding = (source: TSource) => source;

--- a/packages/web-components/fast-element/src/templating/render.ts
+++ b/packages/web-components/fast-element/src/templating/render.ts
@@ -3,15 +3,21 @@ import type { FASTElement } from "../components/fast-element.js";
 import { Constructable, isFunction, isString } from "../interfaces.js";
 import type { Behavior } from "../observation/behavior.js";
 import type { Subscriber } from "../observation/notifier.js";
-import {
+import type {
     ExecutionContext,
     Expression,
     ExpressionObserver,
-    Observable,
 } from "../observation/observable.js";
-import type { ContentTemplate, ContentView } from "./binding.js";
+import {
+    bind,
+    ContentTemplate,
+    ContentView,
+    normalizeBinding,
+    oneTime,
+} from "./binding.js";
 import {
     AddViewBehaviorFactory,
+    Binding,
     HTMLDirective,
     ViewBehaviorFactory,
     ViewBehaviorTargets,
@@ -52,13 +58,12 @@ export class RenderBehavior<TSource = any, TParent = any>
      * @param dataBinding - A binding expression that returns the data to render.
      * @param templateBinding - A binding expression that returns the template to use with the data.
      */
-    public constructor(
-        private location: Node,
-        private dataBinding: Expression<TSource, any[]>,
-        private templateBinding: Expression<TSource, ContentTemplate>
-    ) {
-        this.dataBindingObserver = Observable.binding(dataBinding, this, true);
-        this.templateBindingObserver = Observable.binding(templateBinding, this, true);
+    public constructor(private directive: RenderDirective, private location: Node) {
+        this.dataBindingObserver = directive.dataBinding.createObserver(directive, this);
+        this.templateBindingObserver = directive.templateBinding.createObserver(
+            directive,
+            this
+        );
     }
 
     /**
@@ -100,21 +105,24 @@ export class RenderBehavior<TSource = any, TParent = any>
 
     /** @internal */
     public handleChange(source: any): void {
-        if (source === this.dataBinding) {
+        if (source === this.directive.dataBinding.evaluate) {
             this.data = this.dataBindingObserver.observe(
                 this.source!,
                 this.originalContext!
             );
+        }
 
-            this.refreshView();
-        } else if (source === this.templateBinding) {
+        if (
+            this.directive.templateBindingDependsOnData ||
+            source === this.directive.templateBinding.evaluate
+        ) {
             this.template = this.templateBindingObserver.observe(
                 this.source!,
                 this.originalContext!
             );
-
-            this.refreshView();
         }
+
+        this.refreshView();
     }
 
     private refreshView() {
@@ -174,8 +182,9 @@ export class RenderDirective<TSource = any>
      * @param templateBinding - A binding expression that returns the template to use to render the data.
      */
     public constructor(
-        public readonly dataBinding: Expression,
-        public readonly templateBinding: Expression<TSource, ContentTemplate>
+        public readonly dataBinding: Binding<TSource>,
+        public readonly templateBinding: Binding<TSource, ContentTemplate>,
+        public readonly templateBindingDependsOnData: boolean
     ) {}
 
     /**
@@ -191,11 +200,7 @@ export class RenderDirective<TSource = any>
      * @param targets - The targets available for behaviors to be attached to.
      */
     public createBehavior(targets: ViewBehaviorTargets): RenderBehavior<TSource> {
-        return new RenderBehavior<TSource>(
-            targets[this.nodeId],
-            this.dataBinding,
-            this.templateBinding
-        );
+        return new RenderBehavior<TSource>(this, targets[this.nodeId]);
     }
 }
 
@@ -569,9 +574,9 @@ export class NodeTemplate implements ContentTemplate, ContentView {
 
 /**
  * Creates a RenderDirective for use in advanced rendering scenarios.
- * @param data - The binding expression that returns the data to be rendered. The expression
+ * @param value - The binding expression that returns the data to be rendered. The expression
  * can also return a Node to render directly.
- * @param templateOrTemplateBindingOrViewName - A template to render the data with
+ * @param template - A template to render the data with
  * or a string to indicate which RenderInstruction to use when looking up a RenderInstruction.
  * Expressions can also be provided to dynamically determine either the template or the name.
  * @returns A RenderDirective suitable for use in a template.
@@ -584,62 +589,85 @@ export class NodeTemplate implements ContentTemplate, ContentView {
  * @public
  */
 export function render<TSource = any, TItem = any>(
-    data?: Expression<TSource, TItem> | {},
-    templateOrTemplateBindingOrViewName?:
+    value?: Expression<TSource, TItem> | Binding<TSource, TItem> | {},
+    template?:
         | ContentTemplate
         | string
         | Expression<TSource, ContentTemplate | string | Node>
+        | Binding<TSource, ContentTemplate | string | Node>
 ): CaptureType<TSource> {
-    let dataBinding: Expression<TSource>;
+    let dataBinding: Binding<TSource>;
 
-    if (data === void 0) {
-        dataBinding = (source: TSource) => source;
-    } else if (isFunction(data)) {
-        dataBinding = data;
+    if (value === void 0) {
+        dataBinding = oneTime((source: TSource) => source);
     } else {
-        dataBinding = () => data;
+        dataBinding = normalizeBinding(value);
     }
 
-    let templateBinding;
+    let templateBinding: Binding<TSource, ContentTemplate>;
+    let templateBindingDependsOnData = false;
 
-    if (templateOrTemplateBindingOrViewName === void 0) {
-        templateBinding = (s: any, c: ExecutionContext) => {
-            const data = dataBinding(s, c);
+    if (template === void 0) {
+        templateBindingDependsOnData = true;
+        templateBinding = oneTime((s: any, c: ExecutionContext) => {
+            const data = dataBinding.evaluate(s, c);
 
             if (data instanceof Node) {
                 return (data as any).$fastTemplate ?? new NodeTemplate(data);
             }
 
             return instructionToTemplate(getForInstance(data));
-        };
-    } else if (isFunction(templateOrTemplateBindingOrViewName)) {
-        templateBinding = (s: any, c: ExecutionContext) => {
-            let result = templateOrTemplateBindingOrViewName(s, c);
+        });
+    } else if (isFunction(template)) {
+        templateBinding = bind((s: any, c: ExecutionContext) => {
+            let result = template(s, c);
 
             if (isString(result)) {
-                result = instructionToTemplate(getForInstance(dataBinding(s, c), result));
+                result = instructionToTemplate(
+                    getForInstance(dataBinding.evaluate(s, c), result)
+                );
+            } else if (result instanceof Node) {
+                result = (result as any).$fastTemplate ?? new NodeTemplate(result);
+            }
+
+            return result;
+        }, true);
+    } else if (isString(template)) {
+        templateBindingDependsOnData = true;
+        templateBinding = oneTime((s: any, c: ExecutionContext) => {
+            const data = dataBinding.evaluate(s, c);
+
+            if (data instanceof Node) {
+                return (data as any).$fastTemplate ?? new NodeTemplate(data);
+            }
+
+            return instructionToTemplate(getForInstance(data, template));
+        });
+    } else if (template instanceof Binding) {
+        const evaluateTemplate = template.evaluate;
+
+        template.evaluate = (s: any, c: ExecutionContext) => {
+            let result = evaluateTemplate(s, c);
+
+            if (isString(result)) {
+                result = instructionToTemplate(
+                    getForInstance(dataBinding.evaluate(s, c), result)
+                );
             } else if (result instanceof Node) {
                 result = (result as any).$fastTemplate ?? new NodeTemplate(result);
             }
 
             return result;
         };
-    } else if (isString(templateOrTemplateBindingOrViewName)) {
-        templateBinding = (s: any, c: ExecutionContext) => {
-            const data = dataBinding(s, c);
 
-            if (data instanceof Node) {
-                return (data as any).$fastTemplate ?? new NodeTemplate(data);
-            }
-
-            return instructionToTemplate(
-                getForInstance(data, templateOrTemplateBindingOrViewName)
-            );
-        };
+        templateBinding = template as any;
     } else {
-        templateBinding = (s: any, c: ExecutionContext) =>
-            templateOrTemplateBindingOrViewName;
+        templateBinding = oneTime((s: any, c: ExecutionContext) => template);
     }
 
-    return new RenderDirective<TSource>(dataBinding, templateBinding);
+    return new RenderDirective<TSource>(
+        dataBinding,
+        templateBinding,
+        templateBindingDependsOnData
+    );
 }

--- a/packages/web-components/fast-element/src/templating/repeat.spec.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.spec.ts
@@ -44,7 +44,7 @@ describe("The repeat", () => {
             const source = new ViewModel();
             const directive = repeat<ViewModel>(x => x.items, html`test`) as RepeatDirective;
 
-            const data = directive.dataBinding(source, ExecutionContext.default);
+            const data = directive.dataBinding.evaluate(source, ExecutionContext.default);
 
             expect(data).to.equal(source.items);
         });
@@ -54,7 +54,7 @@ describe("The repeat", () => {
             const itemTemplate = html`test`;
             const directive = repeat(array, itemTemplate) as RepeatDirective;
 
-            const data = directive.dataBinding({}, ExecutionContext.default);
+            const data = directive.dataBinding.evaluate({}, ExecutionContext.default);
 
             expect(data).to.equal(array);
         });
@@ -63,7 +63,7 @@ describe("The repeat", () => {
             const source = new ViewModel();
             const itemTemplate = html`test`;
             const directive = repeat<ViewModel>(x => x.items, itemTemplate) as RepeatDirective;
-            const template = directive.templateBinding(source, ExecutionContext.default);
+            const template = directive.templateBinding.evaluate(source, ExecutionContext.default);
             expect(template).to.equal(itemTemplate);
         });
 
@@ -71,7 +71,7 @@ describe("The repeat", () => {
             const source = new ViewModel();
             const itemTemplate = html`test`;
             const directive = repeat<ViewModel>(x => x.items, () => itemTemplate) as RepeatDirective;
-            const template = directive.templateBinding(source, ExecutionContext.default);
+            const template = directive.templateBinding.evaluate(source, ExecutionContext.default);
             expect(template).equal(itemTemplate);
         });
     });

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -3,7 +3,7 @@ import type { Behavior } from "../observation/behavior.js";
 import type { Notifier, Subscriber } from "../observation/notifier.js";
 import {
     Binding,
-    BindingObserver,
+    BindingNotifier,
     ExecutionContext,
     Observable,
 } from "../observation/observable.js";
@@ -66,10 +66,10 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
     private source: TSource | null = null;
     private views: SyntheticView[] = [];
     private template: SyntheticViewTemplate;
-    private templateBindingObserver: BindingObserver<TSource, SyntheticViewTemplate>;
+    private templateBindingObserver: BindingNotifier<TSource, SyntheticViewTemplate>;
     private items: readonly any[] | null = null;
     private itemsObserver: Notifier | null = null;
-    private itemsBindingObserver: BindingObserver<TSource, any[]>;
+    private itemsBindingObserver: BindingNotifier<TSource, any[]>;
     private context: ExecutionContext | undefined = void 0;
     private childContext: ExecutionContext | undefined = void 0;
     private bindView: typeof bindWithoutPositioning = bindWithoutPositioning;

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -343,7 +343,7 @@ HTMLDirective.define(RepeatDirective);
 /**
  * A directive that enables list rendering.
  * @param items - The array to render.
- * @param templateOrTemplateBinding - The template or a template binding used obtain a template
+ * @param template - The template or a template binding used obtain a template
  * to render for each item in the array.
  * @param options - Options used to turn on special repeat features.
  * @public
@@ -356,13 +356,13 @@ export function repeat<
         | Expression<TSource, TArray, ExecutionContext<TSource>>
         | Binding<TSource, TArray>
         | ReadonlyArray<any>,
-    templateOrTemplateBinding:
+    template:
         | Expression<TSource, ViewTemplate>
         | Binding<TSource, ViewTemplate>
         | ViewTemplate,
     options: RepeatOptions = defaultRepeatOptions
 ): CaptureType<TSource> {
     const dataBinding = normalizeBinding(items);
-    const templateBinding = normalizeBinding(templateOrTemplateBinding);
+    const templateBinding = normalizeBinding(template);
     return new RepeatDirective(dataBinding, templateBinding, options) as any;
 }

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -1,9 +1,9 @@
 import type { Behavior } from "../observation/behavior.js";
 import type { Notifier, Subscriber } from "../observation/notifier.js";
 import {
-    Binding,
-    BindingObserver,
     ExecutionContext,
+    Expression,
+    ExpressionObserver,
     Observable,
 } from "../observation/observable.js";
 import { emptyArray } from "../platform.js";
@@ -12,7 +12,7 @@ import { defaultBinding } from "../index.js";
 import { Markup, nextId } from "./markup.js";
 import {
     AddViewBehaviorFactory,
-    BindingConfiguration,
+    Binding,
     HTMLDirective,
     ViewBehaviorFactory,
     ViewBehaviorTargets,
@@ -67,10 +67,10 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
     private source: TSource | null = null;
     private views: SyntheticView[] = [];
     private template: SyntheticViewTemplate;
-    private templateBindingObserver: BindingObserver<TSource, SyntheticViewTemplate>;
+    private templateBindingObserver: ExpressionObserver<TSource, SyntheticViewTemplate>;
     private items: readonly any[] | null = null;
     private itemsObserver: Notifier | null = null;
-    private itemsBindingObserver: BindingObserver<TSource, any[]>;
+    private itemsBindingObserver: ExpressionObserver<TSource, any[]>;
     private context: ExecutionContext | undefined = void 0;
     private childContext: ExecutionContext | undefined = void 0;
     private bindView: typeof bindWithoutPositioning = bindWithoutPositioning;
@@ -322,11 +322,8 @@ export class RepeatDirective<TSource = any>
      * @param options - Options used to turn on special repeat features.
      */
     public constructor(
-        public readonly dataBinding: BindingConfiguration<TSource>,
-        public readonly templateBinding: BindingConfiguration<
-            TSource,
-            SyntheticViewTemplate
-        >,
+        public readonly dataBinding: Binding<TSource>,
+        public readonly templateBinding: Binding<TSource, SyntheticViewTemplate>,
         public readonly options: RepeatOptions
     ) {
         ArrayObserver.enable();
@@ -356,12 +353,12 @@ export function repeat<
     TArray extends ReadonlyArray<any> = ReadonlyArray<any>
 >(
     items:
-        | Binding<TSource, TArray, ExecutionContext<TSource>>
-        | BindingConfiguration<TSource, TArray>
+        | Expression<TSource, TArray, ExecutionContext<TSource>>
+        | Binding<TSource, TArray>
         | ReadonlyArray<any>,
     templateOrTemplateBinding:
+        | Expression<TSource, ViewTemplate>
         | Binding<TSource, ViewTemplate>
-        | BindingConfiguration<TSource, ViewTemplate>
         | ViewTemplate,
     options: RepeatOptions = defaultRepeatOptions
 ): CaptureType<TSource> {

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -8,7 +8,7 @@ import {
 } from "../observation/observable.js";
 import { emptyArray } from "../platform.js";
 import { ArrayObserver, Splice } from "../observation/arrays.js";
-import { defaultBinding } from "../index.js";
+import { normalizeBinding } from "../index.js";
 import { Markup, nextId } from "./markup.js";
 import {
     AddViewBehaviorFactory,
@@ -362,7 +362,7 @@ export function repeat<
         | ViewTemplate,
     options: RepeatOptions = defaultRepeatOptions
 ): CaptureType<TSource> {
-    const dataBinding = defaultBinding(items);
-    const templateBinding = defaultBinding(templateOrTemplateBinding);
+    const dataBinding = normalizeBinding(items);
+    const templateBinding = normalizeBinding(templateOrTemplateBinding);
     return new RepeatDirective(dataBinding, templateBinding, options) as any;
 }

--- a/packages/web-components/fast-element/src/templating/template.spec.ts
+++ b/packages/web-components/fast-element/src/templating/template.spec.ts
@@ -316,7 +316,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(stringValue);
+        expect(factory!.dataBinding.evaluate(null, ExecutionContext.default)).equals(stringValue);
     });
 
     it(`captures an attribute with an interpolated number`, () => {
@@ -336,7 +336,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(numberValue);
+        expect(factory!.dataBinding.evaluate(null, ExecutionContext.default)).equals(numberValue);
     });
 
     it(`captures a boolean attribute with an expression`, () => {
@@ -390,7 +390,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(true);
+        expect(factory!.dataBinding.evaluate(null, ExecutionContext.default)).equals(true);
     });
 
     it(`captures a case-sensitive property with an expression`, () => {
@@ -444,7 +444,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(stringValue);
+        expect(factory!.dataBinding.evaluate(null, ExecutionContext.default)).equals(stringValue);
     });
 
     it(`captures a case-sensitive property with an interpolated number`, () => {
@@ -464,7 +464,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(numberValue);
+        expect(factory!.dataBinding.evaluate(null, ExecutionContext.default)).equals(numberValue);
     });
 
     it(`captures a case-sensitive property with an inline directive`, () => {

--- a/packages/web-components/fast-element/src/templating/template.spec.ts
+++ b/packages/web-components/fast-element/src/templating/template.spec.ts
@@ -316,7 +316,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.binding(null, ExecutionContext.default)).equals(stringValue);
+        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(stringValue);
     });
 
     it(`captures an attribute with an interpolated number`, () => {
@@ -336,7 +336,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.binding(null, ExecutionContext.default)).equals(numberValue);
+        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(numberValue);
     });
 
     it(`captures a boolean attribute with an expression`, () => {
@@ -390,7 +390,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.binding(null, ExecutionContext.default)).equals(true);
+        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(true);
     });
 
     it(`captures a case-sensitive property with an expression`, () => {
@@ -444,7 +444,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.binding(null, ExecutionContext.default)).equals(stringValue);
+        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(stringValue);
     });
 
     it(`captures a case-sensitive property with an interpolated number`, () => {
@@ -464,7 +464,7 @@ describe(`The html tag template helper`, () => {
         );
 
         const factory = getFactory(template, HTMLBindingDirective);
-        expect(factory!.binding(null, ExecutionContext.default)).equals(numberValue);
+        expect(factory!.dataBinding.binding(null, ExecutionContext.default)).equals(numberValue);
     });
 
     it(`captures a case-sensitive property with an inline directive`, () => {

--- a/packages/web-components/fast-element/src/templating/template.ts
+++ b/packages/web-components/fast-element/src/templating/template.ts
@@ -1,12 +1,12 @@
 import { isFunction, isString } from "../interfaces.js";
-import { Binding, ExecutionContext } from "../observation/observable.js";
+import { ExecutionContext, Expression } from "../observation/observable.js";
 import { bind, HTMLBindingDirective, oneTime } from "./binding.js";
 import { Compiler } from "./compiler.js";
 import {
     AddViewBehaviorFactory,
     Aspect,
     Aspected,
-    BindingConfiguration,
+    Binding,
     HTMLDirective,
     HTMLDirectiveDefinition,
     ViewBehaviorFactory,
@@ -145,8 +145,8 @@ export interface CaptureType<TSource> {}
  * @public
  */
 export type TemplateValue<TSource, TParent = any> =
+    | Expression<TSource, any, TParent>
     | Binding<TSource, any, TParent>
-    | BindingConfiguration<TSource, any, TParent>
     | HTMLDirective
     | CaptureType<TSource>;
 
@@ -206,7 +206,7 @@ export function html<TSource = any, TParent = any>(
             } else {
                 html += currentValue;
             }
-        } else if (currentValue instanceof BindingConfiguration) {
+        } else if (currentValue instanceof Binding) {
             html += createAspectedHTML(
                 new HTMLBindingDirective(currentValue),
                 currentString,

--- a/packages/web-components/fast-element/src/templating/template.ts
+++ b/packages/web-components/fast-element/src/templating/template.ts
@@ -1,11 +1,12 @@
 import { isFunction, isString } from "../interfaces.js";
 import { Binding, ExecutionContext } from "../observation/observable.js";
-import { bind, BindingConfiguration, HTMLBindingDirective, oneTime } from "./binding.js";
+import { bind, HTMLBindingDirective, oneTime } from "./binding.js";
 import { Compiler } from "./compiler.js";
 import {
     AddViewBehaviorFactory,
     Aspect,
     Aspected,
+    BindingConfiguration,
     HTMLDirective,
     HTMLDirectiveDefinition,
     ViewBehaviorFactory,

--- a/packages/web-components/fast-element/src/templating/when.spec.ts
+++ b/packages/web-components/fast-element/src/templating/when.spec.ts
@@ -1,7 +1,7 @@
 import { expect } from "chai";
 import { when } from "./when.js";
 import { html } from "./template.js";
-import { Binding, ExecutionContext } from "../observation/observable.js";
+import { Expression, ExecutionContext } from "../observation/observable.js";
 
 describe("The 'when' template function", () => {
     it("returns an expression", () => {
@@ -14,25 +14,25 @@ describe("The 'when' template function", () => {
         const template = html`template1`;
 
         it("returns a template when the condition binding is true", () => {
-            const expression = when(() => true, template) as Binding;
+            const expression = when(() => true, template) as Expression;
             const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(template);
         });
 
         it("returns a template when the condition is statically true", () => {
-            const expression = when(true, template) as Binding;
+            const expression = when(true, template) as Expression;
             const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(template);
         });
 
         it("returns null when the condition binding is false", () => {
-            const expression = when(() => false, template) as Binding;
+            const expression = when(() => false, template) as Expression;
             const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(null);
         });
 
         it("returns null when the condition is statically false", () => {
-            const expression = when(false, template) as Binding;
+            const expression = when(false, template) as Expression;
             const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(null);
         });
@@ -41,7 +41,7 @@ describe("The 'when' template function", () => {
             const expression = when(
                 () => true,
                 () => template
-            ) as Binding;
+            ) as Expression;
             const result = expression(scope, ExecutionContext.default);
             expect(result).to.equal(template);
         });

--- a/packages/web-components/fast-element/src/templating/when.ts
+++ b/packages/web-components/fast-element/src/templating/when.ts
@@ -1,5 +1,5 @@
 import { isFunction } from "../interfaces.js";
-import type { Binding, ExecutionContext } from "../observation/observable.js";
+import type { ExecutionContext, Expression } from "../observation/observable.js";
 import type { CaptureType, SyntheticViewTemplate } from "./template.js";
 
 /**
@@ -10,10 +10,10 @@ import type { CaptureType, SyntheticViewTemplate } from "./template.js";
  * @public
  */
 export function when<TSource = any, TReturn = any>(
-    condition: Binding<TSource, TReturn> | boolean,
+    condition: Expression<TSource, TReturn> | boolean,
     templateOrTemplateBinding:
         | SyntheticViewTemplate
-        | Binding<TSource, SyntheticViewTemplate>
+        | Expression<TSource, SyntheticViewTemplate>
 ): CaptureType<TSource> {
     const dataBinding = isFunction(condition) ? condition : () => condition;
 

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
@@ -1,5 +1,6 @@
 import {
     attr,
+    bind,
     FASTElement,
     observable,
     RepeatBehavior,
@@ -177,9 +178,9 @@ export class FASTDataGridRow extends FASTElement {
 
             this.updateItemTemplate();
 
-            const cellsRepeatDirective = new RepeatDirective(
-                x => x.columnDefinitions,
-                x => x.activeCellItemTemplate,
+            const cellsRepeatDirective = new RepeatDirective<FASTDataGridRow>(
+                bind(x => x.columnDefinitions, false),
+                bind(x => x.activeCellItemTemplate, false),
                 { positioning: true }
             );
             this.cellsRepeatBehavior = cellsRepeatDirective.createBehavior({

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -1,5 +1,6 @@
 import {
     attr,
+    bind,
     FASTElement,
     observable,
     RepeatBehavior,
@@ -340,9 +341,9 @@ export class FASTDataGrid extends FASTElement {
 
         this.toggleGeneratedHeader();
 
-        const rowsRepeatDirective = new RepeatDirective(
-            x => x.rowsData,
-            x => x.rowItemTemplate,
+        const rowsRepeatDirective = new RepeatDirective<FASTDataGrid>(
+            bind(x => x.rowsData, false),
+            bind(x => x.rowItemTemplate, false),
             { positioning: true }
         );
         this.rowsRepeatBehavior = rowsRepeatDirective.createBehavior({

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -1,10 +1,10 @@
 import {
     Behavior,
-    Binding,
-    BindingObserver,
     CSSDirective,
     Disposable,
     ExecutionContext,
+    Expression,
+    ExpressionObserver,
     FASTElement,
     observable,
     Observable,
@@ -348,9 +348,9 @@ class CustomPropertyReflector {
  */
 class DesignTokenBindingObserver<T> implements Disposable {
     public readonly dependencies = new Set<DesignTokenImpl<any>>();
-    private observer: BindingObserver<HTMLElement, DerivedDesignTokenValue<T>>;
+    private observer: ExpressionObserver<HTMLElement, DerivedDesignTokenValue<T>>;
     constructor(
-        public readonly source: Binding<HTMLElement, DerivedDesignTokenValue<T>>,
+        public readonly source: Expression<HTMLElement, DerivedDesignTokenValue<T>>,
         public readonly token: DesignTokenImpl<T>,
         public readonly node: DesignTokenNode
     ) {

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -1,5 +1,6 @@
 import {
     attr,
+    bind,
     html,
     HTMLView,
     observable,
@@ -518,8 +519,8 @@ export class FASTPicker extends FormAssociatedPicker {
         this.updateOptionTemplate();
 
         const itemsRepeatDirective = new RepeatDirective(
-            x => x.selectedItems,
-            x => x.activeListItemTemplate,
+            bind(x => x.selectedItems, false),
+            bind(x => x.activeListItemTemplate, false),
             { positioning: true }
         );
         this.itemsRepeatBehavior = itemsRepeatDirective.createBehavior({
@@ -538,8 +539,8 @@ export class FASTPicker extends FormAssociatedPicker {
         );
 
         const optionsRepeatDirective = new RepeatDirective(
-            x => x.filteredOptionsList,
-            x => x.activeMenuOptionTemplate,
+            bind(x => x.filteredOptionsList, false),
+            bind(x => x.activeMenuOptionTemplate, false),
             { positioning: true }
         );
         this.optionsRepeatBehavior = optionsRepeatDirective.createBehavior({

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -52,7 +52,10 @@ export abstract class FASTElementRenderer extends ElementRenderer {
 
             if (view.hostDynamicAttributes) {
                 for (const attr of view.hostDynamicAttributes) {
-                    const result = attr.binding(this.element, ExecutionContext.default);
+                    const result = attr.dataBinding.evaluate(
+                        this.element,
+                        ExecutionContext.default
+                    );
 
                     const { target } = attr;
                     switch (attr.aspect) {

--- a/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/op-codes.ts
@@ -69,7 +69,7 @@ export type ViewBehaviorFactoryOp = {
  */
 export type AttributeBindingOp = {
     type: OpType.attributeBinding;
-    binding: Binding;
+    dataBinding: Binding;
     target: string;
     aspect: number;
     useCustomElementInstance: boolean;

--- a/packages/web-components/fast-ssr/src/template-parser/template-parser.ts
+++ b/packages/web-components/fast-ssr/src/template-parser/template-parser.ts
@@ -199,10 +199,10 @@ export function parseStringToOpCodes(
                     const factory = Compiler.aggregate(parsed) as ViewBehaviorFactory &
                         Aspected;
                     // Guard against directives like children, ref, and slotted
-                    if (factory.binding && factory.aspectType !== Aspect.content) {
+                    if (factory.dataBinding && factory.aspectType !== Aspect.content) {
                         prev.dynamic.set(current, {
                             type: OpType.attributeBinding,
-                            binding: factory.binding,
+                            dataBinding: factory.dataBinding,
                             aspect: factory.aspectType,
                             target: factory.targetAspect,
                             useCustomElementInstance: Boolean(

--- a/packages/web-components/fast-ssr/src/template-renderer/directives.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/directives.ts
@@ -91,8 +91,8 @@ export const RenderDirectiveRenderer: ViewBehaviorFactoryRenderer<RenderDirectiv
             renderer: TemplateRenderer,
             context: ExecutionContext
         ): IterableIterator<string> {
-            const data = directive.dataBinding(source, context);
-            const template = directive.templateBinding(source, context);
+            const data = directive.dataBinding.evaluate(source, context);
+            const template = directive.templateBinding.evaluate(source, context);
             const childContext = context.createChildContext(source);
 
             if (template instanceof ViewTemplate) {

--- a/packages/web-components/fast-ssr/src/template-renderer/directives.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/directives.ts
@@ -50,8 +50,8 @@ export const RepeatDirectiveRenderer: ViewBehaviorFactoryRenderer<RepeatDirectiv
             renderer: TemplateRenderer,
             context: ExecutionContext
         ): IterableIterator<string> {
-            const items = directive.dataBinding(source, context);
-            const template = directive.templateBinding(source, context);
+            const items = directive.dataBinding.evaluate(source, context);
+            const template = directive.templateBinding.evaluate(source, context);
             const childContext = context.createChildContext(source);
 
             if (template instanceof ViewTemplate) {

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
@@ -93,8 +93,8 @@ export class TemplateRenderer {
                             this,
                             context
                         );
-                    } else if (factory.aspectType && factory.binding) {
-                        const result = factory.binding(source, context);
+                    } else if (factory.aspectType && factory.dataBinding) {
+                        const result = factory.dataBinding.evaluate(source, context);
 
                         // If the result is a template, render the template
                         if (result instanceof ViewTemplate) {
@@ -179,13 +179,13 @@ export class TemplateRenderer {
                 }
 
                 case OpType.attributeBinding: {
-                    const { aspect, binding } = code;
+                    const { aspect, dataBinding: binding } = code;
                     // Don't emit anything for events or directives without bindings
                     if (aspect === Aspect.event) {
                         break;
                     }
 
-                    const result = binding(source, context);
+                    const result = binding.evaluate(source, context);
                     const renderer = this.getAttributeBindingRenderer(code);
 
                     if (renderer) {
@@ -205,7 +205,7 @@ export class TemplateRenderer {
                         const renderer = this.getAttributeBindingRenderer(attr);
 
                         if (renderer) {
-                            const result = attr.binding(source, context);
+                            const result = attr.dataBinding.evaluate(source, context);
                             yield " ";
                             yield* renderer(attr, result, renderInfo);
                         }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR significantly reworks the binding system.

### 🎫 Issues

* Closes #6220 

## 👩‍💻 Reviewer Notes

The core problem was that we had a way to use different "binding modes" but they could only be used for basic bindings. You could not, for example, say that a repeat template was just a `oneTime` binding (which was the most common case).

This PR refactors the system so that a `Binding` is no longer a bare function. In fact, `Binding` has been renamed to `Expression` and a new `Binding` base class as been introduced. Bindings now include the expression, but also carry along with them volatility information, options, and most critically the ability to create an observer for the binding.

All directives have been updated to take these new `Binding` types instead of `Expressions`. This means that we can specify `oneTime` on a `repeat` array, or `signal` on a `render` value, in addition to being able to use these on any standard binding. It's now much easier to write your own new types of bindings, which will work with every directive.

As a result of this, there are a series of optimizations that are also now in place:

* When passing a template to a `repeat`, we can automatically use a `oneTime` binding, which makes the most typical repeat scenario cheaper.
* When passing static data to a `repeat`, we can automatically use a `oneTime` binding.
* When passing templates, data, etc. to the `render` directive, we can use `oneTime` bindings with explicit data-triggered invalidation for most combinations of input.

This is a breaking set of changes in `fast-element`. I have fixed up `fast-foundation` and `fast-ssr` to use these new APIs. Most of the fixes were related to internal use of `RepeatDirective` and `RenderDirective`. I don't expect that this will result in many updates required by customers (if any).

## 📑 Test Plan

All tests have been updated to work against the new APIs.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

After this I plan to take a look at whether we can use view instances as execution contexts, which would open up some new capabilities for behaviors. This might also enable a set of optimizations that I'm thinking through.