### PR TITLE
wait for stable state in flaky playwright tests

### DIFF
--- a/change/@microsoft-fast-foundation-5689d6c8-9ebe-419b-9297-293568866663.json
+++ b/change/@microsoft-fast-foundation-5689d6c8-9ebe-419b-9297-293568866663.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "adjust tests to wait for stable state when needed",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-foundation/playwright.config.ts
+++ b/packages/web-components/fast-foundation/playwright.config.ts
@@ -35,19 +35,15 @@ expect.extend({
 
         name = name.trim();
 
-        const hasAttribute = await recieved.evaluate(
-            (node, name) => node.hasAttribute(name),
-            name
-        );
+        await (await recieved.elementHandle())?.waitForElementState("stable");
 
-        const attributeValue = await recieved.evaluate(
-            (node, name) => node.getAttribute(name),
-            name
-        );
+        const [hasAttribute, attributeValue] = await recieved.evaluate((node, name) => {
+            return [node.hasAttribute(name), node.getAttribute(name)];
+        }, name);
 
         if (this.isNot) {
             return {
-                pass: !!hasAttribute,
+                pass: hasAttribute,
                 message: () => `expected ${name} to not be present`,
             };
         }
@@ -61,12 +57,15 @@ expect.extend({
                 options
             )}
 
-Expected: not ${this.utils.printExpected(name)}
-Received: ${this.utils.printReceived(attributeValue)}`,
+expected ${recieved} to have boolean attribute \`${name}\``,
         };
     },
 
     async hasAttribute(recieved: Locator, attribute: string) {
+        if (await recieved.isVisible()) {
+            await (await recieved.elementHandle())?.waitForElementState("stable");
+        }
+
         const pass = await recieved.evaluate(
             (node, attribute) => node.hasAttribute(attribute),
             attribute

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -142,7 +142,6 @@ test.describe("Accordion", () => {
 
         await secondItemButton.evaluate(node => {
             node.dispatchEvent(new MouseEvent("click", { bubbles: true }));
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(firstItem).not.toHaveBooleanAttribute("expanded");

--- a/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
@@ -37,7 +37,6 @@ test.describe("Button", () => {
 
         await element.evaluate(node => {
             node.toggleAttribute("disabled");
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(control).not.toHaveBooleanAttribute("disabled");
@@ -54,7 +53,6 @@ test.describe("Button", () => {
 
         await element.evaluate(node => {
             node.toggleAttribute("formnovalidate");
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(control).not.toHaveBooleanAttribute("formnovalidate");
@@ -136,7 +134,6 @@ test.describe("Button", () => {
 
         await element.evaluate(node => {
             node.toggleAttribute("autofocus");
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(control).not.toHaveBooleanAttribute("autofocus");
@@ -206,13 +203,15 @@ test.describe("Button", () => {
 
         const content = element.locator(".content");
 
-        const [wasClicked] = await Promise.all([
+        const [wasNotClicked] = await Promise.all([
             element.evaluate(node =>
                 Promise.race([
                     new Promise(resolve => {
                         node.addEventListener("click", () => resolve(false));
                     }),
-                    new Promise(requestAnimationFrame).then(() => Promise.resolve(true)),
+                    new Promise(resolve =>
+                        requestAnimationFrame(() => setTimeout(() => resolve(true)))
+                    ),
                 ])
             ),
 
@@ -221,13 +220,15 @@ test.describe("Button", () => {
                     new Promise(resolve => {
                         node.addEventListener("click", () => resolve(false));
                     }),
-                    new Promise(requestAnimationFrame).then(() => Promise.resolve(true)),
+                    new Promise(resolve =>
+                        requestAnimationFrame(() => setTimeout(() => resolve(true)))
+                    ),
                 ])
             ),
 
             element.click(),
         ]);
 
-        expect(wasClicked).not.toBeFalsy();
+        expect(wasNotClicked).toBeTruthy();
     });
 });

--- a/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
@@ -262,7 +262,7 @@ test.describe("Combobox", () => {
             node.open = true;
         });
 
-        expect(await element.getAttribute("open")).toBeFalsy();
+        await expect(element).toHaveBooleanAttribute("open");
 
         await expect(listbox).toBeVisible();
     });
@@ -285,7 +285,7 @@ test.describe("Combobox", () => {
 
                 await element.locator(".listbox").waitFor({ state: "visible" });
 
-                expect(await element.getAttribute("open")).toBe("");
+                await expect(element).toHaveBooleanAttribute("open");
 
                 const [wasChanged] = await Promise.all([
                     element.evaluate(node =>

--- a/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
@@ -39,14 +39,12 @@ test.describe("Dialog", () => {
     test("should set the `hidden` attribute to equal the value of the `hidden` property", async () => {
         await element.evaluate((node: FASTDialog) => {
             node.hidden = true;
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(element).toHaveBooleanAttribute("hidden");
 
         await element.evaluate((node: FASTDialog) => {
             node.hidden = false;
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(element).not.toHaveBooleanAttribute("hidden");
@@ -97,7 +95,6 @@ test.describe("Dialog", () => {
 
         await element.evaluate((node: FASTDialog) => {
             node.modal = false;
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(control).not.hasAttribute("aria-modal");
@@ -128,14 +125,12 @@ test.describe("Dialog", () => {
 
         await element.evaluate((node: FASTDialog) => {
             node.noFocusTrap = true;
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(element).toHaveBooleanAttribute("no-focus-trap");
 
         await element.evaluate((node: FASTDialog) => {
             node.noFocusTrap = false;
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(element).not.toHaveBooleanAttribute("no-focus-trap");
@@ -182,7 +177,7 @@ test.describe("Dialog", () => {
             `;
         });
 
-        await overlay.waitFor({ state: "visible" });
+        await (await overlay.elementHandle())?.waitForElementState("stable");
 
         const [wasDismissed] = await Promise.all([
             element.evaluate(
@@ -205,7 +200,7 @@ test.describe("Dialog", () => {
             `;
         });
 
-        await overlay.waitFor({ state: "visible" });
+        await (await overlay.elementHandle())?.waitForElementState("stable");
 
         const [wasDismissed] = await Promise.all([
             element.evaluate(
@@ -228,7 +223,7 @@ test.describe("Dialog", () => {
             `;
         });
 
-        await overlay.waitFor({ state: "visible" });
+        await (await overlay.elementHandle())?.waitForElementState("stable");
 
         const [wasDismissed] = await Promise.all([
             element.evaluate(
@@ -238,7 +233,8 @@ test.describe("Dialog", () => {
                     })
             ),
             element
-                .evaluate(() => new Promise(requestAnimationFrame))
+                .elementHandle()
+                .then(handle => handle?.waitForElementState("stable"))
                 .then(() => page.keyboard.press("Escape")),
         ]);
 

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.pw.spec.ts
@@ -32,14 +32,12 @@ test.describe("Disclosure", () => {
 
             await element.evaluate((node: FASTDisclosure) => {
                 node.expanded = true;
-                return new Promise(requestAnimationFrame);
             });
 
             await expect(element).toHaveBooleanAttribute("expanded");
 
             await element.evaluate((node: FASTDisclosure) => {
                 node.expanded = false;
-                return new Promise(requestAnimationFrame);
             });
 
             await expect(element).not.toHaveBooleanAttribute("expanded");

--- a/packages/web-components/fast-foundation/src/flipper/flipper.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.pw.spec.ts
@@ -73,8 +73,9 @@ test.describe("Flipper", () => {
 
         await element.evaluate((node: FASTFlipper) => {
             node.disabled = false;
-            return new Promise(requestAnimationFrame);
         });
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         await expect(element).not.hasAttribute("aria-disabled");
     });
@@ -90,8 +91,9 @@ test.describe("Flipper", () => {
 
         await element.evaluate((node: FASTFlipper) => {
             node.hiddenFromAT = false;
-            return new Promise(requestAnimationFrame);
         });
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         await expect(element).toHaveAttribute("tabindex", "0");
 

--- a/packages/web-components/fast-foundation/src/listbox/listbox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.pw.spec.ts
@@ -46,7 +46,7 @@ test.describe("Listbox", () => {
             `;
         });
 
-        expect(await element.getAttribute("tabindex")).toBeNull();
+        await expect(element).not.hasAttribute("tabindex");
     });
 
     test("should select nothing when no options have the `selected` attribute", async () => {
@@ -258,9 +258,8 @@ test.describe("Listbox", () => {
 
         await element.evaluate((node: FASTListboxElement) => {
             node.multiple = false;
-            return new Promise(requestAnimationFrame);
         });
 
-        expect(await element.getAttribute("aria-multiselectable")).toBeNull();
+        await expect(element).not.hasAttribute("aria-multiselectable");
     });
 });

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.pw.spec.ts
@@ -113,14 +113,14 @@ test.describe("Menu item", () => {
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
-    test("should aria-checked attribute of radio item to true when clicked", async () => {
+    test("should set the `aria-checked` attribute of radio item to true when clicked", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu-item role="menuitemradio">Menu item</fast-menu-item>
             `;
         });
 
-        expect(await element.getAttribute("aria-checked")).toBe(null);
+        await expect(element).not.hasAttribute("aria-checked");
 
         await element.click();
 

--- a/packages/web-components/fast-foundation/src/menu/menu.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.pw.spec.ts
@@ -250,8 +250,9 @@ test.describe("Menu", () => {
 
         await element.evaluate(node => {
             node.focus();
-            return new Promise(requestAnimationFrame);
         });
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         await expect(menuItems.nth(0)).toBeFocused();
 
@@ -277,8 +278,9 @@ test.describe("Menu", () => {
 
         await menuItems.nth(2).evaluate(node => {
             node.removeAttribute("hidden");
-            return new Promise(requestAnimationFrame);
         });
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         await element.press("ArrowDown");
 
@@ -446,9 +448,10 @@ test.describe("Menu", () => {
             window.focus();
         });
 
+        await (await element.elementHandle())?.waitForElementState("stable");
+
         await element.evaluate(node => {
             node.focus();
-            return new Promise(requestAnimationFrame);
         });
 
         await expect(menuItems.nth(0)).toBeFocused({ timeout: 500 });

--- a/packages/web-components/fast-foundation/src/number-field/number-field.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.pw.spec.ts
@@ -138,8 +138,9 @@ test.describe("NumberField", () => {
 
         await element.evaluate((node: FASTNumberField) => {
             node.max = 10;
-            return new Promise(requestAnimationFrame);
         });
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         await expect(element).toHaveJSProperty("value", "10");
     });

--- a/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
@@ -257,15 +257,15 @@ test.describe("Search", () => {
 
             await expect(element).toHaveJSProperty("value", "test value");
 
-            expect(await element.getAttribute("value")).toBeNull();
+            await expect(element).not.hasAttribute("value");
 
             await form.evaluate<void, HTMLFormElement>(node => {
                 node.reset();
             });
 
-            await expect(element).toHaveJSProperty("value", "");
+            await expect(element).not.hasAttribute("value");
 
-            expect(await element.getAttribute("value")).toBeNull();
+            await expect(element).toHaveJSProperty("value", "");
         });
 
         test("should reset its `value` property to the value of the value attribute if it is set", async () => {

--- a/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
@@ -98,7 +98,7 @@ test.describe("Select", () => {
             `;
         });
 
-        expect(await element.getAttribute("tabindex")).toBeNull();
+        await expect(element).not.hasAttribute("tabindex");
     });
 
     test("should set its value to the first enabled option when disabled", async () => {
@@ -310,7 +310,11 @@ test.describe("Select", () => {
                                         resolve(eventName)
                                     )
                                 ),
-                                new Promise(requestAnimationFrame),
+                                new Promise(resolve =>
+                                    requestAnimationFrame(() =>
+                                        setTimeout(() => resolve(false))
+                                    )
+                                ),
                             ]),
                         eventName
                     ),
@@ -369,7 +373,11 @@ test.describe("Select", () => {
                                         resolve(eventName)
                                     )
                                 ),
-                                new Promise(requestAnimationFrame),
+                                new Promise(resolve =>
+                                    requestAnimationFrame(() =>
+                                        setTimeout(() => resolve(false))
+                                    )
+                                ),
                             ]),
                         eventName
                     ),

--- a/packages/web-components/fast-foundation/src/slider/slider.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.pw.spec.ts
@@ -71,7 +71,7 @@ test.describe("Slider", () => {
             `;
         });
 
-        expect(await element.getAttribute("aria-disabled")).toBe(null);
+        await expect(element).not.hasAttribute("aria-disabled");
     });
 
     test("should set a default `aria-orientation` value when `orientation` is not defined", async () => {
@@ -94,7 +94,7 @@ test.describe("Slider", () => {
             `;
         });
 
-        expect(await element.getAttribute("aria-readonly")).toBe(null);
+        await expect(element).not.hasAttribute("aria-readonly");
     });
 
     test("should initialize to the initial value if no value property is set", async () => {

--- a/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
@@ -250,7 +250,6 @@ test.describe("Tabs", () => {
 
             await element.evaluate((node: FASTTabs, secondTabId) => {
                 node.activeid = secondTabId;
-                return new Promise(requestAnimationFrame);
             }, secondTabId);
 
             await expect(secondTab).toHaveAttribute("aria-selected", "true");
@@ -333,12 +332,11 @@ test.describe("Tabs", () => {
 
             const secondTabId = (await secondTab.getAttribute("id")) ?? "";
 
+            const tabPanels = element.locator("fast-tab-panel");
+
             await element.evaluate((node: FASTTabs, secondTabId) => {
                 node.activeid = secondTabId;
-                return new Promise(requestAnimationFrame);
             }, secondTabId);
-
-            const tabPanels = element.locator("fast-tab-panel");
 
             await expect(tabPanels.nth(1)).toHaveAttribute(
                 "aria-labelledby",
@@ -409,17 +407,21 @@ test.describe("Tabs", () => {
                     <fast-tab-panel>Tab panel three</fast-tab-panel>
                 </fast-tabs>
             `;
-
-            return new Promise(requestAnimationFrame);
         });
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         const firstTab = tabs.nth(0);
 
-        const firstTabId = (await firstTab.getAttribute("id")) ?? "";
+        const firstTabId = await firstTab.getAttribute("id");
+
+        expect(firstTabId).toBe("tab-1");
 
         await element.evaluate((node: FASTTabs, firstTabId) => {
-            node.activeid = firstTabId;
+            node.activeid = `${firstTabId}`;
         }, firstTabId);
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         await expect(element).toHaveJSProperty("activeid", firstTabId);
 
@@ -428,6 +430,8 @@ test.describe("Tabs", () => {
         await secondTab.evaluate((node: FASTTab) => {
             node.disabled = true;
         });
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         await secondTab.click({ force: true });
 
@@ -439,15 +443,15 @@ test.describe("Tabs", () => {
 
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
-            <fast-tabs>
-                <fast-tab>Tab one</fast-tab>
-                <fast-tab disabled>Tab two</fast-tab>
-                <fast-tab>Tab three</fast-tab>
-                <fast-tab-panel>Tab panel one</fast-tab-panel>
-                <fast-tab-panel>Tab panel two</fast-tab-panel>
-                <fast-tab-panel>Tab panel three</fast-tab-panel>
-            </fast-tabs>
-        `;
+                <fast-tabs>
+                    <fast-tab>Tab one</fast-tab>
+                    <fast-tab disabled>Tab two</fast-tab>
+                    <fast-tab>Tab three</fast-tab>
+                    <fast-tab-panel>Tab panel one</fast-tab-panel>
+                    <fast-tab-panel>Tab panel two</fast-tab-panel>
+                    <fast-tab-panel>Tab panel three</fast-tab-panel>
+                </fast-tabs>
+            `;
         });
 
         const firstTab = tabs.nth(0);
@@ -470,8 +474,9 @@ test.describe("Tabs", () => {
 
         await secondTab.evaluate((node: FASTTab) => {
             node.disabled = false;
-            return new Promise(requestAnimationFrame);
         });
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         await secondTab.click({ force: true });
 

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
@@ -234,21 +234,23 @@ test.describe("TreeItem", () => {
             `;
             });
 
-            const expandCollapseButton = element
-                .first()
-                .locator(".expand-collapse-button");
+            const firstElement = element.first();
+
+            const expandCollapseButton = firstElement.locator(".expand-collapse-button");
 
             const [wasClicked] = await Promise.all([
-                element.first().evaluate(node => {
+                firstElement.evaluate(node => {
                     return new Promise(resolve => {
                         node.addEventListener("expanded-change", () => {
                             resolve(true);
                         });
                     });
                 }),
-                expandCollapseButton.evaluate((node: HTMLElement) => {
-                    return new Promise(requestAnimationFrame).then(() => node.click());
-                }),
+                firstElement.elementHandle().then(handle =>
+                    handle?.waitForElementState("stable").then(() => {
+                        expandCollapseButton.first().click();
+                    })
+                ),
             ]);
 
             expect(wasClicked).toBe(true);
@@ -288,7 +290,7 @@ test.describe("TreeItem", () => {
 
             await expect(element).not.toHaveBooleanAttribute("selected");
 
-            expect(await element.getAttribute("aria-selected")).toBeNull();
+            await expect(element).not.hasAttribute("aria-selected");
         });
 
         test("should fire an event when expanded state changes via the `expanded` attribute", async () => {

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
@@ -53,9 +53,9 @@ test.describe("TreeView", () => {
                     </fast-tree-item>
                 </fast-tree-view>
             `;
-
-            return new Promise(requestAnimationFrame);
         });
+
+        await (await element.elementHandle())?.waitForElementState("stable");
 
         const treeItems = element.locator("> fast-tree-item");
 
@@ -119,8 +119,6 @@ test.describe("TreeView", () => {
                     </fast-tree-item>
                 </fast-tree-view>
             `;
-
-            return new Promise(requestAnimationFrame);
         });
 
         const treeItems = element.locator("> fast-tree-item");
@@ -161,8 +159,6 @@ test.describe("TreeView", () => {
                     </fast-tree-item>
                 </fast-tree-view>
             `;
-
-            return new Promise(requestAnimationFrame);
         });
 
         const firstTreeItem = element.locator("> fast-tree-item").first();


### PR DESCRIPTION
# Pull Request

## 📖 Description

Allows flaky tests to wait for a `stable` state.

## 👩‍💻 Reviewer Notes

> Element is considered stable when it has maintained the same bounding box for at least two consecutive animation frames.

https://playwright.dev/docs/actionability

## 📑 Test Plan

All tests should pass in all pipelines.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
