### PR TITLE
fix: ensure fast foundation templates support extended classes

### DIFF
--- a/change/@microsoft-fast-foundation-a9bb978a-8674-4ba4-878d-bf561b5add75.json
+++ b/change/@microsoft-fast-foundation-a9bb978a-8674-4ba4-878d-bf561b5add75.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update templates to ensure component classes can be extended",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-a9bb978a-8674-4ba4-878d-bf561b5add75.json
+++ b/change/@microsoft-fast-foundation-a9bb978a-8674-4ba4-878d-bf561b5add75.json
@@ -3,5 +3,5 @@
   "comment": "update templates to ensure component classes can be extended",
   "packageName": "@microsoft/fast-foundation",
   "email": "chhol@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -35,10 +35,10 @@ export type AccordionItemOptions = StartEndOptions & {
 };
 
 // @public
-export function accordionItemTemplate(options?: AccordionItemOptions): ElementViewTemplate<FASTAccordionItem>;
+export function accordionItemTemplate<T extends FASTAccordionItem>(options?: AccordionItemOptions): ElementViewTemplate<T>;
 
 // @public
-export function accordionTemplate(): ElementViewTemplate<FASTAccordion>;
+export function accordionTemplate<T extends FASTAccordion>(): ElementViewTemplate<T>;
 
 // @public
 export interface AnchoredRegionConfig {
@@ -71,7 +71,7 @@ export const AnchoredRegionPositionLabel: {
 export type AnchoredRegionPositionLabel = typeof AnchoredRegionPositionLabel[keyof typeof AnchoredRegionPositionLabel];
 
 // @public
-export function anchoredRegionTemplate(): ElementViewTemplate<FASTAnchoredRegion>;
+export function anchoredRegionTemplate<T extends FASTAnchoredRegion>(): ElementViewTemplate<T>;
 
 // @public
 export type AnchorOptions = StartEndOptions;
@@ -88,7 +88,7 @@ export const AnchorTarget: {
 export type AnchorTarget = typeof AnchorTarget[keyof typeof AnchorTarget];
 
 // @public
-export function anchorTemplate(options?: AnchorOptions): ElementViewTemplate<FASTAnchor>;
+export function anchorTemplate<T extends FASTAnchor>(options?: AnchorOptions): ElementViewTemplate<T>;
 
 // @public
 export function applyMixins(derivedCtor: any, ...baseCtors: any[]): void;
@@ -131,7 +131,7 @@ export type AvatarOptions = {
 };
 
 // @public
-export function avatarTemplate(options?: AvatarOptions): ElementViewTemplate<FASTAvatar>;
+export function avatarTemplate<T extends FASTAvatar>(options?: AvatarOptions): ElementViewTemplate<T>;
 
 // @public
 export const AxisPositioningMode: {
@@ -154,7 +154,7 @@ export const AxisScalingMode: {
 export type AxisScalingMode = typeof AxisScalingMode[keyof typeof AxisScalingMode];
 
 // @public
-export function badgeTemplate(): ElementViewTemplate<FASTBadge>;
+export function badgeTemplate<T extends FASTBadge>(): ElementViewTemplate<T>;
 
 // @public
 export type BreadcrumbItemOptions = StartEndOptions & {
@@ -162,16 +162,16 @@ export type BreadcrumbItemOptions = StartEndOptions & {
 };
 
 // @public
-export function breadcrumbItemTemplate(options?: BreadcrumbItemOptions): ElementViewTemplate<FASTBreadcrumbItem>;
+export function breadcrumbItemTemplate<T extends FASTBreadcrumbItem>(options?: BreadcrumbItemOptions): ElementViewTemplate<T>;
 
 // @public
-export function breadcrumbTemplate(): ElementViewTemplate<FASTBreadcrumb>;
+export function breadcrumbTemplate<T extends FASTBreadcrumb>(): ElementViewTemplate<T>;
 
 // @public
 export type ButtonOptions = StartEndOptions;
 
 // @public
-export function buttonTemplate(options?: ButtonOptions): ElementViewTemplate<FASTButton>;
+export function buttonTemplate<T extends FASTButton>(options?: ButtonOptions): ElementViewTemplate<T>;
 
 // @public
 export const ButtonType: {
@@ -213,16 +213,16 @@ export type CalendarOptions = StartEndOptions & {
 export function calendarRowTemplate(options: CalendarOptions, todayString: string): ViewTemplate;
 
 // @public
-export function calendarTemplate(options: CalendarOptions): ElementViewTemplate<FASTCalendar>;
+export function calendarTemplate<T extends FASTCalendar>(options: CalendarOptions): ElementViewTemplate<T>;
 
 // @public
-export function calendarTitleTemplate(): ViewTemplate<FASTCalendar>;
+export function calendarTitleTemplate<T extends FASTCalendar>(): ViewTemplate<T>;
 
 // @public
 export function calendarWeekdayTemplate(options: CalendarOptions): ViewTemplate<WeekdayText>;
 
 // @public
-export function cardTemplate(): ElementViewTemplate<FASTCard>;
+export function cardTemplate<T extends FASTCard>(): ElementViewTemplate<T>;
 
 // @public
 export type CellItemTemplateOptions = {
@@ -262,7 +262,7 @@ export type CheckboxOptions = {
 };
 
 // @public
-export function checkboxTemplate(options?: CheckboxOptions): ElementViewTemplate<FASTCheckbox>;
+export function checkboxTemplate<T extends FASTCheckbox>(options?: CheckboxOptions): ElementViewTemplate<T>;
 
 // @public
 export interface ColumnDefinition {
@@ -295,7 +295,7 @@ export type ComboboxOptions = StartEndOptions & {
 };
 
 // @public
-export function comboboxTemplate(options?: ComboboxOptions): ElementViewTemplate<FASTCombobox>;
+export function comboboxTemplate<T extends FASTCombobox>(options?: ComboboxOptions): ElementViewTemplate<T>;
 
 export { composedContains }
 
@@ -323,7 +323,7 @@ export type CSSDisplayPropertyValue = "block" | "contents" | "flex" | "grid" | "
 export const darkModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaStyleSheetBehavior;
 
 // @public
-export function dataGridCellTemplate(): ElementViewTemplate<FASTDataGridCell>;
+export function dataGridCellTemplate<T extends FASTDataGridCell>(): ElementViewTemplate<T>;
 
 // @public
 export const DataGridCellTypes: {
@@ -341,7 +341,7 @@ export type DataGridOptions = {
 };
 
 // @public
-export function dataGridRowTemplate(options: CellItemTemplateOptions): ElementViewTemplate<FASTDataGridRow>;
+export function dataGridRowTemplate<T extends FASTDataGridRow>(options: CellItemTemplateOptions): ElementViewTemplate<T>;
 
 // @public
 export const DataGridRowTypes: {
@@ -354,7 +354,7 @@ export const DataGridRowTypes: {
 export type DataGridRowTypes = typeof DataGridRowTypes[keyof typeof DataGridRowTypes];
 
 // @public
-export function dataGridTemplate(options: DataGridOptions): ElementViewTemplate<FASTDataGrid>;
+export function dataGridTemplate<T extends FASTDataGrid>(options: DataGridOptions): ElementViewTemplate<T>;
 
 // @public
 export class DateFormatter {
@@ -586,7 +586,7 @@ export interface DesignTokenSubscriber<T extends DesignToken<any>> {
 }
 
 // @public
-export function dialogTemplate(): ElementViewTemplate<FASTDialog>;
+export function dialogTemplate<T extends FASTDialog>(): ElementViewTemplate<T>;
 
 // Warning: (ae-internal-missing-underscore) The name "Dimension" should be prefixed with an underscore because the declaration is marked as @internal
 //
@@ -602,7 +602,7 @@ export interface Dimension {
 export const disabledCursor = "not-allowed";
 
 // @public
-export function disclosureTemplate(): ElementViewTemplate<FASTDisclosure>;
+export function disclosureTemplate<T extends FASTDisclosure>(): ElementViewTemplate<T>;
 
 // @public @deprecated
 export function display(displayValue: CSSDisplayPropertyValue): string;
@@ -617,7 +617,7 @@ export const DividerRole: {
 export type DividerRole = typeof DividerRole[keyof typeof DividerRole];
 
 // @public
-export function dividerTemplate(): ElementViewTemplate<FASTDivider>;
+export function dividerTemplate<T extends FASTDivider>(): ElementViewTemplate<T>;
 
 // @public
 export type EndOptions = {
@@ -2316,7 +2316,7 @@ export type HorizontalScrollOptions = StartEndOptions & {
 };
 
 // @public (undocumented)
-export function horizontalScrollTemplate(options?: HorizontalScrollOptions): ElementViewTemplate<FASTHorizontalScroll>;
+export function horizontalScrollTemplate<T extends FASTHorizontalScroll>(options?: HorizontalScrollOptions): ElementViewTemplate<T>;
 
 // @public
 export const HorizontalScrollView: {
@@ -2330,7 +2330,7 @@ export type HorizontalScrollView = typeof HorizontalScrollView[keyof typeof Hori
 // Warning: (ae-internal-missing-underscore) The name "interactiveCalendarGridTemplate" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
-export function interactiveCalendarGridTemplate(options: CalendarOptions, todayString: string): ViewTemplate<FASTCalendar>;
+export function interactiveCalendarGridTemplate<T extends FASTCalendar>(options: CalendarOptions, todayString: string): ViewTemplate<T>;
 
 // @public
 export function isListboxOption(el: Element): el is FASTListboxOption;
@@ -2345,10 +2345,10 @@ export const lightModeStylesheetBehavior: (styles: ElementStyles) => MatchMediaS
 export type ListboxOptionOptions = StartEndOptions;
 
 // @public
-export function listboxOptionTemplate(options?: ListboxOptionOptions): ElementViewTemplate<FASTListboxOption>;
+export function listboxOptionTemplate<T extends FASTListboxOption>(options?: ListboxOptionOptions): ElementViewTemplate<T>;
 
 // @public
-export function listboxTemplate(): ElementViewTemplate<FASTListboxElement>;
+export function listboxTemplate<T extends FASTListboxElement>(): ElementViewTemplate<T>;
 
 // @public
 export abstract class MatchMediaBehavior implements Behavior {
@@ -2395,7 +2395,7 @@ export const MenuItemRole: {
 export type MenuItemRole = typeof MenuItemRole[keyof typeof MenuItemRole];
 
 // @public
-export function menuItemTemplate(options: MenuItemOptions): ElementViewTemplate<FASTMenuItem>;
+export function menuItemTemplate<T extends FASTMenuItem>(options: MenuItemOptions): ElementViewTemplate<T>;
 
 // @beta
 export const MenuPlacement: {
@@ -2411,7 +2411,7 @@ export const MenuPlacement: {
 export type MenuPlacement = typeof MenuPlacement[keyof typeof MenuPlacement];
 
 // @public
-export function menuTemplate(): ElementViewTemplate<FASTMenu>;
+export function menuTemplate<T extends FASTMenu>(): ElementViewTemplate<T>;
 
 // @public
 export const MonthFormat: {
@@ -2436,7 +2436,7 @@ export type MonthInfo = {
 // Warning: (ae-internal-missing-underscore) The name "noninteractiveCalendarTemplate" should be prefixed with an underscore because the declaration is marked as @internal
 //
 // @internal
-export function noninteractiveCalendarTemplate(options: CalendarOptions, todayString: string): ViewTemplate<FASTCalendar>;
+export function noninteractiveCalendarTemplate<T extends FASTCalendar>(options: CalendarOptions, todayString: string): ViewTemplate<T>;
 
 // @public
 export type NumberFieldOptions = StartEndOptions & {
@@ -2445,27 +2445,27 @@ export type NumberFieldOptions = StartEndOptions & {
 };
 
 // @public
-export function numberFieldTemplate(options?: NumberFieldOptions): ElementViewTemplate<FASTNumberField>;
+export function numberFieldTemplate<T extends FASTNumberField>(options?: NumberFieldOptions): ElementViewTemplate<T>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "pickerListItemTemplate" is marked as @public, but its signature references "FASTPickerListItem" which is marked as @beta
 //
 // @public (undocumented)
-export function pickerListItemTemplate(): ElementViewTemplate<FASTPickerListItem>;
+export function pickerListItemTemplate<T extends FASTPickerListItem>(): ElementViewTemplate<T>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "pickerListTemplate" is marked as @public, but its signature references "FASTPickerList" which is marked as @beta
 //
 // @public (undocumented)
-export function pickerListTemplate(): ElementViewTemplate<FASTPickerList>;
+export function pickerListTemplate<T extends FASTPickerList>(): ElementViewTemplate<T>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "pickerMenuOptionTemplate" is marked as @public, but its signature references "FASTPickerMenuOption" which is marked as @beta
 //
 // @public (undocumented)
-export function pickerMenuOptionTemplate(): ElementViewTemplate<FASTPickerMenuOption>;
+export function pickerMenuOptionTemplate<T extends FASTPickerMenuOption>(): ElementViewTemplate<T>;
 
 // Warning: (ae-incompatible-release-tags) The symbol "pickerMenuTemplate" is marked as @public, but its signature references "FASTPickerMenu" which is marked as @beta
 //
 // @public
-export function pickerMenuTemplate(): ElementViewTemplate<FASTPickerMenu>;
+export function pickerMenuTemplate<T extends FASTPickerMenu>(): ElementViewTemplate<T>;
 
 // @public
 export type PickerOptions = {
@@ -2480,7 +2480,7 @@ export type PickerOptions = {
 // Warning: (ae-incompatible-release-tags) The symbol "pickerTemplate" is marked as @public, but its signature references "FASTPicker" which is marked as @beta
 //
 // @public
-export function pickerTemplate(options: PickerOptions): ElementViewTemplate<FASTPicker>;
+export function pickerTemplate<T extends FASTPicker>(options: PickerOptions): ElementViewTemplate<T>;
 
 // @public
 export type ProgressOptions = {
@@ -2494,10 +2494,10 @@ export type ProgressRingOptions = {
 };
 
 // @public
-export function progressRingTemplate(options?: ProgressRingOptions): ElementViewTemplate<FASTProgressRing>;
+export function progressRingTemplate<T extends FASTProgressRing>(options?: ProgressRingOptions): ElementViewTemplate<T>;
 
 // @public
-export function progressTemplate(options?: ProgressOptions): ElementViewTemplate<FASTProgress>;
+export function progressTemplate<T extends FASTProgress>(options?: ProgressOptions): ElementViewTemplate<T>;
 
 // @public
 export class PropertyStyleSheetBehavior implements Behavior {
@@ -2523,7 +2523,7 @@ export type ProxyElement = HTMLSelectElement | HTMLTextAreaElement | HTMLInputEl
 export type RadioControl = Pick<HTMLInputElement, "checked" | "disabled" | "readOnly" | "focus" | "setAttribute" | "getAttribute">;
 
 // @public
-export function radioGroupTemplate(): ElementViewTemplate<FASTRadioGroup>;
+export function radioGroupTemplate<T extends FASTRadioGroup>(): ElementViewTemplate<T>;
 
 // @public
 export type RadioOptions = {
@@ -2531,7 +2531,7 @@ export type RadioOptions = {
 };
 
 // @public
-export function radioTemplate(options?: RadioOptions): ElementViewTemplate<FASTRadio>;
+export function radioTemplate<T extends FASTRadio>(options?: RadioOptions): ElementViewTemplate<T>;
 
 // @beta
 export function reflectAttributes<T = any>(...attributes: string[]): CaptureType<T>;
@@ -2558,7 +2558,7 @@ export type ScrollEasing = typeof ScrollEasing[keyof typeof ScrollEasing];
 export type SearchOptions = StartEndOptions;
 
 // @public
-export function searchTemplate(options?: SearchOptions): ElementViewTemplate<FASTSearch>;
+export function searchTemplate<T extends FASTSearch>(options?: SearchOptions): ElementViewTemplate<T>;
 
 // @public
 export type SelectOptions = StartEndOptions & {
@@ -2575,7 +2575,7 @@ export const SelectPosition: {
 export type SelectPosition = typeof SelectPosition[keyof typeof SelectPosition];
 
 // @public
-export function selectTemplate(options?: SelectOptions): ElementViewTemplate<FASTSelect>;
+export function selectTemplate<T extends FASTSelect>(options?: SelectOptions): ElementViewTemplate<T>;
 
 // @public
 export const SkeletonShape: {
@@ -2587,7 +2587,7 @@ export const SkeletonShape: {
 export type SkeletonShape = typeof SkeletonShape[keyof typeof SkeletonShape];
 
 // @public
-export function skeletonTemplate(): ElementViewTemplate<FASTSkeleton>;
+export function skeletonTemplate<T extends FASTSkeleton>(): ElementViewTemplate<T>;
 
 // @public
 export interface SliderConfiguration {
@@ -2604,7 +2604,7 @@ export interface SliderConfiguration {
 }
 
 // @public
-export function sliderLabelTemplate(): ElementViewTemplate<FASTSliderLabel>;
+export function sliderLabelTemplate<T extends FASTSliderLabel>(): ElementViewTemplate<T>;
 
 // @public
 export const SliderMode: {
@@ -2620,7 +2620,7 @@ export type SliderOptions = {
 };
 
 // @public
-export function sliderTemplate(options?: SliderOptions): ElementViewTemplate<FASTSlider>;
+export function sliderTemplate<T extends FASTSlider>(options?: SliderOptions): ElementViewTemplate<T>;
 
 // @public
 export class StartEnd {
@@ -2653,13 +2653,13 @@ export type SwitchOptions = {
 };
 
 // @public
-export function switchTemplate(options?: SwitchOptions): ElementViewTemplate<FASTSwitch>;
+export function switchTemplate<T extends FASTSwitch>(options?: SwitchOptions): ElementViewTemplate<T>;
 
 // @public
 export type TabOptionOptions = StartEndOptions;
 
 // @public
-export function tabPanelTemplate(): ElementViewTemplate<FASTTabPanel>;
+export function tabPanelTemplate<T extends FASTTabPanel>(): ElementViewTemplate<T>;
 
 // @public
 export type TabsOptions = StartEndOptions;
@@ -2674,10 +2674,10 @@ export const TabsOrientation: {
 export type TabsOrientation = typeof TabsOrientation[keyof typeof TabsOrientation];
 
 // @public
-export function tabsTemplate(options?: TabsOptions): ElementViewTemplate<FASTTabs>;
+export function tabsTemplate<T extends FASTTabs>(options?: TabsOptions): ElementViewTemplate<T>;
 
 // @public
-export function tabTemplate(options?: StartEndOptions): ElementViewTemplate<FASTTab>;
+export function tabTemplate<T extends FASTTab>(options?: StartEndOptions): ElementViewTemplate<T>;
 
 // @beta
 export function tagFor(dependency: TemplateElementDependency): string;
@@ -2697,13 +2697,13 @@ export const TextAreaResize: {
 export type TextAreaResize = typeof TextAreaResize[keyof typeof TextAreaResize];
 
 // @public
-export function textAreaTemplate(): ElementViewTemplate<FASTTextArea>;
+export function textAreaTemplate<T extends FASTTextArea>(): ElementViewTemplate<T>;
 
 // @public
 export type TextFieldOptions = StartEndOptions;
 
 // @public
-export function textFieldTemplate(options?: TextFieldOptions): ElementViewTemplate<FASTTextField>;
+export function textFieldTemplate<T extends FASTTextField>(options?: TextFieldOptions): ElementViewTemplate<T>;
 
 // @public
 export const TextFieldType: {
@@ -2721,7 +2721,7 @@ export type TextFieldType = typeof TextFieldType[keyof typeof TextFieldType];
 export type ToolbarOptions = StartEndOptions;
 
 // @public
-export function toolbarTemplate(options?: ToolbarOptions): ElementViewTemplate<FASTToolbar>;
+export function toolbarTemplate<T extends FASTToolbar>(options?: ToolbarOptions): ElementViewTemplate<T>;
 
 // @public
 export type TooltipOptions = {
@@ -2753,7 +2753,7 @@ export const TooltipPosition: {
 export type TooltipPosition = typeof TooltipPosition[keyof typeof TooltipPosition];
 
 // @public
-export function tooltipTemplate(options: TooltipOptions): ElementViewTemplate<FASTTooltip>;
+export function tooltipTemplate<T extends FASTTooltip>(options: TooltipOptions): ElementViewTemplate<T>;
 
 // @public
 export type TreeItemOptions = StartEndOptions & {
@@ -2761,10 +2761,10 @@ export type TreeItemOptions = StartEndOptions & {
 };
 
 // @public
-export function treeItemTemplate(options?: TreeItemOptions): ElementViewTemplate<FASTTreeItem>;
+export function treeItemTemplate<T extends FASTTreeItem>(options?: TreeItemOptions): ElementViewTemplate<T>;
 
 // @public
-export function treeViewTemplate(): ElementViewTemplate<FASTTreeView>;
+export function treeViewTemplate<T extends FASTTreeView>(): ElementViewTemplate<T>;
 
 // @public
 export const VerticalPosition: {

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2183,7 +2183,7 @@ export type FlipperOptions = {
 };
 
 // @public
-export function flipperTemplate(options?: FlipperOptions): ElementViewTemplate<FASTFlipper>;
+export function flipperTemplate<T extends FASTFlipper>(options?: FlipperOptions): ElementViewTemplate<T>;
 
 // @public
 export const FlyoutPosBottom: AnchoredRegionConfig;

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -6,10 +6,10 @@ import type { AccordionItemOptions, FASTAccordionItem } from "./accordion-item.j
  * The template for the {@link @microsoft/fast-foundation#(FASTAccordionItem:class)} component.
  * @public
  */
-export function accordionItemTemplate(
+export function accordionItemTemplate<T extends FASTAccordionItem>(
     options: AccordionItemOptions = {}
-): ElementViewTemplate<FASTAccordionItem> {
-    return html<FASTAccordionItem>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template class="${x => (x.expanded ? "expanded" : "")}">
             <div
                 class="heading"

--- a/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
@@ -5,8 +5,8 @@ import type { FASTAccordion } from "./accordion.js";
  * Creates a template for the {@link @microsoft/fast-foundation#FASTAccordion} component.
  * @public
  */
-export function accordionTemplate(): ElementViewTemplate<FASTAccordion> {
-    return html<FASTAccordion>`
+export function accordionTemplate<T extends FASTAccordion>(): ElementViewTemplate<T> {
+    return html<T>`
         <template>
             <slot ${slotted({ property: "accordionItems", filter: elements() })}></slot>
         </template>

--- a/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.template.ts
@@ -6,10 +6,10 @@ import type { AnchorOptions, FASTAnchor } from "./anchor.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTAnchor:class)} component.
  * @public
  */
-export function anchorTemplate(
+export function anchorTemplate<T extends FASTAnchor>(
     options: AnchorOptions = {}
-): ElementViewTemplate<FASTAnchor> {
-    return html<FASTAnchor>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <a
             class="control"
             part="control"

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.template.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.template.ts
@@ -5,12 +5,14 @@ import type { FASTAnchoredRegion } from "./anchored-region.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTAnchoredRegion:class)} component.
  * @public
  */
-export function anchoredRegionTemplate(): ElementViewTemplate<FASTAnchoredRegion> {
-    return html<FASTAnchoredRegion>`
+export function anchoredRegionTemplate<
+    T extends FASTAnchoredRegion
+>(): ElementViewTemplate<T> {
+    return html<T>`
         <template class="${x => (x.initialLayoutComplete ? "loaded" : "")}">
             ${when(
                 x => x.initialLayoutComplete,
-                html<FASTAnchoredRegion>`
+                html<T>`
                     <slot></slot>
                 `
             )}

--- a/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
@@ -5,10 +5,10 @@ import type { AvatarOptions, FASTAvatar } from "./avatar.js";
  * The template for {@link @microsoft/fast-foundation#FASTAvatar} component.
  * @public
  */
-export function avatarTemplate(
+export function avatarTemplate<T extends FASTAvatar>(
     options: AvatarOptions = {}
-): ElementViewTemplate<FASTAvatar> {
-    return html<FASTAvatar>`
+): ElementViewTemplate<T> {
+    return html<T>`
     <div
         class="backplate"
         part="backplate"

--- a/packages/web-components/fast-foundation/src/badge/badge.template.ts
+++ b/packages/web-components/fast-foundation/src/badge/badge.template.ts
@@ -5,8 +5,8 @@ import type { FASTBadge } from "./badge.js";
  * The template for the {@link @microsoft/fast-foundation#FASTBadge} component.
  * @public
  */
-export function badgeTemplate(): ElementViewTemplate<FASTBadge> {
-    return html<FASTBadge>`
+export function badgeTemplate<T extends FASTBadge>(): ElementViewTemplate<T> {
+    return html<T>`
         <div class="control" part="control">
             <slot></slot>
         </div>

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.template.ts
@@ -6,15 +6,15 @@ import type { BreadcrumbItemOptions, FASTBreadcrumbItem } from "./breadcrumb-ite
  * The template for the {@link @microsoft/fast-foundation#(FASTBreadcrumbItem:class)} component.
  * @public
  */
-export function breadcrumbItemTemplate(
+export function breadcrumbItemTemplate<T extends FASTBreadcrumbItem>(
     options: BreadcrumbItemOptions = {}
-): ElementViewTemplate<FASTBreadcrumbItem> {
-    return html<FASTBreadcrumbItem>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <div role="listitem" class="listitem" part="listitem">
             ${anchorTemplate(options)}
             ${when(
                 x => x.separator,
-                html<FASTBreadcrumbItem>`
+                html<T>`
                     <span class="separator" part="separator" aria-hidden="true">
                         <slot name="separator">${options.separator || ""}</slot>
                     </span>

--- a/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.template.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.template.ts
@@ -5,8 +5,8 @@ import type { FASTBreadcrumb } from "./breadcrumb.js";
  * The template for the {@link @microsoft/fast-foundation#FASTBreadcrumb} component.
  * @public
  */
-export function breadcrumbTemplate(): ElementViewTemplate<FASTBreadcrumb> {
-    return html<FASTBreadcrumb>`
+export function breadcrumbTemplate<T extends FASTBreadcrumb>(): ElementViewTemplate<T> {
+    return html<T>`
         <template role="navigation">
             <div role="list" class="list" part="list">
                 <slot

--- a/packages/web-components/fast-foundation/src/button/button.template.ts
+++ b/packages/web-components/fast-foundation/src/button/button.template.ts
@@ -6,10 +6,10 @@ import type { ButtonOptions, FASTButton } from "./button.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTButton:class)} component.
  * @public
  */
-export function buttonTemplate(
+export function buttonTemplate<T extends FASTButton>(
     options: ButtonOptions = {}
-): ElementViewTemplate<FASTButton> {
-    return html<FASTButton>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <button
             class="control"
             part="control"

--- a/packages/web-components/fast-foundation/src/calendar/calendar.template.ts
+++ b/packages/web-components/fast-foundation/src/calendar/calendar.template.ts
@@ -13,22 +13,22 @@ import type {
  * @returns - A calendar title template
  * @public
  */
-export function calendarTitleTemplate(): ViewTemplate<FASTCalendar> {
+export function calendarTitleTemplate<T extends FASTCalendar>(): ViewTemplate<T> {
     return html`
         <div
             class="title"
             part="title"
-            aria-label="${(x: FASTCalendar) =>
+            aria-label="${(x: T) =>
                 x.dateFormatter.getDate(`${x.month}-2-${x.year}`, {
                     month: "long",
                     year: "numeric",
                 })}"
         >
             <span part="month">
-                ${(x: FASTCalendar) => x.dateFormatter.getMonth(x.month)}
+                ${(x: T) => x.dateFormatter.getMonth(x.month)}
             </span>
             <span part="year">
-                ${(x: FASTCalendar) => x.dateFormatter.getYear(x.year)}
+                ${(x: T) => x.dateFormatter.getYear(x.year)}
             </span>
         </div>
     `;
@@ -130,14 +130,14 @@ export function calendarRowTemplate(
  *
  * @internal
  */
-export function interactiveCalendarGridTemplate(
+export function interactiveCalendarGridTemplate<T extends FASTCalendar>(
     options: CalendarOptions,
     todayString: string
-): ViewTemplate<FASTCalendar> {
+): ViewTemplate<T> {
     const gridTag: string = tagFor(options.dataGrid);
     const rowTag: string = tagFor(options.dataGridRow);
 
-    return html<FASTCalendar>`
+    return html<T>`
     <${gridTag} class="days interact" part="days" generate-header="none">
         <${rowTag}
             class="week-days"
@@ -162,11 +162,11 @@ export function interactiveCalendarGridTemplate(
  *
  * @internal
  */
-export function noninteractiveCalendarTemplate(
+export function noninteractiveCalendarTemplate<T extends FASTCalendar>(
     options: CalendarOptions,
     todayString: string
-): ViewTemplate<FASTCalendar> {
-    return html<FASTCalendar>`
+): ViewTemplate<T> {
+    return html<T>`
         <div class="days" part="days">
             <div class="week-days" part="week-days">
                 ${repeat(
@@ -178,7 +178,7 @@ export function noninteractiveCalendarTemplate(
                     `
                 )}
             </div>
-            ${repeat<FASTCalendar>(
+            ${repeat<T>(
                 x => x.getDays(),
                 html<CalendarDateInfo[]>`
                     <div class="week">
@@ -233,14 +233,14 @@ export function noninteractiveCalendarTemplate(
  * @returns - a template for a calendar month
  * @public
  */
-export function calendarTemplate(
+export function calendarTemplate<T extends FASTCalendar>(
     options: CalendarOptions
-): ElementViewTemplate<FASTCalendar> {
+): ElementViewTemplate<T> {
     const today: Date = new Date();
     const todayString: string = `${
         today.getMonth() + 1
     }-${today.getDate()}-${today.getFullYear()}`;
-    return html<FASTCalendar>`
+    return html<T>`
         <template>
             ${startSlotTemplate(options)} ${options.title ?? ""}
             <slot></slot>

--- a/packages/web-components/fast-foundation/src/card/card.template.ts
+++ b/packages/web-components/fast-foundation/src/card/card.template.ts
@@ -5,7 +5,7 @@ import type { FASTCard } from "./card.js";
  * The template for the {@link @microsoft/fast-foundation#FASTCard} component.
  * @public
  */
-export function cardTemplate(): ElementViewTemplate<FASTCard> {
+export function cardTemplate<T extends FASTCard>(): ElementViewTemplate<T> {
     return html`
         <slot></slot>
     `;

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
@@ -5,10 +5,10 @@ import type { CheckboxOptions, FASTCheckbox } from "./checkbox.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTCheckbox:class)} component.
  * @public
  */
-export function checkboxTemplate(
+export function checkboxTemplate<T extends FASTCheckbox>(
     options: CheckboxOptions = {}
-): ElementViewTemplate<FASTCheckbox> {
-    return html<FASTCheckbox>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="checkbox"
             aria-checked="${x => x.checked}"

--- a/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.template.ts
@@ -7,9 +7,9 @@ import type { ComboboxOptions, FASTCombobox } from "./combobox.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTCombobox:class)} component.
  * @public
  */
-export function comboboxTemplate(
+export function comboboxTemplate<T extends FASTCombobox>(
     options: ComboboxOptions = {}
-): ElementViewTemplate<FASTCombobox> {
+): ElementViewTemplate<T> {
     return html`
         <template
             aria-disabled="${x => x.ariaDisabled}"

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.template.ts
@@ -6,8 +6,10 @@ import type { FASTDataGridCell } from "./data-grid-cell.js";
  * the provided prefix.
  * @public
  */
-export function dataGridCellTemplate(): ElementViewTemplate<FASTDataGridCell> {
-    return html<FASTDataGridCell>`
+export function dataGridCellTemplate<T extends FASTDataGridCell>(): ElementViewTemplate<
+    T
+> {
+    return html<T>`
         <template
             tabindex="-1"
             role="${x =>

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
@@ -18,11 +18,11 @@ export type CellItemTemplateOptions = {
     dataGridCell: TemplateElementDependency;
 };
 
-function cellItemTemplate(
+function cellItemTemplate<T extends FASTDataGridRow>(
     options: CellItemTemplateOptions
-): ViewTemplate<ColumnDefinition, FASTDataGridRow> {
+): ViewTemplate<ColumnDefinition, T> {
     const cellTag = tagFor(options.dataGridCell);
-    return html<ColumnDefinition, FASTDataGridRow>`
+    return html<ColumnDefinition, T>`
     <${cellTag}
         cell-type="${x => (x.isRowHeader ? "rowheader" : undefined)}"
         grid-column="${(x, c) => c.index + 1}"
@@ -32,11 +32,11 @@ function cellItemTemplate(
 `;
 }
 
-function headerCellItemTemplate(
+function headerCellItemTemplate<T extends FASTDataGridRow>(
     options: CellItemTemplateOptions
-): ViewTemplate<ColumnDefinition, FASTDataGridRow> {
+): ViewTemplate<ColumnDefinition, T> {
     const cellTag = tagFor(options.dataGridCell);
-    return html<ColumnDefinition, FASTDataGridRow>`
+    return html<ColumnDefinition, T>`
     <${cellTag}
         cell-type="columnheader"
         grid-column="${(x, c) => c.index + 1}"
@@ -51,10 +51,10 @@ function headerCellItemTemplate(
  *
  * @public
  */
-export function dataGridRowTemplate(
+export function dataGridRowTemplate<T extends FASTDataGridRow>(
     options: CellItemTemplateOptions
-): ElementViewTemplate<FASTDataGridRow> {
-    return html<FASTDataGridRow>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="row"
             :classList="${x => (x.rowType !== "default" ? x.rowType : "")}"

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.template.ts
@@ -11,9 +11,11 @@ export type DataGridOptions = {
     dataGridRow: TemplateElementDependency;
 };
 
-function rowItemTemplate(options: DataGridOptions): ViewTemplate<any, FASTDataGrid> {
+function rowItemTemplate<T extends FASTDataGrid>(
+    options: DataGridOptions
+): ViewTemplate<any, T> {
     const rowTag = tagFor(options.dataGridRow);
-    return html<any, FASTDataGrid>`
+    return html<any, T>`
     <${rowTag}
         :rowData="${x => x}"
         :cellItemTemplate="${(x, c) => c.parent.cellItemTemplate}"
@@ -28,11 +30,11 @@ function rowItemTemplate(options: DataGridOptions): ViewTemplate<any, FASTDataGr
  *
  * @public
  */
-export function dataGridTemplate(
+export function dataGridTemplate<T extends FASTDataGrid>(
     options: DataGridOptions
-): ElementViewTemplate<FASTDataGrid> {
+): ElementViewTemplate<T> {
     const rowTag = tagFor(options.dataGridRow);
-    return html<FASTDataGrid>`
+    return html<T>`
         <template
             role="grid"
             tabindex="0"

--- a/packages/web-components/fast-foundation/src/dialog/dialog.template.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.template.ts
@@ -5,12 +5,12 @@ import type { FASTDialog } from "./dialog.js";
  * The template for the {@link @microsoft/fast-foundation#FASTDialog} component.
  * @public
  */
-export function dialogTemplate(): ElementViewTemplate<FASTDialog> {
-    return html<FASTDialog>`
+export function dialogTemplate<T extends FASTDialog>(): ElementViewTemplate<T> {
+    return html<T>`
         <div class="positioning-region" part="positioning-region">
             ${when(
                 x => x.modal,
-                html<FASTDialog>`
+                html<T>`
                     <div
                         class="overlay"
                         part="overlay"

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.template.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.template.ts
@@ -5,8 +5,8 @@ import type { FASTDisclosure } from "./disclosure.js";
  * The template for the {@link @microsoft/fast-foundation#FASTDisclosure} component.
  * @public
  */
-export function disclosureTemplate(): ElementViewTemplate<FASTDisclosure> {
-    return html<FASTDisclosure>`
+export function disclosureTemplate<T extends FASTDisclosure>(): ElementViewTemplate<T> {
+    return html<T>`
         <details class="disclosure" ${ref("details")}>
             <summary
                 class="invoker"

--- a/packages/web-components/fast-foundation/src/divider/divider.template.ts
+++ b/packages/web-components/fast-foundation/src/divider/divider.template.ts
@@ -5,8 +5,8 @@ import type { FASTDivider } from "./divider.js";
  * The template for the {@link @microsoft/fast-foundation#FASTDivider} component.
  * @public
  */
-export function dividerTemplate(): ElementViewTemplate<FASTDivider> {
-    return html<FASTDivider>`
+export function dividerTemplate<T extends FASTDivider>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="${x => x.role}"
             aria-orientation="${x => x.orientation}"

--- a/packages/web-components/fast-foundation/src/flipper/flipper.template.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.template.ts
@@ -6,9 +6,9 @@ import { FlipperDirection } from "./flipper.options.js";
  * The template for the {@link @microsoft/fast-foundation#FASTFlipper} component.
  * @public
  */
-export function flipperTemplate(
+export function flipperTemplate<T extends FASTFlipper>(
     options: FlipperOptions = {}
-): ElementViewTemplate<FASTFlipper> {
+): ElementViewTemplate<T> {
     return html`
         <template
             role="button"

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.template.ts
@@ -7,9 +7,9 @@ import type { HorizontalScrollOptions } from "./horizontal-scroll.options.js";
 /**
  * @public
  */
-export function horizontalScrollTemplate(
+export function horizontalScrollTemplate<T extends FASTHorizontalScroll>(
     options: HorizontalScrollOptions = {}
-): ElementViewTemplate<FASTHorizontalScroll> {
+): ElementViewTemplate<T> {
     return html`
         <template
             class="horizontal-scroll"
@@ -38,7 +38,7 @@ export function horizontalScrollTemplate(
                 </div>
                 ${when(
                     x => x.view !== "mobile",
-                    html<FASTHorizontalScroll>`
+                    html<T>`
                         <div
                             class="scroll scroll-prev"
                             part="scroll-prev"

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.template.ts
@@ -6,10 +6,10 @@ import type { FASTListboxOption, ListboxOptionOptions } from "./listbox-option.j
  * The template for the {@link @microsoft/fast-foundation#(FASTListboxOption:class)} component.
  * @public
  */
-export function listboxOptionTemplate(
+export function listboxOptionTemplate<T extends FASTListboxOption>(
     options: ListboxOptionOptions = {}
-): ElementViewTemplate<FASTListboxOption> {
-    return html<FASTListboxOption>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             aria-checked="${x => x.ariaChecked}"
             aria-disabled="${x => x.ariaDisabled}"

--- a/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.template.ts
@@ -5,8 +5,8 @@ import { FASTListboxElement } from "./listbox.element.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTListbox:class)} component.
  * @public
  */
-export function listboxTemplate(): ElementViewTemplate<FASTListboxElement> {
-    return html<FASTListboxElement>`
+export function listboxTemplate<T extends FASTListboxElement>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             aria-activedescendant="${x => x.ariaActiveDescendant}"
             aria-multiselectable="${x => x.ariaMultiSelectable}"

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -9,11 +9,11 @@ import type { FASTMenuItem, MenuItemOptions } from "./menu-item.js";
  *
  * @public
  */
-export function menuItemTemplate(
+export function menuItemTemplate<T extends FASTMenuItem>(
     options: MenuItemOptions
-): ElementViewTemplate<FASTMenuItem> {
+): ElementViewTemplate<T> {
     const anchoredRegionTag = tagFor(options.anchoredRegion);
-    return html<FASTMenuItem>`
+    return html<T>`
     <template
         role="${x => x.role}"
         aria-haspopup="${x => (x.hasSubmenu ? "menu" : void 0)}"
@@ -59,7 +59,7 @@ export function menuItemTemplate(
         ${endSlotTemplate(options)}
         ${when(
             x => x.hasSubmenu,
-            html<FASTMenuItem>`
+            html<T>`
                 <div
                     part="expand-collapse-glyph-container"
                     class="expand-collapse-glyph-container"
@@ -74,7 +74,7 @@ export function menuItemTemplate(
         )}
         ${when(
             x => x.expanded,
-            html<FASTMenuItem>`
+            html<T>`
                 <${anchoredRegionTag}
                     :anchorElement="${x => x}"
                     vertical-positioning-mode="dynamic"

--- a/packages/web-components/fast-foundation/src/menu/menu.template.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.template.ts
@@ -5,8 +5,8 @@ import type { FASTMenu } from "./menu.js";
  * The template for the {@link @microsoft/fast-foundation#FASTMenu} component.
  * @public
  */
-export function menuTemplate(): ElementViewTemplate<FASTMenu> {
-    return html<FASTMenu>`
+export function menuTemplate<T extends FASTMenu>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             slot="${x => (x.slot ? x.slot : x.isNestedMenu() ? "submenu" : void 0)}"
             role="menu"

--- a/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.template.ts
@@ -6,10 +6,10 @@ import type { FASTNumberField, NumberFieldOptions } from "./number-field.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTNumberField:class)} component.
  * @public
  */
-export function numberFieldTemplate(
+export function numberFieldTemplate<T extends FASTNumberField>(
     options: NumberFieldOptions = {}
-): ElementViewTemplate<FASTNumberField> {
-    return html<FASTNumberField>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template class="${x => (x.readOnly ? "readonly" : "")}">
             <label
                 part="label"
@@ -68,7 +68,7 @@ export function numberFieldTemplate(
                 />
                 ${when(
                     x => !x.hideStep && !x.readOnly && !x.disabled,
-                    html<FASTNumberField>`
+                    html<T>`
                         <div class="controls" part="controls">
                             <div
                                 class="step-up"

--- a/packages/web-components/fast-foundation/src/picker/picker-list-item.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list-item.template.ts
@@ -5,8 +5,10 @@ import type { FASTPickerListItem } from "./picker-list-item.js";
  *
  * @public
  */
-export function pickerListItemTemplate(): ElementViewTemplate<FASTPickerListItem> {
-    return html<FASTPickerListItem>`
+export function pickerListItemTemplate<
+    T extends FASTPickerListItem
+>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="listitem"
             tabindex="0"

--- a/packages/web-components/fast-foundation/src/picker/picker-list.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list.template.ts
@@ -5,8 +5,8 @@ import type { FASTPickerList } from "./picker-list.js";
  *
  * @public
  */
-export function pickerListTemplate(): ElementViewTemplate<FASTPickerList> {
-    return html<FASTPickerList>`
+export function pickerListTemplate<T extends FASTPickerList>(): ElementViewTemplate<T> {
+    return html<T>`
         <template slot="list-region" role="list" class="picker-list">
             <slot></slot>
             <slot name="input-region"></slot>

--- a/packages/web-components/fast-foundation/src/picker/picker-menu-option.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-menu-option.template.ts
@@ -5,8 +5,10 @@ import type { FASTPickerMenuOption } from "./picker-menu-option.js";
  *
  * @public
  */
-export function pickerMenuOptionTemplate(): ElementViewTemplate<FASTPickerMenuOption> {
-    return html<FASTPickerMenuOption>`
+export function pickerMenuOptionTemplate<
+    T extends FASTPickerMenuOption
+>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="listitem"
             tabindex="-1"

--- a/packages/web-components/fast-foundation/src/picker/picker-menu.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-menu.template.ts
@@ -5,8 +5,8 @@ import type { FASTPickerMenu } from "./picker-menu.js";
  * The template for the List Picker component.
  * @public
  */
-export function pickerMenuTemplate(): ElementViewTemplate<FASTPickerMenu> {
-    return html<FASTPickerMenu>`
+export function pickerMenuTemplate<T extends FASTPickerMenu>(): ElementViewTemplate<T> {
+    return html<T>`
         <template role="list" slot="menu-region">
             <div class="options-display" part="options-display">
                 <div class="header-region" part="header-region">

--- a/packages/web-components/fast-foundation/src/picker/picker.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.template.ts
@@ -47,13 +47,15 @@ export type PickerOptions = {
  * The template for the List Picker component.
  * @public
  */
-export function pickerTemplate(options: PickerOptions): ElementViewTemplate<FASTPicker> {
+export function pickerTemplate<T extends FASTPicker>(
+    options: PickerOptions
+): ElementViewTemplate<T> {
     const anchoredRegionTag: string = tagFor(options.anchoredRegion);
     const pickerMenuTag: string = tagFor(options.pickerMenu);
     const pickerListTag: string = tagFor(options.pickerList);
     const progressRingTag: string = tagFor(options.progressRing);
 
-    return html<FASTPicker>`
+    return html<T>`
         <template
             :selectedListTag="${() => pickerListTag}"
             :menuTag="${() => pickerMenuTag}"
@@ -69,7 +71,7 @@ export function pickerTemplate(options: PickerOptions): ElementViewTemplate<FAST
 
             ${when(
                 x => x.flyoutOpen,
-                html<FASTPicker>`
+                html<T>`
                 <${anchoredRegionTag}
                     class="region"
                     part="region"
@@ -94,13 +96,13 @@ export function pickerTemplate(options: PickerOptions): ElementViewTemplate<FAST
                 >
                     ${when(
                         x => !x.showNoOptions && !x.showLoading,
-                        html<FASTPicker>`
+                        html<T>`
                             <slot name="menu-region"></slot>
                         `
                     )}
                     ${when(
                         x => x.showNoOptions && !x.showLoading,
-                        html<FASTPicker>`
+                        html<T>`
                             <div class="no-options-display" part="no-options-display">
                                 <slot name="no-options-region">
                                     ${x => x.noSuggestionsText}
@@ -110,7 +112,7 @@ export function pickerTemplate(options: PickerOptions): ElementViewTemplate<FAST
                     )}
                     ${when(
                         x => x.showLoading,
-                        html<FASTPicker>`
+                        html<T>`
                             <div class="loading-display" part="loading-display">
                                 <slot name="loading-region">
                                     <${progressRingTag}

--- a/packages/web-components/fast-foundation/src/progress-ring/progress-ring.template.ts
+++ b/packages/web-components/fast-foundation/src/progress-ring/progress-ring.template.ts
@@ -9,10 +9,10 @@ const progressSegments: number = 44;
  * The template for the {@link @microsoft/fast-foundation#FASTProgressRing} component.
  * @public
  */
-export function progressRingTemplate(
+export function progressRingTemplate<T extends FASTProgressRing>(
     options: ProgressRingOptions = {}
-): ElementViewTemplate<FASTProgressRing> {
-    return html<FASTProgressRing>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="progressbar"
             aria-valuenow="${x => x.value}"
@@ -22,7 +22,7 @@ export function progressRingTemplate(
         >
             ${when(
                 x => typeof x.value === "number",
-                html<FASTProgressRing>`
+                html<T>`
                     <svg
                         class="progress"
                         part="progress"
@@ -51,7 +51,7 @@ export function progressRingTemplate(
             )}
             ${when(
                 x => typeof x.value !== "number",
-                html<FASTProgressRing>`
+                html<T>`
                     <slot name="indeterminate">
                         ${options.indeterminateIndicator || ""}
                     </slot>

--- a/packages/web-components/fast-foundation/src/progress/progress.template.ts
+++ b/packages/web-components/fast-foundation/src/progress/progress.template.ts
@@ -7,9 +7,9 @@ import type { ProgressOptions } from "./progress.options.js";
  * The template for the {@link @microsoft/fast-foundation#FASTProgress} component.
  * @public
  */
-export function progressTemplate(
+export function progressTemplate<T extends FASTProgress>(
     options: ProgressOptions = {}
-): ElementViewTemplate<FASTProgress> {
+): ElementViewTemplate<T> {
     return html`
         <template
             role="progressbar"
@@ -20,7 +20,7 @@ export function progressTemplate(
         >
             ${when(
                 x => typeof x.value === "number",
-                html<FASTProgress>`
+                html<T>`
                     <div class="progress" part="progress" slot="determinate">
                         <div
                             class="determinate"
@@ -32,7 +32,7 @@ export function progressTemplate(
             )}
             ${when(
                 x => typeof x.value !== "number",
-                html<FASTProgress>`
+                html<T>`
                     <div class="progress" part="progress" slot="indeterminate">
                         <slot name="indeterminate">
                             ${options.indeterminateIndicator1 || ""}

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
@@ -6,8 +6,8 @@ import type { FASTRadioGroup } from "./radio-group.js";
  * The template for the {@link @microsoft/fast-foundation#FASTRadioGroup} component.
  * @public
  */
-export function radioGroupTemplate(): ElementViewTemplate<FASTRadioGroup> {
-    return html<FASTRadioGroup>`
+export function radioGroupTemplate<T extends FASTRadioGroup>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="radiogroup"
             aria-disabled="${x => x.disabled}"

--- a/packages/web-components/fast-foundation/src/radio/radio.template.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.template.ts
@@ -7,10 +7,10 @@ import type { FASTRadio, RadioOptions } from "./radio.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTRadio:class)} component.
  * @public
  */
-export function radioTemplate(
+export function radioTemplate<T extends FASTRadio>(
     options: RadioOptions = {}
-): ElementViewTemplate<FASTRadio> {
-    return html`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="radio"
             class="${x =>

--- a/packages/web-components/fast-foundation/src/search/search.template.ts
+++ b/packages/web-components/fast-foundation/src/search/search.template.ts
@@ -7,10 +7,10 @@ import type { FASTSearch, SearchOptions } from "./search.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTSearch:class)} component.
  * @public
  */
-export function searchTemplate(
+export function searchTemplate<T extends FASTSearch>(
     options: SearchOptions = {}
-): ElementViewTemplate<FASTSearch> {
-    return html<FASTSearch>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             class="
             ${x => (x.readOnly ? "readonly" : "")}

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -7,10 +7,10 @@ import type { FASTSelect, SelectOptions } from "./select.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTSelect:class)} component.
  * @public
  */
-export function selectTemplate(
+export function selectTemplate<T extends FASTSelect>(
     options: SelectOptions = {}
-): ElementViewTemplate<FASTSelect> {
-    return html<FASTSelect>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             class="${x =>
                 [
@@ -38,7 +38,7 @@ export function selectTemplate(
         >
             ${when(
                 x => x.collapsible,
-                html<FASTSelect>`
+                html<T>`
                     <div
                         class="control"
                         part="control"

--- a/packages/web-components/fast-foundation/src/skeleton/skeleton.template.ts
+++ b/packages/web-components/fast-foundation/src/skeleton/skeleton.template.ts
@@ -6,8 +6,8 @@ import { FASTSkeleton, SkeletonShape } from "./skeleton.js";
  * The template for the fast-skeleton component
  * @public
  */
-export function skeletonTemplate(): ElementViewTemplate<FASTSkeleton> {
-    return html<FASTSkeleton>`
+export function skeletonTemplate<T extends FASTSkeleton>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             class="${x => (x.shape in SkeletonShape ? x.shape : "rect")}"
             pattern="${x => x.pattern}"

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.template.ts
@@ -6,8 +6,8 @@ import type { FASTSliderLabel } from "./slider-label.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTSliderLabel:class)} component.
  * @public
  */
-export function sliderLabelTemplate(): ElementViewTemplate<FASTSliderLabel> {
-    return html<FASTSliderLabel>`
+export function sliderLabelTemplate<T extends FASTSliderLabel>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             aria-disabled="${x => x.disabled}"
             class="${x => x.sliderOrientation || Orientation.horizontal}

--- a/packages/web-components/fast-foundation/src/slider/slider.template.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.template.ts
@@ -7,10 +7,10 @@ import type { SliderOptions } from "./slider.options.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTSlider:class)} component.
  * @public
  */
-export function sliderTemplate(
+export function sliderTemplate<T extends FASTSlider>(
     options: SliderOptions = {}
-): ElementViewTemplate<FASTSlider> {
-    return html<FASTSlider>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="slider"
             class="${x => (x.readOnly ? "readonly" : "")}

--- a/packages/web-components/fast-foundation/src/switch/switch.template.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.template.ts
@@ -5,10 +5,10 @@ import type { FASTSwitch, SwitchOptions } from "./switch.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTSwitch:class)} component.
  * @public
  */
-export function switchTemplate(
+export function switchTemplate<T extends FASTSwitch>(
     options: SwitchOptions = {}
-): ElementViewTemplate<FASTSwitch> {
-    return html<FASTSwitch>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="switch"
             aria-checked="${x => x.checked}"

--- a/packages/web-components/fast-foundation/src/tab-panel/tab-panel.template.ts
+++ b/packages/web-components/fast-foundation/src/tab-panel/tab-panel.template.ts
@@ -5,8 +5,8 @@ import type { FASTTabPanel } from "./tab-panel.js";
  * The template for the {@link @microsoft/fast-foundation#FASTTabPanel} component.
  * @public
  */
-export function tabPanelTemplate(): ElementViewTemplate<FASTTabPanel> {
-    return html<FASTTabPanel>`
+export function tabPanelTemplate<T extends FASTTabPanel>(): ElementViewTemplate<T> {
+    return html<T>`
         <template slot="tabpanel" role="tabpanel">
             <slot></slot>
         </template>

--- a/packages/web-components/fast-foundation/src/tab/tab.template.ts
+++ b/packages/web-components/fast-foundation/src/tab/tab.template.ts
@@ -7,8 +7,10 @@ import type { FASTTab } from "./tab.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTTab:class)} component.
  * @public
  */
-export function tabTemplate(options: StartEndOptions = {}): ElementViewTemplate<FASTTab> {
-    return html<FASTTab>`
+export function tabTemplate<T extends FASTTab>(
+    options: StartEndOptions = {}
+): ElementViewTemplate<T> {
+    return html<T>`
         <template slot="tab" role="tab" aria-disabled="${x => x.disabled}">
             ${startSlotTemplate(options)}
             <slot></slot>

--- a/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
@@ -6,8 +6,10 @@ import type { FASTTabs, TabsOptions } from "./tabs.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTTabs:class)} component.
  * @public
  */
-export function tabsTemplate(options: TabsOptions = {}): ElementViewTemplate<FASTTabs> {
-    return html<FASTTabs>`
+export function tabsTemplate<T extends FASTTabs>(
+    options: TabsOptions = {}
+): ElementViewTemplate<T> {
+    return html<T>`
         <template class="${x => x.orientation}">
             ${startSlotTemplate(options)}
             <div class="tablist" part="tablist" role="tablist">
@@ -15,7 +17,7 @@ export function tabsTemplate(options: TabsOptions = {}): ElementViewTemplate<FAS
 
                 ${when(
                     x => x.showActiveIndicator,
-                    html<FASTTabs>`
+                    html<T>`
                         <div
                             ${ref("activeIndicatorRef")}
                             class="active-indicator"

--- a/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
@@ -6,8 +6,8 @@ import type { FASTTextArea } from "./text-area.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTTextArea:class)} component.
  * @public
  */
-export function textAreaTemplate(): ElementViewTemplate<FASTTextArea> {
-    return html<FASTTextArea>`
+export function textAreaTemplate<T extends FASTTextArea>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             class="
             ${x => (x.readOnly ? "readonly" : "")}

--- a/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
@@ -7,10 +7,10 @@ import type { FASTTextField, TextFieldOptions } from "./text-field.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTTextField:class)} component.
  * @public
  */
-export function textFieldTemplate(
+export function textFieldTemplate<T extends FASTTextField>(
     options: TextFieldOptions = {}
-): ElementViewTemplate<FASTTextField> {
-    return html<FASTTextField>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             class="
             ${x => (x.readOnly ? "readonly" : "")}

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.template.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.template.ts
@@ -13,10 +13,10 @@ import type { FASTToolbar, ToolbarOptions } from "./toolbar.js";
  *
  * @public
  */
-export function toolbarTemplate(
+export function toolbarTemplate<T extends FASTToolbar>(
     options: ToolbarOptions = {}
-): ElementViewTemplate<FASTToolbar> {
-    return html<FASTToolbar>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             aria-label="${x => x.ariaLabel}"
             aria-labelledby="${x => x.ariaLabelledby}"

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
@@ -14,13 +14,13 @@ export type TooltipOptions = {
  * Creates a template for the {@link @microsoft/fast-foundation#(FASTTooltip:class)} component using the provided prefix.
  * @public
  */
-export function tooltipTemplate(
+export function tooltipTemplate<T extends FASTTooltip>(
     options: TooltipOptions
-): ElementViewTemplate<FASTTooltip> {
-    return html<FASTTooltip>`
+): ElementViewTemplate<T> {
+    return html<T>`
         ${when(
             x => x.tooltipVisible,
-            html<FASTTooltip>`
+            html<T>`
             <${tagFor(options.anchoredRegion)}
                 fixed-placement="true"
                 auto-update-mode="${x => x.autoUpdateMode}"

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -7,10 +7,10 @@ import type { FASTTreeItem, TreeItemOptions } from "./tree-item.js";
  * The template for the {@link @microsoft/fast-foundation#(FASTTreeItem:class)} component.
  * @public
  */
-export function treeItemTemplate(
+export function treeItemTemplate<T extends FASTTreeItem>(
     options: TreeItemOptions = {}
-): ElementViewTemplate<FASTTreeItem> {
-    return html<FASTTreeItem>`
+): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="treeitem"
             slot="${x => (x.isNestedItem() ? "item" : void 0)}"
@@ -39,7 +39,7 @@ export function treeItemTemplate(
                 <div class="content-region" part="content-region">
                     ${when(
                         x => x.childItems && x.childItemLength(),
-                        html<FASTTreeItem>`
+                        html<T>`
                             <div
                                 aria-hidden="true"
                                 class="expand-collapse-button"
@@ -63,7 +63,7 @@ export function treeItemTemplate(
             </div>
             ${when(
                 x => x.childItems && x.childItemLength() && x.expanded,
-                html<FASTTreeItem>`
+                html<T>`
                     <div role="group" class="items" part="items">
                         <slot name="item" ${slotted("items")}></slot>
                     </div>

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.template.ts
@@ -5,8 +5,8 @@ import type { FASTTreeView } from "./tree-view.js";
  * The template for the {@link @microsoft/fast-foundation#FASTTreeView} component.
  * @public
  */
-export function treeViewTemplate(): ElementViewTemplate<FASTTreeView> {
-    return html<FASTTreeView>`
+export function treeViewTemplate<T extends FASTTreeView>(): ElementViewTemplate<T> {
+    return html<T>`
         <template
             role="tree"
             ${ref("treeView")}

--- a/yarn.lock
+++ b/yarn.lock
@@ -3349,11 +3349,6 @@
     "@microsoft/fast-web-utilities" "^5.4.1"
     tslib "^1.13.0"
 
-"@microsoft/fast-element@2.0.0-beta.5":
-  version "2.0.0-beta.5"
-  resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-2.0.0-beta.5.tgz#3f370c12685b85a2c952ba19ff74822536c96375"
-  integrity sha512-GYJC8x+a6KYIR3NaVJqlDvk61rhNkOAxq3m5VmJu1uYIfFowC1YFdgtZVGTME9Y9/gfbsNe1F1luzw98ES7QAg==
-
 "@microsoft/fast-element@^1.0.0", "@microsoft/fast-element@^1.10.0", "@microsoft/fast-element@^1.10.1", "@microsoft/fast-element@^1.10.3", "@microsoft/fast-element@^1.5.1":
   version "1.10.3"
   resolved "https://registry.yarnpkg.com/@microsoft/fast-element/-/fast-element-1.10.3.tgz#0d513583207c2a33e6ec020c366d836c21423fca"


### PR DESCRIPTION
# Pull Request

## 📖 Description
Ensures that foundation templates support extending classes.

### 🎫 Issues
closes #6344 
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->