### PR TITLE
feat: extract all error messages from context and DI

### DIFF
--- a/change/@microsoft-fast-element-6932c197-b0cf-43c8-8426-63c0dd29310f.json
+++ b/change/@microsoft-fast-element-6932c197-b0cf-43c8-8426-63c0dd29310f.json
@@ -3,5 +3,5 @@
   "comment": "feat: extract all error messages from context and DI",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-6932c197-b0cf-43c8-8426-63c0dd29310f.json
+++ b/change/@microsoft-fast-element-6932c197-b0cf-43c8-8426-63c0dd29310f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: extract all error messages from context and DI",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/context.ts
+++ b/packages/web-components/fast-element/src/context.ts
@@ -1,5 +1,6 @@
-import type { Constructable } from "./interfaces.js";
+import { Constructable, Message } from "./interfaces.js";
 import { Metadata } from "./metadata.js";
+import { FAST } from "./platform.js";
 
 /**
  * A Context object defines an optional initial value for a Context, as well as a name identifier for debugging purposes.
@@ -71,7 +72,9 @@ export const Context = Object.freeze({
             index: number
         ): void {
             if (target == null || new.target !== undefined) {
-                throw new Error(`No registration for context: '${Interface.name}'`);
+                throw FAST.error(Message.noRegistrationForContext, {
+                    name: Interface.name,
+                });
             }
 
             if (property) {

--- a/packages/web-components/fast-element/src/debug.ts
+++ b/packages/web-components/fast-element/src/debug.ts
@@ -19,6 +19,19 @@ const debugMessages = {
     [1204 /* hostBindingWithoutHost */]: "No host element is present. Cannot bind host with ${name}.",
     [1205 /* unsupportedBindingBehavior */]: "The requested binding behavior is not supported by the binding engine.",
     [1401 /* missingElementDefinition */]: "Missing FASTElement definition.",
+    [1501 /* noRegistrationForContext */]: "No registration for Context/Interface '${name}'.",
+    [1502 /* noFactoryForResolver */]: "Dependency injection resolver for '${key}' returned a null factory.",
+    [1503 /* invalidResolverStrategy */]: "Invalid dependency injection resolver strategy specified '${strategy}'.",
+    [1504 /* cannotAutoregisterDependency */]: "Unable to autoregister dependency.",
+    [1505 /* cannotResolveKey */]: "Unable to resolve dependency injection key '${key}'.",
+    [1506 /* cannotConstructNativeFunction */]: "'${name}' is a native function and therefore cannot be safely constructed by DI. If this is intentional, please use a callback or cachedCallback resolver.",
+    [1507 /* cannotJITRegisterNonConstructor */]: "Attempted to jitRegister something that is not a constructor '${value}'. Did you forget to register this dependency?",
+    [1508 /* cannotJITRegisterIntrinsic */]: "Attempted to jitRegister an intrinsic type '${value}'. Did you forget to add @inject(Key)?",
+    [1509 /* cannotJITRegisterInterface */]: "Attempted to jitRegister an interface '${value}'.",
+    [1510 /* invalidResolver */]: "A valid resolver was not returned from the register method.",
+    [1511 /* invalidKey */]: "Key/value cannot be null or undefined. Are you trying to inject/register something that doesn't exist with DI?",
+    [1512 /* noDefaultResolver */]: "'${key}' not registered. Did you forget to add @singleton()?",
+    [1513 /* cyclicDependency */]: "Cyclic dependency found '${name}'.",
 };
 
 const allPlaceholders = /(\$\{\w+?})/g;
@@ -30,7 +43,7 @@ function formatMessage(message: string, values: Record<string, any>) {
         .split(allPlaceholders)
         .map(v => {
             const replaced = v.replace(placeholder, "$1");
-            return values[replaced] || v;
+            return String(values[replaced] ?? v);
         })
         .join("");
 }

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -202,6 +202,20 @@ export const enum Message {
     // 1301 - 1400 Styles
     // 1401 - 1500 Components
     missingElementDefinition = 1401,
+    // 1501 - 1600 Context and Dependency Injection
+    noRegistrationForContext = 1501,
+    noFactoryForResolver = 1502,
+    invalidResolverStrategy = 1503,
+    cannotAutoregisterDependency = 1504,
+    cannotResolveKey = 1505,
+    cannotConstructNativeFunction = 1506,
+    cannotJITRegisterNonConstructor = 1507,
+    cannotJITRegisterIntrinsic = 1508,
+    cannotJITRegisterInterface = 1509,
+    invalidResolver = 1510,
+    invalidKey = 1511,
+    noDefaultResolver = 1512,
+    cyclicDependency = 1513,
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR extracts all error messages from the `Context` and `DI` features, updating this code to use the `FAST.error()` helper and the `debug` module.

### 🎫 Issues

* Closes #6060 

## 👩‍💻 Reviewer Notes

This PR started with the intent of fixing #6060 by properly handling the key conversion to string. However, during that process it was discovered that context and DI were not yet using the new error messaging system. So, I took this opportunity to update everything to use that system, which internally also handles the string conversion issue.

## 📑 Test Plan

All existing tests pass.

## ✅ Checklist

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

No additional related work known at this time.