### PR TITLE
Fix: NVDA announces button slots as clickable

### DIFF
--- a/change/@microsoft-fast-foundation-0522614f-d1db-45a7-b87a-3e719b7d174e.json
+++ b/change/@microsoft-fast-foundation-0522614f-d1db-45a7-b87a-3e719b7d174e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove click handler on slots",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-0522614f-d1db-45a7-b87a-3e719b7d174e.json
+++ b/change/@microsoft-fast-foundation-0522614f-d1db-45a7-b87a-3e719b7d174e.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "remove click handler on slots",
+  "comment": "remove unnecessary click handler from legacy button span implementation",
   "packageName": "@microsoft/fast-foundation",
   "email": "32497422+KingOfTac@users.noreply.github.com",
   "dependentChangeType": "prerelease"

--- a/change/@microsoft-fast-foundation-0522614f-d1db-45a7-b87a-3e719b7d174e.json
+++ b/change/@microsoft-fast-foundation-0522614f-d1db-45a7-b87a-3e719b7d174e.json
@@ -3,5 +3,5 @@
   "comment": "remove click handler on slots",
   "packageName": "@microsoft/fast-foundation",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -809,8 +809,6 @@ export class FASTButton extends FormAssociatedButton {
     // (undocumented)
     control: HTMLButtonElement;
     defaultSlottedContent: HTMLElement[];
-    // @internal (undocumented)
-    disconnectedCallback(): void;
     formaction: string;
     // (undocumented)
     protected formactionChanged(): void;

--- a/packages/web-components/fast-foundation/src/button/button.ts
+++ b/packages/web-components/fast-foundation/src/button/button.ts
@@ -168,38 +168,7 @@ export class FASTButton extends FormAssociatedButton {
 
         this.proxy.setAttribute("type", this.type);
         this.handleUnsupportedDelegatesFocus();
-
-        const elements = Array.from(this.control?.children) as HTMLSpanElement[];
-        if (elements) {
-            elements.forEach((span: HTMLSpanElement) => {
-                span.addEventListener("click", this.handleClick);
-            });
-        }
     }
-
-    /**
-     * @internal
-     */
-    public disconnectedCallback(): void {
-        super.disconnectedCallback();
-
-        const elements = Array.from(this.control?.children) as HTMLSpanElement[];
-        if (elements) {
-            elements.forEach((span: HTMLSpanElement) => {
-                span.removeEventListener("click", this.handleClick);
-            });
-        }
-    }
-
-    /**
-     * Prevent events to propagate if disabled and has no slotted content wrapped in HTML elements
-     * @internal
-     */
-    private handleClick = (e: Event) => {
-        if (this.disabled && this.defaultSlottedContent?.length <= 1) {
-            e.stopPropagation();
-        }
-    };
 
     /**
      * Submits the parent form

--- a/packages/web-components/fast-foundation/src/button/stories/button.stories.ts
+++ b/packages/web-components/fast-foundation/src/button/stories/button.stories.ts
@@ -112,3 +112,24 @@ ButtonWithResetType.args = {
     storyContent: "Reset",
     type: "reset",
 };
+
+export const ButtonWithStartSlotIcon: Story<FASTButton> = Button.bind({});
+ButtonWithStartSlotIcon.args = {
+    storyContent: html`
+        <svg
+            slot="start"
+            aria-hidden="true"
+            xmlns="http://www.w3.org/2000/svg"
+            width="1em"
+            height="1em"
+            preserveAspectRatio="xMidYMid meet"
+            viewBox="0 0 20 20"
+        >
+            <path
+                fill="currentColor"
+                d="M14.69 11.503c1 0 1.81.81 1.81 1.81v.689h-.005c-.034.78-.248 1.757-1.123 2.555C14.416 17.43 12.765 18 10 18c-2.766 0-4.416-.57-5.372-1.443c-.875-.798-1.089-1.776-1.123-2.555H3.5v-.69c0-.999.81-1.809 1.81-1.809h9.38ZM6.5 3A1.5 1.5 0 0 0 5 4.5v4A1.5 1.5 0 0 0 6.5 10h7A1.5 1.5 0 0 0 15 8.5v-4A1.5 1.5 0 0 0 13.5 3h-3v-.5A.48.48 0 0 0 10 2c-.276 0-.5.23-.5.5V3h-3ZM7 6.5a1 1 0 1 1 2 0a1 1 0 0 1-2 0Zm4 0a1 1 0 1 1 2 0a1 1 0 0 1-2 0Z"
+            />
+        </svg>
+        Button
+    `,
+};


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes an issue where NVDA announces slots as clickable if they have an onClick event bound.

Just as a general FYI for those interested. The reason why NVDA announces "clickable clickable button" when a svg is in the start slot is because if you set `aria-hidden` on the svg it is hidden from the SR however NVDA announces elements with a click handler bound to them as clickable so for `FASTButton` where it was binding click handlers to all the slots the announcement would look like "clickable '' clickable [default slot content] button". If the svg is in the end slot then it announces "clickable [default slot content] clickable '' button". This same pattern would hold true for any content in the named slots.

### 🎫 Issues
NVDA would announce the named slots in `Button` as clickable if they contained any nodes because the slots had the onClick event bound to them. More info on the NVDA behavior here: https://github.com/nvaccess/nvda/issues/5830

## 👩‍💻 Reviewer Notes
I removed the `disconnectedCallback` from `Button` since all it was doing was removing the event listeners from the slots. I also removed the handleClick method since the internal button already handles disabling clicks when the disabled attribute is present. All tests continue to pass after this change.

## 📑 Test Plan
I added a new story in storybook with an icon slotted into the start slot to show that the "clickable, clickable" announcement no longer happens. To see the old behavior go to this repro and tab through the buttons. https://stackblitz.com/edit/typescript-qp1vkw?file=index.html

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [X] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [X] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
We should see if this can be backported to vCurrent and the fast/fluent component packages