### PR TITLE
fix: change select() method to public on text field, number field, and text area

### DIFF
--- a/change/@microsoft-fast-foundation-14d4f603-9786-4d4d-8db4-af050205e43e.json
+++ b/change/@microsoft-fast-foundation-14d4f603-9786-4d4d-8db4-af050205e43e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "change select() method to public on number field, text field, and text area",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1325,7 +1325,7 @@ export class FASTNumberField extends FormAssociatedNumberField {
     minlength: number;
     placeholder: string;
     readOnly: boolean;
-    public select(): void;
+    select(): void;
     size: number;
     step: number;
     stepDown(): void;
@@ -1859,7 +1859,7 @@ export class FASTTextArea extends FormAssociatedTextArea {
     protected readOnlyChanged(): void;
     resize: TextAreaResize;
     rows: number;
-    public select(): void;
+    select(): void;
     spellcheck: boolean;
     // (undocumented)
     protected spellcheckChanged(): void;
@@ -1906,7 +1906,7 @@ export class FASTTextField extends FormAssociatedTextField {
     readOnly: boolean;
     // (undocumented)
     protected readOnlyChanged(): void;
-    public select(): void;
+    select(): void;
     size: number;
     // (undocumented)
     protected sizeChanged(): void;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1325,7 +1325,7 @@ export class FASTNumberField extends FormAssociatedNumberField {
     minlength: number;
     placeholder: string;
     readOnly: boolean;
-    protected select(): void;
+    public select(): void;
     size: number;
     step: number;
     stepDown(): void;
@@ -1859,7 +1859,7 @@ export class FASTTextArea extends FormAssociatedTextArea {
     protected readOnlyChanged(): void;
     resize: TextAreaResize;
     rows: number;
-    protected select(): void;
+    public select(): void;
     spellcheck: boolean;
     // (undocumented)
     protected spellcheckChanged(): void;
@@ -1906,7 +1906,7 @@ export class FASTTextField extends FormAssociatedTextField {
     readOnly: boolean;
     // (undocumented)
     protected readOnlyChanged(): void;
-    protected select(): void;
+    public select(): void;
     size: number;
     // (undocumented)
     protected sizeChanged(): void;

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -316,7 +316,7 @@ export class FASTNumberField extends FormAssociatedNumberField {
      *
      * @public
      */
-    protected select(): void {
+    public select(): void {
         this.control.select();
 
         /**

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -176,7 +176,7 @@ export class FASTTextArea extends FormAssociatedTextArea {
      *
      * @public
      */
-    protected select(): void {
+    public select(): void {
         this.control.select();
 
         /**

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -217,7 +217,7 @@ export class FASTTextField extends FormAssociatedTextField {
      *
      * @public
      */
-    protected select(): void {
+    public select(): void {
         this.control.select();
 
         /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

In #5900 the select() method was added to the text field, number field, and text area, but it was added as a protected member. It should be public so that it can be called by clients.

### 🎫 Issues

See discussion at end of #5626 

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

N/A

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
