### PR TITLE
add readonly property to identify tree items and update isTreeItemElement check

### DIFF
--- a/change/@microsoft-fast-foundation-3f32a23d-676d-4f08-a6a8-fd448c3b2665.json
+++ b/change/@microsoft-fast-foundation-3f32a23d-676d-4f08-a6a8-fd448c3b2665.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add readonly property to identify tree items and udpate isTreeItemElement check",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2114,7 +2114,7 @@ export class FASTTooltip extends FASTElement {
 // @public
 export class FASTTreeItem extends FASTElement {
     // @internal
-    get childItemLength(): number | void;
+    get childItemLength(): number;
     // @internal (undocumented)
     childItems: HTMLElement[];
     disabled: boolean;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2134,6 +2134,8 @@ export class FASTTreeItem extends FASTElement {
     handleFocus: (e: FocusEvent) => void;
     readonly isNestedItem: () => boolean;
     // @internal
+    readonly isTreeItem: boolean;
+    // @internal
     items: HTMLElement[];
     // (undocumented)
     protected itemsChanged(oldValue: unknown, newValue: HTMLElement[]): void;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2114,7 +2114,7 @@ export class FASTTooltip extends FASTElement {
 // @public
 export class FASTTreeItem extends FASTElement {
     // @internal
-    childItemLength(): number;
+    get childItemLength(): number | void;
     // @internal (undocumented)
     childItems: HTMLElement[];
     disabled: boolean;

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.template.ts
@@ -16,7 +16,7 @@ export function treeItemTemplate<T extends FASTTreeItem>(
             slot="${x => (x.isNestedItem() ? "item" : void 0)}"
             tabindex="-1"
             aria-expanded="${x =>
-                x.childItems && x.childItemLength() > 0 ? x.expanded : void 0}"
+                x.childItems && x.childItemLength > 0 ? x.expanded : void 0}"
             aria-selected="${x => x.selected}"
             aria-disabled="${x => x.disabled}"
             @focusin="${(x, c) => x.handleFocus(c.event as FocusEvent)}"
@@ -29,7 +29,7 @@ export function treeItemTemplate<T extends FASTTreeItem>(
             <div class="positioning-region" part="positioning-region">
                 <div class="content-region" part="content-region">
                     ${when(
-                        x => x.childItems && x.childItemLength(),
+                        x => x.childItems && x.childItemLength > 0,
                         html<T>`
                             <div
                                 aria-hidden="true"
@@ -53,7 +53,7 @@ export function treeItemTemplate<T extends FASTTreeItem>(
                 </div>
             </div>
             ${when(
-                x => x.childItems && x.childItemLength() && x.expanded,
+                x => x.childItems && x.childItemLength > 0 && x.expanded,
                 html<T>`
                     <div role="group" class="items" part="items">
                         <slot name="item" ${slotted("items")}></slot>

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -15,10 +15,7 @@ import { applyMixins } from "../utilities/apply-mixins.js";
  * determines if element is an HTMLElement and if it has the role treeitem
  */
 export function isTreeItemElement(el: Element): el is HTMLElement {
-    return (
-        isHTMLElement(el) &&
-        (el.getAttribute("role") === "treeitem" || el.tagName.includes("TREE-ITEM"))
-    );
+    return isHTMLElement(el) && el.hasOwnProperty("isTreeItem");
 }
 
 /**
@@ -90,6 +87,13 @@ export class FASTTreeItem extends FASTElement {
      * @internal
      */
     public expandCollapseButton: HTMLDivElement;
+
+    /**
+     *  Readonly property identifying the element as a tree item
+     *
+     * @internal
+     */
+    public readonly isTreeItem: boolean = true;
 
     /**
      * Whether the item is focusable

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -15,7 +15,7 @@ import { applyMixins } from "../utilities/apply-mixins.js";
  * determines if element is an HTMLElement and if it has the role treeitem
  */
 export function isTreeItemElement(el: Element): el is HTMLElement {
-    return isHTMLElement(el) && el.hasOwnProperty("isTreeItem");
+    return isHTMLElement(el) && (el as any).isTreeItem;
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -193,10 +193,12 @@ export class FASTTreeItem extends FASTElement {
      *
      * @internal
      */
-    public get childItemLength(): number | void {
+    public get childItemLength(): number {
         if (this.$fastController.isConnected) {
             return this.childItems?.filter(item => isTreeItemElement(item)).length;
         }
+
+        return 0;
     }
 }
 

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -193,13 +193,10 @@ export class FASTTreeItem extends FASTElement {
      *
      * @internal
      */
-    public childItemLength(): number {
-        const treeChildren: HTMLElement[] = this.childItems.filter(
-            (item: HTMLElement) => {
-                return isTreeItemElement(item);
-            }
-        );
-        return treeChildren ? treeChildren.length : 0;
+    public get childItemLength(): number | void {
+        if (this.$fastController.isConnected) {
+            return this.childItems?.filter(item => isTreeItemElement(item)).length;
+        }
     }
 }
 

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.ts
@@ -142,7 +142,7 @@ export class FASTTreeView extends FASTElement {
 
                     if (
                         item instanceof FASTTreeItem &&
-                        item.childItemLength() > 0 &&
+                        item.childItemLength > 0 &&
                         item.expanded
                     ) {
                         item.expanded = false;
@@ -159,14 +159,11 @@ export class FASTTreeView extends FASTElement {
                     const item = e.target as HTMLElement;
                     if (
                         item instanceof FASTTreeItem &&
-                        item.childItemLength() > 0 &&
+                        item.childItemLength > 0 &&
                         !item.expanded
                     ) {
                         item.expanded = true;
-                    } else if (
-                        item instanceof FASTTreeItem &&
-                        item.childItemLength() > 0
-                    ) {
+                    } else if (item instanceof FASTTreeItem && item.childItemLength > 0) {
                         this.focusNextNode(1, e.target as FASTTreeItem);
                     }
                 }


### PR DESCRIPTION
# Pull Request

## 📖 Description
An issue has come up where attempting to check the role attribute as part of the (previous) isTreeItemElement function was always returning null/undefined. Previously the check which was working was comparing the tag name, but this presented a problem for any component extending the Tree Item without "tree item" in the tag name.

After some investigation and discussion w/ @eisenbergeffect, it's likely that this working previously may have in fact been a bug or an inefficiency around lifecycles. All attributes on a template need to be setup as a binding and those bindings don't exist initially when these checks are executing. 

It's always been intended that Tree View support elements with a role of treeitem to the best of its ability. This makes sense considering that someone may want to leverage Tree View but not necessarily Tree Item. Currently there are some gaps which would need to be handled beyond just the role for custom tree items, but it's workable I think. With that in mind, I don't think it makes sense for Tree Item to support arbitrary children with this role as well...they have already opted into the Tree Item model, so I don't think it makes sense API wise to support arbitrary nested tree items which are *not* of the Tree Item class. You could have different extended implementations here or even different visual implementations, but I don't think it makes sense to support *any* element with a role of `treeitem` as a Tree Item from within the class itself.

Given this, I've added a property to identify tree items and updated the helper function to check for the corresponding property.

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->