### PR TITLE
Revert "Add meta name="csp-nonce" to getNonce function"

### DIFF
--- a/change/@microsoft-fast-web-utilities-0a5de467-491d-4b86-9221-22f97f7d85de.json
+++ b/change/@microsoft-fast-web-utilities-0a5de467-491d-4b86-9221-22f97f7d85de.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "Added meta name to getNonce function",
-  "packageName": "@microsoft/fast-web-utilities",
-  "email": "mcentola@appliedengdesign.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/utilities/fast-web-utilities/src/dom.spec.ts
+++ b/packages/utilities/fast-web-utilities/src/dom.spec.ts
@@ -55,42 +55,10 @@ describe("canUseFocusVisible", () => {
     it("should return true if the environment supports focus-visible selectors", () => {
         expect(canUseFocusVisible()).to.equal(true);
     });
-    it("should use a nonce if meta property is present on the page", () => {
+    it("should use a nonce if once is present on the page", () => {
         const nonce: string = "foo-nonce";
         const metaEl: HTMLMetaElement = document.createElement("meta");
         metaEl.setAttribute("property", "csp-nonce");
-        metaEl.setAttribute("content", nonce);
-        document.head.appendChild(metaEl);
-
-        // Run the function and intercept its appendChild call
-        const realAppendChild = document.head.appendChild;
-        const mockAppendChild = chai.spy(realAppendChild);
-        Object.defineProperty(document.head, "appendChild", {
-            value: mockAppendChild,
-            configurable: true,
-        });
-        const mutationObserverCallback = (mutationsList: MutationRecord[]): void => {
-            expect(mutationsList).to.have.length.greaterThan(0);
-            expect(mutationsList[0].addedNodes).to.have.length.greaterThan(0);
-            expect(mutationsList[0].addedNodes.item(0)).not.to.equal(undefined);
-            expect(
-                (mutationsList[0].addedNodes.item(0) as HTMLStyleElement).nonce
-            ).to.equal(nonce);
-        };
-        const mutationObserver = new MutationObserver(mutationObserverCallback);
-        mutationObserver.observe(document.head, { childList: true, subtree: true });
-        canUseFocusVisible();
-
-        expect(mockAppendChild).to.have.been.called.exactly(1);
-        Object.defineProperty(document.head, "appendChild", {
-            value: realAppendChild,
-            configurable: true,
-        });
-    });
-    it("should use a nonce if meta name is present on the page", () => {
-        const nonce: string = "foo-nonce";
-        const metaEl: HTMLMetaElement = document.createElement("meta");
-        metaEl.setAttribute("name", "csp-nonce");
         metaEl.setAttribute("content", nonce);
         document.head.appendChild(metaEl);
 

--- a/packages/utilities/fast-web-utilities/src/dom.ts
+++ b/packages/utilities/fast-web-utilities/src/dom.ts
@@ -31,9 +31,7 @@ export function getDisplayedNodes(
  * Based on https://github.com/cssinjs/jss/blob/master/packages/jss/src/DomRenderer.js
  */
 function getNonce(): string | null {
-    const node = document.querySelector(
-        'meta[property="csp-nonce"], meta[name="csp-nonce"]'
-    );
+    const node = document.querySelector('meta[property="csp-nonce"]');
     if (node) {
         return node.getAttribute("content");
     } else {


### PR DESCRIPTION
Reverts microsoft/fast#6253

Updating this library creates complications in our publishing process while we're iterating on alpha/beta packages because we have non-beta packages that rely on it, so either way we configure the change file, packages will update versions incorrectly. Since this is a non-critical change, I'm going to revert this so we can get packages published.