### PR TITLE
feat: implement DSD polyfill as an optional plugin for FAST SSR

### DIFF
--- a/change/@microsoft-fast-ssr-93d4338f-50c8-4672-bd23-9ad9939af65a.json
+++ b/change/@microsoft-fast-ssr-93d4338f-50c8-4672-bd23-9ad9939af65a.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: implement Declarative Shadow DOM polyfill as an optional plugin for FAST Server Side Rendering",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-ssr-93d4338f-50c8-4672-bd23-9ad9939af65a.json
+++ b/change/@microsoft-fast-ssr-93d4338f-50c8-4672-bd23-9ad9939af65a.json
@@ -3,5 +3,5 @@
   "comment": "feat: implement Declarative Shadow DOM polyfill as an optional plugin for FAST Server Side Rendering",
   "packageName": "@microsoft/fast-ssr",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/examples/ssr/server.js
+++ b/examples/ssr/server.js
@@ -2,7 +2,7 @@
 import "@microsoft/fast-ssr/install-dom-shim";
 import fs from "fs";
 import { html } from "@microsoft/fast-element";
-import fastSSR, { RequestStorageManager } from "@microsoft/fast-ssr";
+import fastSSR, { RequestStorageManager, DeclarativeShadowDOMPolyfill } from "@microsoft/fast-ssr";
 import express from "express";
 import { DefaultTodoList, app as todoApp, TodoList } from "fast-todo-app";
 
