### PR TITLE
fix: prevent registering FASTElement itself

### DIFF
--- a/change/@microsoft-fast-element-94ffb0f7-0710-4351-be86-8aa90f485fd5.json
+++ b/change/@microsoft-fast-element-94ffb0f7-0710-4351-be86-8aa90f485fd5.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: don't allow registering FASTElement itself as a web component",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-94ffb0f7-0710-4351-be86-8aa90f485fd5.json
+++ b/change/@microsoft-fast-element-94ffb0f7-0710-4351-be86-8aa90f485fd5.json
@@ -3,5 +3,5 @@
   "comment": "fix: don't allow registering FASTElement itself as a web component",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -400,6 +400,7 @@ export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Co
     get isDefined(): boolean;
     readonly name: string;
     readonly propertyLookup: Record<string, AttributeDefinition>;
+    static registerBaseType(type: Function): void;
     readonly registry: CustomElementRegistry;
     readonly shadowOptions?: ShadowRootOptions;
     readonly styles?: ElementStyles;

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -400,6 +400,7 @@ export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Co
     get isDefined(): boolean;
     readonly name: string;
     readonly propertyLookup: Record<string, AttributeDefinition>;
+    // @internal
     static registerBaseType(type: Function): void;
     readonly registry: CustomElementRegistry;
     readonly shadowOptions?: ShadowRootOptions;

--- a/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
@@ -2,6 +2,7 @@ import { expect } from "chai";
 import { FASTElementDefinition } from "./fast-definitions.js";
 import { ElementStyles } from "../styles/element-styles.js";
 import { uniqueElementName } from "../testing/fixture.js";
+import { FASTElement } from "./fast-element.js";
 
 describe("FASTElementDefinition", () => {
     class MyElement extends HTMLElement {}
@@ -123,6 +124,38 @@ describe("FASTElementDefinition", () => {
             def.define();
 
             expect(def.isDefined).to.be.true;
+        });
+    });
+
+    context("compose", () => {
+        it("prevents registering FASTElement", () => {
+            const def1 = FASTElementDefinition.compose(
+                FASTElement,
+                uniqueElementName()
+            );
+
+            const def2 = FASTElementDefinition.compose(
+                FASTElement,
+                uniqueElementName()
+            );
+
+            expect(def1.type).not.equal(FASTElement);
+            expect(def2.type).not.equal(FASTElement);
+        });
+
+        it("automatically inherits definitions made directly against FASTElement", () => {
+            const def1 = FASTElementDefinition.compose(
+                FASTElement,
+                uniqueElementName()
+            );
+
+            const def2 = FASTElementDefinition.compose(
+                FASTElement,
+                uniqueElementName()
+            );
+
+            expect(Reflect.getPrototypeOf(def1.type)).equals(FASTElement);
+            expect(Reflect.getPrototypeOf(def2.type)).equals(FASTElement);
         });
     });
 });

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -231,6 +231,7 @@ export class FASTElementDefinition<
     /**
      * Registers a FASTElement base type.
      * @param type - The type to register as a base type.
+     * @internal
      */
     public static registerBaseType(type: Function) {
         fastElementBaseTypes.add(type);

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -7,6 +7,7 @@ import { AttributeConfiguration, AttributeDefinition } from "./attributes.js";
 
 const defaultShadowOptions: ShadowRootInit = { mode: "open" };
 const defaultElementOptions: ElementDefinitionOptions = {};
+const fastElementBaseTypes = new Set<Function>();
 
 const fastElementRegistry: TypeRegistry<FASTElementDefinition> = FAST.getById(
     KernelServiceId.elementRegistry,
@@ -220,13 +221,19 @@ export class FASTElementDefinition<
         type: TType,
         nameOrDef?: string | PartialFASTElementDefinition
     ): FASTElementDefinition<TType> {
-        const found = fastElementRegistry.getByType(type);
-
-        if (found) {
+        if (fastElementBaseTypes.has(type) || fastElementRegistry.getByType(type)) {
             return new FASTElementDefinition<TType>(class extends type {}, nameOrDef);
         }
 
         return new FASTElementDefinition<TType>(type, nameOrDef);
+    }
+
+    /**
+     * Registers a FASTElement base type.
+     * @param type - The type to register as a base type.
+     */
+    public static registerBaseType(type: Function) {
+        fastElementBaseTypes.add(type);
     }
 
     /**

--- a/packages/web-components/fast-element/src/components/fast-element.ts
+++ b/packages/web-components/fast-element/src/components/fast-element.ts
@@ -66,7 +66,7 @@ export interface FASTElement extends HTMLElement {
 function createFASTElement<T extends typeof HTMLElement>(
     BaseType: T
 ): { new (): InstanceType<T> & FASTElement } {
-    return class extends (BaseType as any) {
+    const type = class extends (BaseType as any) {
         public readonly $fastController!: ElementController;
 
         public constructor() {
@@ -98,7 +98,11 @@ function createFASTElement<T extends typeof HTMLElement>(
         ): void {
             this.$fastController.onAttributeChangedCallback(name, oldValue, newValue);
         }
-    } as any;
+    };
+
+    FASTElementDefinition.registerBaseType(type);
+
+    return type as any;
 }
 
 function compose<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(
@@ -160,6 +164,7 @@ export const FASTElement: {
      * @param BaseType - The base element type to inherit from.
      */
     from,
+
     /**
      * Defines a platform custom element based on the provided type and definition.
      * @param type - The custom element type to define.


### PR DESCRIPTION
# Pull Request

## 📖 Description

Prior to this PR, it was possible to do this:

```ts
FASTElement.define({...});
```

This would actually define `FASTElement` itself with the platform, meaning every other web component inheriting from FASTElement would inherit any attributes, observables, etc. that happened to be defined on `FASTElement`. We don't want that to ever be possible.

This PR prevents this scenario by detecting a direct `FASTElement` registration and automatically inheriting a base class. The advantage of this approach is that it is now safe to call the API above, which means we also now support creating simple web components without defining a class (FAST will handle that automatically).

### 🎫 Issues

I just discovered this issue today and skipped straight to the fix since it only took a few minutes.

## 👩‍💻 Reviewer Notes

I thought it would be nice to show a cool side-effect of this fix, which is being able to define a web component without needing a class (for simple scenarios).

```ts
import { FASTElement, html } from "@microsoft/fast-element";
import { ownedState } from "@microsoft/fast-element/state";

const counter = ownedState(0);

function increment(instance) {
  counter.set(instance, counter(instance) + 1);
}

function decrement(instance) {
  counter.set(instance, counter(instance) - 1);
}

FASTElement.define({
  name: "fast-counter",
  template: html`
    <button @click=${decrement}>-</button>
    ${counter}
    <button @click=${increment}>+</button>
  `
});
```

## 📑 Test Plan

I added new tests to ensure the bug is prevented and the new inheritance solution works. All existing tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

n/a