### PR TITLE
Fix storybook fixture setup for all tests

### DIFF
--- a/change/@microsoft-fast-foundation-7a914be2-4b17-4bb7-a806-637b1bb76d8b.json
+++ b/change/@microsoft-fast-foundation-7a914be2-4b17-4bb7-a806-637b1bb76d8b.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix test fixture rendering",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
@@ -6,6 +6,7 @@ import type { FASTAccordionItem } from "./accordion-item.js";
 test.describe("Accordion item", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let heading: Locator;
     let button: Locator;
 
@@ -13,6 +14,8 @@ test.describe("Accordion item", () => {
         page = await browser.newPage();
 
         element = page.locator("fast-accordion-item");
+
+        root = page.locator("#root");
 
         heading = page.locator(`[role="heading"]`);
 
@@ -26,12 +29,14 @@ test.describe("Accordion item", () => {
     });
 
     test("should set a default heading level of 2 when `headinglevel` is not provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion-item>
-                <span slot="heading">Heading 1</span>
-                <div>Content 1</div>
-            </fast-accordion-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion-item>
+                    <span slot="heading">Heading 1</span>
+                    <div>Content 1</div>
+                </fast-accordion-item>
+            `;
+        });
 
         await expect(element).not.hasAttribute("headinglevel");
 
@@ -39,12 +44,14 @@ test.describe("Accordion item", () => {
     });
 
     test("should set the `aria-level` attribute on the internal heading element equal to the heading level", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion-item>
-                <span slot="heading">Heading 1</span>
-                <div>Content 1</div>
-            </fast-accordion-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion-item>
+                    <span slot="heading">Heading 1</span>
+                    <div>Content 1</div>
+                </fast-accordion-item>
+            `;
+        });
 
         await element.evaluate<void, FASTAccordionItem>(node => {
             node.headinglevel = 3;
@@ -54,25 +61,31 @@ test.describe("Accordion item", () => {
     });
 
     test("should NOT have a class of `expanded` when the `expanded` property is false", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion-item></fast-accordion-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion-item></fast-accordion-item>
+            `;
+        });
 
         await expect(element).not.toHaveClass(/expanded/);
     });
 
     test("should have a class of `expanded` when the `expanded` property is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion-item expanded></fast-accordion-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion-item expanded></fast-accordion-item>
+            `;
+        });
 
         await expect(element).toHaveClass(/expanded/);
     });
 
     test("should set `aria-expanded` property on the internal control equal to the `expanded` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion-item expanded></fast-accordion-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion-item expanded></fast-accordion-item>
+            `;
+        });
 
         await expect(button).toHaveAttribute("aria-expanded", "true");
 
@@ -84,9 +97,11 @@ test.describe("Accordion item", () => {
     });
 
     test("should set internal properties to match the id when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion-item id="foo"></fast-accordion-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion-item id="foo"></fast-accordion-item>
+            `;
+        });
 
         await expect(element.locator(`[role="region"]`)).toHaveAttribute(
             "aria-labelledby",

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -6,11 +6,14 @@ import { AccordionExpandMode } from "./accordion.options.js";
 test.describe("Accordion", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-accordion");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("accordion--accordion"));
     });
