### PR TITLE
bump fast-tagged-templates package to 0.2.0

### DIFF
--- a/change/fast-tagged-templates-e0b4449e-cadc-4e4a-90a5-18b59b58efec.json
+++ b/change/fast-tagged-templates-e0b4449e-cadc-4e4a-90a5-18b59b58efec.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "add package publisher",
-  "packageName": "fast-tagged-templates",
-  "email": "863023+radium-v@users.noreply.github.com",
-  "dependentChangeType": "patch"
-}

--- a/packages/tooling/fast-vscode-syntax-highlighting/CHANGELOG.json
+++ b/packages/tooling/fast-vscode-syntax-highlighting/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "fast-tagged-templates",
   "entries": [
     {
+      "date": "Tue, 30 Aug 2022 00:05:56 GMT",
+      "tag": "fast-tagged-templates_v0.2.0",
+      "version": "0.2.0",
+      "comments": {
+        "minor": [
+          {
+            "author": "863023+radium-v@users.noreply.github.com",
+            "package": "fast-tagged-templates",
+            "commit": "08585f91315898861a99d947b407d5596160d313",
+            "comment": "add package publisher"
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 08 Mar 2022 07:12:45 GMT",
       "tag": "fast-tagged-templates_v0.1.0",
       "version": "0.1.0",

--- a/packages/tooling/fast-vscode-syntax-highlighting/CHANGELOG.md
+++ b/packages/tooling/fast-vscode-syntax-highlighting/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - fast-tagged-templates
 
-This log was last generated on Tue, 08 Mar 2022 07:12:45 GMT and should not be manually modified.
+This log was last generated on Tue, 30 Aug 2022 00:05:56 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.2.0
+
+Tue, 30 Aug 2022 00:05:56 GMT
+
+### Minor changes
+
+- add package publisher (863023+radium-v@users.noreply.github.com)
 
 ## 0.1.0
 

--- a/packages/tooling/fast-vscode-syntax-highlighting/package.json
+++ b/packages/tooling/fast-vscode-syntax-highlighting/package.json
@@ -8,7 +8,7 @@
     "url": "https://discord.gg/FcSNfg4"
   },
   "homepage": "https://www.fast.design/",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "license": "MIT",
   "engines": {
     "vscode": "^1.49.0"


### PR DESCRIPTION
# Pull Request

## 📖 Description

Bumps the `fast-tagged-template package` to `0.2.0`.

## 👩‍💻 Reviewer Notes

Since this package isn't published to NPM, it makes more sense to manually bump the version instead of running it through the CI pipeline.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
