### PR TITLE
fix: do not crash when null/undefined is provided literally in templates

### DIFF
--- a/change/@microsoft-fast-element-c12038ed-87b3-4493-86dc-c51a5029f7db.json
+++ b/change/@microsoft-fast-element-c12038ed-87b3-4493-86dc-c51a5029f7db.json
@@ -3,5 +3,5 @@
   "comment": "fix: do not crash when null/undefined is provided literally in templates",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-c12038ed-87b3-4493-86dc-c51a5029f7db.json
+++ b/change/@microsoft-fast-element-c12038ed-87b3-4493-86dc-c51a5029f7db.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: do not crash when null/undefined is provided literally in templates",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/platform.spec.ts
+++ b/packages/web-components/fast-element/src/platform.spec.ts
@@ -1,5 +1,6 @@
 import { expect } from "chai";
 import type { FASTGlobal } from "./interfaces.js";
+import { createTypeRegistry, TypeDefinition } from "./platform.js";
 
 declare const FAST: FASTGlobal;
 
@@ -30,5 +31,21 @@ describe("The FAST global", () => {
 
             expect(found).to.be.null;
         });
+    });
+});
+
+describe("TypeRegistry", () => {
+    it("returns undefined when getting the definition for null", () => {
+        const reg = createTypeRegistry<TypeDefinition>();
+        const value = reg.getForInstance(null);
+
+        expect(value).to.be.undefined;
+    });
+
+    it("returns undefined when getting the definition for undefined", () => {
+        const reg = createTypeRegistry<TypeDefinition>();
+        const value = reg.getForInstance(undefined);
+
+        expect(value).to.be.undefined;
     });
 });

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -96,6 +96,10 @@ export function createTypeRegistry<TDefinition extends TypeDefinition>(): TypeRe
             return typeToDefinition.get(key);
         },
         getForInstance(object: any): TDefinition | undefined {
+            if (object === null || object === void 0) {
+                return void 0;
+            }
+
             return typeToDefinition.get(object.constructor);
         },
     });


### PR DESCRIPTION
# Pull Request

## 📖 Description

We discovered an issue with templates that causes an exception to be thrown when a `null` or `undefined` value is provided literally in the template. This happens because the `html` helper is attempting to determine if the value is a directive. The directive registry then attempts to get the constructor of `null`/`undefined` in order to do the lookup, which fails.

### 🎫 Issues

Discovered today and fast tracking the fix.

## 👩‍💻 Reviewer Notes

This fix was simple. We just needed to detect the null/undefined scenario.

## 📑 Test Plan

I added a couple of tests to verify the bug and the fix.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

It would be nice to have more tests for the type registration helper in the future. Fortunately, a lot of that is tested transitively through other scenarios at the moment.