### PR TITLE
fix(fast-element): attributes properly located in inheritance hierarchy

### DIFF
--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -82,6 +82,11 @@ export type AttributeConfiguration = {
 };
 
 // @public
+export const AttributeConfiguration: Readonly<{
+    locate: (target: {}) => AttributeConfiguration[];
+}>;
+
+// @public
 export class AttributeDefinition implements Accessor {
     constructor(Owner: Function, name: string, attribute?: string, mode?: AttributeMode, converter?: ValueConverter);
     readonly attribute: string;
@@ -187,6 +192,11 @@ export interface ContentView {
     remove(): void;
     unbind(): void;
 }
+
+// Warning: (ae-internal-missing-underscore) The name "createMetadataLocator" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export function createMetadataLocator<TMetadata>(): (target: {}) => TMetadata[];
 
 // Warning: (ae-internal-missing-underscore) The name "createTypeRegistry" should be prefixed with an underscore because the declaration is marked as @internal
 //

--- a/packages/web-components/fast-element/src/components/attributes.spec.ts
+++ b/packages/web-components/fast-element/src/components/attributes.spec.ts
@@ -1,0 +1,32 @@
+import { expect } from "chai";
+import { attr, AttributeDefinition } from "./attributes.js";
+import { FASTElement } from "./fast-element.js";
+
+describe("Attributes", () => {
+    it("should be properly aggregated across an inheritance hierarchy.", () => {
+        abstract class BaseElement extends FASTElement {
+            @attr attributeOne = "";
+        }
+
+        class ComponentA extends BaseElement {
+            @attr attributeTwo = "two-A";
+        }
+
+        class ComponentB extends BaseElement {
+            private get attributeTwo(): string {
+              return "two-B"
+            }
+        }
+
+        const componentAAtributes = AttributeDefinition.collect(
+            ComponentA
+        );
+
+        const componentBAtributes = AttributeDefinition.collect(
+            ComponentB
+        );
+
+        expect(componentAAtributes.length).equal(2);
+        expect(componentBAtributes.length).equal(1);
+    });
+});

--- a/packages/web-components/fast-element/src/components/attributes.ts
+++ b/packages/web-components/fast-element/src/components/attributes.ts
@@ -3,6 +3,7 @@ import type { Notifier } from "../observation/notifier.js";
 import { isString } from "../interfaces.js";
 import { Updates } from "../observation/update-queue.js";
 import { DOM } from "../templating/dom.js";
+import { createMetadataLocator } from "../platform.js";
 
 /**
  * Represents objects that can convert values to and from
@@ -49,6 +50,17 @@ export type AttributeConfiguration = {
     mode?: AttributeMode;
     converter?: ValueConverter;
 };
+
+/**
+ * Metadata used to configure a custom attribute's behavior.
+ * @public
+ */
+export const AttributeConfiguration = Object.freeze({
+    /**
+     * Locates all attribute configurations associated with a type.
+     */
+    locate: createMetadataLocator<AttributeConfiguration>()
+});
 
 /**
  * Metadata used to configure a custom attribute's behavior through a decorator.
@@ -259,7 +271,7 @@ export class AttributeDefinition implements Accessor {
     ): ReadonlyArray<AttributeDefinition> {
         const attributes: AttributeDefinition[] = [];
 
-        attributeLists.push((Owner as any).attributes);
+        attributeLists.push(AttributeConfiguration.locate(Owner));
 
         for (let i = 0, ii = attributeLists.length; i < ii; ++i) {
             const list = attributeLists[i];
@@ -323,11 +335,9 @@ export function attr(
             config.property = $prop;
         }
 
-        const attributes: AttributeConfiguration[] =
-            ($target.constructor as any).attributes ||
-            (($target.constructor as any).attributes = []);
-
-        attributes.push(config);
+        AttributeConfiguration
+            .locate($target.constructor)
+            .push(config);
     }
 
     if (arguments.length > 1) {

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -5,7 +5,7 @@ import {
     KernelServiceId,
     Message,
 } from "../interfaces.js";
-import { FAST } from "../platform.js";
+import { createMetadataLocator, FAST } from "../platform.js";
 import { Updates } from "./update-queue.js";
 import { PropertyChangeNotifier, SubscriberSet } from "./notifier.js";
 import type { Notifier, Subscriber } from "./notifier.js";
@@ -174,7 +174,6 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
     const queueUpdate = Updates.enqueue;
     const volatileRegex = /(:|&&|\|\||if)/;
     const notifierLookup = new WeakMap<any, Notifier>();
-    const accessorLookup = new WeakMap<any, Accessor[]>();
     let watcher: ExpressionNotifierImplementation | undefined = void 0;
     let createArrayObserver = (array: any[]): Notifier => {
         throw FAST.error(Message.needsArrayObservation);
@@ -195,24 +194,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         return found;
     }
 
-    function getAccessors(target: {}): Accessor[] {
-        let accessors = accessorLookup.get(target);
-
-        if (accessors === void 0) {
-            let currentTarget = Reflect.getPrototypeOf(target);
-
-            while (accessors === void 0 && currentTarget !== null) {
-                accessors = accessorLookup.get(currentTarget);
-                currentTarget = Reflect.getPrototypeOf(currentTarget);
-            }
-
-            accessors = accessors === void 0 ? [] : accessors.slice(0);
-
-            accessorLookup.set(target, accessors);
-        }
-
-        return accessors;
-    }
+    const getAccessors = createMetadataLocator<Accessor>();
 
     class DefaultObservableAccessor implements Accessor {
         private field: string;

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -100,3 +100,31 @@ export function createTypeRegistry<TDefinition extends TypeDefinition>(): TypeRe
         },
     });
 }
+
+/**
+ * Creates a function capable of locating metadata associated with a type.
+ * @returns A metadata locator function.
+ * @internal
+ */
+export function createMetadataLocator<TMetadata>(): (target: {}) => TMetadata[] {
+    const metadataLookup = new WeakMap<any, TMetadata[]>();
+
+    return function(target: {}): TMetadata[] {
+        let metadata = metadataLookup.get(target);
+
+        if (metadata === void 0) {
+            let currentTarget = Reflect.getPrototypeOf(target);
+
+            while (metadata === void 0 && currentTarget !== null) {
+                metadata = metadataLookup.get(currentTarget);
+                currentTarget = Reflect.getPrototypeOf(currentTarget);
+            }
+
+            metadata = metadata === void 0 ? [] : metadata.slice(0);
+
+            metadataLookup.set(target, metadata);
+        }
+
+        return metadata;
+    }
+}

--- a/packages/web-components/fast-foundation/src/utilities/apply-mixins.ts
+++ b/packages/web-components/fast-foundation/src/utilities/apply-mixins.ts
@@ -1,9 +1,13 @@
+import { AttributeConfiguration } from "@microsoft/fast-element";
+
 /**
  * Apply mixins to a constructor.
  * Sourced from {@link https://www.typescriptlang.org/docs/handbook/mixins.html | TypeScript Documentation }.
  * @public
  */
 export function applyMixins(derivedCtor: any, ...baseCtors: any[]) {
+    const derivedAttributes = AttributeConfiguration.locate(derivedCtor);
+
     baseCtors.forEach(baseCtor => {
         Object.getOwnPropertyNames(baseCtor.prototype).forEach(name => {
             if (name !== "constructor") {
@@ -16,9 +20,7 @@ export function applyMixins(derivedCtor: any, ...baseCtors: any[]) {
             }
         });
 
-        if (baseCtor.attributes) {
-            const existing = derivedCtor.attributes || [];
-            derivedCtor.attributes = existing.concat(baseCtor.attributes);
-        }
+        const baseAttributes = AttributeConfiguration.locate(baseCtor);
+        baseAttributes.forEach(x => derivedAttributes.push(x));
     });
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR addresses an apparently long-standing bug in `fast-element` related to attributes inherited through a class hierarchy.

### 🎫 Issues

* Fixes #6368 

## 👩‍💻 Reviewer Notes

I refactored the attribute code so that is uses the same mechanism as the observable code. I'm not sure why this wasn't done long ago to be honest. It must have just got missed in the very early prototypes.

I also fixed up the `mixin` helper in `fast-foundation` to use the new API.

## 📑 Test Plan

A failing test was initially added to ensure the changes would fix the bug. All existing tests continue to pass.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

I'll also port this set of fixes to version 1.x.