### PR TITLE
revert tree item changes from playwright migration

### DIFF
--- a/change/@microsoft-fast-foundation-2266fb9e-f78c-4a18-95f1-7de5f7bc8c5b.json
+++ b/change/@microsoft-fast-foundation-2266fb9e-f78c-4a18-95f1-7de5f7bc8c5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "revert tree item changes from playwright migration",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -514,20 +514,6 @@ export class DelegatesARIAToolbar {
 export interface DelegatesARIAToolbar extends ARIAGlobalStatesAndProperties {
 }
 
-// Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
-// Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "DelegatesARIATreeItem" because one of its declarations is marked as @internal
-//
-// @public
-export class DelegatesARIATreeItem {
-    ariaDisabled: "true" | "false" | string | null;
-    ariaExpanded: "true" | "false" | string | null;
-    ariaSelected: "true" | "false" | string | null;
-}
-
-// @internal
-export interface DelegatesARIATreeItem extends ARIAGlobalStatesAndProperties {
-}
-
 // @public
 export type DerivedDesignTokenValue<T> = (resolve: DesignTokenResolver) => T;
 
@@ -2133,8 +2119,6 @@ export class FASTTreeItem extends FASTElement {
     // @internal (undocumented)
     childItems: HTMLElement[];
     disabled: boolean;
-    // (undocumented)
-    protected disabledChanged(prev: boolean | undefined, next: boolean): void;
     // @internal
     expandCollapseButton: HTMLDivElement;
     expanded: boolean;
@@ -2162,7 +2146,7 @@ export class FASTTreeItem extends FASTElement {
 }
 
 // @internal
-export interface FASTTreeItem extends StartEnd, DelegatesARIATreeItem {
+export interface FASTTreeItem extends StartEnd {
 }
 
 // @public

--- a/packages/web-components/fast-foundation/src/tree-item/README.md
+++ b/packages/web-components/fast-foundation/src/tree-item/README.md
@@ -62,7 +62,6 @@ export class FASTTreeItem extends TreeItem {}
 | ----------------- | --------- | ----------- | -------------------------------------------- | ------ | -------------- |
 | `expandedChanged` | protected |             | `prev: boolean or undefined, next: boolean`  | `void` |                |
 | `selectedChanged` | protected |             | `prev: boolean or undefined, next: boolean`  | `void` |                |
-| `disabledChanged` | protected |             | `prev: boolean or undefined, next: boolean`  | `void` |                |
 | `itemsChanged`    | protected |             | `oldValue: unknown, newValue: HTMLElement[]` | `void` |                |
 
 #### Events
@@ -99,18 +98,6 @@ export class FASTTreeItem extends TreeItem {}
 |                          | The default slot for tree item text content                                 |
 | `item`                   | The slot for tree items (fast tree items manage this assignment themselves) |
 | `expand-collapse-button` | The expand/collapse button                                                  |
-
-<hr/>
-
-### class: `DelegatesARIATreeItem`
-
-#### Fields
-
-| Name           | Privacy | Type                                  | Default | Description                                                             | Inherited From |
-| -------------- | ------- | ------------------------------------- | ------- | ----------------------------------------------------------------------- | -------------- |
-| `ariaDisabled` | public  | `"true" or "false" or string or null` |         | See https://www.w3.org/TR/wai-aria-1.2/#treeitem for more information |                |
-| `ariaExpanded` | public  | `"true" or "false" or string or null` |         | See https://www.w3.org/TR/wai-aria-1.2/#treeitem for more information |                |
-| `ariaSelected` | public  | `"true" or "false" or string or null` |         | See https://www.w3.org/TR/wai-aria-1.2/#treeitem for more information |                |
 
 <hr/>
 

--- a/packages/web-components/fast-foundation/src/tree-item/stories/tree-item.register.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/stories/tree-item.register.ts
@@ -137,7 +137,7 @@ const styles = css`
         margin-inline-start: calc(var(--design-unit) * 2px + 2px);
     }
 
-    :host([expanded]) > .items {
+    :host([aria-expanded="true"]) > .items {
         display: block;
     }
 
@@ -195,7 +195,7 @@ const styles = css`
     :host([selected])::after {
         left: calc(var(--focus-stroke-width) * 1px);
     }
-    :host([expanded]) > .positioning-region .expand-collapse-glyph {
+    :host([aria-expanded="true"]) > .positioning-region .expand-collapse-glyph {
         transform: rotate(45deg);
     }
 `;

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
@@ -54,6 +54,18 @@ test.describe("TreeItem", () => {
         await expect(element.first()).toHaveAttribute("aria-expanded", "false");
     });
 
+    test("should set the `aria-expanded` attribute equal to TRUE when the `expanded` attribute is present", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item expanded>
+                    <fast-tree-item>tree item</fast-tree-item>
+                </fast-tree-item>
+            `;
+        });
+
+        await expect(element.first()).toHaveAttribute("aria-expanded", "true");
+    });
+
     test("should NOT set the `aria-expanded` attribute when the tree item has no children", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
@@ -110,6 +122,22 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("aria-selected", "false");
     });
 
