### PR TITLE
fix: fix boolean crash issue and throw error for unknown/object attributes

### DIFF
--- a/change/@microsoft-fast-ssr-804e71af-7827-4c43-915a-9bc391332976.json
+++ b/change/@microsoft-fast-ssr-804e71af-7827-4c43-915a-9bc391332976.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "Fix boolean attribute rendering issues and throw error for unknown/object type of attributes",
   "packageName": "@microsoft/fast-ssr",
   "email": "daviwu@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-ssr-804e71af-7827-4c43-915a-9bc391332976.json
+++ b/change/@microsoft-fast-ssr-804e71af-7827-4c43-915a-9bc391332976.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix boolean attribute rendering issues and throw error for unknown/object type of attributes",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "daviwu@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
@@ -108,19 +108,37 @@ test.describe("FASTElementRenderer", () => {
                 <bare-element ><template shadowroot=\"open\"></template></bare-element>
             `);
         });
-
-        test("should render an attribute when a boolean attr evaluates true/false", () => {
+        test("should render an attribute with no value when a boolean attr evaluates true", () => {
             const { templateRenderer } = fastSSR();
             const result = consolidate(templateRenderer.render(html`
-                <bare-element attr1="${x => true}"></bare-element>
-                <bare-element attr2="${x => false}"></bare-element>
+                <bare-element ?attr="${x => true}"></bare-element>
             `));
             expect(result).toBe(`
-                <bare-element  attr1="true"><template shadowroot=\"open\"></template></bare-element>
-                <bare-element  attr2="false"><template shadowroot=\"open\"></template></bare-element>
+                <bare-element  attr><template shadowroot=\"open\"></template></bare-element>
             `);
         });
-
+        test("should render an attribute with a boolean value for non-aria attributes", () => {
+            const { templateRenderer } = fastSSR();
+            const result = consolidate(templateRenderer.render(html`
+                <bare-element disabled="${x => true}"></bare-element>
+                <bare-element disabled="${x => false}"></bare-element>
+            `));
+            expect(result).toBe(`
+                <bare-element  disabled><template shadowroot=\"open\"></template></bare-element>
+                <bare-element ><template shadowroot=\"open\"></template></bare-element>
+            `);
+        });
+        test("should render an attribute with a boolean value for aria attributes", () => {
+            const { templateRenderer } = fastSSR();
+            const result = consolidate(templateRenderer.render(html`
+                <bare-element aria-expanded="${x => true}"></bare-element>
+                <bare-element aria-expanded="${x => false}"></bare-element>
+            `));
+            expect(result).toBe(`
+                <bare-element  aria-expanded="true"><template shadowroot=\"open\"></template></bare-element>
+                <bare-element  aria-expanded="false"><template shadowroot=\"open\"></template></bare-element>
+            `);
+        });
         test("should render an attribute with a string value", () => {
             const { templateRenderer } = fastSSR();
             const result = consolidate(templateRenderer.render(html`
@@ -130,7 +148,6 @@ test.describe("FASTElementRenderer", () => {
                 <bare-element  attr="my-str-value"><template shadowroot=\"open\"></template></bare-element>
             `);
         });
-
         test("should throw error when rendering an attribute with an object value", () => {
             const { templateRenderer } = fastSSR();
             try {

--- a/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
@@ -109,27 +109,19 @@ test.describe("FASTElementRenderer", () => {
             `);
         });
 
-        test("should render an attribute with no value when a boolean attr evaluates true", () => {
+        test("should render a boolean attribute with the values of true or false", () => {
             const { templateRenderer } = fastSSR();
             const result = consolidate(templateRenderer.render(html`
                 <bare-element ?attr="${x => true}"></bare-element>
+                <bare-element ?attr="${x => false}"></bare-element>
             `));
             expect(result).toBe(`
                 <bare-element  attr><template shadowroot=\"open\"></template></bare-element>
-            `);
-        });
-        test("should render an attribute with a boolean value for non-aria attributes", () => {
-            const { templateRenderer } = fastSSR();
-            const result = consolidate(templateRenderer.render(html`
-                <bare-element disabled="${x => true}"></bare-element>
-                <bare-element disabled="${x => false}"></bare-element>
-            `));
-            expect(result).toBe(`
-                <bare-element  disabled><template shadowroot=\"open\"></template></bare-element>
                 <bare-element ><template shadowroot=\"open\"></template></bare-element>
             `);
         });
-        test("should render an attribute with a boolean value for aria attributes", () => {
+
+        test("should render a non-boolean attribute with the values of true or false", () => {
             const { templateRenderer } = fastSSR();
             const result = consolidate(templateRenderer.render(html`
                 <bare-element aria-expanded="${x => true}"></bare-element>

--- a/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/elemenent-renderer.spec.ts
@@ -109,14 +109,35 @@ test.describe("FASTElementRenderer", () => {
             `);
         });
 
-        test("should render an attribute with no value when a boolean attr evaluates true", () => {
+        test("should render an attribute when a boolean attr evaluates true/false", () => {
             const { templateRenderer } = fastSSR();
             const result = consolidate(templateRenderer.render(html`
-                <bare-element ?attr="${x => true}"></bare-element>
+                <bare-element attr1="${x => true}"></bare-element>
+                <bare-element attr2="${x => false}"></bare-element>
             `));
             expect(result).toBe(`
-                <bare-element  attr><template shadowroot=\"open\"></template></bare-element>
+                <bare-element  attr1="true"><template shadowroot=\"open\"></template></bare-element>
+                <bare-element  attr2="false"><template shadowroot=\"open\"></template></bare-element>
             `);
+        });
+
+        test("should render an attribute with a string value", () => {
+            const { templateRenderer } = fastSSR();
+            const result = consolidate(templateRenderer.render(html`
+                <bare-element attr="${x => 'my-str-value'}"></bare-element>
+            `));
+            expect(result).toBe(`
+                <bare-element  attr="my-str-value"><template shadowroot=\"open\"></template></bare-element>
+            `);
+        });
+
+        test("should throw error when rendering an attribute with an object value", () => {
+            const { templateRenderer } = fastSSR();
+            try {
+                consolidate(templateRenderer.render(html`<bare-element attr="${x => ({ key: 'my-value' })}"></bare-element>`));
+            } catch (error) {
+                expect(error).toEqual(new Error("Cannot assign attribute 'attr' for element bare-element."));
+            }
         });
     });
 

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -208,7 +208,11 @@ function renderAttribute(name: string, value: any, elementTagName: string): stri
     } else if (typeof value === "string") {
         return ` ${name}="${escapeHtml(value)}"`;
     } else if (typeof value === "boolean") {
-        return ` ${name}="${value.toString()}"`;
+        if (name.startsWith("aria-")) {
+            return ` ${name}="${value.toString()}"`;
+        } else {
+            return value ? ` ${name}` : "";
+        }
     } else {
         throw new Error(
             `Cannot assign attribute '${name}' for element ${elementTagName}.`

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -178,7 +178,7 @@ function* renderAttributesSync(this: FASTElementRenderer): IterableIterator<stri
             } else if (typeof value === "string") {
                 yield ` ${name}="${escapeHtml(value)}"`;
             } else if (typeof value === "boolean") {
-                yield ` ${name}="${(value as any).toString()}"`;
+                yield ` ${name}="${value}"`;
             } else {
                 throw new Error(
                     `Cannot assign attribute '${name}' for element ${this.element.tagName}.`

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -136,11 +136,7 @@ export abstract class AsyncFASTElementRenderer extends FASTElementRenderer
                 i < attributes.length && ({ name, value } = attributes[i]);
                 i++
             ) {
-                if (value === "" || value === undefined || value === null) {
-                    yield ` ${name}`;
-                } else {
-                    yield ` ${name}="${escapeHtml(value)}"`;
-                }
+                yield renderAttribute(name, value, this.element.tagName);
             }
         }
     }
@@ -178,11 +174,7 @@ function* renderAttributesSync(this: FASTElementRenderer): IterableIterator<stri
             i < attributes.length && ({ name, value } = attributes[i]);
             i++
         ) {
-            if (value === "" || value === undefined || value === null) {
-                yield ` ${name}`;
-            } else {
-                yield ` ${name}="${escapeHtml(value)}"`;
-            }
+            yield renderAttribute(name, value, this.element.tagName);
         }
     }
 }
@@ -206,6 +198,20 @@ function* renderShadow(
             renderInfo,
             this.element,
             ExecutionContext.default
+        );
+    }
+}
+
+function renderAttribute(name: string, value: any, elementTagName: string): string {
+    if (value === "" || value === undefined || value === null) {
+        return ` ${name}`;
+    } else if (typeof value === "string") {
+        return ` ${name}="${escapeHtml(value)}"`;
+    } else if (typeof value === "boolean") {
+        return ` ${name}="${value.toString()}"`;
+    } else {
+        throw new Error(
+            `Cannot assign attribute '${name}' for element ${elementTagName}.`
         );
     }
 }

