### PR TITLE
refactor(foundation): tooltip inert

### DIFF
--- a/change/@microsoft-fast-foundation-7cbcbbcc-1537-4a7d-a139-98ee3e837d98.json
+++ b/change/@microsoft-fast-foundation-7cbcbbcc-1537-4a7d-a139-98ee3e837d98.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "features inert in tooltip to avoid possible focus",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "yinon@hotmail.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.template.ts
@@ -44,7 +44,7 @@ export function tooltipTemplate<T extends FASTTooltip>(
                 dir="${x => x.currentDirection}"
                 ${ref("region")}
             >
-                <div class="tooltip" part="tooltip" role="tooltip">
+                <div class="tooltip" part="tooltip" role="tooltip" inert>
                     <slot></slot>
                 </div>
             </${tag}>


### PR DESCRIPTION
web.dev argyle's article mentions edge case where screen reader who don't understand a tooltip role might allow users to focus on it.

I'm uncertain on whether screen readers focus on non-focusable elements in any specific use-cases

hoping to get more info here (and potentially win a contribution opportunity)

see

https://web.dev/building-a-tooltip-component/#markup