### PR TITLE
feat: SSR async rendering

### DIFF
--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -215,6 +215,8 @@ export class Controller<TElement extends HTMLElement = HTMLElement> extends Prop
     constructor(element: TElement, definition: FASTElementDefinition);
     addBehaviors(behaviors: ReadonlyArray<Behavior<TElement>>): void;
     addStyles(styles: ElementStyles | HTMLStyleElement | null | undefined): void;
+    // (undocumented)
+    get behaviors(): IterableIterator<Behavior<TElement, any>> | null;
     readonly definition: FASTElementDefinition;
     readonly element: TElement;
     emit(type: string, detail?: any, options?: Omit<CustomEventInit, "detail">): void | boolean;

--- a/packages/web-components/fast-element/src/components/controller.ts
+++ b/packages/web-components/fast-element/src/components/controller.ts
@@ -29,7 +29,7 @@ export class Controller<
     TElement extends HTMLElement = HTMLElement
 > extends PropertyChangeNotifier {
     private boundObservables: Record<string, any> | null = null;
-    private behaviors: Map<Behavior<TElement>, number> | null = null;
+    private _behaviors: Map<Behavior<TElement>, number> | null = null;
     private needsInitialization: boolean = true;
     private hasExistingShadowRoot = false;
     private _template: ElementViewTemplate<TElement> | null = null;
@@ -150,6 +150,10 @@ export class Controller<
         }
     }
 
