### PR TITLE
Use Floating UI for MenuItem submenus

### DIFF
--- a/change/@microsoft-fast-foundation-4b4b433b-fc2b-4777-a993-0554019f10a7.json
+++ b/change/@microsoft-fast-foundation-4b4b433b-fc2b-4777-a993-0554019f10a7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "use floating-ui for menu-item submenus",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-ssr-d20a5285-139e-4090-a290-078ecfe3b5e7.json
+++ b/change/@microsoft-fast-ssr-d20a5285-139e-4090-a290-078ecfe3b5e7.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "use floating-ui for menu-item submenus",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1348,16 +1348,13 @@ export class FASTMenuItem extends FASTElement {
     checked: boolean;
     // (undocumented)
     protected checkedChanged(oldValue: boolean, newValue: boolean): void;
-    // @internal (undocumented)
-    connectedCallback(): void;
-    // @internal
-    currentDirection: Direction;
+    cleanup: () => void;
     disabled: boolean;
     // @internal (undocumented)
     disconnectedCallback(): void;
     expanded: boolean;
     // (undocumented)
-    protected expandedChanged(oldValue: boolean): void;
+    protected expandedChanged(prev: boolean | undefined, next: boolean): void;
     // @internal (undocumented)
     handleMenuItemClick: (e: MouseEvent) => boolean;
     // @internal (undocumented)
@@ -1367,15 +1364,20 @@ export class FASTMenuItem extends FASTElement {
     // @internal (undocumented)
     handleMouseOver: (e: MouseEvent) => boolean;
     // @internal (undocumented)
-    hasSubmenu: boolean;
+    get hasSubmenu(): boolean;
     hidden: boolean;
     role: MenuItemRole;
+    // @internal
+    slottedSubmenu: HTMLElement[];
+    // @internal
+    protected slottedSubmenuChanged(prev: HTMLElement[] | undefined, next: HTMLElement[]): void;
     // @internal (undocumented)
-    submenu: Element | undefined;
+    submenu: HTMLElement | undefined;
+    // @internal
+    submenuContainer: HTMLDivElement;
     // @internal (undocumented)
     submenuLoaded: () => void;
-    // @internal
-    submenuRegion: FASTAnchoredRegion;
+    updateSubmenu(): void;
 }
 
 // @internal
@@ -2383,7 +2385,6 @@ export type MenuItemOptions = StartEndOptions & {
     checkboxIndicator?: string | SyntheticViewTemplate;
     expandCollapseGlyph?: string | SyntheticViewTemplate;
     radioIndicator?: string | SyntheticViewTemplate;
-    anchoredRegion: TemplateElementDependency;
 };
 
 // @public
@@ -2397,7 +2398,7 @@ export const MenuItemRole: {
 export type MenuItemRole = typeof MenuItemRole[keyof typeof MenuItemRole];
 
 // @public
-export function menuItemTemplate<T extends FASTMenuItem>(options: MenuItemOptions): ElementViewTemplate<T>;
+export function menuItemTemplate<T extends FASTMenuItem>(options?: MenuItemOptions): ElementViewTemplate<T>;
 
 // @beta
 export const MenuPlacement: {
@@ -2814,7 +2815,6 @@ export type YearFormat = typeof YearFormat[keyof typeof YearFormat];
 // dist/dts/calendar/calendar.d.ts:51:5 - (ae-incompatible-release-tags) The symbol "dataGrid" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/data-grid/data-grid-row.template.d.ts:9:5 - (ae-incompatible-release-tags) The symbol "dataGridCell" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/data-grid/data-grid.template.d.ts:9:5 - (ae-incompatible-release-tags) The symbol "dataGridRow" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
-// dist/dts/menu-item/menu-item.d.ts:15:5 - (ae-incompatible-release-tags) The symbol "anchoredRegion" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/picker/picker.template.d.ts:9:5 - (ae-incompatible-release-tags) The symbol "anchoredRegion" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/picker/picker.template.d.ts:10:5 - (ae-incompatible-release-tags) The symbol "pickerMenu" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta
 // dist/dts/picker/picker.template.d.ts:11:5 - (ae-incompatible-release-tags) The symbol "pickerMenuOption" is marked as @public, but its signature references "TemplateElementDependency" which is marked as @beta

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -94,6 +94,7 @@
     "wait-on": "^6.0.1"
   },
   "dependencies": {
+    "@floating-ui/dom": "^1.0.3",
     "@microsoft/fast-element": "^2.0.0-beta.15",
     "@microsoft/fast-web-utilities": "^6.0.0",
     "tabbable": "^5.2.0",

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -1,7 +1,14 @@
-import { ElementViewTemplate, html, ref, when } from "@microsoft/fast-element";
-import { endSlotTemplate, startSlotTemplate, tagFor } from "../patterns/index.js";
-import { MenuItemRole } from "./menu-item.js";
+import {
+    elements,
+    ElementViewTemplate,
+    html,
+    ref,
+    slotted,
+    when,
+} from "@microsoft/fast-element";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/index.js";
 import type { FASTMenuItem, MenuItemOptions } from "./menu-item.js";
+import { MenuItemRole } from "./menu-item.options.js";
 
 /**
  * Generates a template for the {@link @microsoft/fast-foundation#(FASTMenuItem:class)} component using
@@ -10,9 +17,8 @@ import type { FASTMenuItem, MenuItemOptions } from "./menu-item.js";
  * @public
  */
 export function menuItemTemplate<T extends FASTMenuItem>(
-    options: MenuItemOptions
+    options: MenuItemOptions = {}
 ): ElementViewTemplate<T> {
-    const anchoredRegionTag = tagFor(options.anchoredRegion);
     return html<T>`
     <template
         aria-haspopup="${x => (x.hasSubmenu ? "menu" : void 0)}"
@@ -69,26 +75,17 @@ export function menuItemTemplate<T extends FASTMenuItem>(
                 </div>
             `
         )}
-        ${when(
-            x => x.expanded,
-            html<T>`
-                <${anchoredRegionTag}
-                    :anchorElement="${x => x}"
-                    vertical-positioning-mode="dynamic"
-                    vertical-default-position="bottom"
-                    vertical-inset="true"
-                    horizontal-positioning-mode="dynamic"
-                    horizontal-default-position="end"
-                    class="submenu-region"
-                    dir="${x => x.currentDirection}"
-                    @loaded="${x => x.submenuLoaded()}"
-                    ${ref("submenuRegion")}
-                    part="submenu-region"
-                >
-                    <slot name="submenu"></slot>
-                </${anchoredRegionTag}>
-            `
-        )}
+        <span
+            ?hidden="${x => !x.expanded}"
+            class="submenu-container"
+            part="submenu-container"
+            ${ref("submenuContainer")}
+        >
+            <slot name="submenu" ${slotted({
+                property: "slottedSubmenu",
+                filter: elements("[role='menu']"),
+            })}></slot>
+        </span>
     </template>
     `;
 }

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -1,3 +1,5 @@
+import type { Placement } from "@floating-ui/dom";
+import { autoUpdate, computePosition, flip, shift, size } from "@floating-ui/dom";
 import {
     attr,
     FASTElement,
@@ -6,22 +8,15 @@ import {
     Updates,
 } from "@microsoft/fast-element";
 import {
-    Direction,
     keyArrowLeft,
     keyArrowRight,
     keyEnter,
     keyEscape,
     keySpace,
 } from "@microsoft/fast-web-utilities";
-import type { FASTAnchoredRegion } from "../anchored-region/anchored-region.js";
-import type { FASTMenu } from "../menu/menu.js";
-import {
-    StartEnd,
-    StartEndOptions,
-    TemplateElementDependency,
-} from "../patterns/index.js";
+import type { StartEndOptions } from "../patterns/start-end.js";
+import { StartEnd } from "../patterns/start-end.js";
 import { applyMixins } from "../utilities/apply-mixins.js";
-import { getDirection } from "../utilities/direction.js";
 import { MenuItemRole, roleForMenuItem } from "./menu-item.options.js";
 
 export { MenuItemRole, roleForMenuItem };
@@ -34,7 +29,6 @@ export type MenuItemOptions = StartEndOptions & {
     checkboxIndicator?: string | SyntheticViewTemplate;
     expandCollapseGlyph?: string | SyntheticViewTemplate;
     radioIndicator?: string | SyntheticViewTemplate;
-    anchoredRegion: TemplateElementDependency;
 };
 
 /**
@@ -80,16 +74,12 @@ export class FASTMenuItem extends FASTElement {
      */
     @attr({ mode: "boolean" })
     public expanded: boolean;
-    protected expandedChanged(oldValue: boolean): void {
+    protected expandedChanged(prev: boolean | undefined, next: boolean): void {
         if (this.$fastController.isConnected) {
-            if (this.submenu === undefined) {
-                return;
+            if (next && this.submenu) {
+                this.updateSubmenu();
             }
-            if (this.expanded === false) {
-                (this.submenu as FASTMenu).collapseExpandedItem();
-            } else {
-                this.currentDirection = getDirection(this);
-            }
+
             this.$emit("expanded-change", this, { bubbles: false });
         }
     }
@@ -103,6 +93,13 @@ export class FASTMenuItem extends FASTElement {
      */
     @attr
     public role: MenuItemRole = MenuItemRole.menuitem;
+
+    /**
+     * Cleanup function for the submenu positioner.
+     *
+     * @public
+     */
+    public cleanup: () => void;
 
     /**
      * The checked value of the element.
@@ -130,59 +127,56 @@ export class FASTMenuItem extends FASTElement {
     public hidden: boolean;
 
     /**
-     * reference to the anchored region
+     * The submenu slotted content.
      *
      * @internal
      */
     @observable
-    public submenuRegion: FASTAnchoredRegion;
+    public slottedSubmenu: HTMLElement[];
 
     /**
      * @internal
      */
-    @observable
-    public hasSubmenu: boolean = false;
+    public get hasSubmenu(): boolean {
+        return !!this.submenu;
+    }
 
     /**
-     * Track current direction to pass to the anchored region
+     * Sets the submenu and updates its position.
      *
      * @internal
      */
-    @observable
-    public currentDirection: Direction = Direction.ltr;
+    protected slottedSubmenuChanged(
+        prev: HTMLElement[] | undefined,
+        next: HTMLElement[]
+    ) {
+        if (next.length) {
+            this.submenu = next[0];
+            this.updateSubmenu();
+        }
+    }
+
+    /**
+     * The container for the submenu.
+     *
+     * @internal
+     */
+    public submenuContainer: HTMLDivElement;
 
     /**
      * @internal
      */
     @observable
-    public submenu: Element | undefined;
+    public submenu: HTMLElement | undefined;
 
     private focusSubmenuOnLoad: boolean = false;
-
-    private observer: MutationObserver | undefined;
-
-    /**
-     * @internal
-     */
-    public connectedCallback(): void {
-        super.connectedCallback();
-        Updates.enqueue(() => {
-            this.updateSubmenu();
-        });
-
-        this.observer = new MutationObserver(this.updateSubmenu);
-    }
 
     /**
      * @internal
      */
     public disconnectedCallback(): void {
+        this.cleanup?.();
         super.disconnectedCallback();
-        this.submenu = undefined;
-        if (this.observer !== undefined) {
-            this.observer.disconnect();
-            this.observer = undefined;
-        }
     }
 
     /**
@@ -243,8 +237,8 @@ export class FASTMenuItem extends FASTElement {
             return;
         }
         this.focusSubmenuOnLoad = false;
-        if (this.hasSubmenu) {
-            (this.submenu as HTMLElement).focus();
+        if (this.submenu) {
+            this.submenu.focus();
             this.setAttribute("tabindex", "-1");
         }
     };
@@ -309,13 +303,12 @@ export class FASTMenuItem extends FASTElement {
                 break;
 
             case MenuItemRole.menuitem:
-                // update submenu
-                this.updateSubmenu();
                 if (this.hasSubmenu) {
                     this.expandAndFocus();
-                } else {
-                    this.$emit("change");
+                    break;
                 }
+
+                this.$emit("change");
                 break;
 
             case MenuItemRole.menuitemradio:
@@ -327,23 +320,45 @@ export class FASTMenuItem extends FASTElement {
     };
 
     /**
-     * Gets the submenu element if any
+     * Calculate and apply submenu positioning.
      *
-     * @internal
+     * @public
      */
-    private updateSubmenu = (): void => {
-        this.submenu = this.domChildren().find((element: Element) => {
-            return element.getAttribute("role") === "menu";
+    public updateSubmenu() {
+        this.cleanup?.();
+
+        if (!this.submenu || !this.expanded) {
+            return;
+        }
+
+        Updates.enqueue(() => {
+            this.cleanup = autoUpdate(this, this.submenuContainer, async () => {
+                const fallbackPlacements: Placement[] = ["left-start", "right-start"];
+                const { x, y } = await computePosition(this, this.submenuContainer, {
+                    middleware: [
+                        shift(),
+                        size({
+                            apply: ({ availableWidth, rects }) => {
+                                if (availableWidth < rects.floating.width) {
+                                    fallbackPlacements.push("bottom-end", "top-end");
+                                }
+                            },
+                        }),
+                        flip({ fallbackPlacements }),
+                    ],
+                    placement: "right-start",
+                    strategy: "fixed",
+                });
+
+                Object.assign(this.submenuContainer.style, {
+                    left: `${x}px`,
+                    position: "fixed",
+                    top: `${y}px`,
+                });
+
+                this.submenuLoaded();
+            });
         });
-
-        this.hasSubmenu = this.submenu === undefined ? false : true;
-    };
-
-    /**
-     * get an array of valid DOM children
-     */
-    private domChildren(): Element[] {
-        return Array.from(this.children).filter(child => !child.hasAttribute("hidden"));
     }
 }
 

--- a/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.register.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.register.ts
@@ -15,7 +15,6 @@ export const styles = css`
         border: calc(var(--focus-stroke-width) * 1px) solid transparent;
         box-sizing: border-box;
         color: var(--neutral-foreground-rest);
-        contain: layout;
         cursor: pointer;
         display: flex;
         fill: currentcolor;
@@ -33,8 +32,6 @@ export const styles = css`
     :host(:hover) {
         background: var(--neutral-fill-stealth-hover);
         color: var(--neutral-foreground-rest);
-        position: relative;
-        z-index: 1;
     }
 
     :host(:active) {
@@ -192,12 +189,18 @@ export const styles = css`
         display: block;
         pointer-events: none;
     }
+
+    .submenu-container {
+        position: fixed;
+        top: 0;
+        left: 0;
+        z-index: 1;
+    }
 `;
 
 FASTMenuItem.define({
     name: "fast-menu-item",
     template: menuItemTemplate({
-        anchoredRegion: "fast-anchored-region",
         checkboxIndicator: /* html */ `
             <svg
                 part="checkbox-indicator"

--- a/packages/web-components/fast-foundation/src/menu/README.md
+++ b/packages/web-components/fast-foundation/src/menu/README.md
@@ -192,20 +192,22 @@ export const myMenuItem = MenuItem.compose<MenuItemOptions>({
 
 #### Fields
 
-| Name       | Privacy | Type           | Default | Description                        | Inherited From |
-| ---------- | ------- | -------------- | ------- | ---------------------------------- | -------------- |
-| `disabled` | public  | `boolean`      |         | The disabled state of the element. |                |
-| `expanded` | public  | `boolean`      |         | The expanded state of the element. |                |
-| `role`     | public  | `MenuItemRole` |         | The role of the element.           |                |
-| `checked`  | public  | `boolean`      |         | The checked value of the element.  |                |
-| `hidden`   | public  | `boolean`      |         | The hidden attribute.              |                |
+| Name       | Privacy | Type           | Default | Description                                  | Inherited From |
+| ---------- | ------- | -------------- | ------- | -------------------------------------------- | -------------- |
+| `disabled` | public  | `boolean`      |         | The disabled state of the element.           |                |
+| `expanded` | public  | `boolean`      |         | The expanded state of the element.           |                |
+| `role`     | public  | `MenuItemRole` |         | The role of the element.                     |                |
+| `cleanup`  | public  | `() => void`   |         | Cleanup function for the submenu positioner. |                |
+| `checked`  | public  | `boolean`      |         | The checked value of the element.            |                |
+| `hidden`   | public  | `boolean`      |         | The hidden attribute.                        |                |
 
 #### Methods
 
-| Name              | Privacy   | Description | Parameters                             | Return | Inherited From |
-| ----------------- | --------- | ----------- | -------------------------------------- | ------ | -------------- |
-| `expandedChanged` | protected |             | `oldValue: boolean`                    | `void` |                |
-| `checkedChanged`  | protected |             | `oldValue: boolean, newValue: boolean` | `void` |                |
+| Name              | Privacy   | Description                              | Parameters                                  | Return | Inherited From |
+| ----------------- | --------- | ---------------------------------------- | ------------------------------------------- | ------ | -------------- |
+| `expandedChanged` | protected |                                          | `prev: boolean or undefined, next: boolean` | `void` |                |
+| `checkedChanged`  | protected |                                          | `oldValue: boolean, newValue: boolean`      | `void` |                |
+| `updateSubmenu`   | public    | Calculate and apply submenu positioning. |                                             |        |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/menu/menu.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.pw.spec.ts
@@ -360,6 +360,7 @@ test.describe("Menu", () => {
     });
 
     test("should close the menu when pressing the escape key", async () => {
+        test.slow();
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -386,6 +387,7 @@ test.describe("Menu", () => {
 
         await element.first().press("Escape");
 
+        await (await element.first().elementHandle())?.waitForElementState("stable");
 
         await expect(menuItems.first()).toBeFocused();
     });

--- a/packages/web-components/fast-ssr/src/dom-shim.spec.ts
+++ b/packages/web-components/fast-ssr/src/dom-shim.spec.ts
@@ -1,8 +1,8 @@
 import "./install-dom-shim.js";
 import { expect, test } from "@playwright/test";
-import  { createWindow } from "./dom-shim.js";
 import * as Foundation from "@microsoft/fast-foundation";
 import { ElementViewTemplate, FASTElement } from "@microsoft/fast-element";
+import  { createWindow } from "./dom-shim.js";
 import fastSSR from "./exports.js";
 
 test.describe("createWindow", () => {
@@ -74,9 +74,7 @@ const componentsAndTemplates: [typeof FASTElement, ElementViewTemplate][] = [
     [Foundation.FASTListbox as any as typeof FASTElement, Foundation.listboxTemplate()],
     [Foundation.FASTListboxOption, Foundation.listboxOptionTemplate()],
     [Foundation.FASTMenu, Foundation.menuTemplate()],
-    [Foundation.FASTMenuItem, Foundation.menuItemTemplate({
-        anchoredRegion
-    })],
+    [Foundation.FASTMenuItem, Foundation.menuItemTemplate()],
     [Foundation.FASTNumberField, Foundation.numberFieldTemplate()],
     [Foundation.FASTPicker, Foundation.pickerTemplate({
         anchoredRegion,

--- a/yarn.lock
+++ b/yarn.lock
@@ -1726,6 +1726,18 @@
     minimatch "^3.1.2"
     strip-json-comments "^3.1.1"
 
+"@floating-ui/core@^1.0.1":
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/@floating-ui/core/-/core-1.0.1.tgz#00e64d74e911602c8533957af0cce5af6b2e93c8"
+  integrity sha512-bO37brCPfteXQfFY0DyNDGB3+IMe4j150KFQcgJ5aBP295p9nBGeHEs/p0czrRbtlHq4Px/yoPXO/+dOCcF4uA==
+
+"@floating-ui/dom@^1.0.3":
+  version "1.0.3"
+  resolved "https://registry.yarnpkg.com/@floating-ui/dom/-/dom-1.0.3.tgz#b439c8a66436c2cae8d97e889f0b76cce757a6ec"
+  integrity sha512-6H1kwjkOZKabApNtXRiYHvMmYJToJ1DV7rQ3xc/WJpOABhQIOJJOdz2AOejj8X+gcybaFmBpisVTZxBZAM3V0w==
+  dependencies:
+    "@floating-ui/core" "^1.0.1"
+
 "@fluentui/svg-icons@^1.1.0", "@fluentui/svg-icons@^1.1.139":
   version "1.1.167"
   resolved "https://registry.yarnpkg.com/@fluentui/svg-icons/-/svg-icons-1.1.167.tgz#b16f2be02061d438f520c8499ab184e700cfcfbf"


### PR DESCRIPTION
# Pull Request

## 📖 Description

Replaces the methods used to position submenus for menu-item with Floating UI.

Changes the `updateSubmenu` method to be public to allow for overriding the default positioning behavior.

### 🎫 Issues

## 👩‍💻 Reviewer Notes

## 📑 Test Plan

All tests for the menu-item and menu components should pass as expected.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
