### PR TITLE
refactor(fast-foundation): remove redundant role

### DIFF
--- a/change/@microsoft-fast-foundation-656e7737-e8d8-4b21-a86d-47dbe895535b.json
+++ b/change/@microsoft-fast-foundation-656e7737-e8d8-4b21-a86d-47dbe895535b.json
@@ -3,5 +3,5 @@
   "comment": "removed redundant role setting in fast foundation menu-item template",
   "packageName": "@microsoft/fast-foundation",
   "email": "yinon@hotmail.com",
-  "dependentChangeType": "none"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-656e7737-e8d8-4b21-a86d-47dbe895535b.json
+++ b/change/@microsoft-fast-foundation-656e7737-e8d8-4b21-a86d-47dbe895535b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "removed redundant role setting in fast foundation menu-item template",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "yinon@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-foundation-656e7737-e8d8-4b21-a86d-47dbe895535b.json
+++ b/change/@microsoft-fast-foundation-656e7737-e8d8-4b21-a86d-47dbe895535b.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "prerelease",
   "comment": "removed redundant role setting in fast foundation menu-item template",
   "packageName": "@microsoft/fast-foundation",
   "email": "yinon@hotmail.com",

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
@@ -72,6 +72,8 @@ describe("Menu item", () => {
 
         await connect();
 
+        await Updates.next();
+
         expect(element.getAttribute("role")).to.equal(MenuItemRole.menuitem);
 
         await disconnect();

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
@@ -36,6 +36,8 @@ describe("Menu item", () => {
 
         await connect();
 
+        await Updates.next();
+
         expect(element.getAttribute("role")).to.equal(role);
 
         await disconnect();

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
@@ -37,7 +37,6 @@ describe("Menu item", () => {
         await connect();
 
         await Updates.next();
-
         expect(element.getAttribute("role")).to.equal(role);
 
         await disconnect();

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
@@ -51,6 +51,8 @@ describe("Menu item", () => {
 
         await connect();
 
+        await Updates.next();
+
         expect(element.getAttribute("role")).to.equal(role);
 
         await disconnect();
@@ -63,6 +65,8 @@ describe("Menu item", () => {
         element.role = role;
 
         await connect();
+
+        await Updates.next();
 
         expect(element.getAttribute("role")).to.equal(role);
 

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.spec.ts
@@ -37,6 +37,7 @@ describe("Menu item", () => {
         await connect();
 
         await Updates.next();
+
         expect(element.getAttribute("role")).to.equal(role);
 
         await disconnect();

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -15,7 +15,6 @@ export function menuItemTemplate<T extends FASTMenuItem>(
     const anchoredRegionTag = tagFor(options.anchoredRegion);
     return html<T>`
     <template
-        role="${x => x.role}"
         aria-haspopup="${x => (x.hasSubmenu ? "menu" : void 0)}"
         aria-checked="${x => (x.role !== MenuItemRole.menuitem ? x.checked : void 0)}"
         aria-disabled="${x => x.disabled}"


### PR DESCRIPTION
this might seem pretentious to simply delete a line but, removing it makes no difference.
the `role` @attr decorated property member (by its default behavior) already reflects to the DOM host, which makes the removed line redundant in template.

https://github.com/microsoft/fast/blob/1d230aa72f4802bb309c4679bf5b2fa27d385e7b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts#L115-L116

is there any other reason why this should stay?

