### PR TITLE
feat: add async rendering support via PendingTask

### DIFF
--- a/change/@microsoft-fast-element-f2bcaaf6-9732-4ef2-8fb0-985c27afbd2f.json
+++ b/change/@microsoft-fast-element-f2bcaaf6-9732-4ef2-8fb0-985c27afbd2f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds PendingTask community protocol",
+  "packageName": "@microsoft/fast-element",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/change/@microsoft-fast-ssr-4675c274-ed0b-4b95-abf3-d8f86163cabd.json
+++ b/change/@microsoft-fast-ssr-4675c274-ed0b-4b95-abf3-d8f86163cabd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Adds support for async component rendering through the PendingTask protocol",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-element/package.json
+++ b/packages/web-components/fast-element/package.json
@@ -70,6 +70,10 @@
       "types": "./dist/dts/di/di.d.ts",
       "default": "./dist/esm/di/di.js"
     },
+    "./pending-task": {
+      "types": "./dist/dts/pending-task.d.ts",
+      "default": "./dist/esm/pending-task.js"
+    },
     "./package.json": "./package.json"
   },
   "unpkg": "dist/fast-element.min.js",

--- a/packages/web-components/fast-element/src/pending-task.ts
+++ b/packages/web-components/fast-element/src/pending-task.ts
@@ -1,0 +1,9 @@
+/**
+ * Implementation of the https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/pending-task.md proposal.
+ * @beta
+ */
+export class PendingTask extends Event {
+    constructor(public complete: Promise<void>) {
+        super("pending-task", { bubbles: true, composed: true });
+    }
+}

