### PR TITLE
indeterminate checkboxes should set an aria-checked value of 'mixed'

### DIFF
--- a/change/@microsoft-fast-foundation-cb37e044-b9ac-4719-a213-fbfee4e64ca6.json
+++ b/change/@microsoft-fast-foundation-cb37e044-b9ac-4719-a213-fbfee4e64ca6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "indeterminate checkboxes should set an aria-checked state of mixed",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/src/checkbox/README.md
+++ b/packages/web-components/fast-foundation/src/checkbox/README.md
@@ -130,10 +130,9 @@ export const myCheckbox = Checkbox.compose<CheckboxOptions>({
 
 #### Attributes
 
-| Name                 | Field         | Inherited From |
-| -------------------- | ------------- | -------------- |
-| `readonly`           | readOnly      |                |
-| `data-indeterminate` | indeterminate |                |
+| Name       | Field    | Inherited From |
+| ---------- | -------- | -------------- |
+| `readonly` | readOnly |                |
 
 #### CSS Parts
 

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.pw.spec.ts
@@ -182,7 +182,7 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("aria-readonly", "false");
     });
 
-    test("should add a data attribute of `indeterminate` when indeterminate is true", async () => {
+    test("should set the aria-checked value to 'mixed' when indeterminate property is true", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -193,13 +193,13 @@ test.describe("Checkbox", () => {
             node.indeterminate = true;
         });
 
-        await expect(element).toHaveBooleanAttribute("data-indeterminate");
+        await expect(element).toHaveAttribute("aria-checked", "mixed");
 
         await element.evaluate((node: FASTCheckbox) => {
             node.indeterminate = false;
         });
 
-        await expect(element).not.toHaveBooleanAttribute("data-indeterminate");
+        await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
     test("should set off `indeterminate` on `checked` change by user click", async () => {

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.template.ts
@@ -11,7 +11,7 @@ export function checkboxTemplate<T extends FASTCheckbox>(
     return html<T>`
         <template
             role="checkbox"
-            aria-checked="${x => x.checked}"
+            aria-checked="${x => (x.indeterminate ? "mixed" : x.checked)}"
             aria-required="${x => x.required}"
             aria-disabled="${x => x.disabled}"
             aria-readonly="${x => x.readOnly}"

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -56,7 +56,7 @@ export class FASTCheckbox extends FormAssociatedCheckbox {
     /**
      * The indeterminate state of the control
      */
-    @attr({ attribute: "data-indeterminate", mode: "boolean" })
+    @observable
     public indeterminate: boolean = false;
 
     constructor() {

--- a/packages/web-components/fast-foundation/src/checkbox/stories/checkbox.register.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/stories/checkbox.register.ts
@@ -119,8 +119,8 @@ const styles = css`
         cursor: var(--disabled-cursor);
     }
 
-    :host([aria-checked="true"]:not([data-indeterminate])) .checked-indicator,
-    :host([data-indeterminate]) .indeterminate-indicator {
+    :host([aria-checked="true"] .checked-indicator,
+    :host([aria-checked="mixed"]) .indeterminate-indicator {
         opacity: 1;
     }
 

--- a/packages/web-components/fast-foundation/src/checkbox/stories/checkbox.register.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/stories/checkbox.register.ts
@@ -119,7 +119,7 @@ const styles = css`
         cursor: var(--disabled-cursor);
     }
 
-    :host([aria-checked="true"] .checked-indicator,
+    :host([aria-checked="true"]) .checked-indicator,
     :host([aria-checked="mixed"]) .indeterminate-indicator {
         opacity: 1;
     }


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR ensures that checkboxes with an `indeterminate` property set an aria-checked value of 'mixed'. This also reverts the move to applying a data-attribute with the fact that `indeterminate` styling of the checkbox can be accomplished via a `mixed` attribute selector.

### 🎫 Issues
closes #6448 
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->