### PR TITLE
Fix: Allow Escape key to close menu items

### DIFF
--- a/change/@microsoft-fast-foundation-e12ef57f-4ba5-4e76-a9b1-32d898326966.json
+++ b/change/@microsoft-fast-foundation-e12ef57f-4ba5-4e76-a9b1-32d898326966.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Adds ability to close menu with Escape key",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "ryan@ryanmerrill.net",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1365,6 +1365,8 @@ export class FASTMenuItem extends FASTElement {
     // (undocumented)
     protected checkedChanged(oldValue: boolean, newValue: boolean): void;
     // @internal (undocumented)
+    closeSubMenu: () => void;
+    // @internal (undocumented)
     connectedCallback(): void;
     // @internal
     currentDirection: Direction;

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -232,8 +232,7 @@ export class FASTMenuItem extends FASTElement {
             case keyArrowLeft:
                 //close submenu
                 if (this.expanded) {
-                    this.expanded = false;
-                    this.focus();
+                    this.closeSubMenu();
                     return false;
                 }
         }

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -10,6 +10,7 @@ import {
     keyArrowLeft,
     keyArrowRight,
     keyEnter,
+    keyEscape,
     keySpace,
 } from "@microsoft/fast-web-utilities";
 import type { FASTAnchoredRegion } from "../anchored-region/anchored-region.js";
@@ -221,6 +222,13 @@ export class FASTMenuItem extends FASTElement {
                 this.expandAndFocus();
                 return false;
 
+            case keyEscape:
+                // close submenu
+                if (this.expanded) {
+                    this.closeSubMenu();
+                    return false;
+                }
+
             case keyArrowLeft:
                 //close submenu
                 if (this.expanded) {
@@ -231,6 +239,15 @@ export class FASTMenuItem extends FASTElement {
         }
 
         return true;
+    };
+
+    /**
+     * @internal
+     */
+    public closeSubMenu = (): void => {
+        // close submenu
+        this.expanded = false;
+        this.focus();
     };
 
     /**


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
Adds the ability to close the menu by hitting the Escape key. This will now close the currently opened sub-menu and place focus on its parent element.

### 🎫 Issues
#5984 

## 👩‍💻 Reviewer Notes


## 📑 Test Plan
Go to the Nested Menu component in Storybook and navigate via a keyboard to verify hitting the "Escape" will close the opened sub-menu and place focus on its parent/

## ✅ Checklist
- [ ] Navigate to the Menu component
- [ ] Focus on the menu and navigate using the keyboard
- [ ] Hit the Escape key to verify menu closes

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [X] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
None