--- a/packages/web-components/fast-element/src/pending-task.ts
+++ b/packages/web-components/fast-element/src/pending-task.ts
@@ -1,11 +1,16 @@
 /**
- * This module provides an implementation of the https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/pending-task.md proposal.
+ * This module provides
+ */
+/**
+ * An implementation of the https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/pending-task.md proposal.
+ * @beta
  */
 export interface PendingTask extends Event {
     complete: Promise<void>;
 }
 
 /**
+ * A concrete implementation of {@link PendingTask}
  * @beta
  */
 export class PendingTaskEvent extends Event implements PendingTask {

--- a/packages/web-components/fast-element/src/pending-task.ts
+++ b/packages/web-components/fast-element/src/pending-task.ts
@@ -2,7 +2,7 @@
  * Implementation of the https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/pending-task.md proposal.
  * @beta
  */
-export class PendingTask extends Event {
+export class PendingTaskEvent extends Event {
     constructor(public complete: Promise<void>) {
         super("pending-task", { bubbles: true, composed: true });
     }

--- a/packages/web-components/fast-element/src/pending-task.ts
+++ b/packages/web-components/fast-element/src/pending-task.ts
@@ -1,9 +1,25 @@
 /**
- * Implementation of the https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/pending-task.md proposal.
+ * This module provides an implementation of the https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/pending-task.md proposal.
+ */
+export interface PendingTask extends Event {
+    complete: Promise<void>;
+}
+
+/**
  * @beta
  */
-export class PendingTaskEvent extends Event {
+export class PendingTaskEvent extends Event implements PendingTask {
+    public static readonly type = "pending-task";
     constructor(public complete: Promise<void>) {
-        super("pending-task", { bubbles: true, composed: true });
+        super(PendingTaskEvent.type, { bubbles: true, composed: true });
+    }
+
+    public static isPendingTask<T extends Event>(
+        value: T | PendingTask
+    ): value is PendingTask {
+        return (
+            value.type === PendingTaskEvent.type &&
+            typeof (value as any).complete?.then === "function"
+        );
     }
 }

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -1,4 +1,6 @@
 import { Aspect, DOM, ExecutionContext, FASTElement } from "@microsoft/fast-element";
+import { PendingTask } from "@microsoft/fast-element/pending-task";
+import { reject } from "lodash-es";
 import { escapeHtml } from "../escape-html.js";
 import { RenderInfo } from "../render-info.js";
 import { StyleRenderer } from "../styles/style-renderer.js";
@@ -117,32 +119,55 @@ export abstract class SyncFASTElementRenderer extends FASTElementRenderer
 }
 export abstract class AsyncFASTElementRenderer extends FASTElementRenderer
     implements AsyncElementRenderer {
-    renderAttributes = renderAttributesAsync;
-    renderShadow = renderShadow as (
-        renderInfo: RenderInfo
-    ) => IterableIterator<string | Promise<string>>;
-}
+    constructor(tagName: string, renderInfo: RenderInfo) {
+        super(tagName, renderInfo);
 
-function* renderAttributesSync(this: FASTElementRenderer): IterableIterator<string> {
-    if (this.element !== undefined) {
-        const { attributes } = this.element;
-        for (
-            let i = 0, name, value;
-            i < attributes.length && ({ name, value } = attributes[i]);
-            i++
-        ) {
-            if (value === "" || value === undefined || value === null) {
-                yield ` ${name}`;
-            } else {
-                yield ` ${name}="${escapeHtml(value)}"`;
+        this.element.addEventListener("pending-task", this.pendingTaskHandler);
+    }
+    public *renderAttributes(
+        this: AsyncFASTElementRenderer
+    ): IterableIterator<string | Promise<string>> {
+        if (this.element !== undefined) {
+            if (this.awaiting.size) {
+                yield this.pauseRendering().then(() => "");
+            }
+            const { attributes } = this.element;
+
+            for (
+                let i = 0, name, value;
+                i < attributes.length && ({ name, value } = attributes[i]);
+                i++
+            ) {
+                if (value === "" || value === undefined || value === null) {
+                    yield ` ${name}`;
+                } else {
+                    yield ` ${name}="${escapeHtml(value)}"`;
+                }
             }
         }
     }
+    renderShadow = renderShadow as (
+        renderInfo: RenderInfo
+    ) => IterableIterator<string | Promise<string>>;
+
+    private async pauseRendering() {
+        for await (const awaiting of this.awaiting) {
+            continue;
+        }
+
+        this.awaiting.clear();
+    }
+
+    private awaiting: Set<Promise<void>> = new Set();
+
+    private pendingTaskHandler = (e: Event) => {
+        if (e instanceof PendingTask) {
+            this.awaiting.add(e.complete);
+        }
+    };
 }
 
-function* renderAttributesAsync(
-    this: FASTElementRenderer
-): IterableIterator<string | Promise<string>> {
+function* renderAttributesSync(this: FASTElementRenderer): IterableIterator<string> {
     if (this.element !== undefined) {
         const { attributes } = this.element;
         for (

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -150,8 +150,13 @@ export abstract class AsyncFASTElementRenderer extends FASTElementRenderer
     ) => IterableIterator<string | Promise<string>>;
 
     private async pauseRendering() {
-        for await (const awaiting of this.awaiting) {
-            continue;
+        for (const awaiting of this.awaiting) {
+            try {
+                await awaiting;
+            } catch (e) {
+                // Await will throw if the Promise is rejected. In that case,
+                // SSR should just continue rendering
+            }
         }
 
         this.awaiting.clear();

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -1,6 +1,5 @@
 import { Aspect, DOM, ExecutionContext, FASTElement } from "@microsoft/fast-element";
-import { PendingTask } from "@microsoft/fast-element/pending-task";
-import { reject } from "lodash-es";
+import { PendingTaskEvent } from "@microsoft/fast-element/pending-task";
 import { escapeHtml } from "../escape-html.js";
 import { RenderInfo } from "../render-info.js";
 import { StyleRenderer } from "../styles/style-renderer.js";
@@ -161,7 +160,7 @@ export abstract class AsyncFASTElementRenderer extends FASTElementRenderer
     private awaiting: Set<Promise<void>> = new Set();
 
     private pendingTaskHandler = (e: Event) => {
-        if (e instanceof PendingTask) {
+        if (e instanceof PendingTaskEvent) {
             this.awaiting.add(e.complete);
         }
     };

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -121,7 +121,7 @@ export abstract class AsyncFASTElementRenderer extends FASTElementRenderer
     constructor(tagName: string, renderInfo: RenderInfo) {
         super(tagName, renderInfo);
 
-        this.element.addEventListener("pending-task", this.pendingTaskHandler);
+        this.element.addEventListener(PendingTaskEvent.type, this.pendingTaskHandler);
     }
     public *renderAttributes(
         this: AsyncFASTElementRenderer
@@ -160,7 +160,7 @@ export abstract class AsyncFASTElementRenderer extends FASTElementRenderer
     private awaiting: Set<Promise<void>> = new Set();
 
     private pendingTaskHandler = (e: Event) => {
-        if (e instanceof PendingTaskEvent) {
+        if (PendingTaskEvent.isPendingTask(e)) {
             this.awaiting.add(e.complete);
         }
     };

--- a/packages/web-components/fast-ssr/src/test-utilities/consolidate.ts
+++ b/packages/web-components/fast-ssr/src/test-utilities/consolidate.ts
@@ -9,3 +9,14 @@ export function consolidate(strings: IterableIterator<string>): string {
 
     return str;
 }
+
+export async function consolidateAsync(
+    strings: IterableIterator<string | Promise<string>>
+) {
+    let value = "";
+    for await (const part of strings) {
+        value += part;
+    }
+
+    return value;
+}


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR adds async rendering support to fast-ssr via the [`PendingTask` protocol](https://github.com/webcomponents-cg/community-protocols/blob/main/proposals/pending-task.md). Elements would emit a `PendingTask` event, which contains a promise indicating whether the task is complete. The AsyncElementRenderer then listens for these events, storing them as they emit. During attribute rendering, the AsyncElementRenderer awaits any pending tasks that have been caught (this works recursively, if tasks kick off other tasks). After all tasks have resolved, the renderer continues yielding attributes from the element.

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes
The other approach we've considered is using a special Behavior that contains a Promise. AsyncElementRenderer would inspect an element's behaviors and if these special async behaviors are found, it would await them prior to rendering.

I like the idea of using PendingTask (thanks @EisenbergEffect), however I have a few reservations:
1. Depending on when these events are emitted, it is possible for the renderer to miss them. It's probably an edge case, but if event emission happens in a new Task (setTimeout), the renderer will have moved on and miss the event.
2. One of the main goals of PendingTask is to communicate to ancestors the async tasks of children so that they can render some placeholder content / loading bar / spinner, etc. In an SSR environment, that parent control will already have been emitted. 
3. We don't really *know* the intent of a PendingTask. The author could intend to the PendingTask to *not* block SSR rendering. The community protocol does not establish types of tasks at this time ([there is discussion on this though](https://github.com/webcomponents-cg/community-protocols/issues/13)). Should we extend the protocol and only block on a specific type?
4. There is a perf cost to emitting events. It's probably negligible in this scenario, but something to consider since event emission is synchronous, and it is work that components would need to do on the client.

In general, I think the PendingTask implementation is going to be easier for authors to implement and generally provides a better authoring experience, but it's good to note the above.

If there is consensus on this approach, I'll add more tests and open the PR up.
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->