### PR TITLE
fix: recycle feature in Repeat should be set to true by default

### DIFF
--- a/change/@microsoft-fast-element-3f983e5a-b3a2-4c16-a9f4-7f2ef2734574.json
+++ b/change/@microsoft-fast-element-3f983e5a-b3a2-4c16-a9f4-7f2ef2734574.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "make sure default options for recycle gets set in different scenarios",
+  "packageName": "@microsoft/fast-element",
+  "email": "prudepixie@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-3f983e5a-b3a2-4c16-a9f4-7f2ef2734574.json
+++ b/change/@microsoft-fast-element-3f983e5a-b3a2-4c16-a9f4-7f2ef2734574.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "make sure default options for recycle gets set in different scenarios",
   "packageName": "@microsoft/fast-element",
   "email": "prudepixie@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/src/templating/repeat.spec.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.spec.ts
@@ -31,6 +31,35 @@ describe("The repeat", () => {
             expect(directive).to.be.instanceOf(RepeatDirective);
         });
 
+        it("returns a RepeatDirective with optional properties set to default values", () => {
+            const directive = repeat(
+                () => [],
+                html`test`
+            ) as RepeatDirective;
+            expect(directive).to.be.instanceOf(RepeatDirective);
+            expect(directive.options).to.deep.equal({positioning: false, recycle: true})
+        });
+
+        it("returns a RepeatDirective with recycle property set to default value when positioning is set to different value", () => {
+            const directive = repeat(
+                () => [],
+                html`test`,
+                {positioning: true}
+            ) as RepeatDirective;
+            expect(directive).to.be.instanceOf(RepeatDirective);
+            expect(directive.options).to.deep.equal({positioning: true, recycle: true})
+        });
+
+        it("returns a RepeatDirective with positioning property set to default value when recycle is set to different value", () => {
+            const directive = repeat(
+                () => [],
+                html`test`,
+                {recycle: false}
+            ) as RepeatDirective;
+            expect(directive).to.be.instanceOf(RepeatDirective);
+            expect(directive.options).to.deep.equal({positioning: false, recycle: false})
+        });
+
         it("returns a RepeatDirective with optional properties set to different values", () => {
             const directive = repeat(
                 () => [],

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -366,5 +366,8 @@ export function repeat<
 ): CaptureType<TSource> {
     const dataBinding = normalizeBinding(items);
     const templateBinding = normalizeBinding(template);
-    return new RepeatDirective(dataBinding, templateBinding, options) as any;
+    return new RepeatDirective(dataBinding, templateBinding, {
+        ...defaultRepeatOptions,
+        ...options,
+    }) as any;
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
There are 2 options you can set with the Repeat directive: positioning and recycle. When you don't set either options, the default value is being set as expected {positioning: false, recycle: true}. When you set only one of them (like in the repro) {positioning: true}, recycle does not get set, that is probably why you were seeing undefined. The fix needs to give options default values when user only sets one of the properties. 
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->