### PR TITLE
feat: enable using design tokens in html

### DIFF
--- a/change/@microsoft-fast-foundation-d9cd55f5-5363-4cf8-88c0-8cdf107c0014.json
+++ b/change/@microsoft-fast-foundation-d9cd55f5-5363-4cf8-88c0-8cdf107c0014.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: enable using design tokens in html",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-d9cd55f5-5363-4cf8-88c0-8cdf107c0014.json
+++ b/change/@microsoft-fast-foundation-d9cd55f5-5363-4cf8-88c0-8cdf107c0014.json
@@ -3,5 +3,5 @@
   "comment": "feat: enable using design tokens in html",
   "packageName": "@microsoft/fast-foundation",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -6,7 +6,7 @@
 
 import type { CaptureType } from '@microsoft/fast-element';
 import { Constructable } from '@microsoft/fast-element';
-import type { CSSDirective } from '@microsoft/fast-element';
+import { CSSDirective } from '@microsoft/fast-element';
 import { Direction } from '@microsoft/fast-web-utilities';
 import type { ElementsFilter } from '@microsoft/fast-element';
 import { ElementStyles } from '@microsoft/fast-element';
@@ -15,6 +15,7 @@ import { FASTElement } from '@microsoft/fast-element';
 import { FASTElementDefinition } from '@microsoft/fast-element';
 import { HostBehavior } from '@microsoft/fast-element';
 import { HostController } from '@microsoft/fast-element';
+import { HTMLDirective } from '@microsoft/fast-element';
 import { Orientation } from '@microsoft/fast-web-utilities';
 import { SyntheticViewTemplate } from '@microsoft/fast-element';
 import { ViewTemplate } from '@microsoft/fast-element';
@@ -301,9 +302,10 @@ export function comboboxTemplate<T extends FASTCombobox>(options?: ComboboxOptio
 export type ConstructableFormAssociated = Constructable<HTMLElement & FASTElement>;
 
 // @public (undocumented)
-export class CSSDesignToken<T> extends DesignToken<T> implements CSSDirective {
+export class CSSDesignToken<T> extends DesignToken<T> implements CSSDirective, HTMLDirective {
     constructor(configuration: CSSDesignTokenConfiguration);
     createCSS(): string;
+    createHTML(): string;
     readonly cssCustomProperty: string;
 }
 

--- a/packages/web-components/fast-foundation/src/design-token/fast-design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/fast-design-token.ts
@@ -1,5 +1,4 @@
 import {
-    AddViewBehaviorFactory,
     CSSDirective,
     HostController,
     htmlDirective,

--- a/packages/web-components/fast-foundation/src/design-token/fast-design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/fast-design-token.ts
@@ -1,4 +1,11 @@
-import type { CSSDirective, HostController, Subscriber } from "@microsoft/fast-element";
+import {
+    AddViewBehaviorFactory,
+    CSSDirective,
+    HostController,
+    htmlDirective,
+    HTMLDirective,
+    Subscriber,
+} from "@microsoft/fast-element";
 import {
     cssDirective,
     FASTElement,
@@ -254,7 +261,9 @@ export class DesignToken<T> {
  * @public
  */
 @cssDirective()
-export class CSSDesignToken<T> extends DesignToken<T> implements CSSDirective {
+@htmlDirective()
+export class CSSDesignToken<T> extends DesignToken<T>
+    implements CSSDirective, HTMLDirective {
     /**
      * The CSS Custom property name of the token.
      */
@@ -267,6 +276,14 @@ export class CSSDesignToken<T> extends DesignToken<T> implements CSSDirective {
     public createCSS(): string {
         return this.cssVar;
     }
+
+    /**
+     * Creates HTML to be used within a template.
+     */
+    public createHTML(): string {
+        return this.cssVar;
+    }
+
     private cssReflector: Subscriber = {
         handleChange: <T>(
             source: DesignToken<T>,


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR implements `HTMLDirective` on `CSSDesignToken` so that it works the same in HTML as it does in CSS.

### 🎫 Issues

* Closes #6459 

## 👩‍💻 Reviewer Notes

Very simple implementation. Basically, one line of code plus registering via decorator.

## 📑 Test Plan

Existing tests pass. Planning to add a simple test to verify this in a follow-up PR, after the security PR is merged. I need test infrastructure from that PR to do it.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Follow up PR to add an HTML Directive tests.