### PR TITLE
fix: recycle feature in Repeat should be set to true by default

### DIFF
--- a/change/@microsoft-fast-element-d32c650f-5342-4e06-8feb-1d9c82bbe1b5.json
+++ b/change/@microsoft-fast-element-d32c650f-5342-4e06-8feb-1d9c82bbe1b5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "default options in repeat should be set in various scenarios",
+  "packageName": "@microsoft/fast-element",
+  "email": "prudepixie@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-react-wrapper-c99427d3-8284-482e-b1c2-a575a3d0c89a.json
+++ b/change/@microsoft-fast-react-wrapper-c99427d3-8284-482e-b1c2-a575a3d0c89a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "updating change file",
+  "packageName": "@microsoft/fast-react-wrapper",
+  "email": "prudepixie@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-router-1d4ccbc9-d1f6-49fe-aba6-4f59ccb9f29c.json
+++ b/change/@microsoft-fast-router-1d4ccbc9-d1f6-49fe-aba6-4f59ccb9f29c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "updating change file",
+  "packageName": "@microsoft/fast-router",
+  "email": "prudepixie@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -19,7 +19,7 @@ export class AttachedBehaviorHTMLDirective<T = any> extends HTMLDirective {
     constructor(name: string, behavior: AttachedBehaviorType<T>, options: T);
     createBehavior(target: Node): Behavior;
     createPlaceholder(index: number): string;
-    }
+}
 
 // @public
 export type AttachedBehaviorType<T = any> = new (target: any, options: T) => Behavior;
@@ -52,7 +52,7 @@ export class AttributeDefinition implements Accessor {
     onAttributeChangedCallback(element: HTMLElement, value: any): void;
     readonly Owner: Function;
     setValue(source: HTMLElement, newValue: any): void;
-    }
+}
 
 // @public
 export type AttributeMode = "reflect" | "boolean" | "fromView";
@@ -135,7 +135,7 @@ export class ChildrenBehavior extends NodeObservationBehavior<ChildrenBehaviorOp
     disconnect(): void;
     protected getNodes(): ChildNode[];
     observe(): void;
-    }
+}
 
 // @public
 export type ChildrenBehaviorOptions<T = any> = ChildListBehaviorOptions<T> | SubtreeBehaviorOptions<T>;
@@ -352,7 +352,7 @@ export class HTMLBindingDirective extends TargetedHTMLDirective {
     targetAtContent(): void;
     get targetName(): string | undefined;
     set targetName(value: string | undefined);
-    }
+}
 
 // @public
 export abstract class HTMLDirective implements NodeBehaviorFactory {
@@ -482,14 +482,20 @@ export class RepeatBehavior<TSource = any> implements Behavior, Subscriber {
     // @internal (undocumented)
     handleChange(source: any, args: Splice[]): void;
     unbind(): void;
-    }
+}
 
 // @public
 export class RepeatDirective<TSource = any> extends HTMLDirective {
     constructor(itemsBinding: Binding, templateBinding: Binding<TSource, SyntheticViewTemplate>, options: RepeatOptions);
     createBehavior(target: Node): RepeatBehavior<TSource>;
     createPlaceholder: (index: number) => string;
-    }
+    // (undocumented)
+    readonly itemsBinding: Binding;
+    // (undocumented)
+    readonly options: RepeatOptions;
+    // (undocumented)
+    readonly templateBinding: Binding<TSource, SyntheticViewTemplate>;
+}
 
 // @public
 export interface RepeatOptions {
@@ -605,14 +611,13 @@ export class ViewTemplate<TSource = any, TParent = any> implements ElementViewTe
     readonly directives: ReadonlyArray<HTMLDirective>;
     readonly html: string | HTMLTemplateElement;
     render(source: TSource, host: Node | string, hostBindingTarget?: Element): HTMLView;
-    }
+}
 
 // @public
 export function volatile(target: {}, name: string | Accessor, descriptor: PropertyDescriptor): PropertyDescriptor;
 
 // @public
 export function when<TSource = any, TReturn = any>(binding: Binding<TSource, TReturn>, templateOrTemplateBinding: SyntheticViewTemplate | Binding<TSource, SyntheticViewTemplate>): CaptureType<TSource>;
