### PR TITLE
fix: correct view state when processing unbindables during rebind

### DIFF
--- a/change/@microsoft-fast-element-196bc410-6c26-4cfa-8ba7-8b51a66c2772.json
+++ b/change/@microsoft-fast-element-196bc410-6c26-4cfa-8ba7-8b51a66c2772.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: correct view state when processing unbindables during rebind",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-196bc410-6c26-4cfa-8ba7-8b51a66c2772.json
+++ b/change/@microsoft-fast-element-196bc410-6c26-4cfa-8ba7-8b51a66c2772.json
@@ -3,5 +3,5 @@
   "comment": "fix: correct view state when processing unbindables during rebind",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/src/templating/view.ts
+++ b/packages/web-components/fast-element/src/templating/view.ts
@@ -296,16 +296,14 @@ export class HTMLView<TSource = any, TParent = any>
      * @param context - The execution context to run the behaviors within.
      */
     public bind(source: TSource): void {
-        const oldSource = this.source;
-
-        if (oldSource === source) {
+        if (this.source === source) {
             return;
         }
 
         let behaviors = this.behaviors;
-        this.source = source;
 
         if (behaviors === null) {
+            this.source = source;
             this.behaviors = behaviors = new Array<ViewBehavior>(this.factories.length);
             const factories = this.factories;
 
@@ -315,9 +313,12 @@ export class HTMLView<TSource = any, TParent = any>
                 behaviors[i] = behavior;
             }
         } else {
-            if (oldSource !== null) {
+            if (this.source !== null) {
                 this.evaluateUnbindables();
             }
+
+            this.isBound = false;
+            this.source = source;
 
             for (let i = 0, ii = behaviors.length; i < ii; ++i) {
                 behaviors[i].bind(this);
@@ -331,13 +332,7 @@ export class HTMLView<TSource = any, TParent = any>
      * Unbinds a view's behaviors from its binding source.
      */
     public unbind(): void {
-        if (!this.isBound) {
-            return;
-        }
-
-        const oldSource = this.source;
-
-        if (oldSource === null) {
+        if (!this.isBound || this.source === null) {
             return;
         }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

When rebinding a view (as is often the case with repeat), the view's state was incorrect while processing the unbindables and the rebound behaviors.

### 🎫 Issues

No issues. The problem was recently discovered and needed a rapid fix.

## 👩‍💻 Reviewer Notes

The `source` property was being set too soon when rebinding, causing behaviors that needed to unbind themselves to get the new source rather than the source they had been bound to. Then, when rebinding the behaviors the `isBound` property was `true` when it should have been `false` at that point, causing some behaviors to not add their needed unbindable behavior (assuming it had already been added when first bound).

Both of these issues were fixed pretty easily by moving the source setting to the right location for rebind scenarios and then ensuring that `isBound` is set to false before rebinding.

## 📑 Test Plan

I added a test to ensure that during a rebind operation the `source` and `isBound` states are correct at the right times from within a behavior.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

None at this time.