### PR TITLE
fix: ensure composed templates receive the existing execution context

### DIFF
--- a/change/@microsoft-fast-element-afea72fb-a645-4bab-ae21-de581d7d064d.json
+++ b/change/@microsoft-fast-element-afea72fb-a645-4bab-ae21-de581d7d064d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: ensure composed templates receive the existing execution context",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-afea72fb-a645-4bab-ae21-de581d7d064d.json
+++ b/change/@microsoft-fast-element-afea72fb-a645-4bab-ae21-de581d7d064d.json
@@ -3,5 +3,5 @@
   "comment": "fix: ensure composed templates receive the existing execution context",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -185,7 +185,7 @@ export interface ContentTemplate {
 
 // @public
 export interface ContentView {
-    bind(source: any): void;
+    bind(source: any, context?: ExecutionContext): void;
     // (undocumented)
     readonly context: ExecutionContext;
     insertBefore(node: Node): void;
@@ -499,8 +499,8 @@ export interface HTMLTemplateCompilationResult<TSource = any, TParent = any> {
 export class HTMLView<TSource = any, TParent = any> implements ElementView<TSource, TParent>, SyntheticView<TSource, TParent>, ExecutionContext<TParent> {
     constructor(fragment: DocumentFragment, factories: ReadonlyArray<ViewBehaviorFactory>, targets: ViewBehaviorTargets);
     appendTo(node: Node): void;
-    bind(source: TSource): void;
-    get context(): ExecutionContext<TParent>;
+    bind(source: TSource, context?: ExecutionContext<TParent>): void;
+    context: ExecutionContext<TParent>;
     dispose(): void;
     static disposeContiguousBatch(views: SyntheticView[]): void;
     get event(): Event;
@@ -509,7 +509,6 @@ export class HTMLView<TSource = any, TParent = any> implements ElementView<TSour
     firstChild: Node;
     index: number;
     insertBefore(node: Node): void;
-    // (undocumented)
     isBound: boolean;
     get isEven(): boolean;
     get isFirst(): boolean;
@@ -525,9 +524,8 @@ export class HTMLView<TSource = any, TParent = any> implements ElementView<TSour
     readonly parent: TParent;
     readonly parentContext: ExecutionContext<TParent>;
     remove(): void;
-    // (undocumented)
-    selfContained: boolean;
     source: TSource | null;
+    readonly sourceLifetime: SourceLifetime;
     // (undocumented)
     readonly targets: ViewBehaviorTargets;
     unbind(): void;
@@ -870,7 +868,7 @@ export interface ValueConverter {
 
 // @public
 export interface View<TSource = any, TParent = any> extends Disposable {
-    bind(source: TSource): void;
+    bind(source: TSource, context?: ExecutionContext<TParent>): void;
     readonly context: ExecutionContext<TParent>;
     readonly source: TSource | null;
     unbind(): void;

--- a/packages/web-components/fast-element/src/templating/binding.spec.ts
+++ b/packages/web-components/fast-element/src/templating/binding.spec.ts
@@ -271,6 +271,19 @@ describe("The HTML binding directive", () => {
             expect(toHTML(parentNode)).to.equal(`This is a template. value`);
         });
 
+        it("pipes the existing execution context through to the new view", () => {
+            const { behavior, parentNode, targets } = contentBinding("computedValue");
+            const template = html`This is a template. ${(x, c) => c.parent.testProp}`;
+            const model = new Model(template);
+            const controller = createController(model, targets);
+            const parent = { testProp: "testing..." };
+
+            controller.context.parent = parent;
+            behavior.bind(controller);
+
+            expect(toHTML(parentNode)).to.equal(`This is a template. testing...`);
+        });
+
         it("allows interpolated HTML tags in templates", async () => {
             const { behavior, parentNode, targets } = contentBinding();
             const template = html`${x => html`<${x.knownValue}>Hi there!</${x.knownValue}>`}`;
@@ -287,7 +300,7 @@ describe("The HTML binding directive", () => {
             await Updates.next()
 
             expect(toHTML(parentNode)).to.equal(`<a>Hi there!</a>`);
-        })
+        });
     })
 
     context("when unbinding template content", () => {

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -79,7 +79,7 @@ export interface ContentView {
      * @param source - The binding source for the view's binding behaviors.
      * @param context - The execution context to run the view within.
      */
-    bind(source: any): void;
+    bind(source: any, context?: ExecutionContext): void;
 
     /**
      * Unbinds a view's behaviors from its binding source and context.
@@ -160,13 +160,13 @@ function updateContent(
         // and that there's actually no need to compose it.
         if (!view.isComposed) {
             view.isComposed = true;
-            view.bind(controller.source);
+            view.bind(controller.source, controller.context);
             view.insertBefore(target);
             target.$fastView = view;
             target.$fastTemplate = value;
         } else if (view.needsBindOnly) {
             view.needsBindOnly = false;
-            view.bind(controller.source);
+            view.bind(controller.source, controller.context);
         }
     } else {
         const view = target.$fastView;


### PR DESCRIPTION
# Pull Request

## 📖 Description

While a partner was updating to the latest fast-element beta, we found an issue where `parent` was undefined in nested template composition scenarios. It turns out that the parent context was not being passed through to the composed view.

### 🎫 Issues

No issues. Just discovered this morning internally and fast tracking a fix.

## 👩‍💻 Reviewer Notes

The change is to enable passing an optional context to `bind` on views. Content bindings now pass the existing context through the the composed view.

While fixing view, I noticed some missing code docs and an incorrect/obsolete property on `HTMLView`. So, I fixed that as well.

## 📑 Test Plan

I added a test to ensure this behavior going forward. This was a regression, so the new test should prevent that in the future.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

n/a