--- a/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
+++ b/packages/web-components/fast-ssr/src/element-renderer/fast-element-renderer.ts
@@ -178,11 +178,7 @@ function* renderAttributesSync(this: FASTElementRenderer): IterableIterator<stri
             } else if (typeof value === "string") {
                 yield ` ${name}="${escapeHtml(value)}"`;
             } else if (typeof value === "boolean") {
-                if (name.startsWith("aria-")) {
-                    yield ` ${name}="${(value as any).toString()}"`;
-                } else {
-                    yield value ? ` ${name}` : "";
-                }
+                yield ` ${name}="${(value as any).toString()}"`;
             } else {
                 throw new Error(
                     `Cannot assign attribute '${name}' for element ${this.element.tagName}.`


### PR DESCRIPTION
- Fix boolean attribute rendering issues and throw error for unknown/object type of attributes

# Pull Request

## 📖 Description

FAST SSR will crash for boolean type attributes because of escapeHtml and it will also convert object type into `[object Object]` string. This PR fixes both of these 2 issues.

### 🎫 Issues

https://github.com/microsoft/fast/issues/6476 (it's reopened as discussed)

## 📑 Test Plan

New unit tests are added. This branch has the testing code in example project: https://github.com/YusakuNo1/fast/tree/daviwu/ssr-boolean-crash-example

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x ] I have included a change request file using `$ yarn change`
- [x ] I have added tests for my changes.
- [x ] I have tested my changes.
- [x ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.