@@ -22,8 +22,10 @@ const template = html`
             <meta charset="UTF-8" />
             <meta name="viewport" content="width=device-width, initial-scale=1.0" />
             <title>SSR Example</title>
+            <style>${DeclarativeShadowDOMPolyfill.undefinedElementStyles}</style>
         <body>
             <todo-app></todo-app>
+            <script>${DeclarativeShadowDOMPolyfill.nonStreamingTemplateUpgrade}</script>
             <!--
                 Use caution in production environments embedding JSON.
                 In general the JSON should be sanitized to prevent

--- a/packages/web-components/fast-ssr/docs/api-report.md
+++ b/packages/web-components/fast-ssr/docs/api-report.md
@@ -19,6 +19,12 @@ export type ComponentDOMEmissionMode = "shadow";
 // @beta (undocumented)
 export type ConstructableElementRenderer = (new (tagName: string, renderInfo: RenderInfo) => ElementRenderer) & typeof ElementRenderer;
 
+// @public
+export const DeclarativeShadowDOMPolyfill: Readonly<{
+    undefinedElementStyles: ":not(:defined) > template[shadowroot] ~ *  {\n    display: none;\n}";
+    nonStreamingTemplateUpgrade: "if (!HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot')) {\n    (function attachShadowRoots(root) {\n        root.querySelectorAll(\"template[shadowroot]\").forEach(template => {\n            const mode = template.getAttribute(\"shadowroot\");\n            const shadowRoot = template.parentNode.attachShadow({ mode });\n            shadowRoot.appendChild(template.content);\n            template.remove();\n            attachShadowRoots(shadowRoot);\n        });\n    })(document);\n}";
+}>;
+
 // @beta (undocumented)
 export abstract class ElementRenderer {
     constructor(tagName: string, renderInfo: RenderInfo);

--- a/packages/web-components/fast-ssr/docs/api-report.md
+++ b/packages/web-components/fast-ssr/docs/api-report.md
@@ -21,8 +21,8 @@ export type ConstructableElementRenderer = (new (tagName: string, renderInfo: Re
 
 // @public
 export const DeclarativeShadowDOMPolyfill: Readonly<{
-    undefinedElementStyles: ":not(:defined) > template[shadowroot] ~ *  {\n    display: none;\n}";
-    nonStreamingTemplateUpgrade: "if (!HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot')) {\n    (function attachShadowRoots(root) {\n        root.querySelectorAll(\"template[shadowroot]\").forEach(template => {\n            const mode = template.getAttribute(\"shadowroot\");\n            const shadowRoot = template.parentNode.attachShadow({ mode });\n            shadowRoot.appendChild(template.content);\n            template.remove();\n            attachShadowRoots(shadowRoot);\n        });\n    })(document);\n}";
+    undefinedElementStyles: string;
+    nonStreamingTemplateUpgrade: string;
 }>;
 
 // @beta (undocumented)

--- a/packages/web-components/fast-ssr/src/declarative-shadow-dom-polyfill.ts
+++ b/packages/web-components/fast-ssr/src/declarative-shadow-dom-polyfill.ts
@@ -12,8 +12,7 @@ export const DeclarativeShadowDOMPolyfill = Object.freeze({
      * These styles should be used in a style element tag in the head
      * of the HTML document.
      */
-    undefinedElementStyles:
-`:not(:defined) > template[shadowroot] ~ *  {
+    undefinedElementStyles: `:not(:defined) > template[shadowroot] ~ *  {
     display: none;
 }` as string,
     /**
@@ -23,8 +22,7 @@ export const DeclarativeShadowDOMPolyfill = Object.freeze({
      * This is a one-time operation that should be placed at the end of the SSR'd
      * HTML but before any other scripts run.
      */
-    nonStreamingTemplateUpgrade:
-`if (!HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot')) {
+    nonStreamingTemplateUpgrade: `if (!HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot')) {
     (function attachShadowRoots(root) {
         root.querySelectorAll("template[shadowroot]").forEach(template => {
             const mode = template.getAttribute("shadowroot");
@@ -34,5 +32,5 @@ export const DeclarativeShadowDOMPolyfill = Object.freeze({
             attachShadowRoots(shadowRoot);
         });
     })(document);
-}` as string
+}` as string,
 });

--- a/packages/web-components/fast-ssr/src/declarative-shadow-dom-polyfill.ts
+++ b/packages/web-components/fast-ssr/src/declarative-shadow-dom-polyfill.ts
@@ -1,0 +1,38 @@
+// Reference: https://web.dev/declarative-shadow-dom/
+
+/**
+ * Provides style and JavaScript code snippets for polyfills related
+ * to Declarative Shadow DOM (DSD).
+ */
+export const DeclarativeShadowDOMPolyfill = Object.freeze({
+    /**
+     * Styles that hide undefined elements, taking account of the
+     * fact that undefined elements with DSD should not be hidden.
+     * @remarks
+     * These styles should be used in a style element tag in the head
+     * of the HTML document.
+     */
+    undefinedElementStyles:
+`:not(:defined) > template[shadowroot] ~ *  {
+    display: none;
+}`,
+    /**
+     * A JavaScript polyfill for DSD that recursively converts all templates
+     * in the document with the shadowroot attribute into actual shadow roots.
+     * @remarks
+     * This is a one-time operation that should be placed at the end of the SSR'd
+     * HTML but before any other scripts run.
+     */
+    nonStreamingTemplateUpgrade:
+`if (!HTMLTemplateElement.prototype.hasOwnProperty('shadowRoot')) {
+    (function attachShadowRoots(root) {
+        root.querySelectorAll("template[shadowroot]").forEach(template => {
+            const mode = template.getAttribute("shadowroot");
+            const shadowRoot = template.parentNode.attachShadow({ mode });
+            shadowRoot.appendChild(template.content);
+            template.remove();
+            attachShadowRoots(shadowRoot);
+        });
+    })(document);
+}`
+});

--- a/packages/web-components/fast-ssr/src/declarative-shadow-dom-polyfill.ts
+++ b/packages/web-components/fast-ssr/src/declarative-shadow-dom-polyfill.ts
@@ -15,7 +15,7 @@ export const DeclarativeShadowDOMPolyfill = Object.freeze({
     undefinedElementStyles:
 `:not(:defined) > template[shadowroot] ~ *  {
     display: none;
-}`,
+}` as string,
     /**
      * A JavaScript polyfill for DSD that recursively converts all templates
      * in the document with the shadowroot attribute into actual shadow roots.
@@ -34,5 +34,5 @@ export const DeclarativeShadowDOMPolyfill = Object.freeze({
             attachShadowRoots(shadowRoot);
         });
     })(document);
-}`
+}` as string
 });

--- a/packages/web-components/fast-ssr/src/exports.ts
+++ b/packages/web-components/fast-ssr/src/exports.ts
@@ -81,6 +81,7 @@ export default function fastSSR(): {
 }
 
 export * from "./request-storage.js";
+export * from "./declarative-shadow-dom-polyfill.js";
 export type {
     ComponentDOMEmissionMode,
     ElementRenderer,


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR embeds the necessary CSS and JavaScript polyfill code to ensure that Declarative Shadow DOM (DSD) is properly handled on browsers that don't yet implement the standard.

The SSR example has been updated to emit the polyfill code into the page.

### 🎫 Issues

* Closes #6288

## 👩‍💻 Reviewer Notes

The polyfill code is generally available on the web. This PR simply embeds it in our SSR package for convenience.

See the SSR example `server.js` file for usage.

## 📑 Test Plan

No tests added for this as this just provides a convenience API over a well-known polyfill.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

An alternative polyfill method that supports streaming could be added. For this, we would embed a small global script in the page head and then emit a script tag immediately following each DSD instance, which called that global function, passing in the `currentScript`. This has some perf implications, since it would block the parser after every DSD instance. It also would require deeper integration into our renderer in order to emit the script tag after the close of the DSD template tag.

Due to the downsides and increased complexity of this approach, I'm not pursuing implementing this for now. We can revisit this if there is a specific request for it. Additionally, it will likely be easier to implement into the renderer after the shared styles feature is complete, since both will need renderer configuration that is passed through the tree and both need to custom render content per component.