### PR TITLE
Fix constraint validation in components

### DIFF
--- a/change/@microsoft-fast-foundation-eb26a2f6-c059-4ee2-bd81-3886503e454b.json
+++ b/change/@microsoft-fast-foundation-eb26a2f6-c059-4ee2-bd81-3886503e454b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix constraint validation in focus-delegated components",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -764,7 +764,6 @@ export class FASTButton extends FormAssociatedButton {
     type: "submit" | "reset" | "button";
     // (undocumented)
     protected typeChanged(previous: "submit" | "reset" | "button" | void, next: "submit" | "reset" | "button"): void;
-    // (undocumented)
     validate(): void;
 }
 
@@ -886,7 +885,6 @@ export class FASTCombobox extends FormAssociatedCombobox {
     setPositioning(): void;
     // @internal
     slottedOptionsChanged(prev: Element[] | undefined, next: Element[]): void;
-    // (undocumented)
     validate(): void;
     get value(): string;
     set value(next: string);
@@ -1357,7 +1355,6 @@ export class FASTNumberField extends FormAssociatedNumberField {
     step: number;
     stepDown(): void;
     stepUp(): void;
-    // (undocumented)
     validate(): void;
     get valueAsNumber(): number;
     set valueAsNumber(next: number);
@@ -1627,7 +1624,6 @@ export class FASTSearch extends FormAssociatedSearch {
     spellcheck: boolean;
     // (undocumented)
     protected spellcheckChanged(): void;
-    // (undocumented)
     validate(): void;
 }
 
@@ -1894,7 +1890,6 @@ export class FASTTextArea extends FormAssociatedTextArea {
     spellcheck: boolean;
     // (undocumented)
     protected spellcheckChanged(): void;
-    // (undocumented)
     validate(): void;
 }
 
@@ -1947,7 +1942,6 @@ export class FASTTextField extends FormAssociatedTextField {
     // (undocumented)
     protected spellcheckChanged(): void;
     type: TextFieldType;
-    // (undocumented)
     validate(): void;
 }
 
@@ -2161,47 +2155,34 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
 //
 // @beta
 export interface FormAssociated extends Omit<ElementInternals_2, "labels"> {
-    // (undocumented)
     attachProxy(): void;
-    // (undocumented)
     currentValue: string;
-    // (undocumented)
     detachProxy(): void;
-    // (undocumented)
     dirtyValue: boolean;
-    // (undocumented)
     disabled: boolean;
     // (undocumented)
     disabledChanged?(previous: boolean, next: boolean): void;
-    // (undocumented)
     readonly elementInternals: ElementInternals_2 | null;
     // (undocumented)
     readonly formAssociated: boolean;
-    // (undocumented)
     formDisabledCallback?(disabled: boolean): void;
     // (undocumented)
     formResetCallback(): void;
-    // (undocumented)
     initialValue: string;
     // (undocumented)
     initialValueChanged?(previous: string, next: string): void;
     // (undocumented)
     readonly labels: ReadonlyArray<Node[]>;
-    // (undocumented)
     name: string;
     // (undocumented)
     nameChanged?(previous: string, next: string): void;
-    // (undocumented)
     required: boolean;
     // (undocumented)
     requiredChanged(prev: boolean, next: boolean): void;
     // (undocumented)
     stopPropagation(e: Event): void;
-    // (undocumented)
     validate(target?: HTMLElement): void;
-    // (undocumented)
     value: string;
-    // (undocumented)
     valueChanged(previous: string, next: string): void;
 }
 

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -762,6 +762,8 @@ export class FASTButton extends FormAssociatedButton {
     type: "submit" | "reset" | "button";
     // (undocumented)
     protected typeChanged(previous: "submit" | "reset" | "button" | void, next: "submit" | "reset" | "button"): void;
+    // (undocumented)
+    validate(): void;
 }
 
 // @internal
@@ -882,6 +884,8 @@ export class FASTCombobox extends FormAssociatedCombobox {
     setPositioning(): void;
     // @internal
     slottedOptionsChanged(prev: Element[] | undefined, next: Element[]): void;
+    // (undocumented)
+    validate(): void;
     get value(): string;
     set value(next: string);
 }
@@ -1351,6 +1355,8 @@ export class FASTNumberField extends FormAssociatedNumberField {
     step: number;
     stepDown(): void;
     stepUp(): void;
+    // (undocumented)
+    validate(): void;
     get valueAsNumber(): number;
     set valueAsNumber(next: number);
     // @internal
@@ -1619,6 +1625,8 @@ export class FASTSearch extends FormAssociatedSearch {
     spellcheck: boolean;
     // (undocumented)
     protected spellcheckChanged(): void;
+    // (undocumented)
+    validate(): void;
 }
 
 // @internal
@@ -1884,6 +1892,8 @@ export class FASTTextArea extends FormAssociatedTextArea {
     spellcheck: boolean;
     // (undocumented)
     protected spellcheckChanged(): void;
+    // (undocumented)
+    validate(): void;
 }
 
 // @internal
@@ -1935,6 +1945,8 @@ export class FASTTextField extends FormAssociatedTextField {
     // (undocumented)
     protected spellcheckChanged(): void;
     type: TextFieldType;
+    // (undocumented)
+    validate(): void;
 }
 
 // @internal
@@ -2184,7 +2196,7 @@ export interface FormAssociated extends Omit<ElementInternals_2, "labels"> {
     // (undocumented)
     stopPropagation(e: Event): void;
     // (undocumented)
-    validate(): void;
+    validate(target?: HTMLElement): void;
     // (undocumented)
     value: string;
     // (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2155,34 +2155,46 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
 //
 // @beta
 export interface FormAssociated extends Omit<ElementInternals_2, "labels"> {
+    // (undocumented)
     attachProxy(): void;
+    // (undocumented)
     currentValue: string;
+    // (undocumented)
     detachProxy(): void;
+    // (undocumented)
     dirtyValue: boolean;
+    // (undocumented)
     disabled: boolean;
     // (undocumented)
     disabledChanged?(previous: boolean, next: boolean): void;
+    // (undocumented)
     readonly elementInternals: ElementInternals_2 | null;
     // (undocumented)
     readonly formAssociated: boolean;
+    // (undocumented)
     formDisabledCallback?(disabled: boolean): void;
     // (undocumented)
     formResetCallback(): void;
+    // (undocumented)
     initialValue: string;
     // (undocumented)
     initialValueChanged?(previous: string, next: string): void;
     // (undocumented)
     readonly labels: ReadonlyArray<Node[]>;
+    // (undocumented)
     name: string;
     // (undocumented)
     nameChanged?(previous: string, next: string): void;
+    // (undocumented)
     required: boolean;
     // (undocumented)
     requiredChanged(prev: boolean, next: boolean): void;
     // (undocumented)
     stopPropagation(e: Event): void;
-    validate(target?: HTMLElement): void;
+    validate(anchor?: HTMLElement): void;
+    // (undocumented)
     value: string;
+    // (undocumented)
     valueChanged(previous: string, next: string): void;
 }
 

--- a/packages/web-components/fast-foundation/src/button/README.md
+++ b/packages/web-components/fast-foundation/src/button/README.md
@@ -117,6 +117,7 @@ This component is built with the expectation that focus is delegated to the butt
 | `formnovalidateChanged` | protected |             |                                                                                            | `void` |                |
 | `formtargetChanged`     | protected |             |                                                                                            | `void` |                |
 | `typeChanged`           | protected |             | `previous: "submit" or "reset" or "button" or void, next: "submit" or "reset" or "button"` | `void` |                |
+| `validate`              | public    |             |                                                                                            | `void` |                |
 
 #### Attributes
 

--- a/packages/web-components/fast-foundation/src/button/README.md
+++ b/packages/web-components/fast-foundation/src/button/README.md
@@ -109,15 +109,15 @@ This component is built with the expectation that focus is delegated to the butt
 
 #### Methods
 
-| Name                    | Privacy   | Description | Parameters                                                                                 | Return | Inherited From |
-| ----------------------- | --------- | ----------- | ------------------------------------------------------------------------------------------ | ------ | -------------- |
-| `formactionChanged`     | protected |             |                                                                                            | `void` |                |
-| `formenctypeChanged`    | protected |             |                                                                                            | `void` |                |
-| `formmethodChanged`     | protected |             |                                                                                            | `void` |                |
-| `formnovalidateChanged` | protected |             |                                                                                            | `void` |                |
-| `formtargetChanged`     | protected |             |                                                                                            | `void` |                |
-| `typeChanged`           | protected |             | `previous: "submit" or "reset" or "button" or void, next: "submit" or "reset" or "button"` | `void` |                |
-| `validate`              | public    |             |                                                                                            | `void` |                |
+| Name                    | Privacy   | Description                                       | Parameters                                                                                 | Return | Inherited From |
+| ----------------------- | --------- | ------------------------------------------------- | ------------------------------------------------------------------------------------------ | ------ | -------------- |
+| `formactionChanged`     | protected |                                                   |                                                                                            | `void` |                |
+| `formenctypeChanged`    | protected |                                                   |                                                                                            | `void` |                |
+| `formmethodChanged`     | protected |                                                   |                                                                                            | `void` |                |
+| `formnovalidateChanged` | protected |                                                   |                                                                                            | `void` |                |
+| `formtargetChanged`     | protected |                                                   |                                                                                            | `void` |                |
+| `typeChanged`           | protected |                                                   | `previous: "submit" or "reset" or "button" or void, next: "submit" or "reset" or "button"` | `void` |                |
+| `validate`              | public    | {@inheritDoc (FormAssociated:interface).validate} |                                                                                            | `void` |                |
 
 #### Attributes
 

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -154,6 +154,10 @@ export class FASTButton extends FormAssociatedButton {
     @observable
     public defaultSlottedContent: HTMLElement[];
 
+    public validate(): void {
+        super.validate(this.control);
+    }
+
     /**
      * @internal
      */

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -154,6 +154,7 @@ export class FASTButton extends FormAssociatedButton {
     @observable
     public defaultSlottedContent: HTMLElement[];
 
+    /** {@inheritDoc (FormAssociated:interface).validate} */
     public validate(): void {
         super.validate(this.control);
     }

--- a/packages/web-components/fast-foundation/src/combobox/README.md
+++ b/packages/web-components/fast-foundation/src/combobox/README.md
@@ -184,6 +184,7 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 | Name                 | Privacy   | Description                                                                | Parameters                                                             | Return | Inherited From |
 | -------------------- | --------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------ | -------------- |
+| `validate`           | public    |                                                                            |                                                                        | `void` |                |
 | `positionChanged`    | protected |                                                                            | `prev: SelectPosition or undefined, next: SelectPosition or undefined` | `void` |                |
 | `filterOptions`      | public    | Filter available options by text value.                                    |                                                                        | `void` |                |
 | `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. | `force`                                                                | `void` |                |

--- a/packages/web-components/fast-foundation/src/combobox/README.md
+++ b/packages/web-components/fast-foundation/src/combobox/README.md
@@ -184,7 +184,7 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 | Name                 | Privacy   | Description                                                                | Parameters                                                             | Return | Inherited From |
 | -------------------- | --------- | -------------------------------------------------------------------------- | ---------------------------------------------------------------------- | ------ | -------------- |
-| `validate`           | public    |                                                                            |                                                                        | `void` |                |
+| `validate`           | public    | {@inheritDoc (FormAssociated:interface).validate}                          |                                                                        | `void` |                |
 | `positionChanged`    | protected |                                                                            | `prev: SelectPosition or undefined, next: SelectPosition or undefined` | `void` |                |
 | `filterOptions`      | public    | Filter available options by text value.                                    |                                                                        | `void` |                |
 | `setPositioning`     | public    | Calculate and apply listbox positioning based on available viewport space. | `force`                                                                | `void` |                |

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -98,6 +98,7 @@ export class FASTCombobox extends FormAssociatedCombobox {
         this.updateValue();
     }
 
+    /** {@inheritDoc (FormAssociated:interface).validate} */
     public validate(): void {
         super.validate(this.control);
     }

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -98,6 +98,10 @@ export class FASTCombobox extends FormAssociatedCombobox {
         this.updateValue();
     }
 
+    public validate(): void {
+        super.validate(this.control);
+    }
+
     private get isAutocompleteInline(): boolean {
         return (
             this.autocomplete === ComboboxAutocomplete.inline || this.isAutocompleteBoth

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -125,7 +125,14 @@ export interface FormAssociated extends Omit<ElementInternals, "labels"> {
     nameChanged?(previous: string, next: string): void;
     requiredChanged(prev: boolean, next: boolean): void;
     stopPropagation(e: Event): void;
-    validate(target?: HTMLElement): void;
+
+    /**
+     * Sets the validity of the custom element. By default this uses the proxy element to determine
+     * validity, but this can be extended or replaced in implementation.
+     *
+     * @param anchor - The anchor element to provide to {@link (FormAssociated:interface).setValidity} for surfacing the browser's constraint validation UI
+     */
+    validate(anchor?: HTMLElement): void;
     valueChanged(previous: string, next: string): void;
 }
 
@@ -625,10 +632,7 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
             this.shadowRoot?.removeChild(this.proxySlot as HTMLSlotElement);
         }
 
-        /**
-         * Sets the validity of the custom element. By default this uses the proxy element to determine
-         * validity, but this can be extended or replaced in implementation.
-         */
+        /** {@inheritDoc (FormAssociated:interface).validate} */
         public validate(anchor?: HTMLElement): void {
             if (this.proxy instanceof HTMLElement) {
                 this.setValidity(

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -130,7 +130,7 @@ export interface FormAssociated extends Omit<ElementInternals, "labels"> {
      * Sets the validity of the custom element. By default this uses the proxy element to determine
      * validity, but this can be extended or replaced in implementation.
      *
-     * @param anchor - The anchor element to provide to {@link (FormAssociated:interface).setValidity} for surfacing the browser's constraint validation UI
+     * @param anchor - The anchor element to provide to ElementInternals.setValidity for surfacing the browser's constraint validation UI
      */
     validate(anchor?: HTMLElement): void;
     valueChanged(previous: string, next: string): void;

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -125,7 +125,7 @@ export interface FormAssociated extends Omit<ElementInternals, "labels"> {
     nameChanged?(previous: string, next: string): void;
     requiredChanged(prev: boolean, next: boolean): void;
     stopPropagation(e: Event): void;
-    validate(): void;
+    validate(target?: HTMLElement): void;
     valueChanged(previous: string, next: string): void;
 }
 
@@ -629,9 +629,13 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
          * Sets the validity of the custom element. By default this uses the proxy element to determine
          * validity, but this can be extended or replaced in implementation.
          */
-        public validate(): void {
+        public validate(anchor?: HTMLElement): void {
             if (this.proxy instanceof HTMLElement) {
-                this.setValidity(this.proxy.validity, this.proxy.validationMessage);
+                this.setValidity(
+                    this.proxy.validity,
+                    this.proxy.validationMessage,
+                    anchor
+                );
             }
         }
 

--- a/packages/web-components/fast-foundation/src/number-field/README.md
+++ b/packages/web-components/fast-foundation/src/number-field/README.md
@@ -131,6 +131,7 @@ This component is built with the expectation that focus is delegated to the inpu
 
 | Name       | Privacy | Description                               | Parameters | Return | Inherited From |
 | ---------- | ------- | ----------------------------------------- | ---------- | ------ | -------------- |
+| `validate` | public  |                                           |            | `void` |                |
 | `stepUp`   | public  | Increments the value using the step value |            | `void` |                |
 | `stepDown` | public  | Decrements the value using the step value |            | `void` |                |
 | `select`   | public  | Selects all the text in the number field  |            | `void` |                |

--- a/packages/web-components/fast-foundation/src/number-field/README.md
+++ b/packages/web-components/fast-foundation/src/number-field/README.md
@@ -129,12 +129,12 @@ This component is built with the expectation that focus is delegated to the inpu
 
 #### Methods
 
-| Name       | Privacy | Description                               | Parameters | Return | Inherited From |
-| ---------- | ------- | ----------------------------------------- | ---------- | ------ | -------------- |
-| `validate` | public  |                                           |            | `void` |                |
-| `stepUp`   | public  | Increments the value using the step value |            | `void` |                |
-| `stepDown` | public  | Decrements the value using the step value |            | `void` |                |
-| `select`   | public  | Selects all the text in the number field  |            | `void` |                |
+| Name       | Privacy | Description                                       | Parameters | Return | Inherited From |
+| ---------- | ------- | ------------------------------------------------- | ---------- | ------ | -------------- |
+| `validate` | public  | {@inheritDoc (FormAssociated:interface).validate} |            | `void` |                |
+| `stepUp`   | public  | Increments the value using the step value         |            | `void` |                |
+| `stepDown` | public  | Decrements the value using the step value         |            | `void` |                |
+| `select`   | public  | Selects all the text in the number field          |            | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -235,6 +235,10 @@ export class FASTNumberField extends FormAssociatedNumberField {
         this.isUserInput = false;
     }
 
+    public validate(): void {
+        super.validate(this.control);
+    }
+
     /**
      * Sets the internal value to a valid number between the min and max properties
      * @param value - user input

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -235,6 +235,7 @@ export class FASTNumberField extends FormAssociatedNumberField {
         this.isUserInput = false;
     }
 
+    /** {@inheritDoc (FormAssociated:interface).validate} */
     public validate(): void {
         super.validate(this.control);
     }

--- a/packages/web-components/fast-foundation/src/search/README.md
+++ b/packages/web-components/fast-foundation/src/search/README.md
@@ -108,19 +108,19 @@ This component is built with the expectation that focus is delegated to the inpu
 
 #### Methods
 
-| Name                 | Privacy   | Description                             | Parameters | Return | Inherited From |
-| -------------------- | --------- | --------------------------------------- | ---------- | ------ | -------------- |
-| `readOnlyChanged`    | protected |                                         |            | `void` |                |
-| `autofocusChanged`   | protected |                                         |            | `void` |                |
-| `placeholderChanged` | protected |                                         |            | `void` |                |
-| `listChanged`        | protected |                                         |            | `void` |                |
-| `maxlengthChanged`   | protected |                                         |            | `void` |                |
-| `minlengthChanged`   | protected |                                         |            | `void` |                |
-| `patternChanged`     | protected |                                         |            | `void` |                |
-| `sizeChanged`        | protected |                                         |            | `void` |                |
-| `spellcheckChanged`  | protected |                                         |            | `void` |                |
-| `validate`           | public    |                                         |            | `void` |                |
-| `handleClearInput`   | public    | Handles the control's clear value event |            | `void` |                |
+| Name                 | Privacy   | Description                                       | Parameters | Return | Inherited From |
+| -------------------- | --------- | ------------------------------------------------- | ---------- | ------ | -------------- |
+| `readOnlyChanged`    | protected |                                                   |            | `void` |                |
+| `autofocusChanged`   | protected |                                                   |            | `void` |                |
+| `placeholderChanged` | protected |                                                   |            | `void` |                |
+| `listChanged`        | protected |                                                   |            | `void` |                |
+| `maxlengthChanged`   | protected |                                                   |            | `void` |                |
+| `minlengthChanged`   | protected |                                                   |            | `void` |                |
+| `patternChanged`     | protected |                                                   |            | `void` |                |
+| `sizeChanged`        | protected |                                                   |            | `void` |                |
+| `spellcheckChanged`  | protected |                                                   |            | `void` |                |
+| `validate`           | public    | {@inheritDoc (FormAssociated:interface).validate} |            | `void` |                |
+| `handleClearInput`   | public    | Handles the control's clear value event           |            | `void` |                |
 
 #### Attributes
 

--- a/packages/web-components/fast-foundation/src/search/README.md
+++ b/packages/web-components/fast-foundation/src/search/README.md
@@ -119,6 +119,7 @@ This component is built with the expectation that focus is delegated to the inpu
 | `patternChanged`     | protected |                                         |            | `void` |                |
 | `sizeChanged`        | protected |                                         |            | `void` |                |
 | `spellcheckChanged`  | protected |                                         |            | `void` |                |
+| `validate`           | public    |                                         |            | `void` |                |
 | `handleClearInput`   | public    | Handles the control's clear value event |            | `void` |                |
 
 #### Attributes

--- a/packages/web-components/fast-foundation/src/search/search.ts
+++ b/packages/web-components/fast-foundation/src/search/search.ts
@@ -200,6 +200,7 @@ export class FASTSearch extends FormAssociatedSearch {
         }
     }
 
+    /** {@inheritDoc (FormAssociated:interface).validate} */
     public validate(): void {
         super.validate(this.control);
     }

--- a/packages/web-components/fast-foundation/src/search/search.ts
+++ b/packages/web-components/fast-foundation/src/search/search.ts
@@ -200,6 +200,10 @@ export class FASTSearch extends FormAssociatedSearch {
         }
     }
 
+    public validate(): void {
+        super.validate(this.control);
+    }
+
     /**
      * Handles the internal control's `input` event
      * @internal

--- a/packages/web-components/fast-foundation/src/text-area/README.md
+++ b/packages/web-components/fast-foundation/src/text-area/README.md
@@ -126,6 +126,7 @@ This component is built with the expectation that focus is delegated to the inpu
 | `minlengthChanged`  | protected |                                       |            | `void` |                |
 | `spellcheckChanged` | protected |                                       |            | `void` |                |
 | `select`            | public    | Selects all the text in the text area |            | `void` |                |
+| `validate`          | public    |                                       |            | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/text-area/README.md
+++ b/packages/web-components/fast-foundation/src/text-area/README.md
@@ -117,16 +117,16 @@ This component is built with the expectation that focus is delegated to the inpu
 
 #### Methods
 
-| Name                | Privacy   | Description                           | Parameters | Return | Inherited From |
-| ------------------- | --------- | ------------------------------------- | ---------- | ------ | -------------- |
-| `readOnlyChanged`   | protected |                                       |            | `void` |                |
-| `autofocusChanged`  | protected |                                       |            | `void` |                |
-| `listChanged`       | protected |                                       |            | `void` |                |
-| `maxlengthChanged`  | protected |                                       |            | `void` |                |
-| `minlengthChanged`  | protected |                                       |            | `void` |                |
-| `spellcheckChanged` | protected |                                       |            | `void` |                |
-| `select`            | public    | Selects all the text in the text area |            | `void` |                |
-| `validate`          | public    |                                       |            | `void` |                |
+| Name                | Privacy   | Description                                       | Parameters | Return | Inherited From |
+| ------------------- | --------- | ------------------------------------------------- | ---------- | ------ | -------------- |
+| `readOnlyChanged`   | protected |                                                   |            | `void` |                |
+| `autofocusChanged`  | protected |                                                   |            | `void` |                |
+| `listChanged`       | protected |                                                   |            | `void` |                |
+| `maxlengthChanged`  | protected |                                                   |            | `void` |                |
+| `minlengthChanged`  | protected |                                                   |            | `void` |                |
+| `spellcheckChanged` | protected |                                                   |            | `void` |                |
+| `select`            | public    | Selects all the text in the text area             |            | `void` |                |
+| `validate`          | public    | {@inheritDoc (FormAssociated:interface).validate} |            | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -214,8 +214,6 @@ export class FASTTextArea extends FormAssociatedTextArea {
     }
 }
 
-const foo = new FASTTextArea();
-foo.disabled;
 /**
  * Mark internal because exporting class and interface of the same name
  * confuses API documenter.

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -207,6 +207,10 @@ export class FASTTextArea extends FormAssociatedTextArea {
     public handleChange(): void {
         this.$emit("change");
     }
+
+    public validate(): void {
+        super.validate(this.control);
+    }
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -208,11 +208,14 @@ export class FASTTextArea extends FormAssociatedTextArea {
         this.$emit("change");
     }
 
+    /** {@inheritDoc (FormAssociated:interface).validate} */
     public validate(): void {
         super.validate(this.control);
     }
 }
 
+const foo = new FASTTextArea();
+foo.disabled;
 /**
  * Mark internal because exporting class and interface of the same name
  * confuses API documenter.

--- a/packages/web-components/fast-foundation/src/text-field/README.md
+++ b/packages/web-components/fast-foundation/src/text-field/README.md
@@ -132,6 +132,7 @@ This component is built with the expectation that focus is delegated to the inpu
 | `sizeChanged`        | protected |                                        |            | `void` |                |
 | `spellcheckChanged`  | protected |                                        |            | `void` |                |
 | `select`             | public    | Selects all the text in the text field |            | `void` |                |
+| `validate`           | public    |                                        |            | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/text-field/README.md
+++ b/packages/web-components/fast-foundation/src/text-field/README.md
@@ -120,19 +120,19 @@ This component is built with the expectation that focus is delegated to the inpu
 
 #### Methods
 
-| Name                 | Privacy   | Description                            | Parameters | Return | Inherited From |
-| -------------------- | --------- | -------------------------------------- | ---------- | ------ | -------------- |
-| `readOnlyChanged`    | protected |                                        |            | `void` |                |
-| `autofocusChanged`   | protected |                                        |            | `void` |                |
-| `placeholderChanged` | protected |                                        |            | `void` |                |
-| `listChanged`        | protected |                                        |            | `void` |                |
-| `maxlengthChanged`   | protected |                                        |            | `void` |                |
-| `minlengthChanged`   | protected |                                        |            | `void` |                |
-| `patternChanged`     | protected |                                        |            | `void` |                |
-| `sizeChanged`        | protected |                                        |            | `void` |                |
-| `spellcheckChanged`  | protected |                                        |            | `void` |                |
-| `select`             | public    | Selects all the text in the text field |            | `void` |                |
-| `validate`           | public    |                                        |            | `void` |                |
+| Name                 | Privacy   | Description                                       | Parameters | Return | Inherited From |
+| -------------------- | --------- | ------------------------------------------------- | ---------- | ------ | -------------- |
+| `readOnlyChanged`    | protected |                                                   |            | `void` |                |
+| `autofocusChanged`   | protected |                                                   |            | `void` |                |
+| `placeholderChanged` | protected |                                                   |            | `void` |                |
+| `listChanged`        | protected |                                                   |            | `void` |                |
+| `maxlengthChanged`   | protected |                                                   |            | `void` |                |
+| `minlengthChanged`   | protected |                                                   |            | `void` |                |
+| `patternChanged`     | protected |                                                   |            | `void` |                |
+| `sizeChanged`        | protected |                                                   |            | `void` |                |
+| `spellcheckChanged`  | protected |                                                   |            | `void` |                |
+| `select`             | public    | Selects all the text in the text field            |            | `void` |                |
+| `validate`           | public    | {@inheritDoc (FormAssociated:interface).validate} |            | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -250,6 +250,7 @@ export class FASTTextField extends FormAssociatedTextField {
         this.$emit("change");
     }
 
+    /** {@inheritDoc (FormAssociated:interface).validate} */
     public validate(): void {
         super.validate(this.control);
     }

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -249,6 +249,10 @@ export class FASTTextField extends FormAssociatedTextField {
     public handleChange(): void {
         this.$emit("change");
     }
+
+    public validate(): void {
+        super.validate(this.control);
+    }
 }
 
 /**


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR adds an optional anchor argument to `FormAssociated.validate()`, which gets provided to `ElementInternals.setValidity()`. This anchor is the element to which the browser should focus within a shadowRoot if the element delegates focus. 
All components that implement `FormAssociated` *and* `delegatesFocus` have been updated to invoke validate() with the shadowed element that the element delegates focus to.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
fixes #5678
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
The linked issue offers a brief discussion around potentially using `@open-wc/form-control` package to address this issue. I've opened a separate discussion for that conversation in #6300. For now, I'd like to fix the bug and we can take migration as a separate consideration and task.
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->