@@ -20,52 +23,58 @@ test.describe("Accordion", () => {
     });
 
     test("should set an expand mode of `multi` when passed to the `expand-mode` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion expand-mode="multi">
-                <fast-accordion-item>
-                    <span slot="heading">Heading 1</span>
-                    <div>Content 1</div>
-                </fast-accordion-item>
-                <fast-accordion-item>
-                    <span slot="heading">Heading 2</span>
-                    <div>Content 2</div>
-                </fast-accordion-item>
-            </fast-accordion>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="multi">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
 
         await expect(element).toHaveAttribute("expand-mode", AccordionExpandMode.multi);
     });
 
     test("should set an expand mode of `single` when passed to the `expand-mode` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion expand-mode="single">
-                <fast-accordion-item>
-                    <span slot="heading">Heading 1</span>
-                    <div>Content 1</div>
-                </fast-accordion-item>
-                <fast-accordion-item>
-                    <span slot="heading">Heading 2</span>
-                    <div>Content 2</div>
-                </fast-accordion-item>
-            </fast-accordion>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="single">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
 
         await expect(element).toHaveAttribute("expand-mode", AccordionExpandMode.single);
     });
 
     test("should set a default expand mode of `multi` when `expand-mode` attribute is not passed", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion>
-                <fast-accordion-item>
-                    <span slot="heading">Heading 1</span>
-                    <div>Content 1</div>
-                </fast-accordion-item>
-                <fast-accordion-item>
-                    <span slot="heading">Heading 2</span>
-                    <div>Content 2</div>
-                </fast-accordion-item>
-            </fast-accordion>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("expandmode", AccordionExpandMode.multi);
 
@@ -73,18 +82,20 @@ test.describe("Accordion", () => {
     });
 
     test("should expand/collapse items when clicked in multi mode", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion expand-mode="multi">
-                <fast-accordion-item>
-                    <span slot="heading">Heading 1</span>
-                    <div>Content 1</div>
-                </fast-accordion-item>
-                <fast-accordion-item>
-                    <span slot="heading">Heading 2</span>
-                    <div>Content 2</div>
-                </fast-accordion-item>
-            </fast-accordion>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="multi">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
 
         const items = element.locator("fast-accordion-item");
 
@@ -98,18 +109,20 @@ test.describe("Accordion", () => {
     });
 
     test("should only have one expanded item in single mode", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion expand-mode="single">
-                <fast-accordion-item>
-                    <span slot="heading">Heading 1</span>
-                    <div>Content 1</div>
-                </fast-accordion-item>
-                <fast-accordion-item>
-                    <span slot="heading">Heading 2</span>
-                    <div>Content 2</div>
-                </fast-accordion-item>
-            </fast-accordion>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="single">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
 
         const items = element.locator("fast-accordion-item");
 
@@ -127,7 +140,7 @@ test.describe("Accordion", () => {
 
         await secondItemButton.click();
 
-        await secondItemButton.evaluate((node: HTMLElement) => {
+        await secondItemButton.evaluate(node => {
             node.dispatchEvent(new MouseEvent("click", { bubbles: true }));
             return new Promise(requestAnimationFrame);
         });
@@ -138,18 +151,20 @@ test.describe("Accordion", () => {
     });
 
     test("should ignore `change` events from components other than accordion items", async () => {
-        await page.setContent(/* html */ `
-            <fast-accordion expand-mode="single">
-                <fast-accordion-item>
-                    <div slot="heading">Accordion Item 1 Heading</div>
-                    Accordion Item 1 Content
-                </fast-accordion-item>
-                <fast-accordion-item>
-                    <div slot="heading">Accordion Item 2 Heading</div>
-                    <fast-checkbox>A checkbox as content</fast-checkbox>
-                </fast-accordion-item>
-            </fast-accordion>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="single">
+                    <fast-accordion-item>
+                        <div slot="heading">Accordion Item 1 Heading</div>
+                        Accordion Item 1 Content
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <div slot="heading">Accordion Item 2 Heading</div>
+                        <fast-checkbox>A checkbox as content</fast-checkbox>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
 
         const item = element.locator("fast-accordion-item").nth(1);
 

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.pw.spec.ts
@@ -6,11 +6,14 @@ import type { FASTAnchoredRegion } from "./anchored-region.js";
 test.describe("Anchored Region", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-anchored-region");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("anchored-region--anchored-region"));
     });
@@ -20,9 +23,11 @@ test.describe("Anchored Region", () => {
     });
 
     test("should set positioning modes to 'uncontrolled' by default", async () => {
-        await page.setContent(/* html */ `
-            <fast-anchored-region></fast-anchored-region>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-anchored-region></fast-anchored-region>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("verticalPositioningMode", "uncontrolled");
 
@@ -35,10 +40,15 @@ test.describe("Anchored Region", () => {
     test("should assign anchor and viewport elements by id", async () => {
         const anchorId = "anchor";
 
-        await page.setContent(/* html */ `
-            <div id="${anchorId}"></div>
-            <fast-anchored-region anchor="${anchorId}" viewport="${anchorId}"></fast-anchored-region>
-        `);
+        await root.evaluate(
+            (node, { anchorId }) => {
+                node.innerHTML = /* html */ `
+                    <div id="${anchorId}"></div>
+                    <fast-anchored-region anchor="${anchorId}" viewport="${anchorId}"></fast-anchored-region>
+                `;
+            },
+            { anchorId }
+        );
 
         await expect(element).toHaveAttribute("anchor", anchorId);
 
@@ -52,11 +62,13 @@ test.describe("Anchored Region", () => {
     });
 
     test("should be sized to match content by default", async () => {
-        await page.setContent(/* html */ `
-            <fast-anchored-region>
-                <div id="content" style="width: 100px; height: 100px;"></div>
-            </fast-anchored-region>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-anchored-region>
+                    <div id="content" style="width: 100px; height: 100px;"></div>
+                </fast-anchored-region>
+            `;
+        });
 
         const elementClientHeight = await element.evaluate(node => node.clientHeight);
 

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.pw.spec.ts
@@ -7,12 +7,15 @@ import type { FASTBreadcrumbItem } from "./breadcrumb-item.js";
 test.describe("Breadcrumb item", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let control: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-breadcrumb-item");
+
+        root = page.locator("#root");
 
         control = element.locator(".control");
 
@@ -24,17 +27,21 @@ test.describe("Breadcrumb item", () => {
     });
 
     test("should include a `role` of `listitem`", async () => {
-        await page.setContent(/* html */ `
-            <fast-breadcrumb-item></fast-breadcrumb-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-breadcrumb-item></fast-breadcrumb-item>
+            `;
+        });
 
         await expect(element.locator("> div")).toHaveAttribute("role", "listitem");
     });
 
     test("should render an internal anchor when the `href` attribute is not provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-breadcrumb-item></fast-breadcrumb-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-breadcrumb-item></fast-breadcrumb-item>
+            `;
+        });
 
         const anchor = element.locator("a");
 
@@ -48,9 +55,11 @@ test.describe("Breadcrumb item", () => {
     });
 
     test("should render an internal anchor when the `href` attribute is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-breadcrumb-item href="https://fast.design"></fast-breadcrumb-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-breadcrumb-item href="https://fast.design"></fast-breadcrumb-item>
+            `;
+        });
 
         const anchor = element.locator("a");
 
@@ -64,9 +73,11 @@ test.describe("Breadcrumb item", () => {
     });
 
     test("should add an element with a class of `separator` when the `separator` property is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-breadcrumb-item></fast-breadcrumb-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-breadcrumb-item></fast-breadcrumb-item>
+            `;
+        });
 
         await element.evaluate<void, FASTBreadcrumbItem>(node => {
             node.separator = true;
@@ -109,9 +120,14 @@ test.describe("Breadcrumb item", () => {
         const attrToken = spinalCase(attribute);
 
         test(`should set the \`${attrToken}\` attribute to \`${value}\` on the internal anchor`, async () => {
-            await page.setContent(`
-                <fast-breadcrumb-item ${attrToken}="${value}" href="#"></fast-breadcrumb-item>
-            `);
+            await root.evaluate(
+                (node, { attrToken, value }) => {
+                    node.innerHTML = /* html */ `
+                        <fast-breadcrumb-item ${attrToken}="${value}" href="#"></fast-breadcrumb-item>
+                    `;
+                },
+                { attrToken, value }
+            );
 
             await expect(control).toHaveAttribute(attrToken, `${value}`);
         });

--- a/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.pw.spec.ts
@@ -6,11 +6,14 @@ import type { FASTBreadcrumb } from "./breadcrumb.js";
 test.describe("Breadcrumb", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-breadcrumb");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("breadcrumb--breadcrumb"));
     });
@@ -20,29 +23,35 @@ test.describe("Breadcrumb", () => {
     });
 
     test("should have a role of 'navigation'", async () => {
-        await page.setContent(/* html */ `
-            <fast-breadcrumb></fast-breadcrumb>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-breadcrumb></fast-breadcrumb>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "navigation");
     });
 
     test("should include an internal element with a `role` of `list`", async () => {
-        await page.setContent(/* html */ `
-            <fast-breadcrumb></fast-breadcrumb>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-breadcrumb></fast-breadcrumb>
+            `;
+        });
 
         await expect(element.locator(".list")).toHaveAttribute("role", "list");
     });
 
     test("should not render a separator on last item", async () => {
-        await page.setContent(/* html */ `
-            <fast-breadcrumb>
-                <fast-breadcrumb-item>Item 1</fast-breadcrumb-item>
-                <fast-breadcrumb-item>Item 2</fast-breadcrumb-item>
-                <fast-breadcrumb-item>Item 3</fast-breadcrumb-item>
-            </fast-breadcrumb>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-breadcrumb>
+                    <fast-breadcrumb-item>Item 1</fast-breadcrumb-item>
+                    <fast-breadcrumb-item>Item 2</fast-breadcrumb-item>
+                    <fast-breadcrumb-item>Item 3</fast-breadcrumb-item>
+                </fast-breadcrumb>
+            `;
+        });
 
         const items = element.locator("fast-breadcrumb-item");
 
@@ -52,13 +61,15 @@ test.describe("Breadcrumb", () => {
     });
 
     test("should set `aria-current` on the internal anchor of the last node when `href` is present", async () => {
-        await page.setContent(/* html */ `
-            <fast-breadcrumb>
-                <fast-breadcrumb-item>Item 1</fast-breadcrumb-item>
-                <fast-breadcrumb-item>Item 2</fast-breadcrumb-item>
-                <fast-breadcrumb-item href="#">Item 3</fast-breadcrumb-item>
-            </fast-breadcrumb>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-breadcrumb>
+                    <fast-breadcrumb-item>Item 1</fast-breadcrumb-item>
+                    <fast-breadcrumb-item>Item 2</fast-breadcrumb-item>
+                    <fast-breadcrumb-item href="#">Item 3</fast-breadcrumb-item>
+                </fast-breadcrumb>
+            `;
+        });
 
         await expect(
             element.locator("fast-breadcrumb-item:last-of-type a")
@@ -66,13 +77,15 @@ test.describe("Breadcrumb", () => {
     });
 
     test("should remove `aria-current` from any prior breadcrumb item children with child anchors when a new node is appended", async () => {
-        await page.setContent(/* html */ `
-            <fast-breadcrumb>
-                <fast-breadcrumb-item>Item 1</fast-breadcrumb-item>
-                <fast-breadcrumb-item>Item 2</fast-breadcrumb-item>
-                <fast-breadcrumb-item href="#">Item 3</fast-breadcrumb-item>
-            </fast-breadcrumb>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-breadcrumb>
+                    <fast-breadcrumb-item>Item 1</fast-breadcrumb-item>
+                    <fast-breadcrumb-item>Item 2</fast-breadcrumb-item>
+                    <fast-breadcrumb-item href="#">Item 3</fast-breadcrumb-item>
+                </fast-breadcrumb>
+            `;
+        });
 
         await expect(
             element.locator("fast-breadcrumb-item:last-of-type a")

--- a/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
@@ -7,12 +7,15 @@ import type { FASTButton } from "./button.js";
 test.describe("Button", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let control: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-button");
+
+        root = page.locator("#root");
 
         control = element.locator(".control");
 
@@ -24,9 +27,11 @@ test.describe("Button", () => {
     });
 
     test("should set the `disabled` attribute on the internal control", async () => {
-        await page.setContent(/* html */ `
-            <fast-button disabled></fast-button>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-button disabled></fast-button>
+            `;
+        });
 
         await expect(control).toHaveBooleanAttribute("disabled");
 
@@ -39,9 +44,11 @@ test.describe("Button", () => {
     });
 
     test("should set the `formnovalidate` attribute on the internal control", async () => {
-        await page.setContent(/* html */ `
-            <fast-button formnovalidate></fast-button>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-button formnovalidate></fast-button>
+            `;
+        });
 
         await expect(control).toHaveBooleanAttribute("formnovalidate");
 
@@ -90,8 +97,13 @@ test.describe("Button", () => {
             const attrToken = spinalCase(attribute);
 
             test(`should set the \`${attrToken}\` attribute to \`${value}\``, async () => {
-                await page.setContent(
-                    `<fast-button ${attrToken}="${value}"></fast-button>`
+                await root.evaluate(
+                    (node, { attrToken, value }) => {
+                        node.innerHTML = /* html */ `
+                            <fast-button ${attrToken}="${value}"></fast-button>
+                        `;
+                    },
+                    { attrToken, value }
                 );
 
                 await expect(control).toHaveAttribute(attrToken, `${value}`);
@@ -100,9 +112,11 @@ test.describe("Button", () => {
     });
 
     test("should set the `form` attribute on the internal button when `formId` is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-button></fast-button>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-button></fast-button>
+            `;
+        });
 
         await element.evaluate((node: FASTButton) => {
             node.formId = "foo";
@@ -112,9 +126,11 @@ test.describe("Button", () => {
     });
 
     test("should set the `autofocus` attribute on the internal control", async () => {
-        await page.setContent(/* html */ `
-            <fast-button autofocus></fast-button>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-button autofocus></fast-button>
+            `;
+        });
 
         await expect(control).toHaveBooleanAttribute("autofocus");
 
@@ -127,11 +143,13 @@ test.describe("Button", () => {
     });
 
     test("of type `submit` should submit the parent form when clicked", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <fast-button type="submit">Submit Button</fast-button>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <fast-button type="submit">Submit Button</fast-button>
+                </form>
+            `;
+        });
 
         const form = page.locator("form");
 
@@ -153,12 +171,14 @@ test.describe("Button", () => {
     });
 
     test("of type `reset` should reset the parent form when clicked", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <input type="text" value="foo" />
-                <fast-button type="reset">Reset Button</fast-button>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <input type="text" value="foo" />
+                    <fast-button type="reset">Reset Button</fast-button>
+                </form>
+            `;
+        });
 
         const form = page.locator("form");
 
@@ -178,9 +198,11 @@ test.describe("Button", () => {
     });
 
     test("should not propagate when clicked and `disabled` is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-button disabled>Disabled Button</fast-button>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-button disabled>Disabled Button</fast-button>
+            `;
+        });
 
         const content = element.locator(".content");
 

--- a/packages/web-components/fast-foundation/src/calendar/calendar.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/calendar/calendar.pw.spec.ts
@@ -7,11 +7,14 @@ import { DateFormatter } from "./date-formatter.js";
 test.describe("Calendar", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-calendar");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("calendar--calendar"));
     });
@@ -205,9 +208,11 @@ test.describe("Calendar", () => {
 
     test.describe("Defaults", () => {
         test("should default to the current month and year", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar></fast-calendar>
+                `;
+            });
 
             const today = new Date();
 
@@ -216,9 +221,11 @@ test.describe("Calendar", () => {
         });
 
         test("should return 5 weeks of days for August 2021", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="8" year="2021"></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="8" year="2021"></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) => {
@@ -234,9 +241,11 @@ test.describe("Calendar", () => {
         });
 
         test("should return 6 weeks of days for August 2021 when min-weeks is set to 6", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="8" year="2021" min-weeks="6"></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="8" year="2021" min-weeks="6"></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) => {
@@ -252,9 +261,11 @@ test.describe("Calendar", () => {
         });
 
         test("should highlight the current date", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar></fast-calendar>
+                `;
+            });
 
             const today = element.locator(`[part="today"]`);
 
@@ -266,9 +277,11 @@ test.describe("Calendar", () => {
 
     test.describe("Month info", () => {
         test("should display 31 days for the month of January in the year 2022", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="1" year="2022" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="1" year="2022" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) => node.getMonthInfo().length)
@@ -280,9 +293,11 @@ test.describe("Calendar", () => {
         });
 
         test("should display 28 days for the month of February in the year 2022", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="2" year="2022" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="2" year="2022" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) => node.getMonthInfo().length)
@@ -294,9 +309,11 @@ test.describe("Calendar", () => {
         });
 
         test("should display 29 days for the month of February in the year 2020", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="2" year="2020" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="2" year="2020" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) => node.getMonthInfo().length)
@@ -308,9 +325,11 @@ test.describe("Calendar", () => {
         });
 
         test("should start on Friday for January 2021", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="1" year="2021" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="1" year="2021" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) => node.getMonthInfo().start)
@@ -322,9 +341,11 @@ test.describe("Calendar", () => {
         });
 
         test("should start on Monday for February 2021", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="2" year="2021" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="2" year="2021" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) => node.getMonthInfo().start)
@@ -338,9 +359,11 @@ test.describe("Calendar", () => {
 
     test.describe("Labels", async () => {
         test("should return January for month 1", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="1" year="2021" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="1" year="2021" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -350,9 +373,11 @@ test.describe("Calendar", () => {
         });
 
         test("should return Jan for month 1 and short format", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="1" year="2021" month-format="short" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="1" year="2021" month-format="short" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -362,9 +387,11 @@ test.describe("Calendar", () => {
         });
 
         test("should return Mon for Monday by default", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="1" year="2021" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="1" year="2021" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -374,9 +401,11 @@ test.describe("Calendar", () => {
         });
 
         test("should return Monday weekday for long format", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="1" year="2021" weekday-format="long" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="1" year="2021" weekday-format="long" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -386,9 +415,11 @@ test.describe("Calendar", () => {
         });
 
         test("should return M for Monday for narrow format", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="1" year="2021" weekday-format="narrow" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="1" year="2021" weekday-format="narrow" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -400,9 +431,11 @@ test.describe("Calendar", () => {
 
     test.describe("Localization", async () => {
         test(`should be "mai" for the month May in French`, async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="5" year="2021" locale="fr" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="5" year="2021" locale="fr" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -412,9 +445,11 @@ test.describe("Calendar", () => {
         });
 
         test("should have French weekday labels for the fr-FR market", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="1" year="2021" locale="fr-FR" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="1" year="2021" locale="fr-FR" readonly></fast-calendar>
+                `;
+            });
 
             const frenchWeekdays = [
                 "dim.",
@@ -432,9 +467,11 @@ test.describe("Calendar", () => {
         });
 
         test('should set the formatted `year` property to "1942" when the `year` attribute is "2021" for the Hindu calendar', async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="6" year="2021" locale="hi-IN-u-ca-indian"></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="6" year="2021" locale="hi-IN-u-ca-indian"></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -444,9 +481,11 @@ test.describe("Calendar", () => {
         });
 
         test('should set the formatted `year` property to "2564" when the `year` attribute is "2021" for the Buddhist calendar', async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="6" year="2021" locale="th-TH-u-ca-buddhist"></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="6" year="2021" locale="th-TH-u-ca-buddhist"></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -456,9 +495,11 @@ test.describe("Calendar", () => {
         });
 
         test("should not be RTL for languages that are not Arabic or Hebrew", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="1" year="2021" locale="fr-FR" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="1" year="2021" locale="fr-FR" readonly></fast-calendar>
+                `;
+            });
 
             await expect(element).not.toHaveAttribute("dir", "rtl");
 
@@ -475,9 +516,11 @@ test.describe("Calendar", () => {
 
         /* FIXME this test is an incorrect assertion */
         test.skip("Should be RTL for Arabic language", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="8" year="2021" locale="ar-XE-u-ca-islamic-nu-arab" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="8" year="2021" locale="ar-XE-u-ca-islamic-nu-arab" readonly></fast-calendar>
+                `;
+            });
 
             const date = element.locator(".date");
 
@@ -491,9 +534,11 @@ test.describe("Calendar", () => {
 
     test.describe("Day states", async () => {
         test("should not show date as disabled by default", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="5" year="2021" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="5" year="2021" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -515,9 +560,11 @@ test.describe("Calendar", () => {
         });
 
         test("should show date as disabled when added to disabled-dates attribute", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="5" year="2021" disabled-dates="5-6-2021,5-7-2021,5-8-2021" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="5" year="2021" disabled-dates="5-6-2021,5-7-2021,5-8-2021" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -542,9 +589,11 @@ test.describe("Calendar", () => {
         });
 
         test("should not show date as selected by default", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="5" year="2021" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="5" year="2021" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
@@ -567,9 +616,11 @@ test.describe("Calendar", () => {
         });
 
         test("should show date as selected when added to selected-dates attribute", async () => {
-            await page.setContent(/* html */ `
-                <fast-calendar month="5" year="2021" selected-dates="5-6-2021,5-7-2021,5-8-2021" readonly></fast-calendar>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-calendar month="5" year="2021" selected-dates="5-6-2021,5-7-2021,5-8-2021" readonly></fast-calendar>
+                `;
+            });
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.pw.spec.ts
@@ -6,12 +6,15 @@ import type { FASTCheckbox } from "./checkbox.js";
 test.describe("Checkbox", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let form: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-checkbox");
+
+        root = page.locator("#root");
 
         form = page.locator("form");
 
@@ -23,16 +26,20 @@ test.describe("Checkbox", () => {
     });
 
     test("should have a role of `checkbox`", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
         await expect(element).toHaveAttribute("role", "checkbox");
     });
 
     test("should set a tabindex of 0 on the element", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("tabIndex", 0);
 
@@ -40,9 +47,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should set a default `aria-checked` value when `checked` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await expect(element).not.toHaveBooleanAttribute("checked");
 
@@ -50,9 +59,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should set the `aria-checked` attribute equal to the `checked` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox checked></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox checked></fast-checkbox>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-checked", "true");
 
@@ -68,9 +79,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should NOT set a default `aria-required` value when `required` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await expect(element).not.toHaveBooleanAttribute("required");
 
@@ -78,9 +91,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should set the `aria-required` attribute equal to the `required` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await element.evaluate((node: FASTCheckbox) => {
             node.required = true;
@@ -100,9 +115,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should set a default `aria-disabled` value when `disabled` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await expect(element).not.toHaveBooleanAttribute("disabled");
 
@@ -110,9 +127,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should set the `aria-disabled` attribute equal to the `disabled` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await element.evaluate((node: FASTCheckbox) => {
             node.disabled = true;
@@ -132,9 +151,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should NOT set a tabindex when `disabled` is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox disabled></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox disabled></fast-checkbox>
+            `;
+        });
 
         await expect(element).not.toHaveJSProperty("tabIndex", 0);
 
@@ -142,9 +163,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should NOT set a default `aria-readonly` value when `readonly` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await expect(element).not.toHaveBooleanAttribute("readonly");
 
@@ -152,9 +175,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should set the `aria-readonly` attribute equal to the `readonly` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await element.evaluate((node: FASTCheckbox) => {
             node.readOnly = true;
@@ -170,9 +195,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should add a class of `readonly` when `readonly` is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox readonly></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox readonly></fast-checkbox>
+            `;
+        });
 
         await expect(element).toHaveClass(/readonly/);
 
@@ -184,9 +211,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should add a class of `indeterminate` when indeterminate is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await element.evaluate((node: FASTCheckbox) => {
             node.indeterminate = true;
@@ -202,9 +231,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should set off `indeterminate` on `checked` change by user click", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox>checkbox</fast-checkbox>
+            `;
+        });
 
         await element.evaluate((node: FASTCheckbox) => {
             node.indeterminate = true;
@@ -218,9 +249,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should set off `indeterminate` on `checked` change by user keypress", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         await element.evaluate((node: FASTCheckbox) => {
             node.indeterminate = true;
@@ -234,11 +267,13 @@ test.describe("Checkbox", () => {
     });
 
     test("should add a class of `label` to the internal label when default slotted content exists", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox>
-                <span>Label</span>
-            </fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox>
+                    <span>Label</span>
+                </fast-checkbox>
+            `;
+        });
 
         const label = element.locator("label");
 
@@ -246,11 +281,13 @@ test.describe("Checkbox", () => {
     });
 
     test("should add classes of `label` and `label__hidden` to the internal label when default slotted content exists", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox>
-                <span>Label</span>
-            </fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox>
+                    <span>Label</span>
+                </fast-checkbox>
+            `;
+        });
 
         const label = element.locator("label");
 
@@ -264,9 +301,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should initialize to the initial value if no value property is set", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         const initialValue = await element.evaluate(
             (node: FASTCheckbox) => node.initialValue
@@ -277,9 +316,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should initialize to the provided `value` attribute when set pre-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox value="foo"></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox value="foo"></fast-checkbox>
+            `;
+        });
 
         const element = page.locator("fast-checkbox");
 
@@ -289,9 +330,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should initialize to the provided `value` attribute when set post-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         const element = page.locator("fast-checkbox");
 
@@ -305,9 +348,11 @@ test.describe("Checkbox", () => {
     });
 
     test("should initialize to the provided `value` property when set pre-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-checkbox></fast-checkbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-checkbox></fast-checkbox>
+            `;
+        });
 
         const expectedValue = "foobar";
 
@@ -323,11 +368,13 @@ test.describe("Checkbox", () => {
     });
 
     test("should be invalid when unchecked", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <fast-checkbox required></fast-checkbox>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <fast-checkbox required></fast-checkbox>
+                </form>
+            `;
+        });
 
         expect(
             await element.evaluate((node: FASTCheckbox) => node.validity.valueMissing)
@@ -335,11 +382,13 @@ test.describe("Checkbox", () => {
     });
 
     test("should be valid when checked", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <fast-checkbox required></fast-checkbox>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <fast-checkbox required>checkbox</fast-checkbox>
+                </form>
+            `;
+        });
 
         await element.click();
 
@@ -351,11 +400,13 @@ test.describe("Checkbox", () => {
     });
 
     test("should set the `checked` property to false if the `checked` attribute is unset", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <fast-checkbox></fast-checkbox>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <fast-checkbox></fast-checkbox>
+                </form>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("checked", false);
 
@@ -373,11 +424,13 @@ test.describe("Checkbox", () => {
     });
 
     test("should set its checked property to true if the checked attribute is set", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <fast-checkbox></fast-checkbox>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <fast-checkbox></fast-checkbox>
+                </form>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("checked", false);
 
@@ -395,11 +448,13 @@ test.describe("Checkbox", () => {
     });
 
     test("should put the control into a clean state, where checked attribute modifications change the checked property prior to user or programmatic interaction", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <fast-checkbox required></fast-checkbox>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <fast-checkbox required></fast-checkbox>
+                </form>
+            `;
+        });
 
         await element.evaluate((node: FASTCheckbox) => {
             node.checked = true;

--- a/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
@@ -6,12 +6,15 @@ import type { FASTCombobox } from "./combobox.js";
 test.describe("Combobox", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let control: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-combobox");
+
+        root = page.locator("#root");
 
         control = element.locator(`input[role="combobox"]`);
 
@@ -23,25 +26,29 @@ test.describe("Combobox", () => {
     });
 
     test('should include a control with a `role` attribute equal to "combobox"', async () => {
-        await page.setContent(/* html */ `
-            <fast-combobox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-combobox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
 
         await expect(control).toHaveCount(1);
     });
 
     test("should set the `aria-disabled` attribute equal to the `disabled` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-combobox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-combobox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-disabled", "false");
 
@@ -59,13 +66,15 @@ test.describe("Combobox", () => {
     });
 
     test("should set and remove the `tabindex` attribute based on the value of the `disabled` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-combobox disabled>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-combobox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox disabled>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
 
         await expect(element).not.hasAttribute("tabindex");
 
@@ -77,13 +86,15 @@ test.describe("Combobox", () => {
     });
 
     test("should NOT set the `value` property to the first available option", async () => {
-        await page.setContent(/* html */ `
-            <fast-combobox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-combobox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "");
 
@@ -91,13 +102,15 @@ test.describe("Combobox", () => {
     });
 
     test("should set the `placeholder` attribute on the internal control equal to the `placeholder` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-combobox placeholder="placeholder text">
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-combobox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox placeholder="placeholder text">
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("placeholder", "placeholder text");
 
@@ -105,13 +118,15 @@ test.describe("Combobox", () => {
     });
 
     test("should set the control's `aria-controls` attribute to the ID of the internal listbox element while open", async () => {
-        await page.setContent(/* html */ `
-            <fast-combobox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-combobox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
 
         const listbox = element.locator(".listbox");
 
@@ -133,13 +148,15 @@ test.describe("Combobox", () => {
     });
 
     test("should set the control's `aria-activedescendant` property to the ID of the currently selected option while open", async () => {
-        await page.setContent(/* html */ `
-            <fast-combobox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-combobox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
 
         const options = element.locator("fast-option");
 
@@ -175,9 +192,9 @@ test.describe("Combobox", () => {
     });
 
     test("should set its value to the first option with the `selected` attribute present", async () => {
-        await page.setContent("");
+        await root.evaluate(node => {
+            node.innerHTML = "";
 
-        await page.evaluate(() => {
             const combobox = document.createElement("fast-combobox");
             const options = ["one", "two", "three"].map(s => {
                 const option = document.createElement("fast-option");
@@ -189,7 +206,7 @@ test.describe("Combobox", () => {
 
             combobox.append(...options);
 
-            document.body.append(combobox);
+            node.append(combobox);
         });
 
         const option2 = element.locator("fast-option:nth-of-type(2)");
@@ -200,23 +217,23 @@ test.describe("Combobox", () => {
     });
 
     test("should return the same value when the `value` property is set before connecting", async () => {
-        await page.setContent("");
+        await root.evaluate(node => {
+            node.innerHTML = "";
 
-        await page.evaluate(() => {
             const combobox = document.createElement("fast-combobox") as FASTCombobox;
             combobox.value = "test";
-            document.body.append(combobox);
+            node.append(combobox);
         });
 
         expect(await element.evaluate((node: FASTCombobox) => node.value)).toBe("test");
     });
 
     test("should return the same value when the `value` property is set after connecting", async () => {
-        await page.setContent("");
+        await root.evaluate(node => {
+            node.innerHTML = "";
 
-        await page.evaluate(() => {
             const combobox = document.createElement("fast-combobox") as FASTCombobox;
-            document.body.append(combobox);
+            node.append(combobox);
         });
 
         await element.evaluate((node: FASTCombobox) => {
@@ -227,13 +244,15 @@ test.describe("Combobox", () => {
     });
 
     test("should display the listbox when the `open` property is true before connecting", async () => {
-        await page.setContent(/* html */ `
-            <fast-combobox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-combobox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
 
         const listbox = element.locator(".listbox");
 
@@ -252,13 +271,15 @@ test.describe("Combobox", () => {
         "should NOT emit a 'change' event when the value changes by user input while open",
         () => {
             test("via arrow down key", async () => {
-                await page.setContent(/* html */ `
-                    <fast-combobox>
-                        <fast-option>Option 1</fast-option>
-                        <fast-option>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-combobox>
-                `);
+                await root.evaluate(node => {
+                    node.innerHTML = /* html */ `
+                        <fast-combobox>
+                            <fast-option>Option 1</fast-option>
+                            <fast-option>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-combobox>
+                    `;
+                });
 
                 await element.click();
 
@@ -282,13 +303,15 @@ test.describe("Combobox", () => {
             });
 
             test("via arrow up key", async () => {
-                await page.setContent(/* html */ `
-                    <fast-combobox>
-                        <fast-option>Option 1</fast-option>
-                        <fast-option>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-combobox>
-                `);
+                await root.evaluate(node => {
+                    node.innerHTML = /* html */ `
+                        <fast-combobox>
+                            <fast-option>Option 1</fast-option>
+                            <fast-option>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-combobox>
+                    `;
+                });
 
                 await element.evaluate((node: FASTCombobox) => {
                     node.value = "two";
@@ -323,13 +346,15 @@ test.describe("Combobox", () => {
         "should NOT emit a 'change' event when the value changes by programmatic interaction",
         () => {
             test("via end key", async () => {
-                await page.setContent(/* html */ `
-                    <fast-combobox>
-                        <fast-option>Option 1</fast-option>
-                        <fast-option>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-combobox>
-                `);
+                await root.evaluate(node => {
+                    node.innerHTML = /* html */ `
+                        <fast-combobox>
+                            <fast-option>Option 1</fast-option>
+                            <fast-option>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-combobox>
+                    `;
+                });
 
                 await element.evaluate((node: FASTCombobox) => {
                     node.value = "two";
@@ -356,15 +381,17 @@ test.describe("Combobox", () => {
 
     test.describe("when the owning form's reset() function is invoked", () => {
         test("should reset the value property to its initial value", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-combobox value="one">
-                        <fast-option>Option 1</fast-option>
-                        <fast-option>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-combobox>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-combobox value="one">
+                            <fast-option>Option 1</fast-option>
+                            <fast-option>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-combobox>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -382,15 +409,17 @@ test.describe("Combobox", () => {
         });
 
         test("should reset its value property to the first option with the `selected` attribute present", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-combobox>
-                        <fast-option>Option 1</fast-option>
-                        <fast-option selected>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-combobox>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-combobox>
+                            <fast-option>Option 1</fast-option>
+                            <fast-option selected>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-combobox>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -411,13 +440,15 @@ test.describe("Combobox", () => {
     });
 
     test("should focus the control when an associated label is clicked", async () => {
-        await page.setContent(/* html */ `
-            <fast-combobox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-combobox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
 
         // Skip this test if the browser if ElementInternals isn't supported
         if (!(await page.evaluate(() => window.hasOwnProperty("ElementInternals")))) {
@@ -426,13 +457,18 @@ test.describe("Combobox", () => {
 
         const label = page.locator("label");
 
-        await element.evaluate(node => {
-            const label = document.createElement("label");
-            label.setAttribute("for", "test-combobox");
-            label.textContent = "label";
-            node.id = "test-combobox";
-            document.body.append(label);
-        });
+        await root.evaluate(
+            (node, { element }) => {
+                const label = document.createElement("label");
+                label.setAttribute("for", "test-combobox");
+                label.textContent = "label";
+
+                element.id = "test-combobox";
+
+                node.append(label);
+            },
+            { element: await element.evaluateHandle((node: FASTCombobox) => node) }
+        );
 
         await label.click();
 

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.pw.spec.ts
@@ -7,11 +7,14 @@ import { DataGridCellTypes } from "./data-grid.options.js";
 test.describe("Data grid cell", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-data-grid-cell");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
     });
@@ -21,57 +24,71 @@ test.describe("Data grid cell", () => {
     });
 
     test('should set the `role` attribute to "gridcell" by default', async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell></fast-data-grid-cell>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "gridcell");
     });
 
     test("should have a tabIndex of -1 by default", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell></fast-data-grid-cell>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "-1");
     });
 
     test('should set the `role` attribute to "columnheader" when the `cell-type` attribute is "columnheader"', async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "columnheader");
     });
 
     test('should add the "column-header" class when the `cell-type` attribute is "columnheader"', async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
+            `;
+        });
 
         await expect(element).toHaveClass(/column-header/);
     });
 
     test('should set the `role` attribute to "rowheader" when the `cell-type` attribute is "rowheader"', async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell cell-type="rowheader"></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell cell-type="rowheader"></fast-data-grid-cell>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "rowheader");
     });
 
     test('should add the "row-header" class when the `cell-type` attribute is "rowheader"', async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell cell-type="rowheader"></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell cell-type="rowheader"></fast-data-grid-cell>
+            `;
+        });
 
         await expect(element).toHaveClass(/row-header/);
     });
 
     test("should set the `grid-column` CSS property to match the `grid-column` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell grid-column="2"></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell grid-column="2"></fast-data-grid-cell>
+            `;
+        });
 
         await expect(element).toHaveCSS("grid-column-start", "2");
 
@@ -79,9 +96,11 @@ test.describe("Data grid cell", () => {
     });
 
     test("should not render data if no columndefinition provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell></fast-data-grid-cell>
+            `;
+        });
 
         await element.evaluate((el: FASTDataGridCell) => {
             el.rowData = {
@@ -96,9 +115,11 @@ test.describe("Data grid cell", () => {
     });
 
     test("should render data when a column definition is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell></fast-data-grid-cell>
+            `;
+        });
 
         await element.evaluate((el: FASTDataGridCell) => {
             el.columnDefinition = { columnDataKey: "item1" };
@@ -114,9 +135,11 @@ test.describe("Data grid cell", () => {
     });
 
     test("should render a custom cell template when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell></fast-data-grid-cell>
+            `;
+        });
 
         await element.evaluate((node: FASTDataGridCell) => {
             node.columnDefinition = {
@@ -129,9 +152,11 @@ test.describe("Data grid cell", () => {
     });
 
     test("should render a custom header cell template if provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
+            `;
+        });
 
         await element.evaluate((node: FASTDataGridCell) => {
             node.columnDefinition = {
@@ -144,9 +169,11 @@ test.describe("Data grid cell", () => {
     });
 
     test(`should fire a "cell-focused" event when focused`, async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell></fast-data-grid-cell>
+            `;
+        });
 
         const wasInvoked = await Promise.all([
             element.evaluate(node => node.addEventListener("cell-focused", () => true)),
@@ -161,9 +188,11 @@ test.describe("Data grid cell", () => {
     });
 
     test("should focus on custom cell template when a focus target callback is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell></fast-data-grid-cell>
+            `;
+        });
 
         await element.evaluate((node: FASTDataGridCell) => {
             node.columnDefinition = {
@@ -182,9 +211,11 @@ test.describe("Data grid cell", () => {
     });
 
     test("should focus on custom header cell template when a focus target callback is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
+            `;
+        });
 
         await element.evaluate((node: FASTDataGridCell, DataGridCellTypes) => {
             node.cellType = DataGridCellTypes.columnHeader;

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.pw.spec.ts
@@ -9,11 +9,14 @@ test.describe("DataGridRow", () => {
 
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-data-grid-row");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("data-grid-data-grid-row--data-grid-row"));
     });
@@ -23,17 +26,21 @@ test.describe("DataGridRow", () => {
     });
 
     test('should set the `role` attribute to "row" by default', async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-row></fast-data-grid-row>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-row></fast-data-grid-row>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "row");
     });
 
     test('should add the "header" class when the `row-type` attribute is "header"', async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-row row-type="header"></fast-data-grid-row>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-row row-type="header"></fast-data-grid-row>
+            `;
+        });
 
         await expect(element).toHaveClass(/header/);
 
@@ -45,9 +52,11 @@ test.describe("DataGridRow", () => {
     });
 
     test('should apply "sticky-header" class when the `row-type` attribute is "sticky-header"', async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-row row-type="sticky-header"></fast-data-grid-row>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-row row-type="sticky-header"></fast-data-grid-row>
+            `;
+        });
 
         await expect(element).toHaveClass(/sticky-header/);
 
@@ -59,9 +68,11 @@ test.describe("DataGridRow", () => {
     });
 
     test("should set `grid-template-columns` style to match attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-row grid-template-columns="1fr 2fr 3fr"></fast-data-grid-row>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-row grid-template-columns="1fr 2fr 3fr"></fast-data-grid-row>
+            `;
+        });
 
         await expect(element).toHaveAttribute(
             "style",
@@ -70,11 +81,13 @@ test.describe("DataGridRow", () => {
     });
 
     test("should fire an event when a child cell is focused", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-row>
-                <fast-data-grid-cell></fast-data-grid-cell>
-            </fast-data-grid-row>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-row>
+                    <fast-data-grid-cell></fast-data-grid-cell>
+                </fast-data-grid-row>
+            `;
+        });
 
         const cell = page.locator(cellQueryString).first();
 
@@ -95,13 +108,15 @@ test.describe("DataGridRow", () => {
     });
 
     test("should move focus with left/right arrow key strokes", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-row>
-                <fast-data-grid-cell></fast-data-grid-cell>
-                <fast-data-grid-cell></fast-data-grid-cell>
-                <fast-data-grid-cell></fast-data-grid-cell>
-            </fast-data-grid-row>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-row>
+                    <fast-data-grid-cell></fast-data-grid-cell>
+                    <fast-data-grid-cell></fast-data-grid-cell>
+                    <fast-data-grid-cell></fast-data-grid-cell>
+                </fast-data-grid-row>
+            `;
+        });
 
         await element.locator(cellQueryString).first().focus();
 
@@ -117,13 +132,15 @@ test.describe("DataGridRow", () => {
     });
 
     test("should move focus to the start/end of the row with home/end keystrokes", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid-row>
-                <fast-data-grid-cell></fast-data-grid-cell>
-                <fast-data-grid-cell></fast-data-grid-cell>
-                <fast-data-grid-cell></fast-data-grid-cell>
-            </fast-data-grid-row>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-row>
+                    <fast-data-grid-cell></fast-data-grid-cell>
+                    <fast-data-grid-cell></fast-data-grid-cell>
+                    <fast-data-grid-cell></fast-data-grid-cell>
+                </fast-data-grid-row>
+            `;
+        });
 
         await element.locator(cellQueryString).first().focus();
 
@@ -141,9 +158,11 @@ test.describe("DataGridRow", () => {
     test("should render no cells if provided no column definitions", async () => {
         const cells = element.locator("fast-data-grid-cell");
 
-        await page.setContent(/* html */ `
-            <fast-data-grid-row></fast-data-grid-row>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-row></fast-data-grid-row>
+            `;
+        });
 
         await element.evaluate((node: FASTDataGridRow) => {
             node.rowData = {
@@ -158,9 +177,11 @@ test.describe("DataGridRow", () => {
     test("should render as many column header cells as specified in column definitions", async () => {
         const cells = element.locator(cellQueryString);
 
-        await page.setContent(/* html */ `
-            <fast-data-grid-row></fast-data-grid-row>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid-row></fast-data-grid-row>
+            `;
+        });
 
         await element.evaluate((node: FASTDataGridRow) => {
             node.columnDefinitions = [{ columnDataKey: "item1" }];

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.pw.spec.ts
@@ -8,13 +8,16 @@ import { DataGridRowTypes } from "./data-grid.options.js";
 test.describe("Data grid", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-data-grid");
 
-        await page.goto(fixtureURL("data-grid-data-grid--data-grid"));
+        root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
     });
 
     test.afterAll(async () => {
@@ -22,38 +25,46 @@ test.describe("Data grid", () => {
     });
 
     test("should set role to 'grid'", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid></fast-data-grid>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "grid");
     });
 
     test("should have a tabIndex of 0 by default", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid></fast-data-grid>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
     test("should have a tabIndex of -1 when no-tabbing is true", async () => {
-        await page.setContent(/* html */ `
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
             <fast-data-grid no-tabbing></fast-data-grid>
-        `);
+        `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "-1");
     });
 
     test("should have a tabIndex of -1 when a cell is focused", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid>
-                <fast-data-grid-row>
-                    <fast-data-grid-cell>Cell 1</fast-data-grid-cell>
-                    <fast-data-grid-cell>Cell 2</fast-data-grid-cell>
-                </fast-data-grid-row>
-            </fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid>
+                    <fast-data-grid-row>
+                        <fast-data-grid-cell>Cell 1</fast-data-grid-cell>
+                        <fast-data-grid-cell>Cell 2</fast-data-grid-cell>
+                    </fast-data-grid-row>
+                </fast-data-grid>
+            `;
+        });
 
         await element.locator("fast-data-grid-cell").first().focus();
 
@@ -61,9 +72,11 @@ test.describe("Data grid", () => {
     });
 
     test("should generate a basic grid with a row header based on rowsData only", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid></fast-data-grid>
+            `;
+        });
 
         element.evaluate((node: FASTDataGrid) => {
             node.rowsData = [
@@ -114,9 +127,11 @@ test.describe("Data grid", () => {
     });
 
     test("should not generate a header when `generateHeader` is `none`", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid generate-header="none"></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid generate-header="none"></fast-data-grid>
+            `;
+        });
 
         element.evaluate((node: FASTDataGrid) => {
             node.rowsData = [
@@ -155,12 +170,14 @@ test.describe("Data grid", () => {
     });
 
     test("should not generate a header when rowsData is empty", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = "";
 
-        element.evaluate((node: FASTDataGrid) => {
-            node.rowsData = [];
+            const dataGrid = document.createElement("fast-data-grid") as FASTDataGrid;
+
+            dataGrid.rowsData = [];
+
+            node.append(dataGrid);
         });
 
         const rows = element.locator("fast-data-grid-row");
@@ -169,9 +186,11 @@ test.describe("Data grid", () => {
     });
 
     test("should generate a sticky header when generateHeader is set to 'sticky'", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid generate-header="sticky"></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid generate-header="sticky"></fast-data-grid>
+            `;
+        });
 
         element.evaluate((node: FASTDataGrid) => {
             node.rowsData = [
@@ -222,9 +241,11 @@ test.describe("Data grid", () => {
     });
 
     test("should set the row index attribute of child rows'", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid generate-header="sticky"></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid generate-header="sticky"></fast-data-grid>
+            `;
+        });
 
         element.evaluate((node: FASTDataGrid) => {
             node.rowsData = [
@@ -246,9 +267,11 @@ test.describe("Data grid", () => {
     });
 
     test("should move focus with up/down arrow key strokes", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid generate-header="none"></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid generate-header="none"></fast-data-grid>
+            `;
+        });
 
         element.evaluate((node: FASTDataGrid) => {
             node.rowsData = [
@@ -292,9 +315,11 @@ test.describe("Data grid", () => {
     });
 
     test("should move focus to first/last cells with ctrl + home/end key strokes", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid generate-header="none"></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid generate-header="none"></fast-data-grid>
+            `;
+        });
 
         element.evaluate((node: FASTDataGrid) => {
             node.rowsData = [
@@ -324,9 +349,11 @@ test.describe("Data grid", () => {
     });
 
     test("should move focus by setting the `focusRowIndex` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid generate-header="none"></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid generate-header="none"></fast-data-grid>
+            `;
+        });
 
         element.evaluate((node: FASTDataGrid) => {
             node.rowsData = [
@@ -364,9 +391,11 @@ test.describe("Data grid", () => {
     });
 
     test("should move focus by setting `focusColumnIndex`", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid generate-header="none"></fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid generate-header="none"></fast-data-grid>
+            `;
+        });
 
         element.evaluate((node: FASTDataGrid) => {
             node.rowsData = [
@@ -404,15 +433,17 @@ test.describe("Data grid", () => {
     });
 
     test("should auto generate grid-columns from a manual row", async () => {
-        await page.setContent(/* html */ `
-            <fast-data-grid generate-header="none">
-                <fast-data-grid-row>
-                    <fast-data-grid-cell>1</fast-data-grid-cell>
-                    <fast-data-grid-cell>2</fast-data-grid-cell>
-                    <fast-data-grid-cell>3</fast-data-grid-cell>
-                </fast-data-grid-row>
-            </fast-data-grid>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-data-grid generate-header="none">
+                    <fast-data-grid-row>
+                        <fast-data-grid-cell>1</fast-data-grid-cell>
+                        <fast-data-grid-cell>2</fast-data-grid-cell>
+                        <fast-data-grid-cell>3</fast-data-grid-cell>
+                    </fast-data-grid-row>
+                </fast-data-grid>
+            `;
+        });
 
         const lastRow = element.locator("fast-data-grid-row");
 

--- a/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
@@ -6,6 +6,7 @@ import type { FASTDialog } from "./index.js";
 test.describe("Dialog", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let control: Locator;
     let overlay: Locator;
 
@@ -13,6 +14,8 @@ test.describe("Dialog", () => {
         page = await browser.newPage();
 
         element = page.locator("fast-dialog");
+
+        root = page.locator("#root");
 
         control = element.locator(`[role="dialog"]`);
 
@@ -50,37 +53,45 @@ test.describe("Dialog", () => {
     });
 
     test("should set the `aria-describedby` attribute on the control when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-dialog aria-describedby="description">
-                <div id="description">Description</div>
-            </fast-dialog>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-dialog aria-describedby="description">
+                    <div id="description">Description</div>
+                </fast-dialog>
+            `;
+        });
 
         await expect(control).toHaveAttribute("aria-describedby", "description");
     });
 
     test("should set the `aria-labelledby` attribute on the dialog control when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-dialog aria-labelledby="label">
-                <div id="label">Label</div>
-            </fast-dialog>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-dialog aria-labelledby="label">
+                    <div id="label">Label</div>
+                </fast-dialog>
+            `;
+        });
 
         await expect(control).toHaveAttribute("aria-labelledby", "label");
     });
 
     test("should set the `aria-label` attribute on the dialog control when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-dialog aria-label="Label"></fast-dialog>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-dialog aria-label="Label"></fast-dialog>
+            `;
+        });
 
         await expect(control).toHaveAttribute("aria-label", "Label");
     });
 
     test("should add an attribute of `aria-modal` with a value equal to the `modal` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-dialog modal></fast-dialog>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-dialog modal></fast-dialog>
+            `;
+        });
 
         await expect(control).toHaveAttribute("aria-modal", "true");
 
@@ -93,9 +104,11 @@ test.describe("Dialog", () => {
     });
 
     test('should add an overlay element with a `role` attribute of "presentation" when the `modal` property is true', async () => {
-        await page.setContent(/* html */ `
-            <fast-dialog modal></fast-dialog>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-dialog modal></fast-dialog>
+            `;
+        });
 
         await expect(overlay).toHaveAttribute("role", "presentation");
 
@@ -107,9 +120,11 @@ test.describe("Dialog", () => {
     });
 
     test("should add an attribute of `no-focus-trap` when `noFocusTrap` is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-dialog no-focus-trap></fast-dialog>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-dialog no-focus-trap></fast-dialog>
+            `;
+        });
 
         await element.evaluate((node: FASTDialog) => {
             node.noFocusTrap = true;
@@ -161,9 +176,11 @@ test.describe("Dialog", () => {
     });
 
     test("should fire a 'dismiss' event when its overlay is clicked", async () => {
-        await page.setContent(/* html */ `
-            <fast-dialog modal></fast-dialog>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-dialog modal></fast-dialog>
+            `;
+        });
 
         await overlay.waitFor({ state: "visible" });
 
@@ -182,9 +199,11 @@ test.describe("Dialog", () => {
     });
 
     test("should fire a `cancel` event when its overlay is clicked", async () => {
-        await page.setContent(/* html */ `
-            <fast-dialog modal></fast-dialog>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-dialog modal></fast-dialog>
+            `;
+        });
 
         await overlay.waitFor({ state: "visible" });
 
@@ -203,9 +222,11 @@ test.describe("Dialog", () => {
     });
 
     test("should fire a 'dismiss' event when keydown is invoked on the document", async () => {
-        await page.setContent(/* html */ `
-            <fast-dialog modal></fast-dialog>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-dialog modal></fast-dialog>
+            `;
+        });
 
         await overlay.waitFor({ state: "visible" });
 

--- a/packages/web-components/fast-foundation/src/divider/divider.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/divider/divider.pw.spec.ts
@@ -8,11 +8,14 @@ import type { FASTDivider } from "./index.js";
 test.describe("Divider", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-divider");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("divider--divider"));
     });
@@ -22,17 +25,21 @@ test.describe("Divider", () => {
     });
 
     test('should set a default `role` attribute of "separator"', async () => {
-        await page.setContent(/* html */ `
-            <fast-divider></fast-divider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-divider></fast-divider>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", DividerRole.separator);
     });
 
     test("should set the `role` attribute equal to the role provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-divider role="presentation"></fast-divider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-divider role="presentation"></fast-divider>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "presentation");
 
@@ -44,9 +51,11 @@ test.describe("Divider", () => {
     });
 
     test("should set the `aria-orientation` attribute equal to the `orientation` value", async () => {
-        await page.setContent(/* html */ `
-            <fast-divider orientation="vertical"></fast-divider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-divider orientation="vertical"></fast-divider>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-orientation", Orientation.vertical);
 

--- a/packages/web-components/fast-foundation/src/flipper/flipper.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.pw.spec.ts
@@ -6,11 +6,14 @@ import type { FASTFlipper } from "./flipper.js";
 test.describe("Flipper", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-flipper");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("flipper--flipper"));
     });
@@ -20,41 +23,51 @@ test.describe("Flipper", () => {
     });
 
     test("should include a role of button", async () => {
-        await page.setContent(/* html */ `
-            <fast-flipper></fast-flipper>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-flipper></fast-flipper>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "button");
     });
 
     test('should set `aria-hidden` to "true" by default', async () => {
-        await page.setContent(/* html */ `
-            <fast-flipper></fast-flipper>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-flipper></fast-flipper>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-hidden", "true");
     });
 
     test("should set the `hiddenFromAT` property to true by default", async () => {
-        await page.setContent(/* html */ `
-            <fast-flipper></fast-flipper>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-flipper></fast-flipper>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("hiddenFromAT", true);
     });
 
     test('should set the `direction` property to "next" by default', async () => {
-        await page.setContent(/* html */ `
-            <fast-flipper></fast-flipper>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-flipper></fast-flipper>
+            `;
+        });
 
         await expect(element.locator("span")).toHaveClass(/next/);
     });
 
     test("should toggle the `aria-disabled` attribute based on the value of the `disabled` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-flipper disabled></fast-flipper>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-flipper disabled></fast-flipper>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-disabled", "true");
 
@@ -67,9 +80,11 @@ test.describe("Flipper", () => {
     });
 
     test('should set the `tabindex` attribute to "-1" when `hiddenFromAT` is true', async () => {
-        await page.setContent(/* html */ `
-            <fast-flipper></fast-flipper>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-flipper></fast-flipper>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "-1");
 
@@ -88,9 +103,11 @@ test.describe("Flipper", () => {
     });
 
     test("should set a `tabindex` of 0 when `aria-hidden` is false", async () => {
-        await page.setContent(/* html */ `
-            <fast-flipper aria-hidden="false"></fast-flipper>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-flipper aria-hidden="false"></fast-flipper>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "0");
 
@@ -102,9 +119,11 @@ test.describe("Flipper", () => {
     });
 
     test('should render a span with a class of "next" when the `direction` attribute is "next"', async () => {
-        await page.setContent(/* html */ `
-            <fast-flipper direction="next"></fast-flipper>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-flipper direction="next"></fast-flipper>
+            `;
+        });
 
         const spans = element.locator("span");
 
@@ -114,9 +133,11 @@ test.describe("Flipper", () => {
     });
 
     test('should render a span with a class of "previous" when the `direction` attribute is "previous"', async () => {
-        await page.setContent(/* html */ `
-            <fast-flipper direction="previous"></fast-flipper>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-flipper direction="previous"></fast-flipper>
+            `;
+        });
 
         const spans = element.locator("span");
 

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
@@ -4,9 +4,11 @@ import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTHorizontalScroll } from "./horizontal-scroll.js";
 
 test.describe("HorizontalScroll", () => {
-    let cards: Locator;
-    let element: Locator;
     let page: Page;
+    let element: Locator;
+    let root: Locator;
+
+    let cards: Locator;
     let scrollNext: Locator;
     let scrollPrevious: Locator;
     let scrollView: Locator;
@@ -15,10 +17,16 @@ test.describe("HorizontalScroll", () => {
         page = await browser.newPage();
 
         element = page.locator("fast-horizontal-scroll");
-        scrollNext = element.locator(".scroll-next");
-        scrollPrevious = element.locator(".scroll-prev");
-        scrollView = element.locator(".scroll-view");
+
+        root = page.locator("#root");
+
         cards = element.locator("fast-card");
+
+        scrollNext = element.locator(".scroll-next");
+
+        scrollPrevious = element.locator(".scroll-prev");
+
+        scrollView = element.locator(".scroll-view");
 
         await page.goto(fixtureURL("horizontal-scroll--horizontal-scroll"));
 
@@ -124,11 +132,13 @@ test.describe("HorizontalScroll", () => {
     });
 
     test("should hide the next flipper if content is less than horizontal-scroll width", async () => {
-        await page.setContent(/* html */ `
-            <fast-horizontal-scroll style="width: 1000px;">
-                <fast-card style="width: 100px;"></fast-card>
-            </fast-horizontal-scroll>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-horizontal-scroll style="width: 1000px;">
+                    <fast-card style="width: 100px;"></fast-card>
+                </fast-horizontal-scroll>
+            `;
+        });
 
         const element = page.locator("fast-horizontal-scroll");
 
@@ -203,7 +213,7 @@ test.describe("HorizontalScroll", () => {
 
             const scrollView = element.locator(".scroll-view");
 
-            const cards = element.locator("fast-card");
+            cards = element.locator("fast-card");
 
             const lastCard = cards.last();
 

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.pw.spec.ts
@@ -6,11 +6,14 @@ import type { FASTListboxOption } from "./listbox-option.js";
 test.describe("ListboxOption", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-option");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("listbox-option--listbox-option"));
     });
@@ -20,17 +23,21 @@ test.describe("ListboxOption", () => {
     });
 
     test("should have a role of `option`", async () => {
-        await page.setContent(/* html */ `
-            <fast-option></fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option></fast-option>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "option");
     });
 
     test("should set the `aria-disabled` attribute when disabled", async () => {
-        await page.setContent(/* html */ `
-            <fast-option disabled></fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option disabled></fast-option>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-disabled", "true");
 
@@ -42,9 +49,11 @@ test.describe("ListboxOption", () => {
     });
 
     test('should add the "disabled" class when disabled', async () => {
-        await page.setContent(/* html */ `
-            <fast-option disabled></fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option disabled></fast-option>
+            `;
+        });
 
         await expect(element).toHaveClass(/disabled/);
 
@@ -56,9 +65,11 @@ test.describe("ListboxOption", () => {
     });
 
     test("should set the `aria-selected` attribute when selected", async () => {
-        await page.setContent(/* html */ `
-            <fast-option selected></fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option selected></fast-option>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-selected", "true");
 
@@ -70,9 +81,11 @@ test.describe("ListboxOption", () => {
     });
 
     test('should add the "selected" class when selected', async () => {
-        await page.setContent(/* html */ `
-            <fast-option selected></fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option selected></fast-option>
+            `;
+        });
 
         await expect(element).toHaveClass(/selected/);
 
@@ -84,9 +97,11 @@ test.describe("ListboxOption", () => {
     });
 
     test("should set the `aria-checked` attribute when checked", async () => {
-        await page.setContent(/* html */ `
-            <fast-option></fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option></fast-option>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-checked");
 
@@ -104,9 +119,11 @@ test.describe("ListboxOption", () => {
     });
 
     test('should add the "checked" class when checked', async () => {
-        await page.setContent(/* html */ `
-            <fast-option></fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option></fast-option>
+            `;
+        });
 
         await expect(element).not.toHaveClass(/checked/);
 
@@ -124,9 +141,11 @@ test.describe("ListboxOption", () => {
     });
 
     test("should have an empty string `value` when the `value` attribute exists and is empty", async () => {
-        await page.setContent(/* html */ `
-            <fast-option value=""></fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option value=""></fast-option>
+            `;
+        });
 
         await element.evaluate((node: FASTListboxOption) => {
             node.innerText = "hello";
@@ -138,9 +157,11 @@ test.describe("ListboxOption", () => {
     });
 
     test("should return the text content when the `value` attribute does not exist", async () => {
-        await page.setContent(/* html */ `
-            <fast-option>hello</fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option>hello</fast-option>
+            `;
+        });
 
         await expect(element).toHaveText("hello");
 
@@ -148,28 +169,26 @@ test.describe("ListboxOption", () => {
     });
 
     test("should return the trimmed text content with the `text` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-option>
-                hello
-                world
-            </fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option>
+                    hello
+                    world
+                </fast-option>
+            `;
+        });
 
-        await expect(element).toHaveJSProperty(
-            "textContent",
-            `
-                hello
-                world
-            `
-        );
+        await expect(element).toHaveText(/\n\s{20}hello\n\s{20}world\n\s{16}/);
 
         await expect(element).toHaveText("hello world");
     });
 
     test("should always return the `value` as a string", async () => {
-        await page.setContent(/* html */ `
-            <fast-option value="1"></fast-option>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-option value="1"></fast-option>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "1");
 

--- a/packages/web-components/fast-foundation/src/listbox/listbox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.pw.spec.ts
@@ -6,11 +6,16 @@ import type { FASTListboxElement } from "./listbox.element.js";
 test.describe("Listbox", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let options: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
+
         element = page.locator("fast-listbox");
+
+        root = page.locator("#root");
+
         options = element.locator("fast-option");
 
         await page.goto(fixtureURL("listbox--listbox"));
@@ -21,33 +26,39 @@ test.describe("Listbox", () => {
     });
 
     test("should have a tabindex of 0 when `disabled` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-listbox>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
     test("should NOT have a tabindex when `disabled` is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox disabled></fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox disabled></fast-listbox>
+            `;
+        });
 
         expect(await element.getAttribute("tabindex")).toBeNull();
     });
 
     test("should select nothing when no options have the `selected` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-listbox>
+            `;
+        });
 
         expect(
             await options.evaluateAll(options =>
@@ -61,13 +72,15 @@ test.describe("Listbox", () => {
     });
 
     test("should select the option with a `selected` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox>
-                <fast-option>Option 1</fast-option>
-                <fast-option selected>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option selected>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-listbox>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("selectedIndex", 1);
 
@@ -77,21 +90,25 @@ test.describe("Listbox", () => {
     });
 
     test("should set the `size` property to match the `size` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox size="5"></fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox size="5"></fast-listbox>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("size", 5);
     });
 
     test("should set the `size` attribute to match the `size` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-listbox>
+            `;
+        });
 
         await element.evaluate((node: FASTListboxElement) => {
             node.size = 5;
@@ -104,13 +121,15 @@ test.describe("Listbox", () => {
         "should set the `size` property to 0 when a negative value is set",
         () => {
             test("via the `size` property", async () => {
-                await page.setContent(/* html */ `
-                    <fast-listbox>
-                        <fast-option>Option 1</fast-option>
-                        <fast-option>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-listbox>
-                `);
+                await root.evaluate(node => {
+                    node.innerHTML = /* html */ `
+                        <fast-listbox>
+                            <fast-option>Option 1</fast-option>
+                            <fast-option>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-listbox>
+                    `;
+                });
 
                 await element.evaluate((node: FASTListboxElement) => {
                     node.size = 1;
@@ -128,13 +147,15 @@ test.describe("Listbox", () => {
             });
 
             test("via the `size` attribute", async () => {
-                await page.setContent(/* html */ `
-                    <fast-listbox>
-                        <fast-option>Option 1</fast-option>
-                        <fast-option>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-listbox>
-                `);
+                await root.evaluate(node => {
+                    node.innerHTML = /* html */ `
+                        <fast-listbox>
+                            <fast-option>Option 1</fast-option>
+                            <fast-option>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-listbox>
+                    `;
+                });
 
                 await element.evaluate((node: FASTListboxElement) =>
                     node.setAttribute("size", "1")
@@ -154,13 +175,15 @@ test.describe("Listbox", () => {
     );
 
     test("should set the `aria-setsize` and `aria-posinset` properties on slotted options", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-listbox>
+            `;
+        });
 
         const optionsCount = await options.count();
 
@@ -175,13 +198,15 @@ test.describe("Listbox", () => {
     });
 
     test("should set a unique ID for each slotted option without an ID", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox>
-                <fast-option>Option 1</fast-option>
-                <fast-option id="second-option">Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option id="second-option">Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-listbox>
+            `;
+        });
 
         await expect(options.nth(0)).toHaveAttribute("id", /option-\d+/);
 
@@ -191,13 +216,15 @@ test.describe("Listbox", () => {
     });
 
     test("should set the `aria-activedescendant` property to the ID of the currently selected option", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-listbox>
+            `;
+        });
 
         const optionsCount = await options.count();
 
@@ -213,13 +240,15 @@ test.describe("Listbox", () => {
     });
 
     test("should set the `aria-multiselectable` attribute to match the `multiple` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-listbox>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-listbox>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-listbox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-listbox>
+            `;
+        });
 
         await element.evaluate((node: FASTListboxElement) => {
             node.multiple = true;
@@ -229,9 +258,8 @@ test.describe("Listbox", () => {
 
         await element.evaluate((node: FASTListboxElement) => {
             node.multiple = false;
+            return new Promise(requestAnimationFrame);
         });
-
-        await page.evaluate(() => new Promise(requestAnimationFrame));
 
         expect(await element.getAttribute("aria-multiselectable")).toBeNull();
     });

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.pw.spec.ts
@@ -7,10 +7,14 @@ import { MenuItemRole } from "./menu-item.options.js";
 test.describe("Menu item", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
+
         element = page.locator("fast-menu-item");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("menu-item--menu-item"));
     });
@@ -20,9 +24,11 @@ test.describe("Menu item", () => {
     });
 
     test("should include a role of `menuitem` by default when no role is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-menu-item>Menu item</fast-menu-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-menu-item>Menu item</fast-menu-item>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", MenuItemRole.menuitem);
     });
@@ -33,9 +39,11 @@ test.describe("Menu item", () => {
             let role: MenuItemRole;
             for (role in MenuItemRole) {
                 test(role, async () => {
-                    await page.setContent(/* html */ `
-                <fast-menu-item>Menu item</fast-menu-item>
-            `);
+                    await root.evaluate(node => {
+                        node.innerHTML = /* html */ `
+                            <fast-menu-item>Menu item</fast-menu-item>
+                        `;
+                    });
 
                     await element.evaluate(
                         (node: FASTMenuItem, role) => (node.role = role),
@@ -48,41 +56,51 @@ test.describe("Menu item", () => {
     );
 
     test("should set the `aria-disabled` attribute with the `disabled` value when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-menu-item disabled>Menu item</fast-menu-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-menu-item disabled>Menu item</fast-menu-item>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-disabled", "true");
     });
 
     test("should set an `aria-expanded` attribute with the `expanded` value when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-menu-item expanded>Menu item</fast-menu-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-menu-item expanded>Menu item</fast-menu-item>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-expanded", "true");
     });
 
     test("should set an `aria-checked` attribute with the `checked` value when provided to a menuitemcheckbox", async () => {
-        await page.setContent(/* html */ `
-            <fast-menu-item role="menuitemcheckbox" checked>Menu item</fast-menu-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-menu-item role="menuitemcheckbox" checked>Menu item</fast-menu-item>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-checked", "true");
     });
 
     test("should NOT set an `aria-checked` attribute when checked is provided to a menuitem", async () => {
-        await page.setContent(/* html */ `
-            <fast-menu-item role="menuitem" checked>Menu item</fast-menu-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-menu-item role="menuitem" checked>Menu item</fast-menu-item>
+            `;
+        });
 
         await expect(element).not.toHaveAttribute("aria-checked", "true");
     });
 
     test("should toggle the `aria-checked` attribute of checkbox item when clicked", async () => {
-        await page.setContent(/* html */ `
-            <fast-menu-item role="menuitemcheckbox">Menu item</fast-menu-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-menu-item role="menuitemcheckbox">Menu item</fast-menu-item>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-checked");
 
@@ -96,9 +114,11 @@ test.describe("Menu item", () => {
     });
 
     test("should aria-checked attribute of radio item to true when clicked", async () => {
-        await page.setContent(/* html */ `
-            <fast-menu-item role="menuitemradio">Menu item</fast-menu-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-menu-item role="menuitemradio">Menu item</fast-menu-item>
+            `;
+        });
 
         expect(await element.getAttribute("aria-checked")).toBe(null);
 
@@ -113,9 +133,11 @@ test.describe("Menu item", () => {
 
     test.describe("events", () => {
         test("should emit a `change` an event when clicked", async () => {
-            await page.setContent(/* html */ `
-                <fast-menu-item>Menu item</fast-menu-item>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-menu-item>Menu item</fast-menu-item>
+                `;
+            });
 
             const [wasClicked] = await Promise.all([
                 element.evaluate(
@@ -131,9 +153,11 @@ test.describe("Menu item", () => {
         });
 
         test("should emit a `keydown` event when space key is invoked", async () => {
-            await page.setContent(/* html */ `
-                <fast-menu-item>Menu item</fast-menu-item>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-menu-item>Menu item</fast-menu-item>
+                `;
+            });
 
             const [wasChanged] = await Promise.all([
                 element.evaluate(node =>
@@ -154,9 +178,11 @@ test.describe("Menu item", () => {
         });
 
         test("should emit a `keydown` event when `Enter` key is invoked", async () => {
-            await page.setContent(/* html */ `
-                <fast-menu-item>Menu item</fast-menu-item>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-menu-item>Menu item</fast-menu-item>
+                `;
+            });
 
             const [wasChanged] = await Promise.all([
                 element.evaluate(node =>

--- a/packages/web-components/fast-foundation/src/number-field/number-field.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.pw.spec.ts
@@ -7,12 +7,15 @@ import type { FASTNumberField } from "./number-field.js";
 test.describe("NumberField", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let control: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-number-field");
+
+        root = page.locator("#root");
 
         control = element.locator(".control");
 
@@ -24,29 +27,49 @@ test.describe("NumberField", () => {
     });
 
     test("should initialize to the provided value attribute if set pre-connection", async () => {
-        await page.setContent(`<fast-number-field value="10"></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field value="10"></fast-number-field>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "10");
     });
 
     test("should set the `autofocus` attribute on the internal control", async () => {
-        await page.setContent(`<fast-number-field autofocus></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field autofocus></fast-number-field>
+            `;
+        });
 
         await expect(control).toHaveBooleanAttribute("autofocus");
     });
 
     test("should set the `disabled` attribute on the internal control", async () => {
-        await page.setContent(`<fast-number-field disabled></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field disabled></fast-number-field>
+            `;
+        });
         await expect(control).toHaveBooleanAttribute("disabled");
     });
 
     test("should set the `readonly` attribute on the internal control", async () => {
-        await page.setContent(`<fast-number-field readonly></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field readonly></fast-number-field>
+            `;
+        });
         await expect(control).toHaveBooleanAttribute("readonly");
     });
 
     test("should set the `required` attribute on the internal control", async () => {
-        await page.setContent(`<fast-number-field required></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field required></fast-number-field>
+            `;
+        });
         await expect(control).toHaveBooleanAttribute("required");
     });
 
@@ -81,8 +104,13 @@ test.describe("NumberField", () => {
         const attrToken = spinalCase(attribute);
 
         test(`should set the \`${attrToken}\` attribute to "${value}" on the internal control`, async () => {
-            await page.setContent(
-                `<fast-number-field ${attrToken}="${value}"></fast-number-field>`
+            await root.evaluate(
+                (node, { attrToken, value }) => {
+                    node.innerHTML = /* html */ `
+                        <fast-number-field ${attrToken}="${value}"></fast-number-field>
+                    `;
+                },
+                { attrToken, value }
             );
 
             await expect(control).toHaveAttribute(attrToken, `${value}`);
@@ -90,7 +118,11 @@ test.describe("NumberField", () => {
     }
 
     test("should set `value` property equal to the `max` property when value is greater than max", async () => {
-        await page.setContent(`<fast-number-field max="10"></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field max="10"></fast-number-field>
+            `;
+        });
 
         await control.fill("11");
 
@@ -98,7 +130,11 @@ test.describe("NumberField", () => {
     });
 
     test("should set `value` property equal to the `max` property when max is less than the value", async () => {
-        await page.setContent(`<fast-number-field value="20"></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field value="20"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.max = 10;
@@ -109,7 +145,11 @@ test.describe("NumberField", () => {
     });
 
     test("should set the `value` property equal to the `min` property when value is less than min", async () => {
-        await page.setContent(`<fast-number-field min="10"></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field min="10"></fast-number-field>
+            `;
+        });
 
         await control.fill("9");
 
@@ -119,7 +159,11 @@ test.describe("NumberField", () => {
     });
 
     test("should update the `value` property when the `min` property is greater than the `value`", async () => {
-        await page.setContent(`<fast-number-field value="10"></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field value="10"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.min = 20;
@@ -131,7 +175,11 @@ test.describe("NumberField", () => {
     });
 
     test("should set the `max` property equal to the `min` property when min is greater than max", async () => {
-        await page.setContent(`<fast-number-field min="10" max="5"></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field min="10" max="5"></fast-number-field>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("max", 10);
 
@@ -139,7 +187,11 @@ test.describe("NumberField", () => {
     });
 
     test("should initialize to the provided `value` attribute if set post-connection", async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.value = "10";
@@ -149,7 +201,11 @@ test.describe("NumberField", () => {
     });
 
     test('should fire a "change" event when the internal control emits a "change" event', async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         const [wasChanged] = await Promise.all([
             element.evaluate(
@@ -169,7 +225,11 @@ test.describe("NumberField", () => {
     });
 
     test('should fire an "input" event when incrementing or decrementing', async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         const [wasIncreased] = await Promise.all([
             element.evaluate(
@@ -201,7 +261,11 @@ test.describe("NumberField", () => {
     });
 
     test("should allow positive float numbers", async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         await control.fill("1.1");
 
@@ -211,7 +275,11 @@ test.describe("NumberField", () => {
     });
 
     test("should allow negative float numbers", async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         await control.fill("-1.1");
 
@@ -221,7 +289,11 @@ test.describe("NumberField", () => {
     });
 
     test("should allow positive integer numbers", async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         await control.fill("1");
 
@@ -231,7 +303,11 @@ test.describe("NumberField", () => {
     });
 
     test("should allow negative integer numbers", async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         await control.fill("-1");
 
@@ -243,7 +319,11 @@ test.describe("NumberField", () => {
     // TODO: This test doesn't account for the `e` character.
     // See https://github.com/microsoft/fast/issues/6251
     test("should disallow non-numeric characters", async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         await control.fill("a");
 
@@ -253,13 +333,21 @@ test.describe("NumberField", () => {
     });
 
     test('should set the `step` property to "1" by default', async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         await expect(control).toHaveAttribute("step", "1");
     });
 
     test("should update the `step` attribute on the internal control when the `step` property is changed", async () => {
-        await page.setContent(`<fast-number-field></fast-number-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.step = 2;
@@ -269,9 +357,11 @@ test.describe("NumberField", () => {
     });
 
     test("should increment the `value` property by the step amount when the `stepUp()` method is invoked", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field step="2" value="5"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field step="2" value="5"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepUp();
@@ -283,9 +373,11 @@ test.describe("NumberField", () => {
     });
 
     test("should decrement the `value` property by the step amount when the `stepDown()` method is invoked", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field step="2" value="5"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field step="2" value="5"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepDown();
@@ -297,9 +389,11 @@ test.describe("NumberField", () => {
     });
 
     test("should offset an undefined `value` from zero when stepped down", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field step="2"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field step="2"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepDown();
@@ -311,9 +405,11 @@ test.describe("NumberField", () => {
     });
 
     test("should offset an undefined `value` from zero when stepped up", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field step="2"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field step="2"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepUp();
@@ -325,9 +421,11 @@ test.describe("NumberField", () => {
     });
 
     test("should offset the `value` from zero after stepping down when `min` is a negative value", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field min="-10"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field min="-10"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepDown();
@@ -339,9 +437,11 @@ test.describe("NumberField", () => {
     });
 
     test("should offset the `value` from zero after stepping up when `min` is a negative value", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field min="-10"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field min="-10"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepUp();
@@ -353,9 +453,11 @@ test.describe("NumberField", () => {
     });
 
     test("should set `value` to match `min` after stepping down when `min` is greater than 0", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field min="10"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field min="10"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepDown();
@@ -367,9 +469,11 @@ test.describe("NumberField", () => {
     });
 
     test("should set `value` to match `min` after stepping up when `min` is greater than 0", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field min="10"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field min="10"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepUp();
@@ -381,9 +485,11 @@ test.describe("NumberField", () => {
     });
 
     test("should set the `value` to match `max` after stepping down when `value` is undefined and `min` and `max` are less than zero", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field min="-10" max="-5"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field min="-10" max="-5"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepDown();
@@ -395,9 +501,11 @@ test.describe("NumberField", () => {
     });
 
     test("should set the `value` to match `max` after stepping up when `value` is undefined and `min` and `max` are less than zero", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field min="-10" max="-5"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field min="-10" max="-5"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepUp();
@@ -409,9 +517,11 @@ test.describe("NumberField", () => {
     });
 
     test("should update the proxy value when stepping down", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field step="2" value="5"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field step="2" value="5"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepDown();
@@ -427,9 +537,11 @@ test.describe("NumberField", () => {
     });
 
     test("should update the proxy value when stepping up", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field step="2" value="5"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field step="2" value="5"></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.stepUp();
@@ -448,9 +560,14 @@ test.describe("NumberField", () => {
         const step = 0.1;
         const value = 0.2;
 
-        await page.setContent(/* html */ `
-            <fast-number-field step="${step}" value="${value}"></fast-number-field>
-        `);
+        await root.evaluate(
+            (node, { step, value }) => {
+                node.innerHTML = /* html */ `
+                    <fast-number-field step="${step}" value="${value}"></fast-number-field>
+                `;
+            },
+            { step, value }
+        );
 
         for (let i = 1; i < 10; i++) {
             await element.evaluate((node: FASTNumberField) => {
@@ -464,9 +581,11 @@ test.describe("NumberField", () => {
     });
 
     test("should not render step controls when `hide-step` attribute is present", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field hide-step></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field hide-step></fast-number-field>
+            `;
+        });
 
         const controls = element.locator(".controls");
 
@@ -474,9 +593,11 @@ test.describe("NumberField", () => {
     });
 
     test("should not render step controls when `readonly` attribute is present", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field readonly></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field readonly></fast-number-field>
+            `;
+        });
 
         const controls = element.locator(".controls");
 
@@ -484,9 +605,11 @@ test.describe("NumberField", () => {
     });
 
     test("should allow setting `valueAsNumber` property with a number", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field></fast-number-field>
+            `;
+        });
 
         await element.evaluate((node: FASTNumberField) => {
             node.valueAsNumber = 18;
@@ -496,9 +619,11 @@ test.describe("NumberField", () => {
     });
 
     test("should allow reading the `valueAsNumber` property as number", async () => {
-        await page.setContent(/* html */ `
-            <fast-number-field value="18"></fast-number-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-number-field value="18"></fast-number-field>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("valueAsNumber", 18);
     });
@@ -507,11 +632,13 @@ test.describe("NumberField", () => {
         test('should reset its `value` property to "" if no `value` attribute is set', async () => {
             const form = page.locator("form");
 
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-number-field></fast-number-field>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-number-field></fast-number-field>
+                    </form>
+                `;
+            });
 
             await element.evaluate((node: FASTNumberField) => {
                 node.value = "10";
@@ -527,11 +654,13 @@ test.describe("NumberField", () => {
         test("should reset the `value` property to match the `value` attribute", async () => {
             const form = page.locator("form");
 
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-number-field value="10"></fast-number-field>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-number-field value="10"></fast-number-field>
+                    </form>
+                `;
+            });
 
             await expect(element).toHaveJSProperty("value", "10");
 
@@ -549,11 +678,13 @@ test.describe("NumberField", () => {
         test("should put the control into a clean state, where `value` attribute modifications change the `value` property prior to user or programmatic interaction", async () => {
             const form = page.locator("form");
 
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-number-field value="10"></fast-number-field>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-number-field value="10"></fast-number-field>
+                    </form>
+                `;
+            });
 
             await expect(element).toHaveJSProperty("value", "10");
 

--- a/packages/web-components/fast-foundation/src/progress-ring/progress-ring.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/progress-ring/progress-ring.pw.spec.ts
@@ -5,11 +5,14 @@ import { fixtureURL } from "../__test__/helpers.js";
 test.describe("Progress ring", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-progress-ring");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("progress-progress-ring--progress-ring"));
     });
@@ -19,49 +22,61 @@ test.describe("Progress ring", () => {
     });
 
     test("should include a role of progressbar", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress-ring></fast-progress-ring>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress-ring></fast-progress-ring>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "progressbar");
     });
 
     test("should set the `aria-valuenow` attribute with the `value` property when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress-ring value="50"></fast-progress-ring>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress-ring value="50"></fast-progress-ring>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-valuenow", "50");
     });
 
     test("should set the `aria-valuemin` attribute with the `min` property when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress-ring min="10"></fast-progress-ring>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress-ring min="10"></fast-progress-ring>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-valuemin", "10");
     });
 
     test("should set the `aria-valuemax` attribute with the `max` property when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress-ring max="75"></fast-progress-ring>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress-ring max="75"></fast-progress-ring>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-valuemax", "75");
     });
 
     test("should add a `paused` class when `paused` is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress-ring paused></fast-progress-ring>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress-ring paused></fast-progress-ring>
+            `;
+        });
 
         await expect(element).toHaveClass(/paused/);
     });
 
     test("should render an element with a `determinate` slot when a value is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress-ring value="50"></fast-progress-ring>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress-ring value="50"></fast-progress-ring>
+            `;
+        });
 
         const progress = element.locator(".progress");
 

--- a/packages/web-components/fast-foundation/src/progress/progress.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/progress/progress.pw.spec.ts
@@ -6,11 +6,14 @@ import type { FASTProgress } from "./progress.js";
 test.describe("Progress ring", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-progress");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("progress--progress"));
     });
@@ -24,41 +27,51 @@ test.describe("Progress ring", () => {
     });
 
     test("should set the `aria-valuenow` attribute with the `value` property when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress value="50"></fast-progress>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress value="50"></fast-progress>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-valuenow", "50");
     });
 
     test("should set the `aria-valuemin` attribute with the `min` property when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress min="50"></fast-progress>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress min="50"></fast-progress>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-valuemin", "50");
     });
 
     test("should set the `aria-valuemax` attribute with the `max` property when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress max="50"></fast-progress>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress max="50"></fast-progress>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-valuemax", "50");
     });
 
     test("should add a `paused` class when `paused` is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress paused></fast-progress>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress paused></fast-progress>
+            `;
+        });
 
         await expect(element).toHaveClass(/paused/);
     });
 
     test("should render an element with a `determinate` slot when a value is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress value="50"></fast-progress>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress value="50"></fast-progress>
+            `;
+        });
 
         const progress = element.locator(".progress");
 
@@ -66,9 +79,11 @@ test.describe("Progress ring", () => {
     });
 
     test("should render an element with an `indeterminate` slot when no value is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress></fast-progress>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress></fast-progress>
+            `;
+        });
 
         const progress = element.locator(".progress");
 
@@ -76,17 +91,21 @@ test.describe("Progress ring", () => {
     });
 
     test("should return the `percentComplete` property as a value between 0 and 100 when `min` and `max` are unset", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress value="50"></fast-progress>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress value="50"></fast-progress>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("percentComplete", 50);
     });
 
     test("should set the `percentComplete` property to match the current `value` in the range of `min` and `max`", async () => {
-        await page.setContent(/* html */ `
-            <fast-progress value="0"></fast-progress>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-progress value="0"></fast-progress>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("percentComplete", 0);
 

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
@@ -8,12 +8,15 @@ import type { FASTRadioGroup } from "./index.js";
 test.describe("Radio Group", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let radios: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-radio-group");
+
+        root = page.locator("#root");
 
         radios = element.locator("fast-radio");
 
@@ -25,17 +28,21 @@ test.describe("Radio Group", () => {
     });
 
     test("should have a role of `radiogroup`", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group></fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group></fast-radio-group>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "radiogroup");
     });
 
     test("should set a matching class on the `positioning-region` when an orientation is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group></fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group></fast-radio-group>
+            `;
+        });
 
         const positioningRegion = element.locator(".positioning-region");
 
@@ -56,17 +63,21 @@ test.describe("Radio Group", () => {
     });
 
     test("should set the `aria-disabled` attribute when disabled", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group disabled></fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group disabled></fast-radio-group>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-disabled", "true");
     });
 
     test("should set the `aria-disabled` attribute equal to the `disabled` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group></fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group></fast-radio-group>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-disabled");
 
@@ -84,17 +95,21 @@ test.describe("Radio Group", () => {
     });
 
     test("should set the `aria-readonly` attribute when the `readonly` attribute is present", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group readonly></fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group readonly></fast-radio-group>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-readonly", "true");
     });
 
     test("should set the `aria-readonly` attribute equal to the `readonly` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group></fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group></fast-radio-group>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-readonly");
 
@@ -112,21 +127,25 @@ test.describe("Radio Group", () => {
     });
 
     test("should NOT set a default `aria-disabled` value when `disabled` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group></fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group></fast-radio-group>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-disabled");
     });
 
     test("should set all child radio elements to disabled when the `disabled` attribute is present", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group disabled>
-                <fast-radio></fast-radio>
-                <fast-radio></fast-radio>
-                <fast-radio></fast-radio>
-            </fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group disabled>
+                    <fast-radio></fast-radio>
+                    <fast-radio></fast-radio>
+                    <fast-radio></fast-radio>
+                </fast-radio-group>
+            `;
+        });
 
         await expect(element).toHaveBooleanAttribute("disabled");
 
@@ -144,13 +163,15 @@ test.describe("Radio Group", () => {
     });
 
     test("should set all child radio elements to readonly when the `readonly` property is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group readonly>
-                <fast-radio></fast-radio>
-                <fast-radio></fast-radio>
-                <fast-radio></fast-radio>
-            </fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group readonly>
+                    <fast-radio></fast-radio>
+                    <fast-radio></fast-radio>
+                    <fast-radio></fast-radio>
+                </fast-radio-group>
+            `;
+        });
 
         await expect(element).toHaveBooleanAttribute("readonly");
 
@@ -168,25 +189,29 @@ test.describe("Radio Group", () => {
     });
 
     test("should set tabindex of 0 to a child radio with a matching `value`", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group value="foo">
-                <fast-radio value="foo"></fast-radio>
-                <fast-radio value="bar"></fast-radio>
-                <fast-radio value="baz"></fast-radio>
-            </fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group value="foo">
+                    <fast-radio value="foo"></fast-radio>
+                    <fast-radio value="bar"></fast-radio>
+                    <fast-radio value="baz"></fast-radio>
+                </fast-radio-group>
+            `;
+        });
 
         await expect(radios.nth(0)).toHaveAttribute("tabindex", "0");
     });
 
     test("should NOT set `tabindex` of 0 to a child radio if its value does not match the radiogroup `value`", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group value="foo">
-                <fast-radio value="bar"></fast-radio>
-                <fast-radio value="baz"></fast-radio>
-                <fast-radio value="qux"></fast-radio>
-            </fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group value="foo">
+                    <fast-radio value="bar"></fast-radio>
+                    <fast-radio value="baz"></fast-radio>
+                    <fast-radio value="qux"></fast-radio>
+                </fast-radio-group>
+            `;
+        });
 
         expect(
             await radios.evaluateAll(radios =>
@@ -196,13 +221,15 @@ test.describe("Radio Group", () => {
     });
 
     test("should set a child radio with a matching `value` to `checked`", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group value="bar">
-                <fast-radio value="foo"></fast-radio>
-                <fast-radio value="bar"></fast-radio>
-                <fast-radio value="baz"></fast-radio>
-            </fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group value="bar">
+                    <fast-radio value="foo"></fast-radio>
+                    <fast-radio value="bar"></fast-radio>
+                    <fast-radio value="baz"></fast-radio>
+                </fast-radio-group>
+            `;
+        });
 
         await expect(radios.nth(0)).not.toBeChecked();
 
@@ -212,13 +239,15 @@ test.describe("Radio Group", () => {
     });
 
     test("should set a child radio with a matching `value` to `checked` when value changes", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group value="foo">
-                <fast-radio value="foo"></fast-radio>
-                <fast-radio value="bar"></fast-radio>
-                <fast-radio value="baz"></fast-radio>
-            </fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group value="foo">
+                    <fast-radio value="foo"></fast-radio>
+                    <fast-radio value="bar"></fast-radio>
+                    <fast-radio value="baz"></fast-radio>
+                </fast-radio-group>
+            `;
+        });
 
         await element.evaluate((node: FASTRadioGroup) => {
             node.value = "bar";
@@ -232,13 +261,15 @@ test.describe("Radio Group", () => {
     });
 
     test("should mark only the last radio defaulted to checked as checked", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group>
-                <fast-radio value="foo" checked></fast-radio>
-                <fast-radio value="bar" checked></fast-radio>
-                <fast-radio value="baz" checked></fast-radio>
-            </fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group>
+                    <fast-radio value="foo" checked></fast-radio>
+                    <fast-radio value="bar" checked></fast-radio>
+                    <fast-radio value="baz" checked></fast-radio>
+                </fast-radio-group>
+            `;
+        });
 
         expect(
             await radios.evaluateAll<number, FASTRadio>(
@@ -254,13 +285,15 @@ test.describe("Radio Group", () => {
     });
 
     test("should mark radio matching value on radio-group over any checked attributes", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio-group value="foo">
-                <fast-radio value="foo"></fast-radio>
-                <fast-radio value="bar" checked></fast-radio>
-                <fast-radio value="baz"></fast-radio>
-            </fast-radio-group>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio-group value="foo">
+                    <fast-radio value="foo"></fast-radio>
+                    <fast-radio value="bar" checked></fast-radio>
+                    <fast-radio value="baz"></fast-radio>
+                </fast-radio-group>
+            `;
+        });
 
         expect(
             await radios.evaluateAll<number, FASTRadio>(
@@ -282,15 +315,17 @@ test.describe("Radio Group", () => {
     });
 
     test("should allow resetting of elements by the parent form", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <fast-radio-group>
-                    <fast-radio value="foo"></fast-radio>
-                    <fast-radio value="bar" checked></fast-radio>
-                    <fast-radio value="baz"></fast-radio>
-                </fast-radio-group>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <fast-radio-group>
+                        <fast-radio value="foo"></fast-radio>
+                        <fast-radio value="bar" checked></fast-radio>
+                        <fast-radio value="baz"></fast-radio>
+                    </fast-radio-group>
+                </form>
+            `;
+        });
 
         const form = page.locator("form");
 

--- a/packages/web-components/fast-foundation/src/radio/radio.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.pw.spec.ts
@@ -6,10 +6,14 @@ import type { FASTRadio } from "./radio.js";
 test.describe("Radio", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
+
         element = page.locator("fast-radio");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("radio--radio"));
     });
@@ -19,17 +23,21 @@ test.describe("Radio", () => {
     });
 
     test("should have a role of `radio`", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio>Radio</fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio>Radio</fast-radio>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "radio");
     });
 
     test("should set ARIA attributes to match the state", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio>Radio</fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio>Radio</fast-radio>
+            `;
+        });
 
         // Checked
         await expect(element).toHaveAttribute("aria-checked", "false");
@@ -83,25 +91,31 @@ test.describe("Radio", () => {
     });
 
     test("should set a tabindex of 0 on the element", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio>Radio</fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio>Radio</fast-radio>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
     test("should NOT set a tabindex when disabled is `true`", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio disabled></fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio disabled></fast-radio>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "");
     });
 
     test("should initialize to the initial value if no value property is set", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio>Radio</fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio>Radio</fast-radio>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "on");
 
@@ -109,9 +123,11 @@ test.describe("Radio", () => {
     });
 
     test("should initialize to the provided value attribute if set pre-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio>Radio</fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio>Radio</fast-radio>
+            `;
+        });
 
         await element.evaluate((node: FASTRadio) => node.setAttribute("value", "foo"));
 
@@ -119,9 +135,11 @@ test.describe("Radio", () => {
     });
 
     test("should initialize to the provided value attribute if set post-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio>Radio</fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio>Radio</fast-radio>
+            `;
+        });
 
         await element.evaluate((node: FASTRadio) => node.setAttribute("value", "foo"));
 
@@ -129,17 +147,21 @@ test.describe("Radio", () => {
     });
 
     test("should initialize to the provided value property if set pre-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio value="foo"></fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio value="foo"></fast-radio>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
     test("should set the `label__hidden` class on the internal label when default slotted content does not exist", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio>label</fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio>label</fast-radio>
+            `;
+        });
 
         const label = element.locator("label");
 
@@ -153,9 +175,11 @@ test.describe("Radio", () => {
     });
 
     test("should fire events when clicked and spacebar is pressed", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio>Radio</fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio>Radio</fast-radio>
+            `;
+        });
 
         const [wasClicked] = await Promise.all([
             element.evaluate(
@@ -192,9 +216,11 @@ test.describe("Radio", () => {
     });
 
     test("should handle validity when the `required` attribute is present", async () => {
-        await page.setContent(/* html */ `
-            <fast-radio required name="name" value="test">Radio</fast-radio>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio required name="name" value="test">Radio</fast-radio>
+            `;
+        });
 
         expect(
             await element.evaluate((node: FASTRadio) => node.validity.valueMissing)
@@ -209,11 +235,13 @@ test.describe("Radio", () => {
 
     test.describe("whose parent form has its reset() method invoked", () => {
         test("should set its checked property to false if the checked attribute is unset", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-radio>Radio</fast-radio>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-radio>Radio</fast-radio>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -229,11 +257,13 @@ test.describe("Radio", () => {
         });
 
         test("should set its checked property to true if the checked attribute is set", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-radio checked></fast-radio>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-radio checked></fast-radio>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -255,11 +285,13 @@ test.describe("Radio", () => {
         });
 
         test("should put the control into a clean state, where `checked` attribute modifications modify the `checked` property prior to user or programmatic interaction", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-radio>Radio</fast-radio>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-radio>Radio</fast-radio>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 

--- a/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
@@ -7,11 +7,16 @@ import type { FASTSearch } from "./search.js";
 test.describe("Search", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let control: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
+
         element = page.locator("fast-search");
+
+        root = page.locator("#root");
+
         control = element.locator(".control");
 
         await page.goto(fixtureURL("search--search"));
@@ -32,9 +37,14 @@ test.describe("Search", () => {
 
         for (const attribute of Object.keys(attributes)) {
             test(`should set ${attribute}`, async () => {
-                await page.setContent(/* html */ `
-                    <fast-search ${attribute}>Search</fast-search>
-                `);
+                await root.evaluate(
+                    (node, { attribute }) => {
+                        node.innerHTML = /* html */ `
+                            <fast-search ${attribute}>Search</fast-search>
+                        `;
+                    },
+                    { attribute }
+                );
 
                 await expect(element).toHaveBooleanAttribute(attribute);
             });
@@ -72,9 +82,11 @@ test.describe("Search", () => {
         for (const [attribute, value] of Object.entries(attributes)) {
             const attrToken = spinalCase(attribute);
             test(`should set ${attrToken} to ${value}`, async () => {
-                await page.setContent(/* html */ `
-                    <fast-search>Search</fast-search>
-                `);
+                await root.evaluate(node => {
+                    node.innerHTML = /* html */ `
+                        <fast-search>Search</fast-search>
+                    `;
+                });
 
                 await element.evaluate(
                     (node: FASTSearch, { attrToken, value }) => {
@@ -89,25 +101,31 @@ test.describe("Search", () => {
     });
 
     test("should initialize to the initial value if no value property is set", async () => {
-        await page.setContent(/* html */ `
-            <fast-search>Search</fast-search>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-search>Search</fast-search>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "");
     });
 
     test("should initialize to the provided value attribute if set pre-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-search value="foo">Search</fast-search>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-search value="foo">Search</fast-search>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
     test("should initialize to the provided value attribute if set post-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-search>Search</fast-search>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-search>Search</fast-search>
+            `;
+        });
 
         await element.evaluate(node => {
             node.setAttribute("value", "foo");
@@ -117,23 +135,23 @@ test.describe("Search", () => {
     });
 
     test("should initialize to the provided value property if set pre-connection", async () => {
-        await page.setContent("");
+        await root.evaluate(node => {
+            node.innerHTML = "";
 
-        await page.evaluate(() => {
-            const node = document.createElement("fast-search") as FASTSearch;
-
-            node.value = "foo";
-
-            document.body.append(node);
+            const searchElement = document.createElement("fast-search") as FASTSearch;
+            searchElement.value = "foo";
+            node.append(searchElement);
         });
 
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
     test("should hide the label when no default slotted content is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-search></fast-search>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-search></fast-search>
+            `;
+        });
 
         const label = element.locator(".label");
 
@@ -141,9 +159,11 @@ test.describe("Search", () => {
     });
 
     test("should hide the label when start content is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-search><span slot="start">Start</span></fast-search>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-search><span slot="start">Start</span></fast-search>
+            `;
+        });
 
         const label = element.locator(".label");
 
@@ -151,9 +171,11 @@ test.describe("Search", () => {
     });
 
     test("should hide the label when end content is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-search><span slot="end">End</span></fast-search>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-search><span slot="end">End</span></fast-search>
+            `;
+        });
 
         const label = element.locator(".label");
 
@@ -161,12 +183,14 @@ test.describe("Search", () => {
     });
 
     test("should hide the label when start and end content is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-search>
-                <span slot="start">Start</span>
-                <span slot="end">End</span>
-            </fast-search>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-search>
+                    <span slot="start">Start</span>
+                    <span slot="end">End</span>
+                </fast-search>
+            `;
+        });
 
         const label = element.locator(".label");
 
@@ -174,9 +198,11 @@ test.describe("Search", () => {
     });
 
     test("should hide the label when space-only text nodes are slotted", async () => {
-        await page.setContent(/* html */ `
-            <fast-search>label</fast-search>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-search>label</fast-search>
+            `;
+        });
 
         const label = element.locator(".label");
 
@@ -190,9 +216,11 @@ test.describe("Search", () => {
     });
 
     test("should fire a change event when the internal control emits a change event", async () => {
-        await page.setContent(/* html */ `
-            <fast-search>Search</fast-search>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-search>Search</fast-search>
+            `;
+        });
 
         const control = element.locator(".control");
 
@@ -213,11 +241,13 @@ test.describe("Search", () => {
 
     test.describe("when the owning form's reset() method is invoked", () => {
         test("should reset its `value` property to an empty string when no value attribute is set", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-search>Search</fast-search>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-search>Search</fast-search>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -239,11 +269,13 @@ test.describe("Search", () => {
         });
 
         test("should reset its `value` property to the value of the value attribute if it is set", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-search value="test value">Search</fast-search>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-search value="test value">Search</fast-search>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -261,11 +293,13 @@ test.describe("Search", () => {
         });
 
         test("should put the control into a clean state, where `value` attribute modifications change the `value` property prior to user or programmatic interaction", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-search>Search</fast-search>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-search>Search</fast-search>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 

--- a/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
@@ -7,13 +7,18 @@ import type { FASTSelect } from "./select.js";
 test.describe("Select", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-select");
 
-        await page.goto(fixtureURL("select--select"));
+        root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"), {
+            waitUntil: "load",
+        });
     });
 
     test.afterAll(async () => {
@@ -21,28 +26,35 @@ test.describe("Select", () => {
     });
 
     test("should have a role of `combobox`", async () => {
-        await page.setContent(/* html */ `
-            <fast-select></fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select></fast-select>
+            `;
+        });
+
         await expect(element).toHaveAttribute("role", "combobox");
     });
 
     test("should have a tabindex of 0 when `disabled` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
     test("should set the `aria-disabled` attribute equal to the `disabled` value", async () => {
-        await page.setContent(/* html */ `
-            <fast-select disabled></fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select disabled></fast-select>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-disabled", "true");
 
@@ -54,21 +66,25 @@ test.describe("Select", () => {
     });
 
     test("should have the attribute aria-expanded set to false", async () => {
-        await page.setContent(/* html */ `
-            <fast-select></fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select></fast-select>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-expanded", "false");
     });
 
     test("should set its value to the first enabled option", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "Option 1");
 
@@ -76,21 +92,25 @@ test.describe("Select", () => {
     });
 
     test("should NOT have a tabindex when `disabled` is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-select disabled></fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select disabled></fast-select>
+            `;
+        });
 
         expect(await element.getAttribute("tabindex")).toBeNull();
     });
 
     test("should set its value to the first enabled option when disabled", async () => {
-        await page.setContent(/* html */ `
-            <fast-select disabled>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select disabled>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "Option 1");
 
@@ -98,13 +118,15 @@ test.describe("Select", () => {
     });
 
     test("should select the first option with a `selected` attribute", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option>Option 1</fast-option>
-                <fast-option selected>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option selected>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "Option 2");
 
@@ -112,13 +134,15 @@ test.describe("Select", () => {
     });
 
     test("should select the first option with a `selected` attribute when disabled", async () => {
-        await page.setContent(/* html */ `
-            <fast-select disabled>
-                <fast-option>Option 1</fast-option>
-                <fast-option selected>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select disabled>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option selected>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "Option 2");
 
@@ -126,25 +150,29 @@ test.describe("Select", () => {
     });
 
     test("should return the same value when the `value` property is set before connect", async () => {
-        await page.setContent(/* html */ `
-            <fast-select value="Option 2">
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select value="Option 2">
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "Option 2");
     });
 
     test("should return the same value when the value property is set after connect", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await element.evaluate<void, FASTSelect>(node => {
             node.value = "Option 3";
@@ -154,13 +182,15 @@ test.describe("Select", () => {
     });
 
     test("should select the next selectable option when the value is set to match a disabled option", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option>Option 1</fast-option>
-                <fast-option disabled>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option disabled>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "Option 1");
 
@@ -176,13 +206,15 @@ test.describe("Select", () => {
     });
 
     test("should update the `value` property when the selected option's `value` property changes", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         const options = element.locator("fast-option");
 
@@ -196,13 +228,15 @@ test.describe("Select", () => {
     });
 
     test("should return the `value` property as a string", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option value="1">Option 1</fast-option>
-                <fast-option value="2">Option 2</fast-option>
-                <fast-option value="3">Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option value="1">Option 1</fast-option>
+                    <fast-option value="2">Option 2</fast-option>
+                    <fast-option value="3">Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "1");
 
@@ -212,13 +246,19 @@ test.describe("Select", () => {
     });
 
     test("should update the aria-expanded attribute when opened", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
+
+        await element.evaluate(node =>
+            Promise.all(node.getAnimations({ subtree: true }).map(a => a.finished))
+        );
 
         element.click();
 
@@ -226,13 +266,15 @@ test.describe("Select", () => {
     });
 
     test("should display the listbox when the `open` property is true before connecting", async () => {
-        await page.setContent(/* html */ `
-            <fast-select open>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select open>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         const listbox = element.locator(".listbox");
 
@@ -249,13 +291,15 @@ test.describe("Select", () => {
             { expectedValue: "Option 1", key: "Home" },
         ].forEach(({ expectedValue, key }) => {
             test(`should NOT emit \`${eventName}\` event while open when the value changes by user input via ${key} key`, async () => {
-                await page.setContent(/* html */ `
-                    <fast-select open>
-                        <fast-option>Option 1</fast-option>
-                        <fast-option>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-select>
-                `);
+                await root.evaluate(node => {
+                    node.innerHTML = /* html */ `
+                        <fast-select open>
+                            <fast-option>Option 1</fast-option>
+                            <fast-option>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-select>
+                    `;
+                });
 
                 const [wasChanged] = await Promise.all([
                     element.evaluate(
@@ -282,13 +326,15 @@ test.describe("Select", () => {
             });
 
             test(`should emit \`${eventName}\` event while closed when the value changes by user input via ${key} key`, async () => {
-                await page.setContent(/* html */ `
-                    <fast-select>
-                        <fast-option>Option 1</fast-option>
-                        <fast-option>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-select>
-                `);
+                await root.evaluate(node => {
+                    node.innerHTML = /* html */ `
+                        <fast-select>
+                            <fast-option>Option 1</fast-option>
+                            <fast-option>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-select>
+                    `;
+                });
 
                 const [wasChanged] = await Promise.all([
                     element.evaluate((node, eventName) => {
@@ -340,15 +386,17 @@ test.describe("Select", () => {
 
     test.describe("when the owning form's reset() function is invoked", () => {
         test("should reset the value property to the first available option", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-select>
-                        <fast-option>Option 1</fast-option>
-                        <fast-option>Option 2</fast-option>
-                        <fast-option>Option 3</fast-option>
-                    </fast-select>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-select>
+                            <fast-option>Option 1</fast-option>
+                            <fast-option>Option 2</fast-option>
+                            <fast-option>Option 3</fast-option>
+                        </fast-select>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -369,13 +417,15 @@ test.describe("Select", () => {
     });
 
     test("should set the `aria-activedescendant` attribute to the ID of the currently selected option", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option id="option-1">Option 1</fast-option>
-                <fast-option id="option-2">Option 2</fast-option>
-                <fast-option id="option-3">Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option id="option-1">Option 1</fast-option>
+                    <fast-option id="option-2">Option 2</fast-option>
+                    <fast-option id="option-3">Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-activedescendant", "option-1");
 
@@ -393,13 +443,15 @@ test.describe("Select", () => {
     });
 
     test("should set the `aria-controls` attribute to the ID of the internal listbox element while open", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         const listbox = element.locator(".listbox");
 
@@ -421,13 +473,15 @@ test.describe("Select", () => {
     });
 
     test("should update the `displayValue` when the selected option's content changes", async () => {
-        await page.setContent(/* html */ `
-            <fast-select>
-                <fast-option>Option 1</fast-option>
-                <fast-option>Option 2</fast-option>
-                <fast-option>Option 3</fast-option>
-            </fast-select>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
 
         const options = element.locator("fast-option");
 

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.pw.spec.ts
@@ -8,13 +8,16 @@ import type { FASTSliderLabel } from "./slider-label.js";
 test.describe("Slider label", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
-        await page.goto(fixtureURL("slider-label--slider-label"));
-
         element = page.locator("fast-slider-label");
+
+        root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider-label--slider-label"));
     });
 
     test.afterAll(async () => {
@@ -22,33 +25,44 @@ test.describe("Slider label", () => {
     });
 
     test("should NOT set the `aria-disabled` attribute when `disabled` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider-label></fast-slider-label>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider-label></fast-slider-label>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-disabled");
     });
 
     test('should add an element with a class of "mark" by default', async () => {
-        await page.setContent(/* html */ `
-            <fast-slider-label></fast-slider-label>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider-label></fast-slider-label>
+            `;
+        });
 
         await expect(element.locator(".mark")).toHaveCount(1);
     });
 
     test("should NOT add an element with a class of `mark` when the `hideMark` property is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider-label hide-mark></fast-slider-label>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider-label hide-mark></fast-slider-label>
+            `;
+        });
 
         await expect(element.locator(".mark")).toHaveCount(0);
     });
 
     test("should add a class equal to the `sliderOrientation` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider-label slider-orientation="${Orientation.horizontal}"></fast-slider-label>
-        `);
+        await root.evaluate(
+            (node, { Orientation }) => {
+                node.innerHTML = /* html */ `
+                    <fast-slider-label slider-orientation="${Orientation.horizontal}"></fast-slider-label>
+                `;
+            },
+            { Orientation }
+        );
 
         await expect(element).toHaveClass(/horizontal/);
 
@@ -63,9 +77,11 @@ test.describe("Slider label", () => {
     });
 
     test("should set the `aria-disabled` attribute when the `disabled` property is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider-label disabled></fast-slider-label>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider-label disabled></fast-slider-label>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-disabled", "true");
 

--- a/packages/web-components/fast-foundation/src/slider/slider.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.pw.spec.ts
@@ -9,12 +9,16 @@ test.describe("Slider", () => {
     let page: Page;
     let element: Locator;
 
+    let root: Locator;
+
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         await page.goto(fixtureURL("slider--slider"));
 
         element = page.locator("fast-slider");
+
+        root = page.locator("#root");
     });
 
     test.afterAll(async () => {
@@ -22,48 +26,60 @@ test.describe("Slider", () => {
     });
 
     test("should have a role of `slider`", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
         await expect(element).toHaveAttribute("role", "slider");
     });
 
     test("should set a default `min` property of 0 when `min` is not provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("min", 0);
     });
 
     test("should set a default `max` property of 0 when `max` is not provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await expect(element).toHaveAttribute("max", "10");
     });
 
     test("should set a `tabindex` of 0", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
     test("should NOT set a default `aria-disabled` value when `disabled` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         expect(await element.getAttribute("aria-disabled")).toBe(null);
     });
 
     test("should set a default `aria-orientation` value when `orientation` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await expect(element).toHaveAttribute(
             "aria-orientation",
@@ -72,17 +88,21 @@ test.describe("Slider", () => {
     });
 
     test("should NOT set a default `aria-readonly` value when `readonly` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         expect(await element.getAttribute("aria-readonly")).toBe(null);
     });
 
     test("should initialize to the initial value if no value property is set", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         const initialValue = await element.evaluate<string, FASTSlider>(
             node => node.initialValue
@@ -92,9 +112,11 @@ test.describe("Slider", () => {
     });
 
     test("should set the `aria-disabled` attribute when `disabled` value is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.disabled = true;
@@ -104,21 +126,25 @@ test.describe("Slider", () => {
     });
 
     test("should NOT set a tabindex when `disabled` value is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.disabled = true;
         });
 
-        await expect(element).not.hasAttribute("tabindex");
+        await expect(element).not.toHaveAttribute("tabindex", "0");
     });
 
     test("should set the `aria-readonly` attribute when `readonly` value is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.readOnly = true;
@@ -128,9 +154,11 @@ test.describe("Slider", () => {
     });
 
     test("should add a class of `readonly` when readonly is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.readOnly = true;
@@ -140,9 +168,11 @@ test.describe("Slider", () => {
     });
 
     test("should set the `aria-orientation` attribute equal to the `orientation` value", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider, Orientation) => {
             node.orientation = Orientation.horizontal;
@@ -158,9 +188,11 @@ test.describe("Slider", () => {
     });
 
     test("should add a class equal to the `orientation` value", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider, Orientation) => {
             node.orientation = Orientation.horizontal;
@@ -176,9 +208,11 @@ test.describe("Slider", () => {
     });
 
     test("should set direction equal to the `direction` value", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider, Direction) => {
             node.direction = Direction.ltr;
@@ -194,9 +228,11 @@ test.describe("Slider", () => {
     });
 
     test("should set the `aria-valuenow` attribute with the `value` property when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.value = "8";
@@ -206,9 +242,11 @@ test.describe("Slider", () => {
     });
 
     test("should set the `aria-valuemin` attribute with the `min` property when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.min = 0;
@@ -218,9 +256,11 @@ test.describe("Slider", () => {
     });
 
     test("should set the `aria-valuemax` attribute with the `max` property when provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.max = 75;
@@ -231,9 +271,11 @@ test.describe("Slider", () => {
 
     test.describe("valueAsNumber", () => {
         test("should allow setting value with number", async () => {
-            await page.setContent(/* html */ `
-                <fast-slider></fast-slider>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-slider></fast-slider>
+                `;
+            });
 
             await element.evaluate((node: FASTSlider) => {
                 node.valueAsNumber = 8;
@@ -243,9 +285,11 @@ test.describe("Slider", () => {
         });
 
         test("should allow reading value as number", async () => {
-            await page.setContent(/* html */ `
-                <fast-slider></fast-slider>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-slider></fast-slider>
+                `;
+            });
 
             await element.evaluate((node: FASTSlider) => {
                 node.value = "8";
@@ -256,9 +300,11 @@ test.describe("Slider", () => {
     });
 
     test("should set an `aria-valuestring` attribute with the result of the valueTextFormatter() method", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.valueTextFormatter = () => "Seventy Five Years";
@@ -269,9 +315,11 @@ test.describe("Slider", () => {
 
     test.describe("increment and decrement methods", () => {
         test("should increment the value when the `increment()` method is invoked", async () => {
-            await page.setContent(/* html */ `
-                <fast-slider min="0" max="100" value="50" step="5"></fast-slider>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-slider min="0" max="100" value="50" step="5"></fast-slider>
+                `;
+            });
 
             await expect(element).toHaveAttribute("aria-valuenow", "50");
 
@@ -285,9 +333,11 @@ test.describe("Slider", () => {
         });
 
         test("should decrement the value when the `decrement()` method is invoked", async () => {
-            await page.setContent(/* html */ `
-                <fast-slider min="0" max="100" value="50" step="5"></fast-slider>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-slider min="0" max="100" value="50" step="5"></fast-slider>
+                `;
+            });
 
             await element.evaluate((node: FASTSlider) => {
                 node.decrement();
@@ -300,9 +350,11 @@ test.describe("Slider", () => {
     });
 
     test("should constrain and normalize the value between `min` and `max` when the value is out of range", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider min="0" max="100"></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider min="0" max="100"></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.value = "200";
@@ -320,9 +372,11 @@ test.describe("Slider", () => {
     });
 
     test("should initialize to the provided value attribute if set pre-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider value="4"></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider value="4"></fast-slider>
+            `;
+        });
 
         await element.waitFor({ state: "attached" });
 
@@ -330,9 +384,11 @@ test.describe("Slider", () => {
     });
 
     test("should initialize to the provided value attribute if set post-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.setAttribute("value", "3");
@@ -342,22 +398,23 @@ test.describe("Slider", () => {
     });
 
     test("should initialize to the provided value property if set pre-connection", async () => {
-        await page.setContent("");
+        await root.evaluate(node => {
+            node.innerHTML = "";
 
-        await page.evaluate(() => {
             const slider = document.createElement("fast-slider") as FASTSlider;
             slider.value = "3";
-
-            document.body.appendChild(slider);
+            node.appendChild(slider);
         });
 
         await expect(element).toHaveJSProperty("value", "3");
     });
 
     test("should update the `stepMultiplier` when the `step` attribute has been updated", async () => {
-        await page.setContent(/* html */ `
-            <fast-slider step="2" value="4"></fast-slider>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-slider step="2" value="4"></fast-slider>
+            `;
+        });
 
         await element.evaluate((node: FASTSlider) => {
             node.increment();
@@ -375,11 +432,13 @@ test.describe("Slider", () => {
 
     test.describe("when the owning form's reset() method is invoked", () => {
         test("should reset its `value` property to the midpoint if no `value` attribute is set", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-slider></fast-slider>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-slider></fast-slider>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -399,11 +458,13 @@ test.describe("Slider", () => {
         });
 
         test("should reset its `value` property to match the `value` attribute when it is set", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-slider min="0" max="100"></fast-slider>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-slider min="0" max="100"></fast-slider>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -426,11 +487,13 @@ test.describe("Slider", () => {
         });
 
         test("should put the control into a clean state, where the value attribute changes the value property prior to user or programmatic interaction", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-slider min="0" max="100"></fast-slider>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-slider min="0" max="100"></fast-slider>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 

--- a/packages/web-components/fast-foundation/src/switch/switch.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.pw.spec.ts
@@ -5,11 +5,15 @@ import type { FASTSwitch } from "./switch.js";
 
 test.describe("Switch", () => {
     let page: Page;
+    let root: Locator;
     let element: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
+
         element = page.locator("fast-switch");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("switch--switch"));
     });
@@ -19,49 +23,61 @@ test.describe("Switch", () => {
     });
 
     test("should have a role of `switch`", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "switch");
     });
 
     test("should set a tabindex of 0 on the element", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
     test("should set a default `aria-checked` value when `checked` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
     test("should set a default `aria-disabled` value when `disabled` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
     test("should NOT set a default `aria-readonly` value when `readonly` is not defined", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-readonly");
     });
 
     test("should set the `aria-checked` attribute equal to the `checked` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await element.evaluate((node: FASTSwitch) => {
             node.checked = true;
@@ -77,9 +93,11 @@ test.describe("Switch", () => {
     });
 
     test("should set the `aria-readonly` attribute equal to the `readonly` value", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await element.evaluate((node: FASTSwitch) => {
             node.readOnly = true;
@@ -95,9 +113,11 @@ test.describe("Switch", () => {
     });
 
     test('should add a class of "checked" when the `checked` property is true', async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await element.evaluate((node: FASTSwitch) => {
             node.checked = true;
@@ -113,9 +133,11 @@ test.describe("Switch", () => {
     });
 
     test("should initialize to the initial value if no value property is set", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         const initialValue = await element.evaluate<string, FASTSwitch>(
             node => node.initialValue
@@ -125,9 +147,11 @@ test.describe("Switch", () => {
     });
 
     test("should add a class of `label` to the internal label when default slotted content exists", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
         const label = element.locator(".label");
 
         await element.evaluate(node => {
@@ -140,9 +164,11 @@ test.describe("Switch", () => {
     });
 
     test("should add classes of `label` and `label__hidden` to the internal label when default slotted content exists", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch>Switch</fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch>Switch</fast-switch>
+            `;
+        });
 
         const label = element.locator(".label");
 
@@ -156,9 +182,11 @@ test.describe("Switch", () => {
     });
 
     test("should set the `aria-disabled` attribute equal to the `disabled` value", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await element.evaluate((node: FASTSwitch) => {
             node.disabled = true;
@@ -174,9 +202,11 @@ test.describe("Switch", () => {
     });
 
     test("should NOT set a tabindex when disabled is `true`", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch disabled></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch disabled></fast-switch>
+            `;
+        });
 
         await expect(element).not.hasAttribute("tabindex");
 
@@ -188,17 +218,21 @@ test.describe("Switch", () => {
     });
 
     test("should initialize to the provided value attribute if set pre-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch value="foo"></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch value="foo"></fast-switch>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
     test("should initialize to the provided value attribute if set post-connection", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         await element.evaluate((node: FASTSwitch) => {
             node.setAttribute("value", "foo");
@@ -208,21 +242,23 @@ test.describe("Switch", () => {
     });
 
     test("should initialize to the provided value property if set pre-connection", async () => {
-        await page.setContent("");
+        await root.evaluate(node => {
+            node.innerHTML = "";
 
-        await page.evaluate(() => {
             const switchElement = document.createElement("fast-switch") as FASTSwitch;
             switchElement.value = "foobar";
-            document.body.appendChild(switchElement);
+            node.appendChild(switchElement);
         });
 
         await expect(element).toHaveJSProperty("value", "foobar");
     });
 
     test("should emit an event when clicked", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         const [wasClicked] = await Promise.all([
             element.evaluate(
@@ -240,9 +276,11 @@ test.describe("Switch", () => {
     });
 
     test("should fire an event when spacebar is invoked", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         const [wasEmitted] = await Promise.all([
             element.evaluate(
@@ -260,9 +298,11 @@ test.describe("Switch", () => {
     });
 
     test("should fire an event when enter is invoked", async () => {
-        await page.setContent(/* html */ `
-            <fast-switch></fast-switch>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-switch></fast-switch>
+            `;
+        });
 
         const [wasEmitted] = await Promise.all([
             element.evaluate(
@@ -280,11 +320,13 @@ test.describe("Switch", () => {
     });
 
     test("should be invalid when required and unchecked", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <fast-switch required></fast-switch>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <fast-switch required></fast-switch>
+                </form>
+            `;
+        });
 
         expect(
             await element.evaluate<boolean, FASTSwitch>(
@@ -294,11 +336,13 @@ test.describe("Switch", () => {
     });
 
     test("should be valid when required and checked", async () => {
-        await page.setContent(/* html */ `
-            <form>
-                <fast-switch required checked></fast-switch>
-            </form>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <form>
+                    <fast-switch required checked></fast-switch>
+                </form>
+            `;
+        });
 
         expect(
             await element.evaluate<boolean, FASTSwitch>(
@@ -309,11 +353,13 @@ test.describe("Switch", () => {
 
     test.describe("who's parent form has it's reset() method invoked", () => {
         test("should set its checked property to false if the checked attribute is unset", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-switch></fast-switch>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-switch></fast-switch>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -333,11 +379,13 @@ test.describe("Switch", () => {
         });
 
         test("should set its checked property to true if the checked attribute is set", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-switch checked></fast-switch>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-switch checked></fast-switch>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 
@@ -357,11 +405,13 @@ test.describe("Switch", () => {
         });
 
         test("should put the control into a clean state, where `checked` attribute modifications update the `checked` property prior to user or programmatic interaction", async () => {
-            await page.setContent(/* html */ `
-                <form>
-                    <fast-switch></fast-switch>
-                </form>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <form>
+                        <fast-switch></fast-switch>
+                    </form>
+                `;
+            });
 
             const form = page.locator("form");
 

--- a/packages/web-components/fast-foundation/src/tab-panel/tab-panel.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tab-panel/tab-panel.pw.spec.ts
@@ -5,11 +5,14 @@ import { fixtureURL } from "../__test__/helpers.js";
 test.describe("TabPanel", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-tab-panel");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("tabs-tab-panel--tab-panel"));
     });
@@ -19,17 +22,21 @@ test.describe("TabPanel", () => {
     });
 
     test("should have a role of `tabpanel`", async () => {
-        await page.setContent(/* html */ `
-            <fast-tab-panel></fast-tab-panel>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tab-panel></fast-tab-panel>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "tabpanel");
     });
 
     test("should have a slot attribute of `tabpanel`", async () => {
-        await page.setContent(/* html */ `
-            <fast-tab-panel></fast-tab-panel>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tab-panel></fast-tab-panel>
+            `;
+        });
 
         await expect(element).toHaveAttribute("slot", "tabpanel");
     });

--- a/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
@@ -1,4 +1,3 @@
-import { Orientation } from "@microsoft/fast-web-utilities";
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import type { FASTTab } from "../tab/tab.js";
@@ -9,6 +8,7 @@ import type { FASTTabs } from "./tabs.js";
 test.describe("Tabs", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let tablist: Locator;
     let tabs: Locator;
 
@@ -27,7 +27,11 @@ test.describe("Tabs", () => {
         page = await browser.newPage();
 
         element = page.locator("fast-tabs");
+
+        root = page.locator("#root");
+
         tablist = element.locator(".tablist");
+
         tabs = element.locator("fast-tab");
 
         await page.goto(fixtureURL("tabs--tabs"));
@@ -38,42 +42,31 @@ test.describe("Tabs", () => {
     });
 
     test("should have an internal element with a role of `tablist`", async () => {
-        await page.setContent(/* html */ `
-            <fast-tabs></fast-tabs>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tabs></fast-tabs>
+            `;
+        });
 
         await expect(tablist).toHaveAttribute("role", "tablist");
     });
 
     test("should set a default orientation value of `horizontal` when `orientation` is not provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-tabs></fast-tabs>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tabs></fast-tabs>
+            `;
+        });
 
         await expect(element).toHaveJSProperty("orientation", "horizontal");
     });
 
-    test("should add a class equal to the `orientation` value", async () => {
-        await page.setContent(/* html */ `
-            <fast-tabs></fast-tabs>
-        `);
-
-        await expect(element).toHaveClass(/horizontal/);
-
-        await element.evaluate<void, typeof Orientation, FASTTabs>(
-            (node, Orientation) => {
-                node.orientation = Orientation.vertical;
-            },
-            Orientation
-        );
-
-        await expect(element).toHaveClass(/vertical/);
-    });
-
     test("should set the `hideActiveIndicator` property to false by default", async () => {
-        await page.setContent(/* html */ `
-            <fast-tabs></fast-tabs>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tabs></fast-tabs>
+            `;
+        });
 
         await expect(element).not.toHaveBooleanAttribute("hide-active-indicator");
 
@@ -81,9 +74,11 @@ test.describe("Tabs", () => {
     });
 
     test("should set the `hideActiveIndicator` property when the `hide-active-indicator` attribute is present", async () => {
-        await page.setContent(/* html */ `
-            <fast-tabs hide-active-indicator></fast-tabs>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tabs hide-active-indicator></fast-tabs>
+            `;
+        });
 
         await expect(element).toHaveBooleanAttribute("hide-active-indicator");
 
@@ -91,17 +86,21 @@ test.describe("Tabs", () => {
     });
 
     test('should render an internal element with a class of "active-indicator" when `hide-active-indicator` is false', async () => {
-        await page.setContent(/* html */ `
-            <fast-tabs></fast-tabs>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tabs></fast-tabs>
+            `;
+        });
 
         await expect(element.locator(".active-indicator")).toHaveCount(1);
     });
 
     test("should set an `id` attribute on the active tab when an `id` is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-tabs></fast-tabs>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tabs></fast-tabs>
+            `;
+        });
 
         const tabCount = await tabs.count();
 
@@ -117,7 +116,12 @@ test.describe("Tabs", () => {
     });
 
     test("should set an `id` attribute on tab items with a unique ID when an `id` is NOT provided", async () => {
-        await page.setContent(template);
+        await root.evaluate(
+            (node, { template }) => {
+                node.innerHTML = template;
+            },
+            { template }
+        );
 
         const tabCount = await tabs.count();
 
@@ -136,7 +140,12 @@ test.describe("Tabs", () => {
     });
 
     test("should set `aria-labelledby` on the tab panel and `aria-controls` on the tab which corresponds to the matching ID when IDs are NOT provided", async () => {
-        await page.setContent(template);
+        await root.evaluate(
+            (node, { template }) => {
+                node.innerHTML = template;
+            },
+            { template }
+        );
 
         const tabCount = await tabs.count();
 
@@ -162,7 +171,12 @@ test.describe("Tabs", () => {
     });
 
     test("should set `aria-labelledby` on the tab panel and `aria-controls` on the tab which corresponds to the matching ID when IDs are NOT provided and additional tabs and panels are added", async () => {
-        await page.setContent(template);
+        await root.evaluate(
+            (node, { template }) => {
+                node.innerHTML = template;
+            },
+            { template }
+        );
 
         let tabCount = await tabs.count();
 
@@ -223,7 +237,12 @@ test.describe("Tabs", () => {
 
     test.describe("active tab", () => {
         test("should set an `aria-selected` attribute on the active tab when `activeid` is provided", async () => {
-            await page.setContent(template);
+            await root.evaluate(
+                (node, { template }) => {
+                    node.innerHTML = template;
+                },
+                { template }
+            );
 
             const secondTab = tabs.nth(1);
 
@@ -238,7 +257,12 @@ test.describe("Tabs", () => {
         });
 
         test("should default the first tab as the active index if `activeid` is NOT provided", async () => {
-            await page.setContent(template);
+            await root.evaluate(
+                (node, { template }) => {
+                    node.innerHTML = template;
+                },
+                { template }
+            );
 
             await expect(tabs.nth(0)).toHaveAttribute("aria-selected", "true");
 
@@ -246,7 +270,12 @@ test.describe("Tabs", () => {
         });
 
         test("should update `aria-selected` attribute on the active tab when `activeId` is updated", async () => {
-            await page.setContent(template);
+            await root.evaluate(
+                (node, { template }) => {
+                    node.innerHTML = template;
+                },
+                { template }
+            );
 
             await expect(tabs.nth(0)).toHaveAttribute("aria-selected", "true");
 
@@ -262,9 +291,18 @@ test.describe("Tabs", () => {
         });
 
         test("should skip updating the active indicator if the same tab is clicked twice", async () => {
-            await page.setContent(template);
+            await root.evaluate(
+                (node, { template }) => {
+                    node.innerHTML = template;
+                },
+                { template }
+            );
 
             const activeIndicator = element.locator(".active-indicator");
+
+            await activeIndicator.evaluate(node => {
+                node.style.transitionDuration = "0s";
+            });
 
             const x = (await activeIndicator.boundingBox())!.x;
 
@@ -284,7 +322,12 @@ test.describe("Tabs", () => {
 
     test.describe("active tabpanel", () => {
         test("should set an `aria-labelledby` attribute on the tabpanel with a value of the tab id when `activeid` is provided", async () => {
-            await page.setContent(template);
+            await root.evaluate(
+                (node, { template }) => {
+                    node.innerHTML = template;
+                },
+                { template }
+            );
 
             const secondTab = tabs.nth(1);
 
@@ -304,7 +347,12 @@ test.describe("Tabs", () => {
         });
 
         test("should set an attribute of hidden if the tabpanel is not active", async () => {
-            await page.setContent(template);
+            await root.evaluate(
+                (node, { template }) => {
+                    node.innerHTML = template;
+                },
+                { template }
+            );
 
             const tabPanels = element.locator("fast-tab-panel");
 
@@ -317,7 +365,8 @@ test.describe("Tabs", () => {
     });
 
     test("should not display an active indicator if all tabs are disabled", async () => {
-        await page.setContent(/* html */ `
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
             <fast-tabs>
                 <fast-tab disabled>Tab one</fast-tab>
                 <fast-tab disabled>Tab two</fast-tab>
@@ -326,7 +375,8 @@ test.describe("Tabs", () => {
                 <fast-tab-panel>Tab panel two</fast-tab-panel>
                 <fast-tab-panel>Tab panel three</fast-tab-panel>
             </fast-tabs>
-        `);
+        `;
+        });
 
         const activeIndicator = element.locator(".active-indicator");
 
@@ -334,28 +384,34 @@ test.describe("Tabs", () => {
     });
 
     test("should display an active indicator if the last tab is disabled", async () => {
-        await page.setContent(/* html */ `
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
             <fast-tabs>
                 <fast-tab>Tab one</fast-tab>
                 <fast-tab>Tab two</fast-tab>
                 <fast-tab disabled>Tab three</fast-tab>
             </fast-tabs>
-        `);
+        `;
+        });
 
         await expect(element).toHaveJSProperty("showActiveIndicator", true);
     });
 
     test("should not allow selecting a tab that has been disabled after it has been connected", async () => {
-        await page.setContent(/* html */ `
-            <fast-tabs>
-                <fast-tab id="tab-1">Tab one</fast-tab>
-                <fast-tab id="tab-2">Tab two</fast-tab>
-                <fast-tab id="tab-3">Tab three</fast-tab>
-                <fast-tab-panel>Tab panel one</fast-tab-panel>
-                <fast-tab-panel>Tab panel two</fast-tab-panel>
-                <fast-tab-panel>Tab panel three</fast-tab-panel>
-            </fast-tabs>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tabs>
+                    <fast-tab id="tab-1">Tab one</fast-tab>
+                    <fast-tab id="tab-2">Tab two</fast-tab>
+                    <fast-tab id="tab-3">Tab three</fast-tab>
+                    <fast-tab-panel>Tab panel one</fast-tab-panel>
+                    <fast-tab-panel>Tab panel two</fast-tab-panel>
+                    <fast-tab-panel>Tab panel three</fast-tab-panel>
+                </fast-tabs>
+            `;
+
+            return new Promise(requestAnimationFrame);
+        });
 
         const firstTab = tabs.nth(0);
 
@@ -381,7 +437,8 @@ test.describe("Tabs", () => {
     test("should allow selecting tab that has been enabled after it has been connected", async () => {
         test.slow();
 
-        await page.setContent(/* html */ `
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
             <fast-tabs>
                 <fast-tab>Tab one</fast-tab>
                 <fast-tab disabled>Tab two</fast-tab>
@@ -390,7 +447,8 @@ test.describe("Tabs", () => {
                 <fast-tab-panel>Tab panel two</fast-tab-panel>
                 <fast-tab-panel>Tab panel three</fast-tab-panel>
             </fast-tabs>
-        `);
+        `;
+        });
 
         const firstTab = tabs.nth(0);
 

--- a/packages/web-components/fast-foundation/src/text-field/text-field.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.pw.spec.ts
@@ -7,13 +7,19 @@ import type { FASTTextField } from "./text-field.js";
 test.describe("TextField", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let control: Locator;
     let label: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
+
         element = page.locator("fast-text-field");
+
+        root = page.locator("#root");
+
         control = element.locator(".control");
+
         label = element.locator(".label");
 
         await page.goto(fixtureURL("debug--blank"));
@@ -24,31 +30,51 @@ test.describe("TextField", () => {
     });
 
     test("should set the `autofocus` attribute on the internal control", async () => {
-        await page.setContent(`<fast-text-field autofocus></fast-text-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field autofocus></fast-text-field>
+            `;
+        });
 
         await expect(control).toHaveBooleanAttribute("autofocus");
     });
 
     test("should set the `disabled` attribute on the internal control", async () => {
-        await page.setContent(`<fast-text-field disabled></fast-text-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field disabled></fast-text-field>
+            `;
+        });
 
         await expect(control).toHaveBooleanAttribute("disabled");
     });
 
     test("should set the `readonly` attribute on the internal control", async () => {
-        await page.setContent(`<fast-text-field readonly></fast-text-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field readonly></fast-text-field>
+            `;
+        });
 
         await expect(control).toHaveBooleanAttribute("readonly");
     });
 
     test("should set the `required` attribute on the internal control", async () => {
-        await page.setContent(`<fast-text-field required></fast-text-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field required></fast-text-field>
+            `;
+        });
 
         await expect(control).toHaveBooleanAttribute("required");
     });
 
     test("should set the `spellcheck` attribute on the internal control", async () => {
-        await page.setContent(`<fast-text-field spellcheck></fast-text-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field spellcheck></fast-text-field>
+            `;
+        });
 
         await expect(control).toHaveBooleanAttribute("spellcheck");
     });
@@ -86,8 +112,13 @@ test.describe("TextField", () => {
             const attrToken = spinalCase(attribute);
 
             test(`should set the \`${attrToken}\` attribute on the internal control`, async () => {
-                await page.setContent(
-                    `<fast-text-field ${attrToken}="${value}"></fast-text-field>`
+                await root.evaluate(
+                    (node, { attrToken, value }) => {
+                        node.innerHTML = /* html */ `
+                            <fast-text-field ${attrToken}="${value}"></fast-text-field>
+                        `;
+                    },
+                    { attrToken, value }
                 );
 
                 await expect(control).toHaveAttribute(attrToken, `${value}`);
@@ -96,7 +127,11 @@ test.describe("TextField", () => {
     });
 
     test("should initialize to the `initialValue` property if no value property is set", async () => {
-        await page.setContent(`<fast-text-field></fast-text-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field></fast-text-field>
+            `;
+        });
 
         const initialValue = await element.evaluate<string, FASTTextField>(
             node => node.initialValue
@@ -106,7 +141,11 @@ test.describe("TextField", () => {
     });
 
     test("should initialize to the provided `value` attribute if set pre-connection", async () => {
-        await page.setContent(`<fast-text-field value="foo"></fast-text-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field value="foo"></fast-text-field>
+            `;
+        });
 
         const element = page.locator("fast-text-field");
 
@@ -114,19 +153,25 @@ test.describe("TextField", () => {
     });
 
     test("should initialize to the provided `value` property if set pre-connection", async () => {
-        await page.setContent(``);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ ``;
 
-        await page.evaluate(() => {
-            const node = document.createElement("fast-text-field") as FASTTextField;
-            node.value = "foo";
-            document.body.appendChild(node);
+            const textField = document.createElement("fast-text-field") as FASTTextField;
+
+            textField.value = "foo";
+
+            node.appendChild(textField);
         });
 
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
     test("should initialize to the provided `value` attribute if set post-connection", async () => {
-        await page.setContent(`<fast-text-field></fast-text-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field></fast-text-field>
+            `;
+        });
 
         await element.evaluate(node => {
             node.setAttribute("value", "foo");
@@ -136,44 +181,54 @@ test.describe("TextField", () => {
     });
 
     test("should hide the label when no default slotted content is provided", async () => {
-        await page.setContent("<fast-text-field></fast-text-field>");
+        await root.evaluate(node => {
+            node.innerHTML = "<fast-text-field></fast-text-field>";
+        });
 
         await expect(label).toHaveClass(/label__hidden/);
     });
 
     test("should hide the label when start content is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-text-field>
-                <div slot="start"></div>
-            </fast-text-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field>
+                    <div slot="start"></div>
+                </fast-text-field>
+            `;
+        });
 
         await expect(label).toHaveClass(/label__hidden/);
     });
 
     test("should hide the label when end content is provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-text-field>
-                <div slot="end"></div>
-            </fast-text-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field>
+                    <div slot="end"></div>
+                </fast-text-field>
+            `;
+        });
 
         await expect(label).toHaveClass(/label__hidden/);
     });
 
     test("should hide the label when start and end content are provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-text-field>
-                <div slot="start"></div>
-                <div slot="end"></div>
-            </fast-text-field>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field>
+                    <div slot="start"></div>
+                    <div slot="end"></div>
+                </fast-text-field>
+            `;
+        });
 
         await expect(label).toHaveClass(/label__hidden/);
     });
 
     test("should hide the label when space-only text nodes are slotted", async () => {
-        await page.setContent("<fast-text-field>\n \n</fast-text-field>");
+        await root.evaluate(node => {
+            node.innerHTML = `<fast-text-field>\n \n</fast-text-field>`;
+        });
 
         await expect(element).toHaveText(/\n\s\n/);
 
@@ -181,7 +236,11 @@ test.describe("TextField", () => {
     });
 
     test("should fire a `change` event when the internal control emits a `change` event", async () => {
-        await page.setContent(`<fast-text-field></fast-text-field>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-text-field></fast-text-field>
+            `;
+        });
 
         const [wasChanged] = await Promise.all([
             element.evaluate(
@@ -204,9 +263,11 @@ test.describe("TextField", () => {
 
     test.describe("with a type of `password`", () => {
         test("should report invalid validity when the `value` property is an empty string and `required` is true", async () => {
-            await page.setContent(
-                `<fast-text-field type="password" required></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="password" required></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -216,9 +277,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the `value` property is a string that is non-empty and `required` is true", async () => {
-            await page.setContent(
-                `<fast-text-field type="password" required value="some-value"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="password" required value="some-value"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -228,9 +291,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` is empty and `minlength` is set", async () => {
-            await page.setContent(
-                `<fast-text-field type="password" minlength="1"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="password" minlength="1"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -240,9 +305,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` has a length less than `minlength`", async () => {
-            await page.setContent(
-                `<fast-text-field type="password" minlength="10" value="123456789"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="password" minlength="10" value="123456789"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -252,9 +319,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` is empty and `maxlength` is set", async () => {
-            await page.setContent(
-                `<fast-text-field type="password" maxlength="10"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="password" maxlength="10"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -264,9 +333,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` has a length which exceeds the `maxlength`", async () => {
-            await page.setContent(
-                `<fast-text-field type="password" maxlength="10" value="12345678901"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="password" maxlength="10" value="12345678901"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -276,9 +347,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the `value` is shorter than `maxlength` and the element is `required`", async () => {
-            await page.setContent(
-                `<fast-text-field type="password" maxlength="10" required value="123456789"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="password" maxlength="10" required value="123456789"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -288,9 +361,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the `value` property matches the `pattern` property", async () => {
-            await page.setContent(
-                `<fast-text-field type="password" pattern="\\d+" value="123456789"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="password" pattern="\\d+" value="123456789"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -300,9 +375,11 @@ test.describe("TextField", () => {
         });
 
         test("should report invalid validity when `value` does not match `pattern`", async () => {
-            await page.setContent(
-                `<fast-text-field type="password" pattern="value" value="other value"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="password" pattern="value" value="other value"></fast-text-field>
+                `;
+            });
 
             const element = page.locator("fast-text-field");
 
@@ -316,9 +393,11 @@ test.describe("TextField", () => {
 
     test.describe("with a type of `tel`", () => {
         test("should report invalid validity when the `value` property is an empty string and `required` is true", async () => {
-            await page.setContent(`
-                <fast-text-field type="tel" required></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="tel" required></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -328,9 +407,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the `value` property is not empty and `required` is true", async () => {
-            await page.setContent(`
-                <fast-text-field type="tel" required value="some-value"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="tel" required value="some-value"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -340,9 +421,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `minlength` is set and `value` is an empty string", async () => {
-            await page.setContent(`
-                <fast-text-field type="tel" minlength="1"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="tel" minlength="1"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -352,9 +435,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the length of `value` is less than `minlength`", async () => {
-            await page.setContent(`
-                <fast-text-field type="tel" minlength="10" value="123456789"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="tel" minlength="10" value="123456789"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -364,9 +449,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` is an empty string", async () => {
-            await page.setContent(`
-                <fast-text-field type="tel" maxlength="10"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="tel" maxlength="10"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -376,9 +463,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` has a length which exceeds `maxlength`", async () => {
-            await page.setContent(
-                `<fast-text-field type="tel" maxlength="10" value="12345678901"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="tel" maxlength="10" value="12345678901"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -388,9 +477,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the `value` is shorter than `maxlength` and the element is `required`", async () => {
-            await page.setContent(
-                `<fast-text-field type="tel" maxlength="10" required value="123456789"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="tel" maxlength="10" required value="123456789"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -400,9 +491,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the `value` matches `pattern`", async () => {
-            await page.setContent(
-                `<fast-text-field type="tel" pattern="\\d+" value="123456789"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="tel" pattern="\\d+" value="123456789"></fast-text-field>
+                `;
+            });
 
             const element = page.locator("fast-text-field");
 
@@ -414,9 +507,11 @@ test.describe("TextField", () => {
         });
 
         test("should report invalid validity when `value` does not match `pattern`", async () => {
-            await page.setContent(
-                `<fast-text-field type="tel" pattern="value" required value="other value"></fast-text-field>`
-            );
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="tel" pattern="value" required value="other value"></fast-text-field>
+                `;
+            });
 
             const element = page.locator("fast-text-field");
 
@@ -430,9 +525,11 @@ test.describe("TextField", () => {
 
     test.describe("with a type of `text`", () => {
         test("should report invalid validity when the `value` property is an empty string and `required` is true", async () => {
-            await page.setContent(`
-                <fast-text-field type="text" required></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="text" required></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -442,9 +539,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the `value` property is not empty and `required` is true", async () => {
-            await page.setContent(`
-                <fast-text-field type="text" required value="some value"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="text" required value="some value"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -454,9 +553,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` is an empty string and `minlength` is set", async () => {
-            await page.setContent(`
-                <fast-text-field type="text" minlength="1"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="text" minlength="1"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -466,9 +567,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` has a length less than `minlength`", async () => {
-            await page.setContent(`
-                <fast-text-field type="text" minlength="6" value="value"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="text" minlength="6" value="value"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -478,9 +581,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` is empty and `maxlength` is set", async () => {
-            await page.setContent(`
-                <fast-text-field type="text" maxlength="0"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="text" maxlength="0"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -490,9 +595,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when `value` has a length which exceeds `maxlength`", async () => {
-            await page.setContent(`
-                <fast-text-field type="text" maxlength="4" value="value"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="text" maxlength="4" value="value"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -502,9 +609,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the `value` is shorter than `maxlength` and the element is `required`", async () => {
-            await page.setContent(`
-                <fast-text-field type="text" maxlength="6" required value="value"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="text" maxlength="6" required value="value"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -514,9 +623,11 @@ test.describe("TextField", () => {
         });
 
         test("should report valid validity when the `value` matches `pattern`", async () => {
-            await page.setContent(`
-                <fast-text-field type="text" pattern="value" required value="value"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="text" pattern="value" required value="value"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -526,9 +637,11 @@ test.describe("TextField", () => {
         });
 
         test("should report invalid validity when `value` does not match `pattern`", async () => {
-            await page.setContent(`
-                <fast-text-field type="text" pattern="value" required value="other value"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="text" pattern="value" required value="other value"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -540,9 +653,11 @@ test.describe("TextField", () => {
 
     test.describe("with a type of `email`", () => {
         test("should report valid validity when `value` is an empty string", async () => {
-            await page.setContent(`
-                <fast-text-field type="email"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="email"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -552,9 +667,11 @@ test.describe("TextField", () => {
         });
 
         test("should have invalid invalidity with a `typeMismatch` when `value` is not a valid email", async () => {
-            await page.setContent(`
-                <fast-text-field type="email" value="not an email"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="email" value="not an email"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -566,9 +683,11 @@ test.describe("TextField", () => {
 
     test.describe("with a type of `url`", () => {
         test("should report valid validity when `value` is an empty string", async () => {
-            await page.setContent(`
-                <fast-text-field type="url"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="url"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -578,9 +697,11 @@ test.describe("TextField", () => {
         });
 
         test("should have invalid invalidity with a `typeMismatch` when `value` is not a valid URL", async () => {
-            await page.setContent(`
-                <fast-text-field type="url" value="not a url"></fast-text-field>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-text-field type="url" value="not a url"></fast-text-field>
+                `;
+            });
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.pw.spec.ts
@@ -6,11 +6,14 @@ import { fixtureURL } from "../__test__/helpers.js";
 test.describe("Toolbar", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-toolbar");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("toolbar--toolbar"));
     });
@@ -24,17 +27,19 @@ test.describe("Toolbar", () => {
     });
 
     test("should move focus to its first focusable element when it receives focus", async () => {
-        await page.setContent(/* html */ `
-            <fast-toolbar>
-                <button>Button 1</button>
-                <button>Button 2</button>
-                <button>Button 3</button>
-                <button>Button 4</button>
-                <button>Button 5</button>
-                <button slot="start">Start Slot Button</button>
-                <button slot="end">End Slot Button</button>
-            </fast-toolbar>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-toolbar>
+                    <button>Button 1</button>
+                    <button>Button 2</button>
+                    <button>Button 3</button>
+                    <button>Button 4</button>
+                    <button>Button 5</button>
+                    <button slot="start">Start Slot Button</button>
+                    <button slot="end">End Slot Button</button>
+                </fast-toolbar>
+            `;
+        });
 
         const element = page.locator("fast-toolbar");
 
@@ -48,17 +53,19 @@ test.describe("Toolbar", () => {
     });
 
     test("should move focus to next element when keyboard incrementer is pressed", async () => {
-        await page.setContent(/* html */ `
-            <fast-toolbar>
-                <button slot="start">Start Slot Button</button>
-                <button>Button 1</button>
-                <button>Button 2</button>
-                <button>Button 3</button>
-                <button>Button 4</button>
-                <button>Button 5</button>
-                <button slot="end">End Slot Button</button>
-            </fast-toolbar>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-toolbar>
+                    <button slot="start">Start Slot Button</button>
+                    <button>Button 1</button>
+                    <button>Button 2</button>
+                    <button>Button 3</button>
+                    <button>Button 4</button>
+                    <button>Button 5</button>
+                    <button slot="end">End Slot Button</button>
+                </fast-toolbar>
+            `;
+        });
 
         const buttons = element.locator("button");
 
@@ -92,17 +99,19 @@ test.describe("Toolbar", () => {
     });
 
     test("should skip disabled elements when keyboard incrementer is pressed", async () => {
-        await page.setContent(/* html */ `
-            <fast-toolbar>
-                <button slot="start">Start Slot Button</button>
-                <button>Button 1</button>
-                <button>Button 2</button>
-                <button>Button 3</button>
-                <button>Button 4</button>
-                <button>Button 5</button>
-                <button slot="end">End Slot Button</button>
-            </fast-toolbar>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-toolbar>
+                    <button slot="start">Start Slot Button</button>
+                    <button>Button 1</button>
+                    <button>Button 2</button>
+                    <button>Button 3</button>
+                    <button>Button 4</button>
+                    <button>Button 5</button>
+                    <button slot="end">End Slot Button</button>
+                </fast-toolbar>
+            `;
+        });
 
         const buttons = element.locator("button:not([slot])");
 
@@ -136,17 +145,19 @@ test.describe("Toolbar", () => {
     });
 
     test("should skip hidden elements when keyboard incrementer is pressed", async () => {
-        await page.setContent(/* html */ `
-            <fast-toolbar>
-                <button slot="start">Start Slot Button</button>
-                <button>Button 1</button>
-                <button>Button 2</button>
-                <button>Button 3</button>
-                <button>Button 4</button>
-                <button>Button 5</button>
-                <button slot="end">End Slot Button</button>
-            </fast-toolbar>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-toolbar>
+                    <button slot="start">Start Slot Button</button>
+                    <button>Button 1</button>
+                    <button>Button 2</button>
+                    <button>Button 3</button>
+                    <button>Button 4</button>
+                    <button>Button 5</button>
+                    <button slot="end">End Slot Button</button>
+                </fast-toolbar>
+            `;
+        });
 
         const buttons = element.locator("button:not([slot])");
 
@@ -180,7 +191,9 @@ test.describe("Toolbar", () => {
     });
 
     test("should move focus to next element when keyboard incrementer is pressed and start slot content is added after connect", async () => {
-        await page.setContent(/* html */ `<fast-toolbar></fast-toolbar>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `<fast-toolbar></fast-toolbar>`;
+        });
 
         const button1 = element.locator("button", { hasText: "Button 1" });
 
@@ -210,7 +223,11 @@ test.describe("Toolbar", () => {
     });
 
     test("should move focus to next element when keyboard incrementer is pressed and end slot content is added after connect", async () => {
-        await page.setContent(/* html */ `<fast-toolbar></fast-toolbar>`);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-toolbar></fast-toolbar>
+            `;
+        });
 
         const endSlotButton = element.locator("button", {
             hasText: "End Slot Button",
@@ -241,17 +258,19 @@ test.describe("Toolbar", () => {
     });
 
     test("should maintain correct activeIndex when the set of focusable children changes", async () => {
-        await page.setContent(/* html */ `
-            <fast-toolbar>
-                <button slot="start">Start Slot Button</button>
-                <button>Button 1</button>
-                <button>Button 2</button>
-                <button>Button 3</button>
-                <button>Button 4</button>
-                <button>Button 5</button>
-                <button slot="end">End Slot Button</button>
-            </fast-toolbar>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-toolbar>
+                    <button slot="start">Start Slot Button</button>
+                    <button>Button 1</button>
+                    <button>Button 2</button>
+                    <button>Button 3</button>
+                    <button>Button 4</button>
+                    <button>Button 5</button>
+                    <button slot="end">End Slot Button</button>
+                </fast-toolbar>
+            `;
+        });
 
         const button1 = element.locator("button", { hasText: "Button 1" });
 
@@ -283,17 +302,19 @@ test.describe("Toolbar", () => {
     });
 
     test("should reset activeIndex to 0 when the focused item is no longer focusable", async () => {
-        await page.setContent(/* html */ `
-            <fast-toolbar>
-                <button slot="start">Start Slot Button</button>
-                <button>Button 1</button>
-                <button>Button 2</button>
-                <button>Button 3</button>
-                <button>Button 4</button>
-                <button>Button 5</button>
-                <button slot="end">End Slot Button</button>
-            </fast-toolbar>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-toolbar>
+                    <button slot="start">Start Slot Button</button>
+                    <button>Button 1</button>
+                    <button>Button 2</button>
+                    <button>Button 3</button>
+                    <button>Button 4</button>
+                    <button>Button 5</button>
+                    <button slot="end">End Slot Button</button>
+                </fast-toolbar>
+            `;
+        });
 
         const button1 = element.locator("button", { hasText: "Button 1" });
 

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
@@ -6,12 +6,15 @@ import type { FASTTooltip } from "./tooltip.js";
 test.describe("Tooltip", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
     let anchoredRegion: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-tooltip");
+
+        root = page.locator("#root");
 
         anchoredRegion = element.locator("fast-anchored-region");
 
@@ -145,10 +148,11 @@ test.describe("Tooltip", () => {
     test("should change anchor element when the `anchor` attribute changes", async () => {
         await page.goto(fixtureURL("tooltip--tooltip"));
 
-        await page.evaluate(() => {
+        await root.evaluate(node => {
             const newAnchor = document.createElement("div");
             newAnchor.id = "new-anchor";
-            document.getElementById("root")?.append(newAnchor);
+
+            node.append(newAnchor);
         });
 
         expect(

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
@@ -6,11 +6,14 @@ import type { FASTTreeItem } from "./tree-item.js";
 test.describe("TreeItem", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-tree-item");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
     });
@@ -20,19 +23,23 @@ test.describe("TreeItem", () => {
     });
 
     test("should include a role of `treeitem`", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>tree item</fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>tree item</fast-tree-item>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "treeitem");
     });
 
     test("should set the `aria-expanded` attribute equal to the `expanded` value when the tree item has children", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>
-                <fast-tree-item>tree item</fast-tree-item>
-            </fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>
+                    <fast-tree-item>tree item</fast-tree-item>
+                </fast-tree-item>
+            `;
+        });
 
         await element.first().evaluate<void, FASTTreeItem>(node => {
             node.expanded = true;
@@ -48,17 +55,21 @@ test.describe("TreeItem", () => {
     });
 
     test("should NOT set the `aria-expanded` attribute when the tree item has no children", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>tree item</fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>tree item</fast-tree-item>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-expanded");
     });
 
     test("should NOT set the `aria-expanded` attribute when the `expanded` state is true and the tree item has no children", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item expanded></fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item expanded></fast-tree-item>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-expanded");
 
@@ -69,26 +80,22 @@ test.describe("TreeItem", () => {
         await expect(element).not.hasAttribute("aria-expanded");
     });
 
-    test("should add a class of `expanded` when expanded is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item expanded></fast-tree-item>
-        `);
-
-        await expect(element).toHaveClass(/expanded/);
-    });
-
     test("should NOT set the `aria-selected` attribute if `selected` value is not provided", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>tree item</fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>tree item</fast-tree-item>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-selected");
     });
 
     test("should set the `aria-selected` attribute equal to the `selected` value", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>tree item</fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>tree item</fast-tree-item>
+            `;
+        });
 
         await element.evaluate<void, FASTTreeItem>(node => {
             node.selected = true;
@@ -103,18 +110,12 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("aria-selected", "false");
     });
 
-    test("should add a class of `selected` when selected is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item selected></fast-tree-item>
-        `);
-
-        await expect(element).toHaveClass(/selected/);
-    });
-
     test("should set the `aria-disabled` attribute equal to the `disabled` property", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>tree item</fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>tree item</fast-tree-item>
+            `;
+        });
 
         await expect(element).not.hasAttribute("aria-disabled");
 
@@ -131,18 +132,14 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test('should add a class of "disabled" when `disabled` is true', async () => {
-        await page.goto(fixtureURL("tree-view-tree-item--tree-item", { disabled: true }));
-
-        await expect(element).toHaveClass(/disabled/);
-    });
-
     test('should add a slot attribute of "item" to nested tree items', async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>
-                <fast-tree-item>tree item</fast-tree-item>
-            </fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>
+                    <fast-tree-item>tree item</fast-tree-item>
+                </fast-tree-item>
+            `;
+        });
 
         await expect(element.first().locator("fast-tree-item")).toHaveAttribute(
             "slot",
@@ -151,9 +148,11 @@ test.describe("TreeItem", () => {
     });
 
     test('should add a class of "nested" when the `nested` property is true', async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>tree item</fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>tree item</fast-tree-item>
+            `;
+        });
 
         await element.evaluate((node: FASTTreeItem) => {
             node.nested = true;
@@ -163,17 +162,21 @@ test.describe("TreeItem", () => {
     });
 
     test("should have a default `tabindex` attribute of -1", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>tree item</fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>tree item</fast-tree-item>
+            `;
+        });
 
         await expect(element).toHaveAttribute("tabindex", "-1");
     });
 
     test("should have a tabindex of 0 when focused", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>tree item</fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>tree item</fast-tree-item>
+            `;
+        });
 
         await element.focus();
 
@@ -181,11 +184,13 @@ test.describe("TreeItem", () => {
     });
 
     test("should render an element with a class of `expand-collapse-button` when nested tree items exist", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>
-                <fast-tree-item>tree item</fast-tree-item>
-            </fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>
+                    <fast-tree-item>tree item</fast-tree-item>
+                </fast-tree-item>
+            `;
+        });
 
         const expandCollapseButton = element.first().locator(".expand-collapse-button");
 
@@ -195,33 +200,39 @@ test.describe("TreeItem", () => {
     });
 
     test("should render an element with a role of `group` when nested tree items exist and `expanded` is true", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item expanded>
-                <fast-tree-item>tree item</fast-tree-item>
-            </fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item expanded>
+                    <fast-tree-item>tree item</fast-tree-item>
+                </fast-tree-item>
+            `;
+        });
 
         await expect(element.first().locator(".items")).toHaveAttribute("role", "group");
     });
 
     test("should NOT render an element with a role of `group` when nested tree items exist and `expanded` is false", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-item>
-                <fast-tree-item>tree item</fast-tree-item>
-            </fast-tree-item>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item>
+                    <fast-tree-item>tree item</fast-tree-item>
+                </fast-tree-item>
+            `;
+        });
 
         await expect(element.first().locator(".items")).toHaveCount(0);
     });
 
     test.describe("events", () => {
         test('should emit a "change" event when the `expanded` property changes', async () => {
-            await page.setContent(/* html */ `
-                <fast-tree-item>
-                    <fast-tree-item>tree item</fast-tree-item>
-                    <fast-tree-item>tree item</fast-tree-item>
-                </fast-tree-item>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-tree-item>
+                        <fast-tree-item>tree item</fast-tree-item>
+                        <fast-tree-item>tree item</fast-tree-item>
+                    </fast-tree-item>
+            `;
+            });
 
             const expandCollapseButton = element
                 .first()
@@ -235,47 +246,20 @@ test.describe("TreeItem", () => {
                         });
                     });
                 }),
-                expandCollapseButton.click(),
+                expandCollapseButton.evaluate((node: HTMLElement) => {
+                    return new Promise(requestAnimationFrame).then(() => node.click());
+                }),
             ]);
 
             expect(wasClicked).toBe(true);
         });
 
-        test("should toggle the expanded state when `expand-collapse-button` is clicked", async () => {
-            test.slow();
-            await page.setContent(/* html */ `
-                <fast-tree-item>
-                    <fast-tree-item>tree item</fast-tree-item>
-                    <fast-tree-item>tree item</fast-tree-item>
-                </fast-tree-item>
-            `);
-
-            const expandCollapseButton = element
-                .first()
-                .locator(".expand-collapse-button");
-
-            await expandCollapseButton.click();
-
-            await page.evaluate(() => new Promise(requestAnimationFrame));
-
-            await expect(element.first()).toHaveBooleanAttribute("expanded");
-
-            await expect(element.first()).toHaveAttribute("aria-expanded", "true");
-
-            await expandCollapseButton.click();
-
-            // FIXME: the state is not updated immediately
-            await page.evaluate(() => new Promise(requestAnimationFrame));
-
-            await expect(element.first()).not.hasAttribute("expanded");
-
-            await expect(element.first()).toHaveAttribute("aria-expanded", "false");
-        });
-
         test("should fire a selected change event when the `selected` property changes", async () => {
-            await page.setContent(/* html */ `
-                <fast-tree-item>tree item</fast-tree-item>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-tree-item>tree item</fast-tree-item>
+                `;
+            });
 
             const [wasChanged] = await Promise.all([
                 element.evaluate(node => {
@@ -294,9 +278,11 @@ test.describe("TreeItem", () => {
         });
 
         test("should NOT set `selected` state when a disabled element is clicked", async () => {
-            await page.setContent(/* html */ `
-                <fast-tree-item disabled>tree item</fast-tree-item>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-tree-item disabled>tree item</fast-tree-item>
+                `;
+            });
 
             await element.click({ force: true });
 
@@ -306,9 +292,11 @@ test.describe("TreeItem", () => {
         });
 
         test("should fire an event when expanded state changes via the `expanded` attribute", async () => {
-            await page.setContent(/* html */ `
-                <fast-tree-item>tree item</fast-tree-item>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-tree-item>tree item</fast-tree-item>
+                `;
+            });
 
             const [wasChanged] = await Promise.all([
                 element.evaluate(node => {
@@ -327,9 +315,11 @@ test.describe("TreeItem", () => {
         });
 
         test("should fire an event when selected state changes via the `selected` attribute", async () => {
-            await page.setContent(/* html */ `
-                <fast-tree-item>tree item</fast-tree-item>
-            `);
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
+                    <fast-tree-item>tree item</fast-tree-item>
+                `;
+            });
 
             const [wasChanged] = await Promise.all([
                 element.evaluate(node => {

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
@@ -6,11 +6,14 @@ import { fixtureURL } from "../__test__/helpers.js";
 test.describe("TreeView", () => {
     let page: Page;
     let element: Locator;
+    let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-tree-view");
+
+        root = page.locator("#root");
 
         await page.goto(fixtureURL("tree-view--tree-view"));
     });
@@ -20,33 +23,39 @@ test.describe("TreeView", () => {
     });
 
     test("should include a role of `tree`", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-view></fast-tree-view>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-view></fast-tree-view>
+            `;
+        });
 
         await expect(element).toHaveAttribute("role", "tree");
     });
 
     test("should set tree item `nested` properties to true if *any* tree item has nested items", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-view>
-                <fast-tree-item>
-                    Root item 1
-                    <fast-tree-item>Nested item 1</fast-tree-item>
-                    <fast-tree-item>Nested item 2</fast-tree-item>
-                    <fast-tree-item>Nested item 3</fast-tree-item>
-                </fast-tree-item>
-                <fast-tree-item>
-                    Root item 2
-                    <fast-tree-item>Nested item 1</fast-tree-item>
-                    <fast-tree-item>Nested item 2</fast-tree-item>
-                    <fast-tree-item>Nested item 3</fast-tree-item>
-                </fast-tree-item>
-                <fast-tree-item>
-                    Root item 3
-                </fast-tree-item>
-            </fast-tree-view>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-view>
+                    <fast-tree-item>
+                        Root item 1
+                        <fast-tree-item>Nested item 1</fast-tree-item>
+                        <fast-tree-item>Nested item 2</fast-tree-item>
+                        <fast-tree-item>Nested item 3</fast-tree-item>
+                    </fast-tree-item>
+                    <fast-tree-item>
+                        Root item 2
+                        <fast-tree-item>Nested item 1</fast-tree-item>
+                        <fast-tree-item>Nested item 2</fast-tree-item>
+                        <fast-tree-item>Nested item 3</fast-tree-item>
+                    </fast-tree-item>
+                    <fast-tree-item>
+                        Root item 3
+                    </fast-tree-item>
+                </fast-tree-view>
+            `;
+
+            return new Promise(requestAnimationFrame);
+        });
 
         const treeItems = element.locator("> fast-tree-item");
 
@@ -58,25 +67,27 @@ test.describe("TreeView", () => {
     });
 
     test("should set the selected state on tree items when a tree item is clicked", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-view>
-                <fast-tree-item>
-                    Root item 1
-                    <fast-tree-item>Nested item 1</fast-tree-item>
-                    <fast-tree-item>Nested item 2</fast-tree-item>
-                    <fast-tree-item>Nested item 3</fast-tree-item>
-                </fast-tree-item>
-                <fast-tree-item>
-                    Root item 2
-                    <fast-tree-item>Nested item 1</fast-tree-item>
-                    <fast-tree-item>Nested item 2</fast-tree-item>
-                    <fast-tree-item>Nested item 3</fast-tree-item>
-                </fast-tree-item>
-                <fast-tree-item>
-                    Root item 3
-                </fast-tree-item>
-            </fast-tree-view>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-view>
+                    <fast-tree-item>
+                        Root item 1
+                        <fast-tree-item>Nested item 1</fast-tree-item>
+                        <fast-tree-item>Nested item 2</fast-tree-item>
+                        <fast-tree-item>Nested item 3</fast-tree-item>
+                    </fast-tree-item>
+                    <fast-tree-item>
+                        Root item 2
+                        <fast-tree-item>Nested item 1</fast-tree-item>
+                        <fast-tree-item>Nested item 2</fast-tree-item>
+                        <fast-tree-item>Nested item 3</fast-tree-item>
+                    </fast-tree-item>
+                    <fast-tree-item>
+                        Root item 3
+                    </fast-tree-item>
+                </fast-tree-view>
+            `;
+        });
 
         const treeItems = element.locator("> fast-tree-item");
 
@@ -88,25 +99,29 @@ test.describe("TreeView", () => {
     });
 
     test("should only allow one tree item to be selected at a time", async () => {
-        await page.setContent(/* html */ `
-            <fast-tree-view>
-                <fast-tree-item>
-                    Root item 1
-                    <fast-tree-item>Nested item 1</fast-tree-item>
-                    <fast-tree-item>Nested item 2</fast-tree-item>
-                    <fast-tree-item>Nested item 3</fast-tree-item>
-                </fast-tree-item>
-                <fast-tree-item>
-                    Root item 2
-                    <fast-tree-item>Nested item 1</fast-tree-item>
-                    <fast-tree-item>Nested item 2</fast-tree-item>
-                    <fast-tree-item>Nested item 3</fast-tree-item>
-                </fast-tree-item>
-                <fast-tree-item>
-                    Root item 3
-                </fast-tree-item>
-            </fast-tree-view>
-        `);
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-view>
+                    <fast-tree-item>
+                        Root item 1
+                        <fast-tree-item>Nested item 1</fast-tree-item>
+                        <fast-tree-item>Nested item 2</fast-tree-item>
+                        <fast-tree-item>Nested item 3</fast-tree-item>
+                    </fast-tree-item>
+                    <fast-tree-item>
+                        Root item 2
+                        <fast-tree-item>Nested item 1</fast-tree-item>
+                        <fast-tree-item>Nested item 2</fast-tree-item>
+                        <fast-tree-item>Nested item 3</fast-tree-item>
+                    </fast-tree-item>
+                    <fast-tree-item>
+                        Root item 3
+                    </fast-tree-item>
+                </fast-tree-view>
+            `;
+
+            return new Promise(requestAnimationFrame);
+        });
 
         const treeItems = element.locator("> fast-tree-item");
 
@@ -123,5 +138,47 @@ test.describe("TreeView", () => {
 
             await expect(selectedTreeItems).toHaveCount(1);
         }
+    });
+
+    test("should toggle the expanded state when `expand-collapse-button` is clicked", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-view>
+                    <fast-tree-item>
+                        Root item 1
+                        <fast-tree-item>Nested item 1</fast-tree-item>
+                        <fast-tree-item>Nested item 2</fast-tree-item>
+                        <fast-tree-item>Nested item 3</fast-tree-item>
+                    </fast-tree-item>
+                    <fast-tree-item>
+                        Root item 2
+                        <fast-tree-item>Nested item 1</fast-tree-item>
+                        <fast-tree-item>Nested item 2</fast-tree-item>
+                        <fast-tree-item>Nested item 3</fast-tree-item>
+                    </fast-tree-item>
+                    <fast-tree-item>
+                        Root item 3
+                    </fast-tree-item>
+                </fast-tree-view>
+            `;
+
+            return new Promise(requestAnimationFrame);
+        });
+
+        const firstTreeItem = element.locator("> fast-tree-item").first();
+
+        const expandCollapseButton = firstTreeItem.locator(".expand-collapse-button");
+
+        await expandCollapseButton.click();
+
+        await expect(firstTreeItem).toHaveBooleanAttribute("expanded");
+
+        await expect(firstTreeItem).toHaveAttribute("aria-expanded", "true");
+
+        await expandCollapseButton.click();
+
+        await expect(firstTreeItem).toHaveJSProperty("expanded", false);
+
+        await expect(firstTreeItem).toHaveAttribute("aria-expanded", "false");
     });
 });

--- a/packages/web-components/fast-foundation/src/utilities/utilities.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/utilities/utilities.pw.spec.ts
@@ -22,7 +22,9 @@ test.describe("Utilities", () => {
         });
 
         test('should return "ltr" for an element with no `dir` attribute', async () => {
-            await page.setContent(`<div></div>`);
+            await page.setContent(/* html */ `
+                <div></div>
+            `);
 
             const element = page.locator("div");
 
@@ -32,7 +34,9 @@ test.describe("Utilities", () => {
         });
 
         test('should return "ltr" for an element with `dir` attribute of "ltr"', async () => {
-            await page.setContent(`<div dir="ltr"></div>`);
+            await page.setContent(/* html */ `
+                <div dir="ltr"></div>
+            `);
 
             const element = page.locator("div");
 
@@ -42,7 +46,9 @@ test.describe("Utilities", () => {
         });
 
         test('should return "rtl" for an element with a `dir` attribute of "rtl"', async () => {
-            await page.setContent(`<div dir="rtl"></div>`);
+            await page.setContent(/* html */ `
+                <div dir="rtl"></div>
+            `);
 
             const element = page.locator("div");
 
@@ -52,7 +58,9 @@ test.describe("Utilities", () => {
         });
 
         test('should return "ltr" for an element with a `dir` property of "ltr"', async () => {
-            await page.setContent(`<div></div>`);
+            await page.setContent(/* html */ `
+                <div></div>
+            `);
 
             const element = page.locator("div");
 
@@ -66,7 +74,9 @@ test.describe("Utilities", () => {
         });
 
         test('should return "rtl" for an element with a `dir` property of "rtl"', async () => {
-            await page.setContent(`<div></div>`);
+            await page.setContent(/* html */ `
+                <div></div>
+            `);
 
             const element = page.locator("div");
 
@@ -88,9 +98,11 @@ test.describe("Utilities", () => {
         });
 
         test("should return true when given an element node", async () => {
-            await page.setContent(`<span>
+            await page.setContent(/* html */ `
+                <span>
                     span
-                </span>`);
+                </span>
+            `);
 
             const element = page.locator("span");
 
@@ -98,9 +110,11 @@ test.describe("Utilities", () => {
         });
 
         test("should return true when given a text node", async () => {
-            await page.setContent(`<span>
+            await page.setContent(/* html */ `
+                <span>
                     text
-                </span>`);
+                </span>
+            `);
 
             const element = page.locator("span");
 
@@ -110,7 +124,9 @@ test.describe("Utilities", () => {
         });
 
         test("should return false when given a text node which only contains spaces", async () => {
-            await page.setContent(`<span>          </span>`);
+            await page.setContent(/* html */ `
+                <span>          </span>
+            `);
 
             const element = page.locator("span");
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

It turns out `page.setContent` removes all content from both the `body` as well as the `head`, which removes essential data such as default styling and some additional required data. This PR replaces the calls by targeting the storybook's built in `#root` element and replacing the content within.

## 📑 Test Plan

All tests should pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

This is needed for #6286 to move forward.