### PR TITLE
fix: observation kernel missing binding observer disconnect method

### DIFF
--- a/change/@microsoft-fast-element-162827a3-f51b-45a1-aeb9-f411fc6a46a7.json
+++ b/change/@microsoft-fast-element-162827a3-f51b-45a1-aeb9-f411fc6a46a7.json
@@ -3,5 +3,5 @@
   "comment": "fix: observation kernel missing binding observer disconnect method",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-162827a3-f51b-45a1-aeb9-f411fc6a46a7.json
+++ b/change/@microsoft-fast-element-162827a3-f51b-45a1-aeb9-f411fc6a46a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: observation kernel missing binding observer disconnect method",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -599,8 +599,8 @@ export const Observable: Readonly<{
     notify(source: unknown, args: any): void;
     defineProperty(target: {}, nameOrAccessor: string | Accessor): void;
     getAccessors: (target: {}) => Accessor[];
-    binding<TSource = any, TReturn = any>(binding: Expression<TSource, TReturn, any>, initialSubscriber?: Subscriber, isVolatileBinding?: boolean): ExpressionNotifier<TSource, TReturn, any>;
-    isVolatileBinding<TSource_1 = any, TReturn_1 = any>(binding: Expression<TSource_1, TReturn_1, any>): boolean;
+    binding<TSource = any, TReturn = any>(expression: Expression<TSource, TReturn, any>, initialSubscriber?: Subscriber, isVolatileBinding?: boolean): ExpressionNotifier<TSource, TReturn, any>;
+    isVolatileBinding<TSource_1 = any, TReturn_1 = any>(expression: Expression<TSource_1, TReturn_1, any>): boolean;
 }>;
 
 // @public

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -49,16 +49,6 @@ export type Mutable<T> = {
 };
 
 /**
- * Extracts the item type from an array.
- * @public
- */
-export type ArrayItem<T> = T extends ReadonlyArray<infer TItem>
-    ? TItem
-    : T extends Array<infer TItem>
-    ? TItem
-    : any;
-
-/**
  * A policy for use with the standard trustedTypes platform API.
  * @public
  */

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -247,11 +247,11 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         private controller: ExpressionController;
 
         constructor(
-            private binding: Expression<TSource, TReturn>,
+            private expression: Expression<TSource, TReturn>,
             initialSubscriber?: Subscriber,
             private isVolatileBinding: boolean = false
         ) {
-            super(binding, initialSubscriber);
+            super(expression, initialSubscriber);
         }
 
         public setMode(isAsync: boolean): void {
@@ -292,12 +292,17 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
             this.needsRefresh = this.isVolatileBinding;
             let result;
             try {
-                result = this.binding(source, context);
+                result = this.expression(source, context);
             } finally {
                 watcher = previousWatcher;
             }
 
             return result;
+        }
+
+        // backwards compat with v1 kernel
+        public disconnect() {
+            this.dispose();
         }
 
         public dispose(): void {
@@ -450,17 +455,17 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         /**
          * Creates a {@link ExpressionNotifier} that can watch the
          * provided {@link Expression} for changes.
-         * @param binding - The binding to observe.
+         * @param expression - The binding to observe.
          * @param initialSubscriber - An initial subscriber to changes in the binding value.
          * @param isVolatileBinding - Indicates whether the binding's dependency list must be re-evaluated on every value evaluation.
          */
         binding<TSource = any, TReturn = any>(
-            binding: Expression<TSource, TReturn>,
+            expression: Expression<TSource, TReturn>,
             initialSubscriber?: Subscriber,
-            isVolatileBinding: boolean = this.isVolatileBinding(binding)
+            isVolatileBinding: boolean = this.isVolatileBinding(expression)
         ): ExpressionNotifier<TSource, TReturn> {
             return new ExpressionNotifierImplementation(
-                binding,
+                expression,
                 initialSubscriber,
                 isVolatileBinding
             );
@@ -469,12 +474,12 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         /**
          * Determines whether a binding expression is volatile and needs to have its dependency list re-evaluated
          * on every evaluation of the value.
-         * @param binding - The binding to inspect.
+         * @param expression - The binding to inspect.
          */
         isVolatileBinding<TSource = any, TReturn = any>(
-            binding: Expression<TSource, TReturn>
+            expression: Expression<TSource, TReturn>
         ): boolean {
-            return volatileRegex.test(binding.toString());
+            return volatileRegex.test(expression.toString());
         },
     });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

The kernel that is shared between on fast instances on page unintentionally had a method removed between v1 and v2. This PR adds that method back.

### 🎫 Issues

Just spotted this one. Quick fix.

## 👩‍💻 Reviewer Notes

There are a couple of renames to params in this PR but the real point of interest is adding the "disconnect" method that is needed for back-compat with v1's kernel. This is not part of the v2 public API but needs to remain in case v1 is consuming the v2. kernel.

## 📑 Test Plan

The functionality is tested already via the "dispose" method.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

n/a