-
 
 // (No @packageDocumentation comment for this package)
 

--- a/packages/web-components/fast-element/src/templating/repeat.spec.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.spec.ts
@@ -1,5 +1,5 @@
 import { expect } from "chai";
-import { repeat, RepeatDirective, RepeatBehavior } from "./repeat";
+import { repeat, RepeatDirective, RepeatOptions, RepeatBehavior } from "./repeat";
 import { html } from "./template";
 import { defaultExecutionContext, observable } from "../observation/observable";
 import { DOM } from "../dom";
@@ -11,8 +11,46 @@ describe("The repeat", () => {
             const directive = repeat(
                 () => [],
                 html`test`
-            );
+            ) as RepeatDirective;
             expect(directive).to.be.instanceOf(RepeatDirective);
+        });
+
+        it("returns a RepeatDirective with optional properties set to default values", () => {
+            const directive = repeat(
+                () => [],
+                html`test`
+            ) as RepeatDirective;
+            expect(directive).to.be.instanceOf(RepeatDirective);
+            expect(directive.options as RepeatOptions).to.deep.equal({positioning: false, recycle: true})
+        });
+        it("returns a RepeatDirective with recycle property set to default value when positioning is set to different value", () => {
+            const directive = repeat(
+                () => [],
+                html`test`,
+                {positioning: true}
+            ) as RepeatDirective;
+            expect(directive).to.be.instanceOf(RepeatDirective);
+            expect(directive.options as RepeatOptions).to.deep.equal({positioning: true, recycle: true})
+        });
+
+        it("returns a RepeatDirective with positioning property set to default value when recycle is set to different value", () => {
+            const directive = repeat(
+                () => [],
+                html`test`,
+                {recycle: false}
+            ) as RepeatDirective;
+            expect(directive).to.be.instanceOf(RepeatDirective);
+            expect(directive.options as RepeatOptions).to.deep.equal({positioning: false, recycle: false})
+        });
+
+        it("returns a RepeatDirective with optional properties set to different values", () => {
+            const directive = repeat(
+                () => [],
+                html`test`,
+                {positioning: true, recycle: false}
+            ) as RepeatDirective;
+            expect(directive).to.be.instanceOf(RepeatDirective);
+            expect(directive.options as RepeatOptions).to.deep.equal({positioning: true, recycle: false})
         });
     });
 

--- a/packages/web-components/fast-element/src/templating/repeat.ts
+++ b/packages/web-components/fast-element/src/templating/repeat.ts
@@ -323,9 +323,9 @@ export class RepeatDirective<TSource = any> extends HTMLDirective {
      * @param options - Options used to turn on special repeat features.
      */
     public constructor(
-        private itemsBinding: Binding,
-        private templateBinding: Binding<TSource, SyntheticViewTemplate>,
-        private options: RepeatOptions
+        public readonly itemsBinding: Binding,
+        public readonly templateBinding: Binding<TSource, SyntheticViewTemplate>,
+        public readonly options: RepeatOptions
     ) {
         super();
         enableArrayObservation();
@@ -369,5 +369,8 @@ export function repeat<TSource = any, TItem = any>(
             ? templateOrTemplateBinding
             : (): SyntheticViewTemplate => templateOrTemplateBinding;
 
-    return new RepeatDirective<TSource>(itemsBinding, templateBinding, options);
+    return new RepeatDirective<TSource>(itemsBinding, templateBinding, {
+        ...defaultRepeatOptions,
+        ...options,
+    });
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

Backport changes from : https://github.com/microsoft/fast/pull/6283

Additionally, I had to make some changes to the RepeatDirective constructor to change some properties to **public readonly**, so the options property can be used for testing purposes. 

There are 2 options you can set with the Repeat directive: positioning and recycle. When you don't set either options, the default value is being set as expected {positioning: false, recycle: true}. When you set only one of them (like in the repro) {positioning: true}, recycle does not get set, that is probably why you were seeing undefined. The fix needs to give options default values when user only sets one of the properties.


<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->