### PR TITLE
feat: Add subpath export for `package.json` to relevant packages

### DIFF
--- a/change/@microsoft-fast-element-a27fdcc8-d888-4229-ac44-2143ed5695c5.json
+++ b/change/@microsoft-fast-element-a27fdcc8-d888-4229-ac44-2143ed5695c5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add subpath export for package.json to packages",
+  "packageName": "@microsoft/fast-element",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-a27fdcc8-d888-4229-ac44-2143ed5695c5.json
+++ b/change/@microsoft-fast-element-a27fdcc8-d888-4229-ac44-2143ed5695c5.json
@@ -3,5 +3,5 @@
   "comment": "add subpath export for package.json to packages",
   "packageName": "@microsoft/fast-element",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-1cc57b28-a6e7-4aaf-a8c6-85db045a5197.json
+++ b/change/@microsoft-fast-foundation-1cc57b28-a6e7-4aaf-a8c6-85db045a5197.json
@@ -3,5 +3,5 @@
   "comment": "add subpath export for package.json to packages",
   "packageName": "@microsoft/fast-foundation",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-1cc57b28-a6e7-4aaf-a8c6-85db045a5197.json
+++ b/change/@microsoft-fast-foundation-1cc57b28-a6e7-4aaf-a8c6-85db045a5197.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add subpath export for package.json to packages",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-ssr-1bf4c529-ce6e-4701-9a14-b8dba91f593a.json
+++ b/change/@microsoft-fast-ssr-1bf4c529-ce6e-4701-9a14-b8dba91f593a.json
@@ -3,5 +3,5 @@
   "comment": "add subpath export for package.json to packages",
   "packageName": "@microsoft/fast-ssr",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-ssr-1bf4c529-ce6e-4701-9a14-b8dba91f593a.json
+++ b/change/@microsoft-fast-ssr-1bf4c529-ce6e-4701-9a14-b8dba91f593a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add subpath export for package.json to packages",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/package.json
+++ b/packages/web-components/fast-element/package.json
@@ -69,7 +69,8 @@
     "./di": {
       "types": "./dist/dts/di/di.d.ts",
       "default": "./dist/esm/di/di.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "unpkg": "dist/fast-element.min.js",
   "sideEffects": [

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -26,7 +26,8 @@
       "types": "./dist/dts/index.d.ts",
       "default": "./dist/esm/index.js"
     },
-    "./custom-elements.json": "./dist/custom-elements.json"
+    "./custom-elements.json": "./dist/custom-elements.json",
+    "./package.json": "./package.json"
   },
   "scripts": {
     "clean:dist": "node ../../../build/clean.js dist",

--- a/packages/web-components/fast-ssr/package.json
+++ b/packages/web-components/fast-ssr/package.json
@@ -45,7 +45,8 @@
     "./dom-shim": {
       "types": "./dist/dts/dom-shim.d.ts",
       "default": "./dist/esm/dom-shim.js"
-    }
+    },
+    "./package.json": "./package.json"
   },
   "dependencies": {
     "parse5": "^6.0.1",


### PR DESCRIPTION
# Pull Request

## 📖 Description
Tooling that reads from the package.json is unable to when the package is using subpath exports unless the package.json is also exported via subpath

### 🎫 Issues
#6255 
#6217

## 👩‍💻 Reviewer Notes
Node scripts using `require.resolve` to read the `package.json` as well as ESM imports throw errors unless the file is exported.

## ✅ Checklist

### General

- [X] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
