### PR TITLE
Make radio group use label as accessible name

### DIFF
--- a/change/@microsoft-fast-foundation-cb166863-88b2-435b-8cad-55534919c3d2.json
+++ b/change/@microsoft-fast-foundation-cb166863-88b2-435b-8cad-55534919c3d2.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Make radio group use label as accessible name",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
@@ -12,15 +12,16 @@ export const radioGroupTemplate: FoundationElementTemplate<ViewTemplate<RadioGro
     context,
     definition
 ) => html`
-    <template
+    <div
         role="radiogroup"
+        aria-labelledby="label"
         aria-disabled="${x => x.disabled}"
         aria-readonly="${x => x.readOnly}"
         @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
         @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
         @focusout="${(x, c) => x.focusOutHandler(c.event as FocusEvent)}"
     >
-        <slot name="label"></slot>
+        <label id="label"><slot name="label"></slot></label>
         <div
             class="positioning-region ${x =>
                 x.orientation === Orientation.horizontal ? "horizontal" : "vertical"}"
@@ -33,5 +34,5 @@ export const radioGroupTemplate: FoundationElementTemplate<ViewTemplate<RadioGro
                 })}
             ></slot>
         </div>
-    </template>
+    </div>
 `;


### PR DESCRIPTION
# Pull Request

## 📖 Description

When the user provides a label for the radio group, that label should automatically serve as the accessible name. This change accomplishes that by:
- introducing a `label` element (wrapping the existing named "label" slot) in the shadow DOM
- introducing a top-level, wrapping `div` element to the shadow DOM (that can reference the `label`'s ID)
- applying the `aria-labelledby` attribute to the new `div` that references the new `label`.

With my change, users should provide the label text in a `div` or `span` element, though a `label` element will continue to work as well.

### 🎫 Issues

#6360 

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

Tests continue to pass

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->