+    test("should set the `aria-selected` attribute equal to TRUE when the selected attribute is present", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item selected>tree item</fast-tree-item>
+            `;
+        });
+
+        await expect(element).toHaveAttribute("aria-selected", "true");
+
+        await element.evaluate<void, FASTTreeItem>(node => {
+            node.disabled = false;
+        });
+
+        await expect(element).toHaveAttribute("aria-disabled", "false");
+    });
+
     test("should set the `aria-disabled` attribute equal to the `disabled` property", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
@@ -130,6 +158,16 @@ test.describe("TreeItem", () => {
         });
 
         await expect(element).toHaveAttribute("aria-disabled", "false");
+    });
+
+    test("should set the `aria-disabled` attribute equal to TRUE when the disabled attribute is present", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tree-item disabled>tree item</fast-tree-item>
+            `;
+        });
+
+        await expect(element).toHaveAttribute("aria-disabled", "true");
     });
 
     test('should add a slot attribute of "item" to nested tree items', async () => {

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -15,9 +15,10 @@ export function treeItemTemplate<T extends FASTTreeItem>(
             role="treeitem"
             slot="${x => (x.isNestedItem() ? "item" : void 0)}"
             tabindex="-1"
-            aria-expanded="${x => x.ariaExpanded}"
-            aria-selected="${x => x.ariaSelected}"
-            aria-disabled="${x => x.ariaDisabled}"
+            aria-expanded="${x =>
+                x.childItems && x.childItemLength() > 0 ? x.expanded : void 0}"
+            aria-selected="${x => x.selected}"
+            aria-disabled="${x => x.disabled}"
             @focusin="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
             @focusout="${(x, c) => x.handleBlur(c.event as FocusEvent)}"
             ${children({

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -5,7 +5,6 @@ import {
     SyntheticViewTemplate,
 } from "@microsoft/fast-element";
 import { isHTMLElement } from "@microsoft/fast-web-utilities";
-import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global.js";
 import { StartEnd, StartEndOptions } from "../patterns/start-end.js";
 import { applyMixins } from "../utilities/apply-mixins.js";
 
@@ -58,12 +57,6 @@ export class FASTTreeItem extends FASTElement {
     public expanded: boolean = false;
     protected expandedChanged(prev: boolean | undefined, next: boolean): void {
         if (this.$fastController.isConnected) {
-            this.ariaExpanded = this.childItems?.length
-                ? next
-                    ? "true"
-                    : "false"
-                : null;
-
             this.$emit("expanded-change", this);
         }
     }
@@ -78,7 +71,6 @@ export class FASTTreeItem extends FASTElement {
     public selected: boolean;
     protected selectedChanged(prev: boolean | undefined, next: boolean): void {
         if (this.$fastController.isConnected) {
-            this.ariaSelected = next ? "true" : "false";
             this.$emit("selected-change", this);
         }
     }
@@ -91,11 +83,6 @@ export class FASTTreeItem extends FASTElement {
      */
     @attr({ mode: "boolean" })
     public disabled: boolean;
-    protected disabledChanged(prev: boolean | undefined, next: boolean): void {
-        if (this.$fastController.isConnected) {
-            this.ariaDisabled = next ? "true" : "false";
-        }
-    }
 
     /**
      *  Reference to the expand/collapse button
@@ -213,54 +200,11 @@ export class FASTTreeItem extends FASTElement {
 }
 
 /**
- * Includes ARIA states and properties relating to the ARIA textbox role
- *
- * @public
- */
-export class DelegatesARIATreeItem {
-    /**
-     * See {@link https://www.w3.org/TR/wai-aria-1.2/#treeitem} for more information
-     * @public
-     * @remarks
-     * HTML Attribute: `aria-disabled`
-     */
-    @observable
-    public ariaDisabled: "true" | "false" | string | null;
-
-    /**
-     * See {@link https://www.w3.org/TR/wai-aria-1.2/#treeitem} for more information
-     * @public
-     * @remarks
-     * HTML Attribute: `aria-expanded`
-     */
-    @observable
-    public ariaExpanded: "true" | "false" | string | null;
-
-    /**
-     * See {@link https://www.w3.org/TR/wai-aria-1.2/#treeitem} for more information
-     * @public
-     * @remarks
-     * HTML Attribute: `aria-expanded`
-     */
-    @observable
-    public ariaSelected: "true" | "false" | string | null;
-}
-
-/**
- * Mark internal because exporting class and interface of the same name
- * confuses API documenter.
- * TODO: https://github.com/microsoft/fast/issues/3317
- * @internal
- */
-export interface DelegatesARIATreeItem extends ARIAGlobalStatesAndProperties {}
-applyMixins(DelegatesARIATreeItem, ARIAGlobalStatesAndProperties);
-
-/**
  * Mark internal because exporting class and interface of the same name
  * confuses API documenter.
  * TODO: https://github.com/microsoft/fast-dna/issues/3317
  * @internal
  */
 /* eslint-disable-next-line */
-export interface FASTTreeItem extends StartEnd, DelegatesARIATreeItem {}
-applyMixins(FASTTreeItem, StartEnd, DelegatesARIATreeItem);
+export interface FASTTreeItem extends StartEnd {}
+applyMixins(FASTTreeItem, StartEnd);

--- a/packages/web-components/fast-foundation/src/tree-view/stories/tree-view.stories.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/stories/tree-view.stories.ts
@@ -26,11 +26,11 @@ TreeView.args = {
         <fast-tree-item>
             Root item 1
             <fast-divider></fast-divider>
-            <fast-tree-item>
+            <fast-tree-item expanded>
                 Flowers
                 <fast-tree-item>Daisy</fast-tree-item>
                 <fast-tree-item disabled>Sunflower</fast-tree-item>
-                <fast-tree-item>
+                <fast-tree-item expanded>
                     Rose
                     <fast-divider role="presentation"></fast-divider>
                     <fast-tree-item>Pink</fast-tree-item>

--- a/packages/web-components/fast-foundation/src/tree-view/stories/tree-view.stories.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/stories/tree-view.stories.ts
@@ -4,7 +4,7 @@ import { renderComponent } from "../../__test__/helpers.js";
 import type { FASTTreeView } from "../tree-view.js";
 
 const storyTemplate = html<StoryArgs<FASTTreeView>>`
-    <fast-tree-view render-collapsed-nodes="${x => x.renderCollapsedNodes}">
+    <fast-tree-view>
         ${x => x.storyContent}
     </fast-tree-view>
 `;
@@ -26,11 +26,11 @@ TreeView.args = {
         <fast-tree-item>
             Root item 1
             <fast-divider></fast-divider>
-            <fast-tree-item expanded>
+            <fast-tree-item>
                 Flowers
                 <fast-tree-item>Daisy</fast-tree-item>
                 <fast-tree-item disabled>Sunflower</fast-tree-item>
-                <fast-tree-item expanded>
+                <fast-tree-item>
                     Rose
                     <fast-divider role="presentation"></fast-divider>
                     <fast-tree-item>Pink</fast-tree-item>
@@ -41,7 +41,7 @@ TreeView.args = {
             <fast-tree-item>Nested item 2</fast-tree-item>
             <fast-tree-item>Nested item 3</fast-tree-item>
         </fast-tree-item>
-        <fast-tree-item>
+        <fast-tree-item expanded>
             Root item 2
             <fast-tree-item>
                 Flowers


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR fixes issues related to some updates made during the playwright migration.

It was discovered that on initial load, when the expanded attribute was set for a given item, `aria-expanded` would not be set. The reason for this is that without an explicit invocation in `connectedCallback()` the attribute isn't set. This behavior would seemingly also occur for the selected and disabled attributes as well since they present similar functionality. One reason this wasn't visually caught was because the styling was tied to the `expanded` attribute rather than the `aria-expanded` attribute, so everything seemed fine. Additionally, I've added tests to ensure that when the attribute is present at load, the corresponding ARIA attributes are provided.

An additional removal here is the addition of the `DelegatesARIATreeItem` code. One reason for the removal here is that the tree item doesn't actually delegate ARIA, it's applied at the host. Secondly, while I believe the intent of the addition of this was to support the ARIA attributes being observable, I don't believe that is needed with the API at present. All host elements support these via the HTML interface and if someone wants to explicitly set those values they can. I would advise _against_ doing that simply because we ensure accessibility by managing the various states via the `disabled`, `expanded`, and `selected` attributes themselves.

### 🎫 Issues
N/A but I believe that #6435 was technically related to this with what was expected.

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->