### PR TITLE
fix: make insertBefore no-op in View if view already exists

### DIFF
--- a/change/@microsoft-fast-element-2fee7ceb-82a3-45ee-8d5f-aa2c622619d1.json
+++ b/change/@microsoft-fast-element-2fee7ceb-82a3-45ee-8d5f-aa2c622619d1.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make insertbefore noop in view",
+  "packageName": "@microsoft/fast-element",
+  "email": "prudepixie@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-2fee7ceb-82a3-45ee-8d5f-aa2c622619d1.json
+++ b/change/@microsoft-fast-element-2fee7ceb-82a3-45ee-8d5f-aa2c622619d1.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "make insertbefore noop in view",
   "packageName": "@microsoft/fast-element",
   "email": "prudepixie@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/src/templating/view.ts
+++ b/packages/web-components/fast-element/src/templating/view.ts
@@ -149,12 +149,12 @@ export class HTMLView<TSource = any, TParent = any>
         if (this.fragment.hasChildNodes()) {
             node.parentNode!.insertBefore(this.fragment, node);
         } else {
-            const parentNode = node.parentNode!;
             const end = this.lastChild!;
+            if (node.previousSibling === end) return;
+
+            const parentNode = node.parentNode!;
             let current = this.firstChild!;
             let next;
-
-            if (node.previousSibling === end) return;
 
             while (current !== end) {
                 next = current.nextSibling;

--- a/packages/web-components/fast-element/src/templating/view.ts
+++ b/packages/web-components/fast-element/src/templating/view.ts
@@ -154,6 +154,8 @@ export class HTMLView<TSource = any, TParent = any>
             let current = this.firstChild!;
             let next;
 
+            if (node.previousSibling === end) return;
+
             while (current !== end) {
                 next = current.nextSibling;
                 parentNode.insertBefore(current, node);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

Following up on the discussions related to Repeat directive updateViews(), 
on line 216 `view.insertBefore(location)`, there were discussions around how there could be optimization opportunity to not run insertBefore() if view already exists. 

After investigating, there were 2 solutions, this being one of them. The other being https://github.com/microsoft/fast/tree/users/wendy/insert-before-repeat.

Before making the final decision on which one to use, there were some bug fixes and other optimization work in the Repeat directive that have been added to the master branch:

- https://github.com/microsoft/fast/pull/6072
- https://github.com/microsoft/fast/pull/6153
- https://github.com/microsoft/fast/pull/6162

Included in these fixes, more tests have been added and as a result, solution from https://github.com/microsoft/fast/tree/users/wendy/insert-before-repeat no longer passes all the tests, also it wasn't considered to be as elegant of a solution as this one.

This solution, while does not affect overall performance (no significant improvement) based on the benchmarks run, it should still be added to the view API as it can return early if conditions are met.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
reference document: https://microsoft-my.sharepoint.com/:w:/p/wendywendy/EaMnhNG4vcpBj5aoFETZNx4BG2OLd0PfuZIhzCSPv8-Wyw?e=IP5yUa
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->