### PR TITLE
Add publisher to syntax highlighting extension

### DIFF
--- a/.vscode/extensions.json
+++ b/.vscode/extensions.json
@@ -4,6 +4,7 @@
     "bierner.jsdoc-markdown-highlighting",
     "dbaeumer.vscode-eslint",
     "ghmcadams.lintlens",
+    "ms-fast.fast-tagged-templates",
     "rvest.vs-code-prettier-eslint",
     "sidneys1.gitconfig"
   ]

--- a/change/fast-tagged-templates-e0b4449e-cadc-4e4a-90a5-18b59b58efec.json
+++ b/change/fast-tagged-templates-e0b4449e-cadc-4e4a-90a5-18b59b58efec.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "add package publisher",
+  "packageName": "fast-tagged-templates",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/fast-vscode-syntax-highlighting/README.md
+++ b/packages/tooling/fast-vscode-syntax-highlighting/README.md
@@ -10,13 +10,13 @@
 
 Both tagged template literals (``css`.style {}`;``) and comment-style untagged template literals (``/* css */`.style {}`;``) are supported.
 
-![CSS tagged template](images/css.png)
+![CSS tagged template](https://github.com/microsoft/fast/raw/HEAD/packages/tooling/fast-vscode-syntax-highlighting/images/css.png)
 
 ### HTML Tagged Templates
 
 In addition to the standard styles, the `html` syntax highlighting also allows for optional generics in Typescript (``html<any>`<div></div>`;`` and ``/* html<Generic> */`<div></div>`;``).
 
-![HTML tagged template](images/html.png)
+![HTML tagged template](https://github.com/microsoft/fast/raw/HEAD/packages/tooling/fast-vscode-syntax-highlighting/images/html.png)
 
 The theme used in the screenshots is [Boxy Tomorrow](https://marketplace.visualstudio.com/items?itemName=trongthanh.theme-boxythemekit#boxy-tomorrow).
 
@@ -24,7 +24,7 @@ The theme used in the screenshots is [Boxy Tomorrow](https://marketplace.visuals
 
 ### Extension Marketplace
 
-Coming soon!
+This extension is available in the [Visual Studio Code Marketplace](https://marketplace.visualstudio.com/items?itemName=ms-fast.fast-tagged-templates).
 
 ### Manual installation
 

--- a/packages/tooling/fast-vscode-syntax-highlighting/package.json
+++ b/packages/tooling/fast-vscode-syntax-highlighting/package.json
@@ -1,5 +1,6 @@
 {
   "name": "fast-tagged-templates",
+  "publisher": "ms-fast",
   "displayName": "FAST Tagged Template Literals",
   "description": "Syntax highlighting support for CSS and HTML tagged template literals",
   "author": {


### PR DESCRIPTION
# Pull Request

## 📖 Description

* Adds the `ms-fast` publisher to the extension manifest for the `fast-tagged-templates` extension.
* Adds the `ms-fast.fast-tagged-templates` extension to the VS Code recommended extensions configuration for this repository.
* Updates the README with a link to the extension on the Visual Studio Code Marketplace website.

## 👩‍💻 Reviewer Notes

The tagged template extension is published here: https://marketplace.visualstudio.com/items?itemName=ms-fast.fast-tagged-templates

The process for publishing and updating the marketplace is currently manual, though we're looking into how we might be able to make the updating process more hands-off/automated.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
