### PR TITLE
feat: enable async rendering type support

### DIFF
--- a/change/@microsoft-fast-ssr-1ea14677-fc86-46b5-b40c-4fd7970f1a60.json
+++ b/change/@microsoft-fast-ssr-1ea14677-fc86-46b5-b40c-4fd7970f1a60.json
@@ -3,5 +3,5 @@
   "comment": "Refactor core components to support Promise return types",
   "packageName": "@microsoft/fast-ssr",
   "email": "nicholasrice@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-ssr-1ea14677-fc86-46b5-b40c-4fd7970f1a60.json
+++ b/change/@microsoft-fast-ssr-1ea14677-fc86-46b5-b40c-4fd7970f1a60.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Refactor core components to support Promise return types",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-ssr/docs/api-report.md
+++ b/packages/web-components/fast-ssr/docs/api-report.md
@@ -12,8 +12,30 @@ import { ExecutionContext } from '@microsoft/fast-element';
 import { ViewBehaviorFactory } from '@microsoft/fast-element';
 import { ViewTemplate } from '@microsoft/fast-element';
 
-// Warning: (ae-forgotten-export) The symbol "AsyncElementRenderer" needs to be exported by the entry point exports.d.ts
-//
+// @beta (undocumented)
+export interface AsyncElementRenderer extends Omit<ElementRenderer, "renderShadow" | "renderAttributes"> {
+    // (undocumented)
+    renderAttributes(): IterableIterator<string | Promise<string>>;
+    // (undocumented)
+    renderShadow(renderInfo: RenderInfo): IterableIterator<string | Promise<string>>;
+}
+
+// @beta (undocumented)
+export interface AsyncTemplateRenderer {
+    // (undocumented)
+    createRenderInfo(): RenderInfo;
+    // (undocumented)
+    render(template: ViewTemplate | string, renderInfo?: RenderInfo, source?: unknown, context?: ExecutionContext): IterableIterator<string | Promise<string>>;
+    // (undocumented)
+    withDefaultElementRenderers(...renderers: ConstructableElementRenderer<AsyncElementRenderer>[]): void;
+}
+
+// @beta
+export interface Configuration {
+    // (undocumented)
+    renderMode: "sync" | "async";
+}
+
 // @beta (undocumented)
 export interface ConstructableElementRenderer<T extends ElementRenderer | AsyncElementRenderer = ElementRenderer> {
     // (undocumented)
@@ -48,10 +70,22 @@ export interface ElementRenderer {
     setProperty(name: string, value: unknown): void;
 }
 
-// @beta
+// @beta (undocumented)
 function fastSSR(): {
     templateRenderer: TemplateRenderer;
     ElementRenderer: ConstructableElementRenderer;
+};
+
+// @beta (undocumented)
+function fastSSR(config: Configuration & Record<"renderMode", "sync">): {
+    templateRenderer: TemplateRenderer;
+    ElementRenderer: ConstructableElementRenderer;
+};
+
+// @beta (undocumented)
+function fastSSR(config: Configuration & Record<"renderMode", "async">): {
+    templateRenderer: AsyncTemplateRenderer;
+    ElementRenderer: ConstructableElementRenderer<AsyncElementRenderer>;
 };
 export default fastSSR;
 
@@ -97,18 +131,12 @@ export interface StyleRenderer {
     render(styles: ComposableStyles): string;
 }
 
-// @public (undocumented)
+// @beta (undocumented)
 export interface TemplateRenderer {
-    // Warning: (ae-incompatible-release-tags) The symbol "createRenderInfo" is marked as @public, but its signature references "RenderInfo" which is marked as @beta
-    //
     // (undocumented)
     createRenderInfo(): RenderInfo;
-    // Warning: (ae-incompatible-release-tags) The symbol "render" is marked as @public, but its signature references "RenderInfo" which is marked as @beta
-    //
     // (undocumented)
     render(template: ViewTemplate | string, renderInfo?: RenderInfo, source?: unknown, context?: ExecutionContext): IterableIterator<string>;
-    // Warning: (ae-incompatible-release-tags) The symbol "withDefaultElementRenderers" is marked as @public, but its signature references "ConstructableElementRenderer" which is marked as @beta
-    //
     // (undocumented)
     withDefaultElementRenderers(...renderers: ConstructableElementRenderer[]): void;
 }

--- a/packages/web-components/fast-ssr/docs/api-report.md
+++ b/packages/web-components/fast-ssr/docs/api-report.md
@@ -97,23 +97,27 @@ export interface StyleRenderer {
     render(styles: ComposableStyles): string;
 }
 
-// @beta
-export class TemplateRenderer {
-    createRenderInfo(renderers?: ConstructableElementRenderer[]): RenderInfo;
-    render(template: ViewTemplate | string, renderInfo?: RenderInfo, source?: unknown, context?: ExecutionContext): IterableIterator<string>;
-    // Warning: (ae-forgotten-export) The symbol "Op" needs to be exported by the entry point exports.d.ts
+// @public (undocumented)
+export interface TemplateRenderer {
+    // Warning: (ae-incompatible-release-tags) The symbol "createRenderInfo" is marked as @public, but its signature references "RenderInfo" which is marked as @beta
     //
-    // @internal
-    renderOpCodes(codes: Op[], renderInfo: RenderInfo, source: unknown, context: ExecutionContext): IterableIterator<string>;
+    // (undocumented)
+    createRenderInfo(): RenderInfo;
+    // Warning: (ae-incompatible-release-tags) The symbol "render" is marked as @public, but its signature references "RenderInfo" which is marked as @beta
+    //
+    // (undocumented)
+    render(template: ViewTemplate | string, renderInfo?: RenderInfo, source?: unknown, context?: ExecutionContext): IterableIterator<string>;
+    // Warning: (ae-incompatible-release-tags) The symbol "withDefaultElementRenderers" is marked as @public, but its signature references "ConstructableElementRenderer" which is marked as @beta
+    //
+    // (undocumented)
     withDefaultElementRenderers(...renderers: ConstructableElementRenderer[]): void;
-    // @internal
-    withViewBehaviorFactoryRenderers(...renderers: ViewBehaviorFactoryRenderer<any>[]): void;
 }
 
 // @beta
 export interface ViewBehaviorFactoryRenderer<T extends ViewBehaviorFactory> {
     matcher: Constructable<T>;
-    render(behavior: T, renderInfo: RenderInfo, source: any, renderer: TemplateRenderer, context: ExecutionContext): IterableIterator<string>;
+    // Warning: (ae-forgotten-export) The symbol "DefaultTemplateRenderer" needs to be exported by the entry point exports.d.ts
+    render(behavior: T, renderInfo: RenderInfo, source: any, renderer: DefaultTemplateRenderer, context: ExecutionContext): IterableIterator<string>;
 }
 
 // Warnings were encountered during analysis:

--- a/packages/web-components/fast-ssr/docs/api-report.md
+++ b/packages/web-components/fast-ssr/docs/api-report.md
@@ -9,12 +9,8 @@ import { ComposableStyles } from '@microsoft/fast-element';
 import { Constructable } from '@microsoft/fast-element';
 import { DOMContainer } from '@microsoft/fast-element/di';
 import { ExecutionContext } from '@microsoft/fast-element';
-import { FASTElement } from '@microsoft/fast-element';
 import { ViewBehaviorFactory } from '@microsoft/fast-element';
 import { ViewTemplate } from '@microsoft/fast-element';
-
-// @beta
-export type ComponentDOMEmissionMode = "shadow";
 
 // Warning: (ae-forgotten-export) The symbol "AsyncElementRenderer" needs to be exported by the entry point exports.d.ts
 //
@@ -50,21 +46,6 @@ export interface ElementRenderer {
     setAttribute(name: string, value: string): void;
     // (undocumented)
     setProperty(name: string, value: unknown): void;
-}
-
-// Warning: (ae-forgotten-export) The symbol "DefaultElementRenderer" needs to be exported by the entry point exports.d.ts
-//
-// @beta
-export abstract class FASTElementRenderer extends DefaultElementRenderer {
-    constructor(tagName: string, renderInfo: RenderInfo);
-    attributeChangedCallback(name: string, old: string | null, value: string | null): void;
-    connectedCallback(): void;
-    readonly element: FASTElement;
-    static matchesClass(ctor: typeof HTMLElement): boolean;
-    renderLight(renderInfo: RenderInfo): IterableIterator<string>;
-    renderShadow(renderInfo: RenderInfo): IterableIterator<string>;
-    protected abstract styleRenderer: StyleRenderer;
-    protected abstract templateRenderer: TemplateRenderer;
 }
 
 // @beta
@@ -118,7 +99,6 @@ export interface StyleRenderer {
 
 // @beta
 export class TemplateRenderer {
-    readonly componentDOMEmissionMode: ComponentDOMEmissionMode;
     createRenderInfo(renderers?: ConstructableElementRenderer[]): RenderInfo;
     render(template: ViewTemplate | string, renderInfo?: RenderInfo, source?: unknown, context?: ExecutionContext): IterableIterator<string>;
     // Warning: (ae-forgotten-export) The symbol "Op" needs to be exported by the entry point exports.d.ts

--- a/packages/web-components/fast-ssr/docs/api-report.md
+++ b/packages/web-components/fast-ssr/docs/api-report.md
@@ -16,8 +16,17 @@ import { ViewTemplate } from '@microsoft/fast-element';
 // @beta
 export type ComponentDOMEmissionMode = "shadow";
 
+// Warning: (ae-forgotten-export) The symbol "AsyncElementRenderer" needs to be exported by the entry point exports.d.ts
+//
 // @beta (undocumented)
-export type ConstructableElementRenderer = (new (tagName: string, renderInfo: RenderInfo) => ElementRenderer) & typeof ElementRenderer;
+export interface ConstructableElementRenderer<T extends ElementRenderer | AsyncElementRenderer = ElementRenderer> {
+    // (undocumented)
+    new (tagName: string, renderInfo: RenderInfo): T;
+    // Warning: (ae-forgotten-export) The symbol "AttributesMap" needs to be exported by the entry point exports.d.ts
+    //
+    // (undocumented)
+    matchesClass(ctor: typeof HTMLElement, tagName: string, attributes: AttributesMap): boolean;
+}
 
 // @beta
 export const DeclarativeShadowDOMPolyfill: Readonly<{
@@ -26,31 +35,27 @@ export const DeclarativeShadowDOMPolyfill: Readonly<{
 }>;
 
 // @beta (undocumented)
-export abstract class ElementRenderer {
-    constructor(tagName: string, renderInfo: RenderInfo);
+export interface ElementRenderer {
     // (undocumented)
-    abstract attributeChangedCallback(name: string, prev: string | null, next: string | null): void;
+    attributeChangedCallback(name: string, prev: string | null, next: string | null): void;
     // (undocumented)
-    abstract connectedCallback(): void;
+    connectedCallback(): void;
     // (undocumented)
     dispatchEvent(event: Event): boolean;
     // (undocumented)
-    abstract readonly element?: HTMLElement;
-    // (undocumented)
-    elementChanged(): void;
-    // Warning: (ae-forgotten-export) The symbol "AttributesMap" needs to be exported by the entry point exports.d.ts
-    static matchesClass(ctor: typeof HTMLElement, tagName: string, attributes: AttributesMap): boolean;
     renderAttributes(): IterableIterator<string>;
     // (undocumented)
-    abstract renderShadow(renderInfo: RenderInfo): IterableIterator<string>;
-    setAttribute(name: string, value: string): void;
-    setProperty(name: string, value: unknown): void;
+    renderShadow(renderInfo: RenderInfo): IterableIterator<string>;
     // (undocumented)
-    readonly tagName: string;
+    setAttribute(name: string, value: string): void;
+    // (undocumented)
+    setProperty(name: string, value: unknown): void;
 }
 
+// Warning: (ae-forgotten-export) The symbol "DefaultElementRenderer" needs to be exported by the entry point exports.d.ts
+//
 // @beta
-export abstract class FASTElementRenderer extends ElementRenderer {
+export abstract class FASTElementRenderer extends DefaultElementRenderer {
     constructor(tagName: string, renderInfo: RenderInfo);
     attributeChangedCallback(name: string, old: string | null, value: string | null): void;
     connectedCallback(): void;

--- a/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
@@ -1,7 +1,7 @@
 import "../install-dom-shim.js";
 import { FASTElement, customElement, css, html, attr, observable } from "@microsoft/fast-element";
 import { expect, test } from '@playwright/test';
-import { FASTElementRenderer } from "./fast-element-renderer.js";
+import { SyncFASTElementRenderer } from "./fast-element-renderer.js";
 import fastSSR from "../exports.js";
 import { consolidate } from "../test-utilities/consolidate.js";
 
@@ -28,11 +28,11 @@ test.describe("FASTElementRenderer", () => {
     test.describe("should have a 'matchesClass' method", () => {
         test("that returns true when invoked with a class that extends FASTElement ",  () => {
             class MyElement extends FASTElement {}
-            expect(FASTElementRenderer.matchesClass(MyElement)).toBe(true);
+            expect(SyncFASTElementRenderer.matchesClass(MyElement)).toBe(true);
         });
         test("that returns false when invoked with a class that does not extend FASTElement ", () => {
             class MyElement extends HTMLElement {}
-            expect(FASTElementRenderer.matchesClass(MyElement)).toBe(false);
+            expect(SyncFASTElementRenderer.matchesClass(MyElement)).toBe(false);
         });
     });
 

--- a/packages/web-components/fast-ssr/src/element-renderer/element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/element-renderer.ts
@@ -7,17 +7,7 @@ import { RenderInfo } from "../render-info.js";
 import { escapeHtml } from "../escape-html.js";
 import { HTMLElement as ShimHTMLElement } from "../dom-shim.js";
 import { shouldBubble } from "../event-utilities.js";
-
-type AttributesMap = Map<string, string>;
-
-/**
- * @beta
- */
-export type ConstructableElementRenderer = (new (
-    tagName: string,
-    renderInfo: RenderInfo
-) => ElementRenderer) &
-    typeof ElementRenderer;
+import { AttributesMap, ElementRenderer } from "./interfaces.js";
 
 export const getElementRenderer = (
     renderInfo: RenderInfo,
@@ -41,7 +31,7 @@ export const getElementRenderer = (
 /**
  * @beta
  */
-export abstract class ElementRenderer {
+export abstract class DefaultElementRenderer {
     private parent: ElementRenderer | null = null;
     @observable
     abstract readonly element?: HTMLElement;
@@ -150,7 +140,7 @@ export abstract class ElementRenderer {
  * An ElementRenderer used as a fallback in the case where a custom element is
  * either unregistered or has no other matching renderer.
  */
-class FallbackRenderer extends ElementRenderer {
+class FallbackRenderer extends DefaultElementRenderer {
     public element?: HTMLElement | undefined;
     private readonly _attributes: { [name: string]: string } = {};
 

--- a/packages/web-components/fast-ssr/src/element-renderer/element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/element-renderer.ts
@@ -31,7 +31,8 @@ export const getElementRenderer = (
 /**
  * @beta
  */
-export abstract class DefaultElementRenderer {
+export abstract class DefaultElementRenderer
+    implements Omit<ElementRenderer, "renderShadow" | "renderAttributes"> {
     private parent: ElementRenderer | null = null;
     @observable
     abstract readonly element?: HTMLElement;
@@ -76,9 +77,9 @@ export abstract class DefaultElementRenderer {
 
     constructor(
         public readonly tagName: string,
-        private readonly renderInfo: RenderInfo
+        private readonly renderInfo?: RenderInfo
     ) {
-        this.parent = renderInfo.customElementInstanceStack.at(-1) || null;
+        this.parent = renderInfo?.customElementInstanceStack.at(-1) || null;
     }
 
     abstract connectedCallback(): void;
@@ -111,36 +112,13 @@ export abstract class DefaultElementRenderer {
             this.attributeChangedCallback(name, prev, value);
         }
     }
-
-    public abstract renderShadow(renderInfo: RenderInfo): IterableIterator<string>;
-
-    /**
-     * Render an element's attributes.
-     *
-     * Default implementation serializes all attributes on the element instance.
-     */
-    public *renderAttributes(): IterableIterator<string> {
-        if (this.element !== undefined) {
-            const { attributes } = this.element;
-            for (
-                let i = 0, name, value;
-                i < attributes.length && ({ name, value } = attributes[i]);
-                i++
-            ) {
-                if (value === "" || value === undefined || value === null) {
-                    yield ` ${name}`;
-                } else {
-                    yield ` ${name}="${escapeHtml(value)}"`;
-                }
-            }
-        }
-    }
 }
+
 /**
  * An ElementRenderer used as a fallback in the case where a custom element is
  * either unregistered or has no other matching renderer.
  */
-class FallbackRenderer extends DefaultElementRenderer {
+class FallbackRenderer extends DefaultElementRenderer implements ElementRenderer {
     public element?: HTMLElement | undefined;
     private readonly _attributes: { [name: string]: string } = {};
 

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -1,7 +1,7 @@
 import { Aspect, DOM, ExecutionContext, FASTElement } from "@microsoft/fast-element";
 import { RenderInfo } from "../render-info.js";
 import { StyleRenderer } from "../styles/style-renderer.js";
-import { TemplateRenderer } from "../template-renderer/template-renderer.js";
+import { DefaultTemplateRenderer } from "../template-renderer/template-renderer.js";
 import { SSRView } from "../view.js";
 import { DefaultElementRenderer } from "./element-renderer.js";
 import { FASTSSRStyleStrategy } from "./style-strategy.js";
@@ -21,7 +21,7 @@ export abstract class FASTElementRenderer extends DefaultElementRenderer {
     /**
      * The template renderer to use when rendering a component template
      */
-    protected abstract templateRenderer: TemplateRenderer;
+    protected abstract templateRenderer: DefaultTemplateRenderer;
 
     /**
      * Responsible for rendering stylesheets

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -3,7 +3,7 @@ import { RenderInfo } from "../render-info.js";
 import { StyleRenderer } from "../styles/style-renderer.js";
 import { TemplateRenderer } from "../template-renderer/template-renderer.js";
 import { SSRView } from "../view.js";
-import { ElementRenderer } from "./element-renderer.js";
+import { DefaultElementRenderer } from "./element-renderer.js";
 import { FASTSSRStyleStrategy } from "./style-strategy.js";
 
 /**
@@ -12,7 +12,7 @@ import { FASTSSRStyleStrategy } from "./style-strategy.js";
  *
  * @beta
  */
-export abstract class FASTElementRenderer extends ElementRenderer {
+export abstract class FASTElementRenderer extends DefaultElementRenderer {
     /**
      * The element instance represented by the {@link FASTElementRenderer}.
      */

--- a/packages/web-components/fast-ssr/src/element-renderer/interfaces.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/interfaces.ts
@@ -1,0 +1,46 @@
+import { RenderInfo } from "../render-info.js";
+
+/**
+ * @beta
+ */
+export interface ElementRenderer {
+    connectedCallback(): void;
+    attributeChangedCallback(
+        name: string,
+        prev: string | null,
+        next: string | null
+    ): void;
+    dispatchEvent(event: Event): boolean;
+    setProperty(name: string, value: unknown): void;
+    setAttribute(name: string, value: string): void;
+    renderShadow(renderInfo: RenderInfo): IterableIterator<string>;
+    renderAttributes(): IterableIterator<string>;
+}
+
+/**
+ * @beta
+ */
+export interface AsyncElementRenderer
+    extends Omit<ElementRenderer, "renderShadow" | "renderAttributes"> {
+    renderShadow(renderInfo: RenderInfo): IterableIterator<string | Promise<string>>;
+    renderAttributes(): IterableIterator<string | Promise<string>>;
+}
+
+/**
+ * @beta
+ */
+export interface ConstructableElementRenderer<
+    T extends ElementRenderer | AsyncElementRenderer = ElementRenderer
+> {
+    new (tagName: string, renderInfo: RenderInfo): T;
+    matchesClass(
+        ctor: typeof HTMLElement,
+        tagName: string,
+        attributes: AttributesMap
+    ): boolean;
+}
+
+/**
+ * @internal
+ */
+export type AttributesMap = Map<string, string>;

--- a/packages/web-components/fast-ssr/src/exports.ts
+++ b/packages/web-components/fast-ssr/src/exports.ts
@@ -12,7 +12,10 @@ import {
     defaultViewBehaviorFactoryRenderers,
     ViewBehaviorFactoryRenderer,
 } from "./template-renderer/directives.js";
-import { TemplateRenderer } from "./template-renderer/template-renderer.js";
+import {
+    DefaultTemplateRenderer,
+    TemplateRenderer,
+} from "./template-renderer/template-renderer.js";
 import { SSRView } from "./view.js";
 import {
     ConstructableElementRenderer,
@@ -55,9 +58,9 @@ export default function fastSSR(): {
     templateRenderer: TemplateRenderer;
     ElementRenderer: ConstructableElementRenderer;
 } {
-    const templateRenderer = new TemplateRenderer();
+    const templateRenderer = new DefaultTemplateRenderer();
     const ElementRenderer = class extends FASTElementRenderer {
-        protected templateRenderer: TemplateRenderer = templateRenderer;
+        protected templateRenderer: DefaultTemplateRenderer = templateRenderer;
         protected styleRenderer = new StyleElementStyleRenderer();
     };
 

--- a/packages/web-components/fast-ssr/src/exports.ts
+++ b/packages/web-components/fast-ssr/src/exports.ts
@@ -20,7 +20,7 @@ import { SSRView } from "./view.js";
 import {
     ConstructableElementRenderer,
     ElementRenderer,
-} from "./element-renderer/element-renderer.js";
+} from "./element-renderer/interfaces.js";
 
 Compiler.setDefaultStrategy(
     (

--- a/packages/web-components/fast-ssr/src/exports.ts
+++ b/packages/web-components/fast-ssr/src/exports.ts
@@ -5,7 +5,10 @@ import {
     ViewBehaviorFactory,
 } from "@microsoft/fast-element";
 import { RenderInfo } from "./render-info.js";
-import { SyncFASTElementRenderer } from "./element-renderer/fast-element-renderer.js";
+import {
+    AsyncFASTElementRenderer,
+    SyncFASTElementRenderer,
+} from "./element-renderer/fast-element-renderer.js";
 import { FASTSSRStyleStrategy } from "./element-renderer/style-strategy.js";
 import { StyleElementStyleRenderer, StyleRenderer } from "./styles/style-renderer.js";
 import {
@@ -13,11 +16,13 @@ import {
     ViewBehaviorFactoryRenderer,
 } from "./template-renderer/directives.js";
 import {
+    AsyncTemplateRenderer,
     DefaultTemplateRenderer,
     TemplateRenderer,
 } from "./template-renderer/template-renderer.js";
 import { SSRView } from "./view.js";
 import {
+    AsyncElementRenderer,
     ConstructableElementRenderer,
     ElementRenderer,
 } from "./element-renderer/interfaces.js";
@@ -41,6 +46,33 @@ ElementStyles.setDefaultStrategy(FASTSSRStyleStrategy);
 Updates.setMode(false);
 
 /**
+ * Configuration for SSR factory.
+ * @beta
+ */
+export interface Configuration {
+    renderMode: "sync" | "async";
+}
+
+/** @beta */
+function fastSSR(): {
+    templateRenderer: TemplateRenderer;
+    ElementRenderer: ConstructableElementRenderer;
+};
+/** @beta */
+function fastSSR(
+    config: Configuration & Record<"renderMode", "sync">
+): {
+    templateRenderer: TemplateRenderer;
+    ElementRenderer: ConstructableElementRenderer;
+};
+/** @beta */
+function fastSSR(
+    config: Configuration & Record<"renderMode", "async">
+): {
+    templateRenderer: AsyncTemplateRenderer;
+    ElementRenderer: ConstructableElementRenderer<AsyncElementRenderer>;
+};
+/**
  * Factory for creating SSR rendering assets.
  * @example
  * ```ts
@@ -54,33 +86,41 @@ Updates.setMode(false);
  *
  * @beta
  */
-export default function fastSSR(): {
-    templateRenderer: TemplateRenderer;
-    ElementRenderer: ConstructableElementRenderer;
-} {
+function fastSSR(config?: Configuration): any {
+    const async = config && config.renderMode === "async";
     const templateRenderer = new DefaultTemplateRenderer();
-    const ElementRenderer = class extends SyncFASTElementRenderer {
-        protected templateRenderer: DefaultTemplateRenderer = templateRenderer;
-        protected styleRenderer = new StyleElementStyleRenderer();
-    };
+    const elementRenderer = !async
+        ? class extends SyncFASTElementRenderer {
+              protected templateRenderer: DefaultTemplateRenderer = templateRenderer;
+              protected styleRenderer = new StyleElementStyleRenderer();
+          }
+        : class extends AsyncFASTElementRenderer {
+              protected templateRenderer: DefaultTemplateRenderer = templateRenderer;
+              protected styleRenderer = new StyleElementStyleRenderer();
+          };
 
-    templateRenderer.withDefaultElementRenderers(ElementRenderer);
+    templateRenderer.withDefaultElementRenderers(
+        elementRenderer as ConstructableElementRenderer
+    );
     templateRenderer.withViewBehaviorFactoryRenderers(
         ...defaultViewBehaviorFactoryRenderers
     );
 
     return {
         templateRenderer,
-        ElementRenderer,
+        ElementRenderer: elementRenderer,
     };
 }
 
+export default fastSSR;
 export * from "./request-storage.js";
 export * from "./declarative-shadow-dom-polyfill.js";
 export type {
     ElementRenderer,
+    AsyncElementRenderer,
     StyleRenderer,
     TemplateRenderer,
+    AsyncTemplateRenderer,
     ViewBehaviorFactoryRenderer,
     RenderInfo,
     ConstructableElementRenderer,

--- a/packages/web-components/fast-ssr/src/exports.ts
+++ b/packages/web-components/fast-ssr/src/exports.ts
@@ -12,10 +12,7 @@ import {
     defaultViewBehaviorFactoryRenderers,
     ViewBehaviorFactoryRenderer,
 } from "./template-renderer/directives.js";
-import {
-    ComponentDOMEmissionMode,
-    TemplateRenderer,
-} from "./template-renderer/template-renderer.js";
+import { TemplateRenderer } from "./template-renderer/template-renderer.js";
 import { SSRView } from "./view.js";
 import {
     ConstructableElementRenderer,
@@ -78,9 +75,7 @@ export default function fastSSR(): {
 export * from "./request-storage.js";
 export * from "./declarative-shadow-dom-polyfill.js";
 export type {
-    ComponentDOMEmissionMode,
     ElementRenderer,
-    FASTElementRenderer,
     StyleRenderer,
     TemplateRenderer,
     ViewBehaviorFactoryRenderer,

--- a/packages/web-components/fast-ssr/src/exports.ts
+++ b/packages/web-components/fast-ssr/src/exports.ts
@@ -5,7 +5,7 @@ import {
     ViewBehaviorFactory,
 } from "@microsoft/fast-element";
 import { RenderInfo } from "./render-info.js";
-import { FASTElementRenderer } from "./element-renderer/fast-element-renderer.js";
+import { SyncFASTElementRenderer } from "./element-renderer/fast-element-renderer.js";
 import { FASTSSRStyleStrategy } from "./element-renderer/style-strategy.js";
 import { StyleElementStyleRenderer, StyleRenderer } from "./styles/style-renderer.js";
 import {
@@ -59,7 +59,7 @@ export default function fastSSR(): {
     ElementRenderer: ConstructableElementRenderer;
 } {
     const templateRenderer = new DefaultTemplateRenderer();
-    const ElementRenderer = class extends FASTElementRenderer {
+    const ElementRenderer = class extends SyncFASTElementRenderer {
         protected templateRenderer: DefaultTemplateRenderer = templateRenderer;
         protected styleRenderer = new StyleElementStyleRenderer();
     };

--- a/packages/web-components/fast-ssr/src/render-info.ts
+++ b/packages/web-components/fast-ssr/src/render-info.ts
@@ -5,7 +5,7 @@
 import {
     ConstructableElementRenderer,
     ElementRenderer,
-} from "./element-renderer/element-renderer.js";
+} from "./element-renderer/interfaces.js";
 
 /**
  * @beta

--- a/packages/web-components/fast-ssr/src/template-renderer/directives.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/directives.ts
@@ -10,7 +10,7 @@ import {
 } from "@microsoft/fast-element";
 import { RenderDirective } from "@microsoft/fast-element/render";
 import { RenderInfo } from "../render-info.js";
-import { TemplateRenderer } from "./template-renderer.js";
+import { DefaultTemplateRenderer } from "./template-renderer.js";
 
 /**
  * Describes an implementation that can render a directive.
@@ -30,7 +30,7 @@ export interface ViewBehaviorFactoryRenderer<T extends ViewBehaviorFactory> {
         behavior: T,
         renderInfo: RenderInfo,
         source: any,
-        renderer: TemplateRenderer,
+        renderer: DefaultTemplateRenderer,
         context: ExecutionContext
     ): IterableIterator<string>;
 
@@ -47,7 +47,7 @@ export const RepeatDirectiveRenderer: ViewBehaviorFactoryRenderer<RepeatDirectiv
             directive: RepeatDirective,
             renderInfo: RenderInfo,
             source: any,
-            renderer: TemplateRenderer,
+            renderer: DefaultTemplateRenderer,
             context: ExecutionContext
         ): IterableIterator<string> {
             const items = directive.dataBinding.evaluate(source, context);
@@ -88,7 +88,7 @@ export const RenderDirectiveRenderer: ViewBehaviorFactoryRenderer<RenderDirectiv
             directive: RenderDirective,
             renderInfo: RenderInfo,
             source: any,
-            renderer: TemplateRenderer,
+            renderer: DefaultTemplateRenderer,
             context: ExecutionContext
         ): IterableIterator<string> {
             const data = directive.dataBinding.evaluate(source, context);

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
@@ -19,19 +19,6 @@ class WithHostAttributes extends FASTElement {}
 
 
 test.describe("TemplateRenderer", () => {
-    test.describe("should have an initial configuration", () => {
-        test("that emits to shadow DOM", () => {
-            const instance = new TemplateRenderer();
-            expect(instance.componentDOMEmissionMode).toBe("shadow")
-        });
-    });
-
-    test.describe.skip("should allow configuration", () => {
-        test("that emits to light DOM", () => {
-            const instance = new TemplateRenderer(/* Re-implement w/ light mode emission is finished {componentDOMEmissionMode: "light"} */);
-            expect(instance.componentDOMEmissionMode).toBe("light");
-        });
-    });
 
     test.describe("should have a createRenderInfo method", () => {
         test("that returns unique object instances for every invocation", () => {

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
@@ -5,7 +5,7 @@ import fastSSR from "../exports.js";
 import { consolidate } from "../test-utilities/consolidate.js";
 import { TemplateRenderer } from "./template-renderer.js";
 import { render } from "@microsoft/fast-element/render";
-import { ElementRenderer } from "../element-renderer/element-renderer.js";
+import { DefaultElementRenderer } from "../element-renderer/element-renderer.js";
 import { RenderInfo } from "../render-info.js";
 
 @customElement("hello-world")
@@ -40,7 +40,7 @@ test.describe("TemplateRenderer", () => {
         });
         test("that can be populated with ElementRenderers with the 'withDefaultElementRenderer()' method", () => {
             const renderer = new TemplateRenderer();
-            class MyRenderer extends ElementRenderer {
+            class MyRenderer extends DefaultElementRenderer {
                 element?: HTMLElement | undefined;
                 attributeChangedCallback(name: string, prev: string | null, next: string | null): void {}
                 connectedCallback(): void {}

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.spec.ts
@@ -3,7 +3,7 @@ import { children, customElement, ExecutionContext, FASTElement, html, ref, repe
 import { expect, test } from "@playwright/test";
 import fastSSR from "../exports.js";
 import { consolidate } from "../test-utilities/consolidate.js";
-import { TemplateRenderer } from "./template-renderer.js";
+import { DefaultTemplateRenderer } from "./template-renderer.js";
 import { render } from "@microsoft/fast-element/render";
 import { DefaultElementRenderer } from "../element-renderer/element-renderer.js";
 import { RenderInfo } from "../render-info.js";
@@ -19,14 +19,13 @@ class WithHostAttributes extends FASTElement {}
 
 
 test.describe("TemplateRenderer", () => {
-
     test.describe("should have a createRenderInfo method", () => {
         test("that returns unique object instances for every invocation", () => {
-            const renderer = new TemplateRenderer();
+            const renderer = new DefaultTemplateRenderer();
             expect(renderer.createRenderInfo()).not.toBe(renderer.createRenderInfo())
         });
         test("that can be populated with ElementRenderers with the 'withDefaultElementRenderer()' method", () => {
-            const renderer = new TemplateRenderer();
+            const renderer = new DefaultTemplateRenderer();
             class MyRenderer extends DefaultElementRenderer {
                 element?: HTMLElement | undefined;
                 attributeChangedCallback(name: string, prev: string | null, next: string | null): void {}

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
@@ -6,11 +6,8 @@ import {
     ViewTemplate,
 } from "@microsoft/fast-element";
 import { DefaultRenderInfo, RenderInfo } from "../render-info.js";
-import {
-    ConstructableElementRenderer,
-    ElementRenderer,
-    getElementRenderer,
-} from "../element-renderer/element-renderer.js";
+import { getElementRenderer } from "../element-renderer/element-renderer.js";
+import { ConstructableElementRenderer } from "../element-renderer/interfaces.js";
 import { AttributeBindingOp, Op, OpType } from "../template-parser/op-codes.js";
 import {
     parseStringToOpCodes,

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
@@ -22,6 +22,7 @@ function getLast<T>(arr: T[]): T | undefined {
     return arr[arr.length - 1];
 }
 
+/** @beta */
 export interface TemplateRenderer {
     render(
         template: ViewTemplate | string,
@@ -32,6 +33,8 @@ export interface TemplateRenderer {
     createRenderInfo(): RenderInfo;
     withDefaultElementRenderers(...renderers: ConstructableElementRenderer[]): void;
 }
+
+/** @beta */
 export interface AsyncTemplateRenderer {
     render(
         template: ViewTemplate | string,
@@ -50,7 +53,7 @@ export interface AsyncTemplateRenderer {
  * rendering {@link @microsoft/fast-element#ViewTemplate} instances as well
  * as arbitrary HTML strings.
  *
- * @beta
+ * @internal
  */
 export class DefaultTemplateRenderer implements TemplateRenderer {
     private viewBehaviorFactoryRenderers: Map<

--- a/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
+++ b/packages/web-components/fast-ssr/src/template-renderer/template-renderer.ts
@@ -20,12 +20,6 @@ function getLast<T>(arr: T[]): T | undefined {
 }
 
 /**
- * The mode for which a component's internals should be rendered.
- * @beta
- */
-export type ComponentDOMEmissionMode = "shadow";
-
-/**
  * A class designed to render HTML templates. The renderer supports
  * rendering {@link @microsoft/fast-element#ViewTemplate} instances as well
  * as arbitrary HTML strings.
@@ -39,11 +33,6 @@ export class TemplateRenderer {
     > = new Map();
 
     private defaultElementRenderers: ConstructableElementRenderer[] = [];
-
-    /**
-     * Controls how the {@link TemplateRenderer} will emit component DOM internals.
-     */
-    public readonly componentDOMEmissionMode: ComponentDOMEmissionMode = "shadow";
 
     /**
      * Renders a {@link @microsoft/fast-element#ViewTemplate} or HTML string.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR makes some architectural changes to `@microsoft/fast-ssr` to support asynchronous rendering. It does *not* implement any async rendering business logic, but refactors the package and types to support `Promise<string>` return types.

The high level overview of the changes are:
1. Adds a `Configuration` argument to the default export which constructs the SSR renderer. This configuration can take a `renderMode` of `"sync | "async"`, defaulting to `"sync"`, eg `fastSSR({renderMode: "async"});`
2. Refactors the `ElementRenderer` abstract base class to a set of two interfaces, `ElementRenderer` and `AsyncElementRenderer`. The package is refactored to code against the `ElementRenderer` interfaces instead of an abstract class so that it doesn't require a concrete implementation. 
3. Refactors TemplateRenderer concrete implementation to a set of two interfaces, `TemplateRenderer` and `AsyncTemplateRenderer`. A concrete implementation is created that handles both rendering cases.
4. private, concrete implementations of the `FASTElementRenderer` are created for both sync and async rendering.

In the PR to implement async rendering, the `renderAttributesAsync()` method will be updated to defer rendering until promises have been resolved. awaiting during attribute rendering will allow components to mutate attributes as a result of async rendering, such as hiding / unhiding an element as a result of async work.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
Related to #6339
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
I spent a decent amount of time trying to massage TypeScript to get this all to work nicely, but I still haven't found an approach I'm satisfied with. If anyone has any suggestions, I'd be happy to hear them. In short, the concrete implementations need to support two modes, a "sync" mode that operates on `ElementRenderer` and yields `string` and an "async" mode that operates on `AsyncElementRenderer` and yields `string | Promise<string>`. The business logic for these two modes is almost identical, but getting the types to flow for both cases is a huge pain without duplicating the implementation. 

Right now, the codebase is coded for synchronous rendering and the default export does some type assertion to provide intilsense to the author based on the configuration. At this time, this is mostly safe because the system doesn't do anything with yielded values. 

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->