### PR TITLE
fix: prevent event callbacks when controller is not bound

### DIFF
--- a/change/@microsoft-fast-element-86101b93-75a7-43ab-ac5a-69d6bd4bd25f.json
+++ b/change/@microsoft-fast-element-86101b93-75a7-43ab-ac5a-69d6bd4bd25f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: prevent event callbacks when controller is not bound",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-86101b93-75a7-43ab-ac5a-69d6bd4bd25f.json
+++ b/change/@microsoft-fast-element-86101b93-75a7-43ab-ac5a-69d6bd4bd25f.json
@@ -3,5 +3,5 @@
   "comment": "fix: prevent event callbacks when controller is not bound",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -383,17 +383,19 @@ export class HTMLBindingDirective
 
     /** @internal */
     handleEvent(event: Event): void {
-        const target = event.currentTarget!;
+        const controller = event.currentTarget![this.data] as ViewController;
 
-        ExecutionContext.setEvent(event);
+        if (controller.isBound) {
+            ExecutionContext.setEvent(event);
+            const result = this.dataBinding.evaluate(
+                controller.source,
+                controller.context
+            );
+            ExecutionContext.setEvent(null);
 
-        const controller = target[this.data] as ViewController;
-        const result = this.dataBinding.evaluate(controller.source, controller.context);
-
-        ExecutionContext.setEvent(null);
-
-        if (result !== true) {
-            event.preventDefault();
+            if (result !== true) {
+                event.preventDefault();
+            }
         }
     }
 

--- a/packages/web-components/fast-element/src/testing/fakes.ts
+++ b/packages/web-components/fast-element/src/testing/fakes.ts
@@ -1,4 +1,9 @@
-import { ExecutionContext } from "../index.js";
+import {
+    ExecutionContext,
+    ViewBehavior,
+    ViewBehaviorTargets,
+    ViewController,
+} from "../index.js";
 
 export const Fake = Object.freeze({
     executionContext<TParent = any>(
@@ -85,6 +90,44 @@ export const Fake = Object.freeze({
              */
             eventTarget<TTarget extends EventTarget>(): TTarget {
                 return this.event.target! as TTarget;
+            },
+        };
+    },
+
+    viewController<TSource = any, TParent = any>(
+        targets: ViewBehaviorTargets,
+        ...behaviors: ViewBehavior<TSource, TParent>[]
+    ) {
+        const unbindables = new Set<{ unbind(controller: ViewController) }>();
+
+        return {
+            isBound: false,
+            context: (null as any) as ExecutionContext<TParent>,
+            onUnbind(object) {
+                unbindables.add(object);
+            },
+            source: (null as any) as TSource,
+            targets,
+            bind(
+                source: TSource,
+                context: ExecutionContext<TParent> = Fake.executionContext()
+            ) {
+                if (this.isBound) {
+                    return;
+                }
+
+                this.source = source;
+                this.context = context;
+                behaviors.forEach(x => x.bind(this));
+                this.isBound = true;
+            },
+            unbind() {
+                if (this.isBound) {
+                    unbindables.forEach(x => x.unbind(this));
+                    this.source = null;
+                    this.context = null;
+                    this.isBound = false;
+                }
             },
         };
     },


### PR DESCRIPTION
# Pull Request

## 📖 Description

An optimization that allows event handlers to remain after view teardown, introduced a bug whereby event handlers that fire after the view is unbound, results in errors due to null source and context.

### 🎫 Issues

* Internal

## 👩‍💻 Reviewer Notes

The fix was pretty straight forward: just check whether the controller is bound before executing callbacks.

## 📑 Test Plan

A failing test was added to catch the bug and then the fix was applied to pass the test. To create a test for this, the fake view controller needed to be enhanced. As part of that work some test refactoring was done to clean up the binding tests.

All existing tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

While working on this fix, I saw some extra code in the HTMLDirective that should be cleaned up. There is also an opportunity to improve the tests by using the new view controller fake and looking for similar refactorings in tests. I will follow up with additional PRs for some of this work.