### PR TITLE
Adaptive UI: Fix overlay default value

### DIFF
--- a/change/@microsoft-adaptive-ui-2719e09a-87b8-4885-82ef-70da2fc5c024.json
+++ b/change/@microsoft-adaptive-ui-2719e09a-87b8-4885-82ef-70da2fc5c024.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix neutral color overlay mode default value",
+  "packageName": "@microsoft/adaptive-ui",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/utilities/adaptive-ui/src/design-tokens/color.ts
+++ b/packages/utilities/adaptive-ui/src/design-tokens/color.ts
@@ -43,7 +43,7 @@ export const fillColor = create<Swatch>("fill-color").withDefault(
 
 /** @public */
 export const neutralAsOverlay = createNonCss<boolean>("neutral-as-overlay").withDefault(
-    true
+    false
 );
 
 // Accent Fill


### PR DESCRIPTION
# Pull Request

## 📖 Description

I recently added the "overlay" mode for neutral color recipes, which was intended to be opt-in, but I left the default value turned on. This PR puts it back to the functionality before that feature was introduced.


## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
