### PR TITLE
fix: use regex to check for version format in fast-benchmarks

### DIFF
--- a/packages/utilities/fast-benchmarks/scripts/template.js
+++ b/packages/utilities/fast-benchmarks/scripts/template.js
@@ -239,7 +239,8 @@ export async function generateBenchmarks(
         ];
 
         versions.forEach(version => {
-            const isPublishedVersion = version.includes(".");
+            // regex exp that checks if string is indeed in version format: ${number}.${number}.${number}
+            const isPublishedVersion = /[0-9]+\.[0-9]+\.[0-9]+/.test(version);
             const isLocalBranch = localProps.branchName && version === LOCAL;
             const isBranch = isLocalBranch || !isPublishedVersion;
             const url =


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
When a string is passed into the **versions** argument of the node script for running a benchmark in fast-benchmark, it would resolve that as a fast-element version number (i.e 1.9.0 or 2.0.0-beta). The same argument also accepts branch names as a possible value to be passed under **versions**, resulting in a possible bug if someone passes in a branch name that has a '.' in it (ie.  users/jokreitl/update-engine.io)

The solution to this is to strengthen the check for the fast-element version format using regex, anything that does not follow number-period character-number-period character -number will be resolved as a branch name.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
#6427
## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->