### PR TITLE
chore: move ViewBehaviorOrchestrator to utilities

### DIFF
--- a/change/@microsoft-fast-element-076c59cf-8308-49f9-9d81-e21e0ca3b1c7.json
+++ b/change/@microsoft-fast-element-076c59cf-8308-49f9-9d81-e21e0ca3b1c7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: move ViewBehaviorOrchestrator to utilities",
+  "packageName": "@microsoft/fast-element",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-076c59cf-8308-49f9-9d81-e21e0ca3b1c7.json
+++ b/change/@microsoft-fast-element-076c59cf-8308-49f9-9d81-e21e0ca3b1c7.json
@@ -3,5 +3,5 @@
   "comment": "chore: move ViewBehaviorOrchestrator to utilities",
   "packageName": "@microsoft/fast-element",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-9a782ea3-339a-48cc-bd6c-6a53b5ba91ba.json
+++ b/change/@microsoft-fast-foundation-9a782ea3-339a-48cc-bd6c-6a53b5ba91ba.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: move ViewBehaviorOrchestrator to utilities",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-9a782ea3-339a-48cc-bd6c-6a53b5ba91ba.json
+++ b/change/@microsoft-fast-foundation-9a782ea3-339a-48cc-bd6c-6a53b5ba91ba.json
@@ -3,5 +3,5 @@
   "comment": "chore: move ViewBehaviorOrchestrator to utilities",
   "packageName": "@microsoft/fast-foundation",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -906,19 +906,6 @@ export interface ViewBehaviorFactory {
 }
 
 // @public
-export interface ViewBehaviorOrchestrator<TSource = any, TParent = any> extends ViewController<TSource, TParent>, HostBehavior<TSource> {
-    addBehavior(behavior: ViewBehavior): void;
-    addBehaviorFactory(factory: ViewBehaviorFactory, target: Node): void;
-    // (undocumented)
-    addTarget(nodeId: string, target: Node): void;
-}
-
-// @public
-export const ViewBehaviorOrchestrator: Readonly<{
-    create<TSource = any, TParent = any>(source: TSource): ViewBehaviorOrchestrator<TSource, TParent>;
-}>;
-
-// @public
 export type ViewBehaviorTargets = {
     [id: string]: Node;
 };

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
@@ -4,9 +4,9 @@ import {
     FASTElement,
     observable,
     RepeatDirective,
-    ViewBehaviorOrchestrator,
     ViewTemplate,
 } from "@microsoft/fast-element";
+import { ViewBehaviorOrchestrator } from "@microsoft/fast-element/utilities";
 import {
     eventFocusOut,
     eventKeyDown,

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -6,8 +6,8 @@ import {
     observable,
     RepeatDirective,
     Updates,
-    ViewBehaviorOrchestrator,
 } from "@microsoft/fast-element";
+import { ViewBehaviorOrchestrator } from "@microsoft/fast-element/utilities";
 import {
     eventFocus,
     eventFocusOut,

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -7,9 +7,9 @@ import {
     ref,
     RepeatDirective,
     Updates,
-    ViewBehaviorOrchestrator,
     ViewTemplate,
 } from "@microsoft/fast-element";
+import { ViewBehaviorOrchestrator } from "@microsoft/fast-element/utilities";
 import {
     keyArrowDown,
     keyArrowLeft,


### PR DESCRIPTION
# Pull Request

## 📖 Description

This is the first of several cleanup tasks designed to prepare fast-element 2.0 for production release. This PR moves `ViewBehaviorOrchestrator` to utilities, since it is not used by fast-element itself and only used by a very specific set of components in foundation. Its usage would not be common.

### 🎫 Issues

* #6502 

## 👩‍💻 Reviewer Notes

This is just a basic move of the code. It did cause a break in foundation, but that is easily fixed by correcting the imports to point to the new location.

## 📑 Test Plan

All existing tests pass. No new tests added as part of this move.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

We should add some tests for `ViewBehaviorOrchestrator` in a future PR.