### PR TITLE
resolve d3-color to ^3.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -123,6 +123,7 @@
     "clean-css": "^4.2.3",
     "css-select": "^4.2.1",
     "dns-packet": "^1.3.4",
+    "d3-color": "^3.1.0",
     "favicons/colors": "1.4.0",
     "glob-parent": "^5.1.2",
     "immer": "^9.0.6",

--- a/yarn.lock
+++ b/yarn.lock
@@ -9397,12 +9397,7 @@ d3-collection@1:
   resolved "https://registry.yarnpkg.com/d3-collection/-/d3-collection-1.0.7.tgz#349bd2aa9977db071091c13144d5e4f16b5b310e"
   integrity sha512-ii0/r5f4sjKNTfh84Di+DpztYwqKhEyUlKoPrzUFfeSkWxjW49xU2QzO9qrPrNkpdI0XJkfzvmTu8V2Zylln6A==
 
-d3-color@1:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-1.4.1.tgz#c52002bf8846ada4424d55d97982fef26eb3bc8a"
-  integrity sha512-p2sTHSLCJI2QKunbGb7ocOh7DgTAn8IrLx21QRc/BSnodXM4sv6aLQlnfpvehFMLZEfBc6g9pH9SWQccFYfJ9Q==
-
-"d3-color@1 - 3", d3-color@3:
+d3-color@1, "d3-color@1 - 3", d3-color@3, d3-color@^3.1.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/d3-color/-/d3-color-3.1.0.tgz#395b2833dfac71507f12ac2f7af23bf819de24e2"
   integrity sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==


### PR DESCRIPTION
# Pull Request

## 📖 Description

Resolves `d3-color` entries to `^3.1.0` to resolve a security vulnerability.

## 👩‍💻 Reviewer Notes

`d3-color` is a transient dependency of `mermaid`, which is used in the `fast-site` project. `mermaid` depends on both `d3@^7.0.0` as well as `dagre-d3@^0.6.4`, the latter of which is unmaintained and depends on `d3@^5.14`.

Since the version difference for `d3` is already explicitly defined in `mermaid`, it's unlikely that forcing all versions of `d3-color` to the same resolution will have any major impact.

## 📑 Test Plan

All packages should build successfully and all tests should pass.

The only place where Mermaid is currently being used is the Documentation site's introduction page.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.