### PR TITLE
fix storybook story bugs

### DIFF
--- a/change/@microsoft-fast-foundation-f2de503c-f983-4a1e-a523-49b76eac024d.json
+++ b/change/@microsoft-fast-foundation-f2de503c-f983-4a1e-a523-49b76eac024d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix storybook story bugs",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-foundation/src/avatar/stories/avatar.stories.ts
+++ b/packages/web-components/fast-foundation/src/avatar/stories/avatar.stories.ts
@@ -1,4 +1,4 @@
-import { css, html } from "@microsoft/fast-element";
+import { css, html, Updates } from "@microsoft/fast-element";
 import type { Meta, Story, StoryArgs } from "../../__test__/helpers.js";
 import { renderComponent } from "../../__test__/helpers.js";
 import type { FASTAvatar } from "../avatar.js";
@@ -19,21 +19,23 @@ export default {
         Story => {
             const renderedStory = Story() as FASTAvatar;
 
-            renderedStory.$fastController.addStyles(css`
-                ::slotted(fast-badge) {
-                    bottom: 0;
-                    right: 0;
-                }
+            Updates.enqueue(() => {
+                renderedStory.$fastController.addStyles(css`
+                    ::slotted(fast-badge) {
+                        bottom: 0;
+                        right: 0;
+                    }
 
-                .control {
-                    height: 8px;
-                    min-width: 8px;
-                }
+                    .control {
+                        height: 8px;
+                        min-width: 8px;
+                    }
 
-                ::slotted(.container) {
-                    padding: 1em;
-                }
-            `);
+                    ::slotted(.container) {
+                        padding: 1em;
+                    }
+                `);
+            });
 
             return renderedStory;
         },

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/stories/horizontal-scroll.stories.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/stories/horizontal-scroll.stories.ts
@@ -1,4 +1,4 @@
-import { css, html, repeat } from "@microsoft/fast-element";
+import { css, html, repeat, Updates } from "@microsoft/fast-element";
 import { storyTemplate as cardStoryTemplate } from "../../card/stories/card.stories.js";
 import type { Meta, Story, StoryArgs } from "../../__test__/helpers.js";
 import { renderComponent } from "../../__test__/helpers.js";
@@ -44,18 +44,20 @@ export default {
         Story => {
             const renderedStory = Story() as FASTHorizontalScroll;
 
-            renderedStory.$fastController.addStyles(css`
-                ::slotted(fast-card) {
-                    color: var(--neutral-foreground-rest);
-                    height: 200px;
-                    width: 120px;
-                }
+            Updates.enqueue(() => {
+                renderedStory.$fastController.addStyles(css`
+                    ::slotted(fast-card) {
+                        color: var(--neutral-foreground-rest);
+                        height: 200px;
+                        width: 120px;
+                    }
 
-                :host {
-                    max-width: 620px;
-                    margin: 20px;
-                }
-            `);
+                    :host {
+                        max-width: 620px;
+                        margin: 20px;
+                    }
+                `);
+            });
 
             return renderedStory;
         },

--- a/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.stories.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.stories.ts
@@ -1,4 +1,4 @@
-import { css, html, repeat } from "@microsoft/fast-element";
+import { css, html, repeat, Updates } from "@microsoft/fast-element";
 import type { Meta, Story, StoryArgs } from "../../__test__/helpers.js";
 import { renderComponent } from "../../__test__/helpers.js";
 import type { FASTMenuItem } from "../menu-item.js";
