### PR TITLE
feat: replace anchored region for floating UI menu item

### DIFF
--- a/change/@microsoft-fast-foundation-2a6c7e7f-2bce-4594-9fbf-896d2479f757.json
+++ b/change/@microsoft-fast-foundation-2a6c7e7f-2bce-4594-9fbf-896d2479f757.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "replace anchored region with floating-ui in menu item",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/change/@microsoft-fast-ssr-551263b9-61b5-4f77-86c9-675d62612d27.json
+++ b/change/@microsoft-fast-ssr-551263b9-61b5-4f77-86c9-675d62612d27.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "update dom-shim test with menu item template changes",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -621,11 +621,11 @@ export function dividerTemplate<T extends FASTDivider>(): ElementViewTemplate<T>
 
 // @public
 export type EndOptions = {
-    end?: string | SyntheticViewTemplate;
+    end?: string | SyntheticViewTemplate | undefined;
 };
 
 // @public
-export function endSlotTemplate(options: EndOptions): ViewTemplate<StartEnd>;
+export function endSlotTemplate(options?: EndOptions): ViewTemplate<StartEnd>;
 
 // @public
 export class FASTAccordion extends FASTElement {
@@ -1346,6 +1346,8 @@ export class FASTMenuItem extends FASTElement {
     checked: boolean;
     // (undocumented)
     protected checkedChanged(oldValue: boolean, newValue: boolean): void;
+    // (undocumented)
+    cleanupSubmenuPosition: () => void;
     // @internal (undocumented)
     connectedCallback(): void;
     // @internal
@@ -1367,14 +1369,12 @@ export class FASTMenuItem extends FASTElement {
     // @internal (undocumented)
     hasSubmenu: boolean;
     role: MenuItemRole;
+    setSubmenuPosition: () => void;
     // @internal (undocumented)
     startColumnCount: MenuItemColumnCount;
     // @internal (undocumented)
     submenu: Element | undefined;
-    // @internal (undocumented)
-    submenuLoaded: () => void;
-    // @internal
-    submenuRegion: FASTAnchoredRegion;
+    submenuPositioning: SubmenuPosition;
 }
 
 // @internal
@@ -2381,7 +2381,6 @@ export type MenuItemOptions = StartEndOptions & {
     checkboxIndicator?: string | SyntheticViewTemplate;
     expandCollapseGlyph?: string | SyntheticViewTemplate;
     radioIndicator?: string | SyntheticViewTemplate;
-    anchoredRegion: TemplateElementDependency;
 };
 
 // @public
@@ -2395,7 +2394,11 @@ export const MenuItemRole: {
 export type MenuItemRole = typeof MenuItemRole[keyof typeof MenuItemRole];
 
 // @public
+<<<<<<< HEAD
 export function menuItemTemplate<T extends FASTMenuItem>(options: MenuItemOptions): ElementViewTemplate<T>;
+=======
+export function menuItemTemplate(options?: MenuItemOptions): ElementViewTemplate<FASTMenuItem>;
+>>>>>>> replace anchored region in menu item with floating-ui
 
 // @beta
 export const MenuPlacement: {
@@ -2635,14 +2638,33 @@ export type StartEndOptions = StartOptions & EndOptions;
 
 // @public
 export type StartOptions = {
-    start?: string | SyntheticViewTemplate;
+    start?: string | SyntheticViewTemplate | undefined;
 };
 
 // @public
-export function startSlotTemplate(options: StartOptions): ViewTemplate<StartEnd>;
+export function startSlotTemplate(options?: StartOptions): ViewTemplate<StartEnd>;
 
 // @public
 export type StaticDesignTokenValue<T> = T extends (...args: any[]) => any ? DerivedDesignTokenValue<T> : T;
+
+// @public
+export const SubmenuPosition: {
+    readonly top: "top";
+    readonly topStart: "top-start";
+    readonly topEnd: "top-end";
+    readonly right: "right";
+    readonly rightStart: "right-start";
+    readonly rightEnd: "right-end";
+    readonly bottom: "bottom";
+    readonly bottomStart: "bottom-start";
+    readonly bottomEnd: "bottom-end";
+    readonly left: "left";
+    readonly leftStart: "left-start";
+    readonly leftEnd: "left-end";
+};
+
+// @public
+export type SubmenuPosition = typeof SubmenuPosition[keyof typeof SubmenuPosition];
 
 // @alpha (undocumented)
 export const supportsElementInternals: boolean;
@@ -2812,7 +2834,6 @@ export type YearFormat = typeof YearFormat[keyof typeof YearFormat];
 // dist/dts/calendar/calendar.d.ts:51:5 - (ae-incompatible-release-tags) The symbol "dataGrid" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/data-grid/data-grid-row.template.d.ts:9:5 - (ae-incompatible-release-tags) The symbol "dataGridCell" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/data-grid/data-grid.template.d.ts:9:5 - (ae-incompatible-release-tags) The symbol "dataGridRow" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
-// dist/dts/menu-item/menu-item.d.ts:20:5 - (ae-incompatible-release-tags) The symbol "anchoredRegion" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/picker/picker.template.d.ts:9:5 - (ae-incompatible-release-tags) The symbol "anchoredRegion" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/picker/picker.template.d.ts:10:5 - (ae-incompatible-release-tags) The symbol "pickerMenu" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/picker/picker.template.d.ts:11:5 - (ae-incompatible-release-tags) The symbol "pickerMenuOption" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -35,10 +35,10 @@ export type AccordionItemOptions = StartEndOptions & {
 };
 
 // @public
-export function accordionItemTemplate<T extends FASTAccordionItem>(options?: AccordionItemOptions): ElementViewTemplate<T>;
+export function accordionItemTemplate(options?: AccordionItemOptions): ElementViewTemplate<FASTAccordionItem>;
 
 // @public
-export function accordionTemplate<T extends FASTAccordion>(): ElementViewTemplate<T>;
+export function accordionTemplate(): ElementViewTemplate<FASTAccordion>;
 
 // @public
 export interface AnchoredRegionConfig {
@@ -71,7 +71,7 @@ export const AnchoredRegionPositionLabel: {
 export type AnchoredRegionPositionLabel = typeof AnchoredRegionPositionLabel[keyof typeof AnchoredRegionPositionLabel];
 
 // @public
-export function anchoredRegionTemplate<T extends FASTAnchoredRegion>(): ElementViewTemplate<T>;
+export function anchoredRegionTemplate(): ElementViewTemplate<FASTAnchoredRegion>;
 
 // @public
 export type AnchorOptions = StartEndOptions;
@@ -88,7 +88,7 @@ export const AnchorTarget: {
 export type AnchorTarget = typeof AnchorTarget[keyof typeof AnchorTarget];
 
 // @public
-export function anchorTemplate<T extends FASTAnchor>(options?: AnchorOptions): ElementViewTemplate<T>;
+export function anchorTemplate(options?: AnchorOptions): ElementViewTemplate<FASTAnchor>;
 
 // @public
 export function applyMixins(derivedCtor: any, ...baseCtors: any[]): void;
@@ -131,7 +131,7 @@ export type AvatarOptions = {
 };
 
 // @public
-export function avatarTemplate<T extends FASTAvatar>(options?: AvatarOptions): ElementViewTemplate<T>;
+export function avatarTemplate(options?: AvatarOptions): ElementViewTemplate<FASTAvatar>;
 
 // @public
 export const AxisPositioningMode: {
@@ -154,7 +154,7 @@ export const AxisScalingMode: {
 export type AxisScalingMode = typeof AxisScalingMode[keyof typeof AxisScalingMode];
 
 // @public
-export function badgeTemplate<T extends FASTBadge>(): ElementViewTemplate<T>;
+export function badgeTemplate(): ElementViewTemplate<FASTBadge>;
 
 // @public
 export type BreadcrumbItemOptions = StartEndOptions & {
@@ -162,16 +162,16 @@ export type BreadcrumbItemOptions = StartEndOptions & {
 };
 
 // @public
-export function breadcrumbItemTemplate<T extends FASTBreadcrumbItem>(options?: BreadcrumbItemOptions): ElementViewTemplate<T>;
+export function breadcrumbItemTemplate(options?: BreadcrumbItemOptions): ElementViewTemplate<FASTBreadcrumbItem>;
 
 // @public
-export function breadcrumbTemplate<T extends FASTBreadcrumb>(): ElementViewTemplate<T>;
+export function breadcrumbTemplate(): ElementViewTemplate<FASTBreadcrumb>;
 
 // @public
 export type ButtonOptions = StartEndOptions;
 
 // @public
-export function buttonTemplate<T extends FASTButton>(options?: ButtonOptions): ElementViewTemplate<T>;
+export function buttonTemplate(options?: ButtonOptions): ElementViewTemplate<FASTButton>;
 
 // @public
 export const ButtonType: {
@@ -213,16 +213,16 @@ export type CalendarOptions = StartEndOptions & {
 export function calendarRowTemplate(options: CalendarOptions, todayString: string): ViewTemplate;
 
 // @public
-export function calendarTemplate<T extends FASTCalendar>(options: CalendarOptions): ElementViewTemplate<T>;
+export function calendarTemplate(options: CalendarOptions): ElementViewTemplate<FASTCalendar>;
 
 // @public
-export function calendarTitleTemplate<T extends FASTCalendar>(): ViewTemplate<T>;
+export function calendarTitleTemplate(): ViewTemplate<FASTCalendar>;
 
 // @public
 export function calendarWeekdayTemplate(options: CalendarOptions): ViewTemplate<WeekdayText>;
 
 // @public
-export function cardTemplate<T extends FASTCard>(): ElementViewTemplate<T>;
+export function cardTemplate(): ElementViewTemplate<FASTCard>;
 
 // @public
 export type CellItemTemplateOptions = {
@@ -262,7 +262,7 @@ export type CheckboxOptions = {
 };
 
 // @public
-export function checkboxTemplate<T extends FASTCheckbox>(options?: CheckboxOptions): ElementViewTemplate<T>;
+export function checkboxTemplate(options?: CheckboxOptions): ElementViewTemplate<FASTCheckbox>;
 
 // @public
 export interface ColumnDefinition {
@@ -295,7 +295,7 @@ export type ComboboxOptions = StartEndOptions & {
 };
 
 // @public
-export function comboboxTemplate<T extends FASTCombobox>(options?: ComboboxOptions): ElementViewTemplate<T>;
+export function comboboxTemplate(options?: ComboboxOptions): ElementViewTemplate<FASTCombobox>;
 
 export { composedContains }
 
@@ -323,7 +323,7 @@ export type CSSDisplayPropertyValue = "block" | "contents" | "flex" | "grid" | "
 export const darkModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
 // @public
-export function dataGridCellTemplate<T extends FASTDataGridCell>(): ElementViewTemplate<T>;
+export function dataGridCellTemplate(): ElementViewTemplate<FASTDataGridCell>;
 
 // @public
 export const DataGridCellTypes: {
@@ -341,7 +341,7 @@ export type DataGridOptions = {
 };
 
 // @public
-export function dataGridRowTemplate<T extends FASTDataGridRow>(options: CellItemTemplateOptions): ElementViewTemplate<T>;
+export function dataGridRowTemplate(options: CellItemTemplateOptions): ElementViewTemplate<FASTDataGridRow>;
 
 // @public
 export const DataGridRowTypes: {
@@ -354,7 +354,7 @@ export const DataGridRowTypes: {
 export type DataGridRowTypes = typeof DataGridRowTypes[keyof typeof DataGridRowTypes];
 
 // @public
-export function dataGridTemplate<T extends FASTDataGrid>(options: DataGridOptions): ElementViewTemplate<T>;
+export function dataGridTemplate(options: DataGridOptions): ElementViewTemplate<FASTDataGrid>;
 
 // @public
 export class DateFormatter {
@@ -586,7 +586,7 @@ export interface DesignTokenSubscriber<T extends DesignToken<any>> {
 }
 
 // @public
-export function dialogTemplate<T extends FASTDialog>(): ElementViewTemplate<T>;
+export function dialogTemplate(): ElementViewTemplate<FASTDialog>;
 
 // Warning: (ae-internal-missing-underscore) The name "Dimension" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -602,7 +602,7 @@ export interface Dimension {
 export const disabledCursor = "not-allowed";
 
 // @public
-export function disclosureTemplate<T extends FASTDisclosure>(): ElementViewTemplate<T>;
+export function disclosureTemplate(): ElementViewTemplate<FASTDisclosure>;
 
 // @public @deprecated
 export function display(displayValue: CSSDisplayPropertyValue): string;
@@ -617,7 +617,7 @@ export const DividerRole: {
 export type DividerRole = typeof DividerRole[keyof typeof DividerRole];
 
 // @public
-export function dividerTemplate<T extends FASTDivider>(): ElementViewTemplate<T>;
+export function dividerTemplate(): ElementViewTemplate<FASTDivider>;
 
 // @public
 export type EndOptions = {
@@ -2133,6 +2133,8 @@ export class FASTTreeItem extends FASTElement {
     protected itemsChanged(oldValue: unknown, newValue: HTMLElement[]): void;
     // @internal
     nested: boolean;
+    // @internal (undocumented)
+    renderCollapsedChildren: boolean;
     selected: boolean;
     // (undocumented)
     protected selectedChanged(): void;
@@ -2159,6 +2161,7 @@ export class FASTTreeView extends FASTElement {
     handleKeyDown: (e: KeyboardEvent) => boolean | void;
     // @internal
     handleSelectedChange: (e: Event) => boolean | void;
+    renderCollapsedNodes: boolean;
     // @internal
     slottedTreeItems: HTMLElement[];
     // (undocumented)
@@ -2183,7 +2186,7 @@ export type FlipperOptions = {
 };
 
 // @public
-export function flipperTemplate<T extends FASTFlipper>(options?: FlipperOptions): ElementViewTemplate<T>;
+export function flipperTemplate(options?: FlipperOptions): ElementViewTemplate<FASTFlipper>;
 
 // @public
 export const FlyoutPosBottom: AnchoredRegionConfig;
@@ -2316,7 +2319,7 @@ export type HorizontalScrollOptions = StartEndOptions & {
 };
 
 // @public (undocumented)
-export function horizontalScrollTemplate<T extends FASTHorizontalScroll>(options?: HorizontalScrollOptions): ElementViewTemplate<T>;
+export function horizontalScrollTemplate(options?: HorizontalScrollOptions): ElementViewTemplate<FASTHorizontalScroll>;
 
 // @public
 export const HorizontalScrollView: {
@@ -2330,7 +2333,7 @@ export type HorizontalScrollView = typeof HorizontalScrollView[keyof typeof Hori
 // Warning: (ae-internal-missing-underscore) The name "interactiveCalendarGridTemplate" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
-export function interactiveCalendarGridTemplate<T extends FASTCalendar>(options: CalendarOptions, todayString: string): ViewTemplate<T>;
+export function interactiveCalendarGridTemplate(options: CalendarOptions, todayString: string): ViewTemplate<FASTCalendar>;
 
 // @public
 export function isListboxOption(el: Element): el is FASTListboxOption;
@@ -2345,10 +2348,10 @@ export const lightModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaS
 export type ListboxOptionOptions = StartEndOptions;
 
 // @public
-export function listboxOptionTemplate<T extends FASTListboxOption>(options?: ListboxOptionOptions): ElementViewTemplate<T>;
+export function listboxOptionTemplate(options?: ListboxOptionOptions): ElementViewTemplate<FASTListboxOption>;
 
 // @public
-export function listboxTemplate<T extends FASTListboxElement>(): ElementViewTemplate<T>;
+export function listboxTemplate(): ElementViewTemplate<FASTListboxElement>;
 
 // @public
 export abstract class MatchMediaBehavior implements Behavior {
@@ -2394,11 +2397,7 @@ export const MenuItemRole: {
 export type MenuItemRole = typeof MenuItemRole[keyof typeof MenuItemRole];
 
 // @public
-<<<<<<< HEAD
-export function menuItemTemplate<T extends FASTMenuItem>(options: MenuItemOptions): ElementViewTemplate<T>;
-=======
 export function menuItemTemplate(options?: MenuItemOptions): ElementViewTemplate<FASTMenuItem>;
->>>>>>> replace anchored region in menu item with floating-ui
 
 // @beta
 export const MenuPlacement: {
@@ -2414,7 +2413,7 @@ export const MenuPlacement: {
 export type MenuPlacement = typeof MenuPlacement[keyof typeof MenuPlacement];
 
 // @public
-export function menuTemplate<T extends FASTMenu>(): ElementViewTemplate<T>;
+export function menuTemplate(): ElementViewTemplate<FASTMenu>;
 
 // @public
 export const MonthFormat: {
@@ -2439,7 +2438,7 @@ export type MonthInfo = {
 // Warning: (ae-internal-missing-underscore) The name "noninteractiveCalendarTemplate" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
-export function noninteractiveCalendarTemplate<T extends FASTCalendar>(options: CalendarOptions, todayString: string): ViewTemplate<T>;
+export function noninteractiveCalendarTemplate(options: CalendarOptions, todayString: string): ViewTemplate<FASTCalendar>;
 
 // @public
 export type NumberFieldOptions = StartEndOptions & {
@@ -2448,27 +2447,27 @@ export type NumberFieldOptions = StartEndOptions & {
 };
 
 // @public
-export function numberFieldTemplate<T extends FASTNumberField>(options?: NumberFieldOptions): ElementViewTemplate<T>;
+export function numberFieldTemplate(options?: NumberFieldOptions): ElementViewTemplate<FASTNumberField>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "pickerListItemTemplate" is marked as @public, but its signature references "FASTPickerListItem" which is marked as @beta
 //
 // @public (undocumented)
-export function pickerListItemTemplate<T extends FASTPickerListItem>(): ElementViewTemplate<T>;
+export function pickerListItemTemplate(): ElementViewTemplate<FASTPickerListItem>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "pickerListTemplate" is marked as @public, but its signature references "FASTPickerList" which is marked as @beta
 //
 // @public (undocumented)
-export function pickerListTemplate<T extends FASTPickerList>(): ElementViewTemplate<T>;
+export function pickerListTemplate(): ElementViewTemplate<FASTPickerList>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "pickerMenuOptionTemplate" is marked as @public, but its signature references "FASTPickerMenuOption" which is marked as @beta
 //
 // @public (undocumented)
-export function pickerMenuOptionTemplate<T extends FASTPickerMenuOption>(): ElementViewTemplate<T>;
+export function pickerMenuOptionTemplate(): ElementViewTemplate<FASTPickerMenuOption>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "pickerMenuTemplate" is marked as @public, but its signature references "FASTPickerMenu" which is marked as @beta
 //
 // @public
-export function pickerMenuTemplate<T extends FASTPickerMenu>(): ElementViewTemplate<T>;
+export function pickerMenuTemplate(): ElementViewTemplate<FASTPickerMenu>;
 
 // @public
 export type PickerOptions = {
@@ -2483,7 +2482,7 @@ export type PickerOptions = {
 // Warning: (ae-incompatible-release-tags) The symbol "pickerTemplate" is marked as @public, but its signature references "FASTPicker" which is marked as @beta
 //
 // @public
-export function pickerTemplate<T extends FASTPicker>(options: PickerOptions): ElementViewTemplate<T>;
+export function pickerTemplate(options: PickerOptions): ElementViewTemplate<FASTPicker>;
 
 // @public
 export type ProgressOptions = {
@@ -2497,10 +2496,10 @@ export type ProgressRingOptions = {
 };
 
 // @public
-export function progressRingTemplate<T extends FASTProgressRing>(options?: ProgressRingOptions): ElementViewTemplate<T>;
+export function progressRingTemplate(options?: ProgressRingOptions): ElementViewTemplate<FASTProgressRing>;
 
 // @public
-export function progressTemplate<T extends FASTProgress>(options?: ProgressOptions): ElementViewTemplate<T>;
+export function progressTemplate(options?: ProgressOptions): ElementViewTemplate<FASTProgress>;
 
 // @public
 export class PropertyStyleSheetBehavior implements Behavior {
@@ -2526,7 +2525,7 @@ export type ProxyElement = HTMLSelectElement | HTMLTextAreaElement | HTMLInputEl
 export type RadioControl = Pick<HTMLInputElement, "checked" | "disabled" | "readOnly" | "focus" | "setAttribute" | "getAttribute">;
 
 // @public
-export function radioGroupTemplate<T extends FASTRadioGroup>(): ElementViewTemplate<T>;
+export function radioGroupTemplate(): ElementViewTemplate<FASTRadioGroup>;
 
 // @public
 export type RadioOptions = {
@@ -2534,7 +2533,7 @@ export type RadioOptions = {
 };
 
 // @public
-export function radioTemplate<T extends FASTRadio>(options?: RadioOptions): ElementViewTemplate<T>;
+export function radioTemplate(options?: RadioOptions): ElementViewTemplate<FASTRadio>;
 
 // @beta
 export function reflectAttributes<T = any>(...attributes: string[]): CaptureType<T>;
@@ -2561,7 +2560,7 @@ export type ScrollEasing = typeof ScrollEasing[keyof typeof ScrollEasing];
 export type SearchOptions = StartEndOptions;
 
 // @public
-export function searchTemplate<T extends FASTSearch>(options?: SearchOptions): ElementViewTemplate<T>;
+export function searchTemplate(options?: SearchOptions): ElementViewTemplate<FASTSearch>;
 
 // @public
 export type SelectOptions = StartEndOptions & {
@@ -2578,7 +2577,7 @@ export const SelectPosition: {
 export type SelectPosition = typeof SelectPosition[keyof typeof SelectPosition];
 
 // @public
-export function selectTemplate<T extends FASTSelect>(options?: SelectOptions): ElementViewTemplate<T>;
+export function selectTemplate(options?: SelectOptions): ElementViewTemplate<FASTSelect>;
 
 // @public
 export const SkeletonShape: {
@@ -2590,7 +2589,7 @@ export const SkeletonShape: {
 export type SkeletonShape = typeof SkeletonShape[keyof typeof SkeletonShape];
 
 // @public
-export function skeletonTemplate<T extends FASTSkeleton>(): ElementViewTemplate<T>;
+export function skeletonTemplate(): ElementViewTemplate<FASTSkeleton>;
 
 // @public
 export interface SliderConfiguration {
@@ -2607,7 +2606,7 @@ export interface SliderConfiguration {
 }
 
 // @public
-export function sliderLabelTemplate<T extends FASTSliderLabel>(): ElementViewTemplate<T>;
+export function sliderLabelTemplate(): ElementViewTemplate<FASTSliderLabel>;
 
 // @public
 export const SliderMode: {
@@ -2623,7 +2622,7 @@ export type SliderOptions = {
 };
 
 // @public
-export function sliderTemplate<T extends FASTSlider>(options?: SliderOptions): ElementViewTemplate<T>;
+export function sliderTemplate(options?: SliderOptions): ElementViewTemplate<FASTSlider>;
 
 // @public
 export class StartEnd {
@@ -2675,13 +2674,13 @@ export type SwitchOptions = {
 };
 
 // @public
-export function switchTemplate<T extends FASTSwitch>(options?: SwitchOptions): ElementViewTemplate<T>;
+export function switchTemplate(options?: SwitchOptions): ElementViewTemplate<FASTSwitch>;
 
 // @public
 export type TabOptionOptions = StartEndOptions;
 
 // @public
-export function tabPanelTemplate<T extends FASTTabPanel>(): ElementViewTemplate<T>;
+export function tabPanelTemplate(): ElementViewTemplate<FASTTabPanel>;
 
 // @public
 export type TabsOptions = StartEndOptions;
@@ -2696,10 +2695,10 @@ export const TabsOrientation: {
 export type TabsOrientation = typeof TabsOrientation[keyof typeof TabsOrientation];
 
 // @public
-export function tabsTemplate<T extends FASTTabs>(options?: TabsOptions): ElementViewTemplate<T>;
+export function tabsTemplate(options?: TabsOptions): ElementViewTemplate<FASTTabs>;
 
 // @public
-export function tabTemplate<T extends FASTTab>(options?: StartEndOptions): ElementViewTemplate<T>;
+export function tabTemplate(options?: StartEndOptions): ElementViewTemplate<FASTTab>;
 
 // @beta
 export function tagFor(dependency: TemplateElementDependency): string;
@@ -2719,13 +2718,13 @@ export const TextAreaResize: {
 export type TextAreaResize = typeof TextAreaResize[keyof typeof TextAreaResize];
 
 // @public
-export function textAreaTemplate<T extends FASTTextArea>(): ElementViewTemplate<T>;
+export function textAreaTemplate(): ElementViewTemplate<FASTTextArea>;
 
 // @public
 export type TextFieldOptions = StartEndOptions;
 
 // @public
-export function textFieldTemplate<T extends FASTTextField>(options?: TextFieldOptions): ElementViewTemplate<T>;
+export function textFieldTemplate(options?: TextFieldOptions): ElementViewTemplate<FASTTextField>;
 
 // @public
 export const TextFieldType: {
@@ -2743,7 +2742,7 @@ export type TextFieldType = typeof TextFieldType[keyof typeof TextFieldType];
 export type ToolbarOptions = StartEndOptions;
 
 // @public
-export function toolbarTemplate<T extends FASTToolbar>(options?: ToolbarOptions): ElementViewTemplate<T>;
+export function toolbarTemplate(options?: ToolbarOptions): ElementViewTemplate<FASTToolbar>;
 
 // @public
 export type TooltipOptions = {
@@ -2775,7 +2774,7 @@ export const TooltipPosition: {
 export type TooltipPosition = typeof TooltipPosition[keyof typeof TooltipPosition];
 
 // @public
-export function tooltipTemplate<T extends FASTTooltip>(options: TooltipOptions): ElementViewTemplate<T>;
+export function tooltipTemplate(options: TooltipOptions): ElementViewTemplate<FASTTooltip>;
 
 // @public
 export type TreeItemOptions = StartEndOptions & {
@@ -2783,10 +2782,10 @@ export type TreeItemOptions = StartEndOptions & {
 };
 
 // @public
-export function treeItemTemplate<T extends FASTTreeItem>(options?: TreeItemOptions): ElementViewTemplate<T>;
+export function treeItemTemplate(options?: TreeItemOptions): ElementViewTemplate<FASTTreeItem>;
 
 // @public
-export function treeViewTemplate<T extends FASTTreeView>(): ElementViewTemplate<T>;
+export function treeViewTemplate(): ElementViewTemplate<FASTTreeView>;
 
 // @public
 export const VerticalPosition: {

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -120,7 +120,12 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
+<<<<<<< HEAD
     "@microsoft/fast-element": "^2.0.0-beta.6",
+=======
+    "@floating-ui/dom": "^1.0.0",
+    "@microsoft/fast-element": "^2.0.0-beta.5",
+>>>>>>> replace anchored region in menu item with floating-ui
     "@microsoft/fast-web-utilities": "^6.0.0",
     "tabbable": "^5.2.0",
     "tslib": "^2.4.0"

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -120,12 +120,8 @@
     "webpack-cli": "^4.9.2"
   },
   "dependencies": {
-<<<<<<< HEAD
-    "@microsoft/fast-element": "^2.0.0-beta.6",
-=======
     "@floating-ui/dom": "^1.0.0",
-    "@microsoft/fast-element": "^2.0.0-beta.5",
->>>>>>> replace anchored region in menu item with floating-ui
+    "@microsoft/fast-element": "^2.0.0-beta.6",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "tabbable": "^5.2.0",
     "tslib": "^2.4.0"

--- a/packages/web-components/fast-foundation/src/menu-item/index.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/index.ts
@@ -1,2 +1,3 @@
+export * from "./menu-item.options.js";
 export * from "./menu-item.template.js";
 export * from "./menu-item.js";

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.options.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.options.ts
@@ -1,5 +1,5 @@
-import type { StartEndOptions } from "../patterns/start-end.js";
 import type { SyntheticViewTemplate } from "@microsoft/fast-element";
+import type { StartEndOptions } from "../patterns/start-end.js";
 
 /**
  * Types of menu item column count.

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.options.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.options.ts
@@ -1,3 +1,22 @@
+import type { StartEndOptions } from "../patterns/start-end.js";
+import type { SyntheticViewTemplate } from "@microsoft/fast-element";
+
+/**
+ * Types of menu item column count.
+ * @public
+ */
+export type MenuItemColumnCount = 0 | 1 | 2;
+
+/**
+ * Menu Item configuration options
+ * @public
+ */
+export type MenuItemOptions = StartEndOptions & {
+    checkboxIndicator?: string | SyntheticViewTemplate;
+    expandCollapseGlyph?: string | SyntheticViewTemplate;
+    radioIndicator?: string | SyntheticViewTemplate;
+};
+
 /**
  * Menu items roles.
  * @public
@@ -35,3 +54,77 @@ export const roleForMenuItem: {
     [MenuItemRole.menuitemcheckbox]: "menuitemcheckbox",
     [MenuItemRole.menuitemradio]: "menuitemradio",
 };
+
+/**
+ * Enumerates possible submenu positions
+ *
+ * @public
+ */
+export const SubmenuPosition = {
+    /**
+     * The submenu is positioned above the element
+     */
+    top: "top",
+
+    /**
+     * The submenu is positioned above the element and and in the logical start position
+     */
+    topStart: "top-start",
+
+    /**
+     * The submenu is positioned above the element and in the logical end position
+     */
+    topEnd: "top-end",
+
+    /**
+     * The submenu is positioned to the right of the element
+     */
+    right: "right",
+
+    /**
+     * The submenu is positioned to the right the element and in the logical start position
+     */
+    rightStart: "right-start",
+
+    /**
+     * The submenu is positioned to the right of the element and in the logical end position
+     */
+    rightEnd: "right-end",
+
+    /**
+     * The submenu is positioned below the element
+     */
+    bottom: "bottom",
+
+    /**
+     * The submenu is positioned below the element and and in the logical start position
+     */
+    bottomStart: "bottom-start",
+
+    /**
+     * The submenu is positioned below the element and in the logical end position
+     */
+    bottomEnd: "bottom-end",
+
+    /**
+     * The submenu is positioned to the left of the element
+     */
+    left: "left",
+
+    /**
+     * The submenu is positioned to the left the element and in the logical start position
+     */
+    leftStart: "left-start",
+
+    /**
+     * The submenu is positioned to the left of the element and in the logical end position
+     */
+    leftEnd: "left-end",
+} as const;
+
+/**
+ * The possible submenu positions
+ *
+ * @public
+ */
+export type SubmenuPosition = typeof SubmenuPosition[keyof typeof SubmenuPosition];

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
@@ -4,20 +4,11 @@ import { fixture, uniqueElementName } from "@microsoft/fast-element/testing";
 import { Updates } from "@microsoft/fast-element";
 import { MenuItemRole } from "./menu-item.js";
 import { keyEnter, keySpace } from "@microsoft/fast-web-utilities";
-import { FASTAnchoredRegion, anchoredRegionTemplate } from "../anchored-region/index.js";
-
-const anchoredRegionName = uniqueElementName();
-FASTAnchoredRegion.compose({
-    name: anchoredRegionName,
-    template: anchoredRegionTemplate()
-});
 
 const menuItemName = uniqueElementName();
 FASTMenuItem.define({
     name: menuItemName,
-    template: menuItemTemplate({
-        anchoredRegion: anchoredRegionName
-    })
+    template: menuItemTemplate()
 });
 
 async function setup() {

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -1,5 +1,5 @@
 import { ElementViewTemplate, html, when } from "@microsoft/fast-element";
-import { endSlotTemplate, startSlotTemplate, tagFor } from "../patterns/index.js";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/index.js";
 import { MenuItemRole } from "./menu-item.js";
 import type { FASTMenuItem } from "./menu-item.js";
 import type { MenuItemOptions } from "./menu-item.options.js";
@@ -33,7 +33,7 @@ export function menuItemTemplate<T extends FASTMenuItem>(
                     <div part="input-container" class="input-container">
                         <span part="checkbox" class="checkbox">
                             <slot name="checkbox-indicator">
-                                ${options.checkboxIndicator ?? ""}
+                                ${options?.checkboxIndicator ?? ""}
                             </slot>
                         </span>
                     </div>
@@ -45,7 +45,7 @@ export function menuItemTemplate<T extends FASTMenuItem>(
                     <div part="input-container" class="input-container">
                         <span part="radio" class="radio">
                             <slot name="radio-indicator">
-                                ${options.radioIndicator ?? ""}
+                                ${options?.radioIndicator ?? ""}
                             </slot>
                         </span>
                     </div>
@@ -66,7 +66,7 @@ export function menuItemTemplate<T extends FASTMenuItem>(
                 >
                     <span part="expand-collapse" class="expand-collapse">
                         <slot name="expand-collapse-indicator">
-                            ${options.expandCollapseGlyph ?? ""}
+                            ${options?.expandCollapseGlyph ?? ""}
                         </slot>
                     </span>
                 </div>

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -1,7 +1,8 @@
-import { ElementViewTemplate, html, ref, when } from "@microsoft/fast-element";
+import { ElementViewTemplate, html, when } from "@microsoft/fast-element";
 import { endSlotTemplate, startSlotTemplate, tagFor } from "../patterns/index.js";
 import { MenuItemRole } from "./menu-item.js";
-import type { FASTMenuItem, MenuItemOptions } from "./menu-item.js";
+import type { FASTMenuItem } from "./menu-item.js";
+import type { MenuItemOptions } from "./menu-item.options.js";
 
 /**
  * Generates a template for the {@link @microsoft/fast-foundation#(FASTMenuItem:class)} component using
@@ -10,9 +11,8 @@ import type { FASTMenuItem, MenuItemOptions } from "./menu-item.js";
  * @public
  */
 export function menuItemTemplate<T extends FASTMenuItem>(
-    options: MenuItemOptions
+    options?: MenuItemOptions
 ): ElementViewTemplate<T> {
-    const anchoredRegionTag = tagFor(options.anchoredRegion);
     return html<T>`
     <template
         role="${x => x.role}"
@@ -72,26 +72,7 @@ export function menuItemTemplate<T extends FASTMenuItem>(
                 </div>
             `
         )}
-        ${when(
-            x => x.expanded,
-            html<T>`
-                <${anchoredRegionTag}
-                    :anchorElement="${x => x}"
-                    vertical-positioning-mode="dynamic"
-                    vertical-default-position="bottom"
-                    vertical-inset="true"
-                    horizontal-positioning-mode="dynamic"
-                    horizontal-default-position="end"
-                    class="submenu-region"
-                    dir="${x => x.currentDirection}"
-                    @loaded="${x => x.submenuLoaded()}"
-                    ${ref("submenuRegion")}
-                    part="submenu-region"
-                >
-                    <slot name="submenu"></slot>
-                </${anchoredRegionTag}>
-            `
-        )}
+        <slot name="submenu"></slot>
     </template>
     `;
 }

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -6,7 +6,7 @@ import {
     keyEnter,
     keySpace,
 } from "@microsoft/fast-web-utilities";
-import { computePosition, flip, autoUpdate } from "@floating-ui/dom";
+import { autoUpdate, computePosition, flip, hide, shift } from "@floating-ui/dom";
 import type { FASTMenu } from "../menu/menu.js";
 import { StartEnd } from "../patterns/index.js";
 import { getDirection } from "../utilities/direction.js";
@@ -257,7 +257,7 @@ export class FASTMenuItem extends FASTElement {
                     this.submenu as HTMLElement,
                     {
                         placement: this.submenuPositioning || SubmenuPosition.rightStart,
-                        middleware: [flip()],
+                        middleware: [flip(), shift()],
                     }
                 ).then(({ x, y }) => {
                     Object.assign((this.submenu as HTMLElement)!.style, {

--- a/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.register.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.register.ts
@@ -271,7 +271,6 @@ const styles = css`
 FASTMenuItem.define({
     name: "fast-menu-item",
     template: menuItemTemplate({
-        anchoredRegion: "fast-anchored-region",
         checkboxIndicator: /* html */ `
             <svg
                 part="checkbox-indicator"

--- a/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.register.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.register.ts
@@ -9,6 +9,7 @@ const styles = css`
 
     :host {
         --icon-col: minmax(42px, auto);
+        position: relative;
         align-items: center;
         background: var(--neutral-fill-stealth-rest);
         border-radius: calc(var(--control-corner-radius) * 1px);
@@ -256,6 +257,14 @@ const styles = css`
     :host([aria-checked="true"]) ::slotted([slot="radio-indicator"]) {
         display: block;
         pointer-events: none;
+    }
+
+    ::slotted([slot="submenu"]) {
+        display: block;
+        visibility: hidden;
+    }
+    :host([aria-expanded="true"]) ::slotted([slot="submenu"]) {
+        visibility: visible;
     }
 `;
 

--- a/packages/web-components/fast-foundation/src/menu/README.md
+++ b/packages/web-components/fast-foundation/src/menu/README.md
@@ -165,9 +165,10 @@ export const myMenuItem = MenuItem.compose<MenuItemOptions>({
 
 ### Variables
 
-| Name           | Description       | Type                                                                                              |
-| -------------- | ----------------- | ------------------------------------------------------------------------------------------------- |
-| `MenuItemRole` | Menu items roles. | `{ menuitem: "menuitem", menuitemcheckbox: "menuitemcheckbox", menuitemradio: "menuitemradio", }` |
+| Name              | Description                           | Type                                                                                                                                                                                                                                                              |
+| ----------------- | ------------------------------------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- |
+| `MenuItemRole`    | Menu items roles.                     | `{ menuitem: "menuitem", menuitemcheckbox: "menuitemcheckbox", menuitemradio: "menuitemradio", }`                                                                                                                                                                 |
+| `SubmenuPosition` | Enumerates possible submenu positions | `{ top: "top", topStart: "top-start", topEnd: "top-end", right: "right", rightStart: "right-start", rightEnd: "right-end", bottom: "bottom", bottomStart: "bottom-start", bottomEnd: "bottom-end", left: "left", leftStart: "left-start", leftEnd: "left-end", }` |
 
 <hr/>
 
@@ -183,12 +184,15 @@ export const myMenuItem = MenuItem.compose<MenuItemOptions>({
 
 #### Fields
 
-| Name       | Privacy | Type           | Default | Description                        | Inherited From |
-| ---------- | ------- | -------------- | ------- | ---------------------------------- | -------------- |
-| `disabled` | public  | `boolean`      |         | The disabled state of the element. |                |
-| `expanded` | public  | `boolean`      |         | The expanded state of the element. |                |
-| `role`     | public  | `MenuItemRole` |         | The role of the element.           |                |
-| `checked`  | public  | `boolean`      |         | The checked value of the element.  |                |
+| Name                     | Privacy | Type              | Default | Description                        | Inherited From |
+| ------------------------ | ------- | ----------------- | ------- | ---------------------------------- | -------------- |
+| `disabled`               | public  | `boolean`         |         | The disabled state of the element. |                |
+| `expanded`               | public  | `boolean`         |         | The expanded state of the element. |                |
+| `role`                   | public  | `MenuItemRole`    |         | The role of the element.           |                |
+| `submenuPositioning`     | public  | `SubmenuPosition` |         | The positioning of the submenu     |                |
+| `checked`                | public  | `boolean`         |         | The checked value of the element.  |                |
+| `cleanupSubmenuPosition` | public  | `() => void`      |         |                                    |                |
+| `setSubmenuPosition`     | public  |                   |         | Sets the submenu position          |                |
 
 #### Methods
 
@@ -206,12 +210,13 @@ export const myMenuItem = MenuItem.compose<MenuItemOptions>({
 
 #### Attributes
 
-| Name   | Field    | Inherited From |
-| ------ | -------- | -------------- |
-|        | disabled |                |
-|        | expanded |                |
-| `role` | role     |                |
-|        | checked  |                |
+| Name                 | Field              | Inherited From |
+| -------------------- | ------------------ | -------------- |
+|                      | disabled           |                |
+|                      | expanded           |                |
+| `role`               | role               |                |
+| `submenuPositioning` | submenuPositioning |                |
+|                      | checked            |                |
 
 #### CSS Parts
 
@@ -223,7 +228,6 @@ export const myMenuItem = MenuItem.compose<MenuItemOptions>({
 | `content`                         | The element wrapping the menu item content                     |
 | `expand-collapse-glyph-container` | The element wrapping the expand collapse element               |
 | `expand-collapse`                 | The expand/collapse element                                    |
-| `submenu-region`                  | The container for the submenu, used for positioning            |
 
 #### Slots
 

--- a/packages/web-components/fast-foundation/src/menu/menu.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.spec.ts
@@ -4,20 +4,11 @@ import { FASTMenuItem, menuItemTemplate, MenuItemRole } from "../menu-item/index
 import { fixture, uniqueElementName } from "@microsoft/fast-element/testing";
 import { Updates } from "@microsoft/fast-element";
 import { keyArrowDown, keyArrowUp } from "@microsoft/fast-web-utilities";
-import { FASTAnchoredRegion, anchoredRegionTemplate } from "../anchored-region/index.js";
-
-const anchoredRegionName = uniqueElementName();
-FASTAnchoredRegion.compose({
-    name: anchoredRegionName,
-    template: anchoredRegionTemplate()
-});
 
 const menuItemName = uniqueElementName();
 FASTMenuItem.define({
     name: menuItemName,
-    template: menuItemTemplate({
-        anchoredRegion: anchoredRegionName
-    })
+    template: menuItemTemplate()
 });
 
 const menuName = uniqueElementName();

--- a/packages/web-components/fast-foundation/src/menu/stories/menu.register.ts
+++ b/packages/web-components/fast-foundation/src/menu/stories/menu.register.ts
@@ -27,6 +27,8 @@ const styles = css`
         margin: 0 calc(var(--design-unit) * 1px);
         width: max-content;
         position: absolute;
+        top: 0;
+        left: 0;
     }
 
     ::slotted(hr) {

--- a/packages/web-components/fast-foundation/src/menu/stories/menu.register.ts
+++ b/packages/web-components/fast-foundation/src/menu/stories/menu.register.ts
@@ -26,6 +26,7 @@ const styles = css`
     :host([slot="submenu"]) {
         margin: 0 calc(var(--design-unit) * 1px);
         width: max-content;
+        position: absolute;
     }
 
     ::slotted(hr) {

--- a/packages/web-components/fast-foundation/src/patterns/start-end.ts
+++ b/packages/web-components/fast-foundation/src/patterns/start-end.ts
@@ -5,7 +5,7 @@ import { html, ref, SyntheticViewTemplate, ViewTemplate } from "@microsoft/fast-
  * @public
  */
 export type StartOptions = {
-    start?: string | SyntheticViewTemplate;
+    start?: string | SyntheticViewTemplate | undefined;
 };
 
 /**
@@ -13,7 +13,7 @@ export type StartOptions = {
  * @public
  */
 export type EndOptions = {
-    end?: string | SyntheticViewTemplate;
+    end?: string | SyntheticViewTemplate | undefined;
 };
 
 /**
@@ -39,9 +39,9 @@ export class StartEnd {
  *
  * @public
  */
-export function endSlotTemplate(options: EndOptions): ViewTemplate<StartEnd> {
+export function endSlotTemplate(options?: EndOptions): ViewTemplate<StartEnd> {
     return html`
-        <slot name="end" ${ref("end")}>${options.end || ""}</slot>
+        <slot name="end" ${ref("end")}>${options?.end || ""}</slot>
     `;
 }
 
@@ -51,8 +51,8 @@ export function endSlotTemplate(options: EndOptions): ViewTemplate<StartEnd> {
  *
  * @public
  */
-export function startSlotTemplate(options: StartOptions): ViewTemplate<StartEnd> {
+export function startSlotTemplate(options?: StartOptions): ViewTemplate<StartEnd> {
     return html`
-        <slot name="start" ${ref("start")}>${options.start || ""}</slot>
+        <slot name="start" ${ref("start")}>${options?.start || ""}</slot>
     `;
 }

--- a/packages/web-components/fast-ssr/src/dom-shim.spec.ts
+++ b/packages/web-components/fast-ssr/src/dom-shim.spec.ts
@@ -74,9 +74,7 @@ const componentsAndTemplates: [typeof FASTElement, ElementViewTemplate][] = [
     [Foundation.FASTListbox as any as typeof FASTElement, Foundation.listboxTemplate()],
     [Foundation.FASTListboxOption, Foundation.listboxOptionTemplate()],
     [Foundation.FASTMenu, Foundation.menuTemplate()],
-    [Foundation.FASTMenuItem, Foundation.menuItemTemplate({
-        anchoredRegion
-    })],
+    [Foundation.FASTMenuItem, Foundation.menuItemTemplate()],
     [Foundation.FASTNumberField, Foundation.numberFieldTemplate()],
     [Foundation.FASTPicker, Foundation.pickerTemplate({
         anchoredRegion,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1800,6 +1800,18 @@
     unique-filename "^1.1.1"
     which "^1.3.1"
 
+"@floating-ui/core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
+  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
+
+"@floating-ui/dom@^1.0.0":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.1.tgz#3321d4e799d6ac2503e729131d07ad0e714aabeb"
+  integrity sha512-wBDiLUKWU8QNPNOTAFHiIAkBv1KlHauG2AhqjSeh2H+wR8PX+AArXfz8NkRexH5PgMJMmSOS70YS89AbWYh5dA==
+  dependencies:
+    "@floating-ui/core" "^1.0.1"
+
 "@fluentui/svg-icons@^1.1.0", "@fluentui/svg-icons@^1.1.139":
   version "1.1.167"
   resolved "https://registry.yarnpkg.com/@fluentui/svg-icons/-/svg-icons-1.1.167.tgz#b16f2be02061d438f520c8499ab184e700cfcfbf"


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR serves to initiate the migration of Menu Item anchored positioning to use `floating-ui/dom`. There are a few ways we can look at approaching this. 

1. The initial work here (what is being proposed) is to start with a fairly minimal exposed API surface as it relates to `floating-ui/dom`. Floating UI provides a significant amount of configuration, but with each applied portion of middleware, etc, we likely add unshakeable code. The menu item provides a public function for setting the submenu position. This would provide the ability to configure the implementation by extending the component. Out of the box we have submenu positioning with a very familiar API as it relates to the previous implementation but with a more intuitive DOM structure. If you need more, you can extend the component and override the `setSubmenuPosition` method.

2. An alternative here could be to create a mixin which exposes either a full or partial configuration of Floating UI. This provides a more direct API to interact with, but also exposes a set of API's which we may want to move away from when native anchored positioning comes into play. Exposing so much of the floating-ui API as part of the baseline feature set of Foundation seems like overkill at this time. While it may be a convenience for some who want that full customization out of the box, in the most basic menu scenarios (without submenus) it would be extremely heavy. With that said, we could add a mixin and not bake it into the primary exported template, instead providing examples on how to implement and customize. With that said, again this feels like more of a convenience to a smaller subset of folks and I'm not sure there's a benefit to exporting the a mixin we don't intend to use.

3. Rather than provide a public function to override, we could make this pluggable and enable some method of passing the configuration and middleware to the component optionally.

One additional consideration while we're here is that if I don't need a menu item with submenus I'm still getting this code. In the case of a very simple menu, does it make sense to break out the submenu behavior and enable that to be inserted in a way that could support tree shaking? Alternatively, this should provide a reduction in complexity (no dependent components) and weight overall - do we mind if you get this for free?

### 🎫 Issues
addresses part of #6185 

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->