+    public get behaviors() {
+        return this._behaviors?.keys() || null;
+    }
+
     /**
      * Creates a Controller to control the specified element.
      * @param element - The element to be controlled by this controller.
@@ -258,7 +262,7 @@ export class Controller<
      * @param behaviors - The behaviors to add.
      */
     public addBehaviors(behaviors: ReadonlyArray<Behavior<TElement>>): void {
-        const targetBehaviors = this.behaviors ?? (this.behaviors = new Map());
+        const targetBehaviors = this._behaviors ?? (this._behaviors = new Map());
         const length = behaviors.length;
         const behaviorsToBind: Behavior<TElement>[] = [];
 
@@ -292,7 +296,7 @@ export class Controller<
         behaviors: ReadonlyArray<Behavior<TElement>>,
         force: boolean = false
     ): void {
-        const targetBehaviors = this.behaviors;
+        const targetBehaviors = this._behaviors;
 
         if (targetBehaviors === null) {
             return;
@@ -340,7 +344,7 @@ export class Controller<
             this.view.bind(element, context);
         }
 
-        const behaviors = this.behaviors;
+        const behaviors = this._behaviors;
 
         if (behaviors !== null) {
             for (const behavior of behaviors.keys()) {
@@ -367,7 +371,7 @@ export class Controller<
             view.unbind();
         }
 
-        const behaviors = this.behaviors;
+        const behaviors = this._behaviors;
 
         if (behaviors !== null) {
             const element = this.element;

--- a/packages/web-components/fast-ssr/docs/api-report.md
+++ b/packages/web-components/fast-ssr/docs/api-report.md
@@ -19,7 +19,7 @@ export type ComponentDOMEmissionMode = "shadow";
 // @beta (undocumented)
 export type ConstructableElementRenderer = (new (tagName: string, renderInfo: RenderInfo) => ElementRenderer) & typeof ElementRenderer;
 
-// @public
+// @beta
 export const DeclarativeShadowDOMPolyfill: Readonly<{
     undefinedElementStyles: string;
     nonStreamingTemplateUpgrade: string;
@@ -56,7 +56,6 @@ export abstract class FASTElementRenderer extends ElementRenderer {
     connectedCallback(): void;
     readonly element: FASTElement;
     static matchesClass(ctor: typeof HTMLElement): boolean;
-    renderLight(renderInfo: RenderInfo): IterableIterator<string>;
     renderShadow(renderInfo: RenderInfo): IterableIterator<string>;
     protected abstract styleRenderer: StyleRenderer;
     protected abstract templateRenderer: TemplateRenderer;
@@ -116,10 +115,13 @@ export interface StyleRenderer {
 export class TemplateRenderer {
     readonly componentDOMEmissionMode: ComponentDOMEmissionMode;
     render(template: ViewTemplate | string, renderInfo: RenderInfo, source?: unknown, context?: ExecutionContext): IterableIterator<string>;
+    renderAsync(template: ViewTemplate | string, renderInfo: RenderInfo, source?: unknown, context?: ExecutionContext): IterableIterator<string | Promise<string>>;
     // Warning: (ae-forgotten-export) The symbol "Op" needs to be exported by the entry point exports.d.ts
     //
     // @internal
     renderOpCodes(codes: Op[], renderInfo: RenderInfo, source: unknown, context: ExecutionContext): IterableIterator<string>;
+    // (undocumented)
+    renderOpCodes(codes: Op[], renderInfo: RenderInfo, source: unknown, context: ExecutionContext, async: true): IterableIterator<string | Promise<string>>;
     // @internal
     withViewBehaviorFactoryRenderers(...renderers: ViewBehaviorFactoryRenderer<any>[]): void;
 }

--- a/packages/web-components/fast-ssr/src/async-behavior/behavior.ts
+++ b/packages/web-components/fast-ssr/src/async-behavior/behavior.ts
@@ -1,0 +1,21 @@
+import { Behavior, Constructable, FASTElement } from "@microsoft/fast-element";
+
+export interface AsyncBehavior extends Behavior {
+    ready: Promise<any>;
+}
+
+const asyncRenderBehaviors = new WeakSet<Constructable<AsyncBehavior>>();
+export function asyncRender(source: Constructable<AsyncBehavior>) {
+    asyncRenderBehaviors.add(source);
+}
+
+export function getAsyncBehaviors(target: FASTElement): null | AsyncBehavior[] {
+    const behaviors = target.$fastController.behaviors;
+    if (behaviors == null) {
+        return null;
+    } else {
+        return Array.from(behaviors).filter(behavior =>
+            asyncRenderBehaviors.has(Object.getPrototypeOf(behavior).constructor)
+        ) as AsyncBehavior[];
+    }
+}

--- a/packages/web-components/fast-ssr/src/declarative-shadow-dom-polyfill.ts
+++ b/packages/web-components/fast-ssr/src/declarative-shadow-dom-polyfill.ts
@@ -3,6 +3,8 @@
 /**
  * Provides style and JavaScript code snippets for polyfills related
  * to Declarative Shadow DOM (DSD).
+ *
+ * @beta
  */
 export const DeclarativeShadowDOMPolyfill = Object.freeze({
     /**

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -108,15 +108,6 @@ export abstract class FASTElementRenderer extends ElementRenderer {
     }
 
     /**
-     * Renders the component internals to light DOM instead of shadow DOM.
-     * @param renderInfo - information about the current rendering context.
-     */
-    public *renderLight(renderInfo: RenderInfo): IterableIterator<string> {
-        // TODO - this will yield out the element's template using the template renderer, skipping any shadow-DOM specific emission.
-        yield "";
-    }
-
-    /**
      * Render the component internals to shadow DOM.
      * @param renderInfo - information about the current rendering context.
      */

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -112,6 +112,7 @@ export abstract class FASTElementRenderer extends ElementRenderer {
      * @param renderInfo - information about the current rendering context.
      */
     public *renderShadow(renderInfo: RenderInfo): IterableIterator<string> {
+        // TODO We need to render async when in async mode here
         const view = this.element.$fastController.view;
         const styles = FASTSSRStyleStrategy.getStylesFor(this.element);
 

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
@@ -47,6 +47,7 @@ export class TemplateRenderer {
      * @param template - The template to render.
      * @param renderInfo - Information about the rendering context.
      * @param source - Any source data to render the template and evaluate bindings with.
+     * @param context - The {@link @microsoft/fast-element#ExecutionContext} to render with.
      */
     public *render(
         template: ViewTemplate | string,
@@ -54,6 +55,27 @@ export class TemplateRenderer {
         source: unknown = undefined,
         context: ExecutionContext = ExecutionContext.default
     ): IterableIterator<string> {
+        const codes =
+            template instanceof ViewTemplate
+                ? parseTemplateToOpCodes(template)
+                : parseStringToOpCodes(template, {});
+
+        yield* this.renderOpCodes(codes, renderInfo, source, context);
+    }
+
+    /**
+     * Renders a {@link @microsoft/fast-element#ViewTemplate} or HTML string, accounting for async component rendering.
+     * @param template - The template to render.
+     * @param renderInfo - Information about the rendering context.
+     * @param source - Any source data to render the template and evaluate bindings with.
+     * @param context - The {@link @microsoft/fast-element#ExecutionContext} to render with.
+     */
+    public *renderAsync(
+        template: ViewTemplate | string,
+        renderInfo: RenderInfo,
+        source: unknown = undefined,
+        context: ExecutionContext = ExecutionContext.default
+    ): IterableIterator<string | Promise<string>> {
         const codes =
             template instanceof ViewTemplate
                 ? parseTemplateToOpCodes(template)

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
@@ -196,6 +196,7 @@ export class TemplateRenderer {
                             const asyncBehaviors = getAsyncBehaviors(
                                 currentRenderer.element
                             );
+
                             if (asyncBehaviors?.length) {
                                 // Block rendering until all async behaviors are resolved, then continue
                                 yield Promise.all(asyncBehaviors.map(x => x.ready)).then(


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
Feature is still in exploration phase. Prototypes the implementation for async component rendering in SSR.



<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
The big open question that I'd love input on is how an element instance communicates to the `TemplateRenderer` that it has async work that needs to complete before rendering. I've started with exposing all component `Behaviors` from the `Controller` so that the `TemplateRenderer` can inspect them. It also adds an `AsyncBehavior` that can be implemented and decorated with the `@asyncRender` decorator. During template rendering, if a component is found to have behaviors decorated with `@asyncRender`, those it blocks rendering until all of the 'ready' promises are resolved. It blocks rendering just prior to yielding the element attributes so that any async work has the opportunity to set attributes for the element.

I'm going to play around with some other ideas on how components can communicate async to see if there are some more ergonomic solutions.
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->