### PR TITLE
feat: prepare fast-element for scoped custom element registries

### DIFF
--- a/change/@microsoft-fast-element-320549b7-b0d8-43cd-be5a-87342681f7c2.json
+++ b/change/@microsoft-fast-element-320549b7-b0d8-43cd-be5a-87342681f7c2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: prepare fast-element for scoped element registries",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-320549b7-b0d8-43cd-be5a-87342681f7c2.json
+++ b/change/@microsoft-fast-element-320549b7-b0d8-43cd-be5a-87342681f7c2.json
@@ -3,5 +3,5 @@
   "comment": "feat: prepare fast-element for scoped element registries",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-f8e8f658-ebbb-4608-92f7-e26763d9aa4d.json
+++ b/change/@microsoft-fast-element-f8e8f658-ebbb-4608-92f7-e26763d9aa4d.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "persist totalAvailableViews to compare against removeIndex",
   "packageName": "@microsoft/fast-element",
   "email": "wendywendy@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -394,13 +394,14 @@ export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Co
     readonly attributes: ReadonlyArray<AttributeDefinition>;
     static compose<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(type: TType, nameOrDef?: string | PartialFASTElementDefinition): FASTElementDefinition<TType>;
     define(registry?: CustomElementRegistry): this;
-    readonly elementOptions?: ElementDefinitionOptions;
+    readonly elementOptions: ElementDefinitionOptions;
     static readonly getByType: (key: Function) => FASTElementDefinition<Constructable<HTMLElement>> | undefined;
     static readonly getForInstance: (object: any) => FASTElementDefinition<Constructable<HTMLElement>> | undefined;
     get isDefined(): boolean;
     readonly name: string;
     readonly propertyLookup: Record<string, AttributeDefinition>;
-    readonly shadowOptions?: ShadowRootInit;
+    readonly registry: CustomElementRegistry;
+    readonly shadowOptions?: ShadowRootOptions;
     readonly styles?: ElementStyles;
     readonly template?: ElementViewTemplate;
     readonly type: TType;
@@ -624,7 +625,8 @@ export interface PartialFASTElementDefinition {
     readonly attributes?: (AttributeConfiguration | string)[];
     readonly elementOptions?: ElementDefinitionOptions;
     readonly name: string;
-    readonly shadowOptions?: Partial<ShadowRootInit> | null;
+    readonly registry?: CustomElementRegistry;
+    readonly shadowOptions?: Partial<ShadowRootOptions> | null;
     readonly styles?: ComposableStyles | ComposableStyles[];
     readonly template?: ElementViewTemplate;
 }
@@ -681,6 +683,12 @@ export class RepeatDirective<TSource = any> implements HTMLDirective, ViewBehavi
 export interface RepeatOptions {
     positioning?: boolean;
     recycle?: boolean;
+}
+
+// @public
+export interface ShadowRootOptions extends ShadowRootInit {
+    // @beta
+    registry?: CustomElementRegistry;
 }
 
 // @public

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -14,6 +14,19 @@ const fastElementRegistry: TypeRegistry<FASTElementDefinition> = FAST.getById(
 );
 
 /**
+ * Shadow root initialization options.
+ * @public
+ */
+export interface ShadowRootOptions extends ShadowRootInit {
+    /**
+     * A registry that provides the custom elements visible
+     * from within this shadow root.
+     * @beta
+     */
+    registry?: CustomElementRegistry
+}
+
+/**
  * Represents metadata configuration for a custom element.
  * @public
  */
@@ -40,13 +53,23 @@ export interface PartialFASTElementDefinition {
 
     /**
      * Options controlling the creation of the custom element's shadow DOM.
+     * @remarks
+     * If not provided, defaults to an open shadow root. Provide null
+     * to render to the associated template to the light DOM instead.
      */
-    readonly shadowOptions?: Partial<ShadowRootInit> | null;
+    readonly shadowOptions?: Partial<ShadowRootOptions> | null;
 
     /**
      * Options controlling how the custom element is defined with the platform.
      */
     readonly elementOptions?: ElementDefinitionOptions;
+
+    /**
+     * The registry to register this component in by default.
+     * @remarks
+     * If not provided, defaults to the global registry.
+     */
+    readonly registry?: CustomElementRegistry;
 }
 
 /**
@@ -103,12 +126,17 @@ export class FASTElementDefinition<
     /**
      * Options controlling the creation of the custom element's shadow DOM.
      */
-    public readonly shadowOptions?: ShadowRootInit;
+    public readonly shadowOptions?: ShadowRootOptions;
 
     /**
      * Options controlling how the custom element is defined with the platform.
      */
-    public readonly elementOptions?: ElementDefinitionOptions;
+    public readonly elementOptions: ElementDefinitionOptions;
+
+    /**
+     * The registry to register this component in by default.
+     */
+    readonly registry: CustomElementRegistry;
 
     private constructor(
         type: TType,
@@ -121,6 +149,7 @@ export class FASTElementDefinition<
         this.type = type;
         this.name = nameOrConfig.name;
         this.template = nameOrConfig.template;
+        this.registry = nameOrConfig.registry ?? customElements;
 
         const proto = type.prototype;
         const attributes = AttributeDefinition.collect(type, nameOrConfig.attributes);
@@ -168,7 +197,7 @@ export class FASTElementDefinition<
      * @remarks
      * This operation is idempotent per registry.
      */
-    public define(registry: CustomElementRegistry = customElements): this {
+    public define(registry: CustomElementRegistry = this.registry): this {
         const type = this.type;
 
         if (!registry.get(this.name)) {

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -23,7 +23,7 @@ export interface ShadowRootOptions extends ShadowRootInit {
      * from within this shadow root.
      * @beta
      */
-    registry?: CustomElementRegistry
+    registry?: CustomElementRegistry;
 }
 
 /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR makes a few changes to `fast-element` that enable [Scoped Custom Elements](https://github.com/WICG/webcomponents/blob/gh-pages/proposals/Scoped-Custom-Element-Registries.md). Note that this feature is not yet implemented in any browser. I'm doing this so that polyfills for the feature can be used with FAST and so that we are ready to go as soon as Chromium has a prototype available behind a flag.

### 🎫 Issues

* Closes #6327 

## 👩‍💻 Reviewer Notes

The changes required to enable Scoped Custom Elements are pretty minor. There are two parts:

1. Enable a registry to be passed to the shadow dom that contains only the elements that should be visible in the shadow dom.
2. Enable a default registry to be associated with an element definition. This allows the developer to specify which registry to define the component itself with by default.

To enable passing a registry to shadow dom, we just need to enable developers to associate that with the shadow root init object. The change I made was to create a new interface that inherits from the TS-defined interface, so that I could add the `registry` property. So, no change to functionality, only to types. The platform/polyfill will handle the rest.

To enable changing the default registry, the decorator and the define/compose APIs now take an optional `registry` property. Technically, the existing API was already registry independent. So, to support this new configuration, I just had to make some small changes to how the default define parameter was supplied.


## 📑 Test Plan

No tests for scoped registries since those don't exist yet. The first scenario above should be handled automatically since we already pass the shadow dom init along to the platform API. The second scenario listed above is tested via existing tests.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

The new shadow root init option property is marked as beta and will remain that way until the proposal reaches full consensus and turns into an official spec. At that time, we'll remove the beta designation (or the entire interface depending on what TS does). If the proposal evolves to rename that property or handle registry association in some other way, then I'll update this implementation.