### PR TITLE
compare tree item instanceof to determine if an element is a tree item

### DIFF
--- a/change/@microsoft-fast-foundation-803b5cc6-2602-425b-955b-0a2ed6677ddc.json
+++ b/change/@microsoft-fast-foundation-803b5cc6-2602-425b-955b-0a2ed6677ddc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "compare tree item using instance of to determine if an element is a tree item",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -9,19 +9,6 @@ import { StartEnd, StartEndOptions } from "../patterns/start-end.js";
 import { applyMixins } from "../utilities/apply-mixins.js";
 
 /**
- * check if the item is a tree item
- * @public
- * @remarks
- * determines if element is an HTMLElement and if it has the role treeitem
- */
-export function isTreeItemElement(el: Element): el is HTMLElement {
-    return (
-        isHTMLElement(el) &&
-        (el.getAttribute("role") === "treeitem" || el.tagName.includes("TREE-ITEM"))
-    );
-}
-
-/**
  * Tree Item configuration options
  * @public
  */
@@ -117,7 +104,7 @@ export class FASTTreeItem extends FASTElement {
     protected itemsChanged(oldValue: unknown, newValue: HTMLElement[]): void {
         if (this.$fastController.isConnected) {
             this.items.forEach((node: HTMLElement) => {
-                if (isTreeItemElement(node)) {
+                if (FASTTreeItem.isFASTTreeItemElement(node)) {
                     // TODO: maybe not require it to be a TreeItem?
                     (node as FASTTreeItem).nested = true;
                 }
@@ -152,7 +139,7 @@ export class FASTTreeItem extends FASTElement {
      * @public
      */
     public readonly isNestedItem = (): boolean => {
-        return isTreeItemElement(this.parentElement as Element);
+        return FASTTreeItem.isFASTTreeItemElement(this.parentElement as Element);
     };
 
     /**
@@ -192,10 +179,14 @@ export class FASTTreeItem extends FASTElement {
     public childItemLength(): number {
         const treeChildren: HTMLElement[] = this.childItems.filter(
             (item: HTMLElement) => {
-                return isTreeItemElement(item);
+                return FASTTreeItem.isFASTTreeItemElement(item);
             }
         );
         return treeChildren ? treeChildren.length : 0;
+    }
+
+    public static isFASTTreeItemElement(el: Element): el is HTMLElement {
+        return isHTMLElement(el) && el instanceof FASTTreeItem;
     }
 }
 

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -10,7 +10,7 @@ import {
     keyEnter,
     keyHome,
 } from "@microsoft/fast-web-utilities";
-import { FASTTreeItem, isTreeItemElement } from "../tree-item/tree-item.js";
+import { FASTTreeItem } from "../tree-item/tree-item.js";
 
 /**
  * A Tree view Custom HTML Element.
@@ -203,7 +203,10 @@ export class FASTTreeView extends FASTElement {
             return;
         }
 
-        if (!(e.target instanceof Element) || !isTreeItemElement(e.target as Element)) {
+        if (
+            !(e.target instanceof Element) ||
+            !this.isTreeItemElement(e.target as Element)
+        ) {
             // not a tree item, ignore
             return true;
         }
@@ -228,7 +231,10 @@ export class FASTTreeView extends FASTElement {
             return;
         }
 
-        if (!(e.target instanceof Element) || !isTreeItemElement(e.target as Element)) {
+        if (
+            !(e.target instanceof Element) ||
+            !this.isTreeItemElement(e.target as Element)
+        ) {
             return true;
         }
 
@@ -278,13 +284,13 @@ export class FASTTreeView extends FASTElement {
         if (this.currentFocused === null || !this.contains(this.currentFocused)) {
             this.currentFocused = this.getValidFocusableItem();
         }
-
+        console.log(this.currentFocused, "this current focused");
         // toggle properties on child elements
         this.nested = this.checkForNestedItems();
 
         const treeItems: HTMLElement[] | void = this.getVisibleNodes();
         treeItems.forEach(node => {
-            if (isTreeItemElement(node)) {
+            if (this.isTreeItemElement(node)) {
                 (node as FASTTreeItem).nested = this.nested;
             }
         });
@@ -313,7 +319,7 @@ export class FASTTreeView extends FASTElement {
      */
     private checkForNestedItems(): boolean {
         return this.slottedTreeItems.some((node: HTMLElement) => {
-            return isTreeItemElement(node) && node.querySelector("[role='treeitem']");
+            return node.nodeType === 1 && this.isTreeItemElement(node);
         });
     }
 
@@ -321,7 +327,7 @@ export class FASTTreeView extends FASTElement {
      * check if the item is focusable
      */
     private isFocusableElement = (el: Element): el is HTMLElement => {
-        return isTreeItemElement(el);
+        return this.isTreeItemElement(el);
     };
 
     private isSelectedElement = (el: FASTTreeItem): el is FASTTreeItem => {
@@ -330,5 +336,12 @@ export class FASTTreeView extends FASTElement {
 
     private getVisibleNodes(): HTMLElement[] {
         return getDisplayedNodes(this, "[role='treeitem']") || [];
+    }
+
+    private isTreeItemElement(el: Element): el is HTMLElement {
+        return (
+            FASTTreeItem.isFASTTreeItemElement(el) ??
+            el.getAttribute("role") === "treeitem"
+        );
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description
There is an odd bug which has raised it's head in tree item where attempting to check the role attribute as part of the (previous) `isTreeItemElement` function was _always_ returning null/undefined. The check which was working was comparing the tag name, but this presented a problem for any component extending the Tree Item without "tree item" in the tag name.

After some investigation, I haven't yet isolated a repro, but I've come up with a solution to the above problem.

First, it's always been intended that _Tree View_ support elements with a role of `treeitem` to the best of its ability. This makes sense considering that someone may want to leverage Tree View but not necessarily Tree Item. Currently there are some gaps which would need to be handled beyond just the role for custom tree items, but it's workable I think. With that in mind, I don't think it makes sense for Tree Item to support arbitrary children with this role...they have already opted into the Tree Item model, so I don't think it's a logical support case.

Given this, I've adjusted the logic for Tree Item and moved the exported function to a static function of the class which specifically checks if the element is an instance of Tree Item. The Tree View class leverages that for its own function as well as an additional check for the role, which doesn't have the same issue which presents with the Tree Item + Tree Item template implementation.

It may be more ideal to leverage the prior implementation, so perhaps more investigation is warranted.

### 🎫 Issues
N/A

## 👩‍💻 Reviewer Notes
See above on details - I tested this by creating a custom item which extended the Tree Item class and then leveraging it within the Tree View stories.
<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->