@@ -126,17 +126,21 @@ MenuItemExpanded.args = {
 MenuItemExpanded.decorators = [
     Story => {
         const renderedStory = Story() as FASTMenuItem;
-        // Disable cursor interaction to prevent the state from changing
-        renderedStory.$fastController.addStyles(css`
-            :host {
-                width: 50%;
-                pointer-events: none;
-            }
 
-            ::slotted(div) {
-                padding: 10px;
-            }
-        `);
+        Updates.enqueue(() => {
+            // Disable cursor interaction to prevent the state from changing
+            renderedStory.$fastController.addStyles(css`
+                :host {
+                    width: 50%;
+                    pointer-events: none;
+                }
+
+                ::slotted(div) {
+                    padding: 10px;
+                }
+            `);
+        });
+
         return renderedStory;
     },
 ];

--- a/packages/web-components/fast-foundation/src/select/stories/select.register.ts
+++ b/packages/web-components/fast-foundation/src/select/stories/select.register.ts
@@ -194,7 +194,7 @@ export class Select extends FASTSelect {
     }
 
     protected maxHeightChanged(prev: number | undefined, next: number): void {
-        if (this.isConnected) {
+        if (this.$fastController.isConnected) {
             if (this.collapsible) {
                 this.updateComputedStylesheet();
             }

--- a/packages/web-components/fast-foundation/src/skeleton/stories/skeleton.stories.ts
+++ b/packages/web-components/fast-foundation/src/skeleton/stories/skeleton.stories.ts
@@ -61,10 +61,11 @@ SkeletonCardExample.args = {
         { shape: SkeletonShape.rect, shimmer: true },
     ],
 };
-SkeletonCardExample.parameters = { controls: { disable: true } };
+SkeletonCardExample.parameters = { controls: { include: [] } };
 SkeletonCardExample.decorators = [
     Story => {
         const renderedStory = Story() as FASTCard;
+
         renderedStory.$fastController.addStyles(css`
             :host(fast-card) {
                 height: auto;

--- a/packages/web-components/fast-foundation/src/skeleton/stories/skeleton.stories.ts
+++ b/packages/web-components/fast-foundation/src/skeleton/stories/skeleton.stories.ts
@@ -1,4 +1,4 @@
-import { css, html, repeat } from "@microsoft/fast-element";
+import { css, html, repeat, Updates } from "@microsoft/fast-element";
 import type { FASTCard } from "../../card/card.js";
 import { storyTemplate as cardStoryTemplate } from "../../card/stories/card.stories.js";
 import type { Meta, Story, StoryArgs } from "../../__test__/helpers.js";
@@ -35,12 +35,16 @@ export const Skeleton: Story<FASTSkeleton> = renderComponent(storyTemplate).bind
 Skeleton.decorators = [
     Story => {
         const renderedStory = Story() as FASTSkeleton;
-        renderedStory.$fastController.addStyles(css`
-            :host(fast-skeleton) {
-                height: 100px;
-                width: 100px;
-            }
-        `);
+
+        Updates.enqueue(() => {
+            renderedStory.$fastController.addStyles(css`
+                :host(fast-skeleton) {
+                    height: 100px;
+                    width: 100px;
+                }
+            `);
+        });
+
         return renderedStory;
     },
 ];
@@ -66,30 +70,32 @@ SkeletonCardExample.decorators = [
     Story => {
         const renderedStory = Story() as FASTCard;
 
-        renderedStory.$fastController.addStyles(css`
-            :host(fast-card) {
-                height: auto;
-                padding: 1rem;
-                width: 300px;
-            }
+        Updates.enqueue(() => {
+            renderedStory.$fastController.addStyles(css`
+                :host(fast-card) {
+                    height: auto;
+                    padding: 1rem;
+                    width: 300px;
+                }
 
-            ::slotted(fast-skeleton[shape="circle"]) {
-                height: 50px;
-                width: 50px;
-            }
+                ::slotted(fast-skeleton[shape="circle"]) {
+                    height: 50px;
+                    width: 50px;
+                }
 
-            ::slotted(fast-skeleton[shape="rect"]:not(:first-of-type)) {
-                border-radius: 4px;
-                height: 10px;
-                margin: 10px 0;
-            }
+                ::slotted(fast-skeleton[shape="rect"]:not(:first-of-type)) {
+                    border-radius: 4px;
+                    height: 10px;
+                    margin: 10px 0;
+                }
 
-            ::slotted(fast-skeleton[shape="rect"]:last-of-type) {
-                height: 30px;
-                margin: 20px 0 0;
-                width: 75px;
-            }
-        `);
+                ::slotted(fast-skeleton[shape="rect"]:last-of-type) {
+                    height: 30px;
+                    margin: 20px 0 0;
+                    width: 75px;
+                }
+            `);
+        });
 
         return renderedStory;
     },

--- a/packages/web-components/fast-foundation/src/slider/stories/slider.stories.ts
+++ b/packages/web-components/fast-foundation/src/slider/stories/slider.stories.ts
@@ -1,4 +1,4 @@
-import { css, html, repeat } from "@microsoft/fast-element";
+import { css, html, repeat, Updates } from "@microsoft/fast-element";
 import { Orientation } from "@microsoft/fast-web-utilities";
 import { storyTemplate as sliderLabelStoryTemplate } from "../../slider-label/stories/slider-label.stories.js";
 import type { Meta, Story, StoryArgs } from "../../__test__/helpers.js";
@@ -61,11 +61,14 @@ SliderWithLabels.args = {
 SliderWithLabels.decorators = [
     Story => {
         const renderedStory = Story() as FASTSlider;
-        renderedStory.$fastController.addStyles(css`
-            :host([orientation="horizontal"]) {
-                padding: 0 1em;
-            }
-        `);
+
+        Updates.enqueue(() => {
+            renderedStory.$fastController.addStyles(css`
+                :host([orientation="horizontal"]) {
+                    padding: 0 1em;
+                }
+            `);
+        });
 
         return renderedStory;
     },


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes a few storybook-related bugs:

* Use `Updates.enqueue` when calling `renderedStory.$fastController.addStyles` in story decorators
* Fix `isConnected` call in select's `maxHeightChanged` (this is only present in the register module)
* Modify the skeleton card example story parameters to from include no args instead of entirely disabling the controls

## 👩‍💻 Reviewer Notes

Errors were emitted only in Safari when calling `this.$fastController.addStyles` in decorators.

## 📑 Test Plan

These changes should not affect the playwright tests.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
