### PR TITLE
refactor: remove duplication and re-organize binding behavior logic

### DIFF
--- a/change/@microsoft-fast-element-ddaddb30-57bf-4509-bdbd-9feaadcf73dc.json
+++ b/change/@microsoft-fast-element-ddaddb30-57bf-4509-bdbd-9feaadcf73dc.json
@@ -3,5 +3,5 @@
   "comment": "refactor: remove duplication and re-organize binding behavior logic",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-ddaddb30-57bf-4509-bdbd-9feaadcf73dc.json
+++ b/change/@microsoft-fast-element-ddaddb30-57bf-4509-bdbd-9feaadcf73dc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "refactor: remove duplication and re-organize binding behavior logic",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -96,7 +96,7 @@ export class AttributeDefinition implements Accessor {
 export type AttributeMode = typeof reflectMode | typeof booleanMode | "fromView";
 
 // @public
-export function bind<T = any>(binding: Expression<T>, isVolatile?: boolean): Binding<T>;
+export function bind<T = any>(expression: Expression<T>, isVolatile?: boolean): Binding<T>;
 
 // @public
 export abstract class Binding<TSource = any, TReturn = any, TParent = any> {
@@ -436,13 +436,7 @@ export class HTMLBindingDirective implements HTMLDirective, ViewBehaviorFactory,
     constructor(dataBinding: Binding);
     aspectType: Aspect;
     // @internal (undocumented)
-    bind: (controller: ViewController) => void;
-    // @internal (undocumented)
-    bindContent(controller: ViewController): void;
-    // @internal (undocumented)
-    bindDefault(controller: ViewController): void;
-    // @internal (undocumented)
-    bindEvent(controller: ViewController): void;
+    bind(controller: ViewController): void;
     createBehavior(): ViewBehavior;
     createHTML(add: AddViewBehaviorFactory): string;
     // (undocumented)
@@ -529,7 +523,7 @@ export interface LengthObserver extends Subscriber {
 export function lengthOf<T>(array: readonly T[]): number;
 
 // @public
-export function listener<T = any>(binding: Expression<T>, options?: AddEventListenerOptions): Binding<T>;
+export function listener<T = any>(expression: Expression<T>, options?: AddEventListenerOptions): Binding<T>;
 
 // @public
 export const Markup: Readonly<{
@@ -600,7 +594,7 @@ export interface ObservationRecord {
 }
 
 // @public
-export function oneTime<T = any>(binding: Expression<T>): Binding<T>;
+export function oneTime<T = any>(expression: Expression<T>): Binding<T>;
 
 // @public
 export const Parser: Readonly<{


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR is a follow-up to a recent bug fix in events. While doing that work I noticed there was some duplicate code and an odd internal monkey-patching pattern that I wanted to eliminate.

### 🎫 Issues

* Related to #6439 

## 👩‍💻 Reviewer Notes

This PR moves bind logic out of separate methods that were monkey patched and into a single method with simple branching logic.

I also noticed a few parameters that missed getting renamed with other APIs changed, so I fixed those up as well.

## 📑 Test Plan

This was just an internal refactor, so no new tests added. Existing tests all continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

I'm pondering some ideas to potentially clean some of this up further but I'm not sure about the approach just yet. I also want to get the new security policy work in place first, since that will affect some of this same logic.