### PR TITLE
Adaptive UI: fixed missing export and incorrect min-contrast token values

### DIFF
--- a/change/@microsoft-adaptive-ui-86f29544-ac82-46b2-9c74-1253dd8a514d.json
+++ b/change/@microsoft-adaptive-ui-86f29544-ac82-46b2-9c74-1253dd8a514d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixed missing export and incorrect min-contrast token values",
+  "packageName": "@microsoft/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/utilities/adaptive-ui/docs/api-report.md
+++ b/packages/utilities/adaptive-ui/docs/api-report.md
@@ -98,6 +98,14 @@ export const _black: SwatchRGB;
 // @public
 export function blackOrWhiteByContrast(reference: Swatch, minContrast: number, defaultBlack: boolean): Swatch;
 
+// @public
+export function blackOrWhiteByContrastSet(restReference: Swatch, hoverReference: Swatch, activeReference: Swatch, focusReference: Swatch, minContrast: number, defaultBlack: boolean): {
+    rest: Swatch;
+    hover: Swatch;
+    active: Swatch;
+    focus: Swatch;
+};
+
 // @public (undocumented)
 export const bodyFont: CSSDesignToken<string>;
 
@@ -114,6 +122,12 @@ export function contrastAndDeltaSwatchSet(palette: Palette, reference: Swatch, m
 
 // @public
 export function contrastSwatch(palette: Palette, reference: Swatch, minContrast: number, direction?: PaletteDirection): Swatch;
+
+// @public
+export const ContrastTarget: Readonly<{
+    readonly NormalText: 4.5;
+    readonly LargeText: 3;
+}>;
 
 // @public (undocumented)
 export const controlCornerRadius: CSSDesignToken<number>;

--- a/packages/utilities/adaptive-ui/src/color/recipes/index.ts
+++ b/packages/utilities/adaptive-ui/src/color/recipes/index.ts
@@ -1,3 +1,4 @@
+export * from "./black-or-white-by-contrast-set.js";
 export * from "./black-or-white-by-contrast.js";
 export * from "./contrast-and-delta-swatch-set.js";
 export * from "./contrast-swatch.js";

--- a/packages/utilities/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/utilities/adaptive-ui/src/design-tokens/color.ts
@@ -14,6 +14,11 @@ import { Swatch, SwatchRGB } from "../color/swatch.js";
 import { create, createNonCss } from "./create.js";
 import { accentPalette, neutralPalette } from "./palette.js";
 
+/**
+ * Convenience values for WCAG contrast requirements.
+ *
+ * @public
+ */
 export const ContrastTarget = Object.freeze({
     /**
      * Minimum contrast for normal (<= 14pt) text (AA rating).

--- a/packages/utilities/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/utilities/adaptive-ui/src/design-tokens/color.ts
@@ -14,10 +14,17 @@ import { Swatch, SwatchRGB } from "../color/swatch.js";
 import { create, createNonCss } from "./create.js";
 import { accentPalette, neutralPalette } from "./palette.js";
 
-enum ContrastTarget {
-    NormalText = 4.5,
-    LargeText = 3,
-}
+export const ContrastTarget = Object.freeze({
+    /**
+     * Minimum contrast for normal (<= 14pt) text (AA rating).
+     */
+    NormalText: 4.5,
+
+    /**
+     * Minimum contrast for large (> 14pt) text (AA rating).
+     */
+    LargeText: 3,
+} as const);
 
 /** @public */
 export const fillColor = create<Swatch>("fill-color").withDefault(
@@ -149,7 +156,7 @@ export const foregroundOnAccentFocus = create<Swatch>(
 /** @public */
 export const accentForegroundMinContrast = createNonCss<number>(
     "accent-foreground-min-contrast"
-).withDefault(0);
+).withDefault(ContrastTarget.NormalText);
 
 /** @public */
 export const accentForegroundRestDelta = createNonCss<number>(
@@ -584,7 +591,7 @@ export const neutralFillStealthFocus = create<Swatch>(
 /** @public */
 export const neutralFillStrongMinContrast = createNonCss<number>(
     "neutral-fill-strong-min-contrast"
-).withDefault(0);
+).withDefault(3);
 
 /** @public */
 export const neutralFillStrongRestDelta = createNonCss<number>(

--- a/packages/utilities/adaptive-ui/src/type/type-ramp.ts
+++ b/packages/utilities/adaptive-ui/src/type/type-ramp.ts
@@ -1,4 +1,4 @@
-import { cssPartial } from "@microsoft/fast-element";
+import { css } from "@microsoft/fast-element";
 import {
     bodyFont,
     typeRampBaseFontSize,
@@ -31,7 +31,7 @@ import {
 } from "../design-tokens/type.js";
 
 /** @public */
-export const typeRampBase = cssPartial`
+export const typeRampBase = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampBaseFontSize};
     line-height: ${typeRampBaseLineHeight};
@@ -40,7 +40,7 @@ export const typeRampBase = cssPartial`
 `;
 
 /** @public */
-export const typeRampMinus1 = cssPartial`
+export const typeRampMinus1 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampMinus1FontSize};
     line-height: ${typeRampMinus1LineHeight};
@@ -49,7 +49,7 @@ export const typeRampMinus1 = cssPartial`
 `;
 
 /** @public */
-export const typeRampMinus2 = cssPartial`
+export const typeRampMinus2 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampMinus2FontSize};
     line-height: ${typeRampMinus2LineHeight};
@@ -58,7 +58,7 @@ export const typeRampMinus2 = cssPartial`
 `;
 
 /** @public */
-export const typeRampPlus1 = cssPartial`
+export const typeRampPlus1 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus1FontSize};
     line-height: ${typeRampPlus1LineHeight};
@@ -67,7 +67,7 @@ export const typeRampPlus1 = cssPartial`
 `;
 
 /** @public */
-export const typeRampPlus2 = cssPartial`
+export const typeRampPlus2 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus2FontSize};
     line-height: ${typeRampPlus2LineHeight};
@@ -76,7 +76,7 @@ export const typeRampPlus2 = cssPartial`
 `;
 
 /** @public */
-export const typeRampPlus3 = cssPartial`
+export const typeRampPlus3 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus3FontSize};
     line-height: ${typeRampPlus3LineHeight};
@@ -85,7 +85,7 @@ export const typeRampPlus3 = cssPartial`
 `;
 
 /** @public */
-export const typeRampPlus4 = cssPartial`
+export const typeRampPlus4 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus4FontSize};
     line-height: ${typeRampPlus4LineHeight};
@@ -94,7 +94,7 @@ export const typeRampPlus4 = cssPartial`
 `;
 
 /** @public */
-export const typeRampPlus5 = cssPartial`
+export const typeRampPlus5 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus5FontSize};
     line-height: ${typeRampPlus5LineHeight};
@@ -103,7 +103,7 @@ export const typeRampPlus5 = cssPartial`
 `;
 
 /** @public */
-export const typeRampPlus6 = cssPartial`
+export const typeRampPlus6 = css.partial`
     font-family: ${bodyFont};
     font-size: ${typeRampPlus6FontSize};
     line-height: ${typeRampPlus6LineHeight};


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixed missing export for `black-or-white-by-contrast-set`.
Fixed incorrect default value `0` for `accent-foreground-min-contrast` and `neutral-fill-strong-min-contrast`.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.