### PR TITLE
feat: shim DOMTokenList for class and part properties on HTMLElement

### DIFF
--- a/change/@microsoft-fast-ssr-98fe57e7-b330-4251-80ac-f87ee4835fb7.json
+++ b/change/@microsoft-fast-ssr-98fe57e7-b330-4251-80ac-f87ee4835fb7.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: shim DOMTokenList for class and part properties on HTMLElement",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "roeisenb@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-ssr-98fe57e7-b330-4251-80ac-f87ee4835fb7.json
+++ b/change/@microsoft-fast-ssr-98fe57e7-b330-4251-80ac-f87ee4835fb7.json
@@ -3,5 +3,5 @@
   "comment": "feat: shim DOMTokenList for class and part properties on HTMLElement",
   "packageName": "@microsoft/fast-ssr",
   "email": "roeisenb@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-ssr/src/dom-shim.spec.ts
+++ b/packages/web-components/fast-ssr/src/dom-shim.spec.ts
@@ -4,6 +4,7 @@ import * as Foundation from "@microsoft/fast-foundation";
 import { ElementViewTemplate, FASTElement } from "@microsoft/fast-element";
 import  { createWindow } from "./dom-shim.js";
 import fastSSR from "./exports.js";
+import { uniqueElementName } from "@microsoft/fast-element/testing";
 
 test.describe("createWindow", () => {
     test("should create a window with a document property that is an instance of the window's Document constructor", () => {
@@ -164,5 +165,104 @@ test.describe("The DOM shim", () => {
 
             expect(list).toBeInstanceOf(MyMediaQueryList);
         })
+    });
+
+    test.describe("DOMTokenList", () => {
+        class TestElement extends FASTElement {}
+        TestElement.define({ name: uniqueElementName() })
+
+        test("adds a token", () => {
+            const element = new TestElement();
+            const cList = element.classList;
+
+            cList.toggle("c1");
+            expect(cList.contains("c1"), "adds a token that is not present").toBeTruthy();
+
+            expect(
+                cList.toggle("c2"),
+                "returns true when token is added"
+            ).toStrictEqual(true);
+        });
+
+        test("removes a token", () => {
+            const element = new TestElement();
+            const cList = element.classList;
+
+            cList.add("c1");
+            cList.toggle("c1");
+
+            expect(!cList.contains("c1"), "removes a token that is present").toBeTruthy();
+
+            cList.add("c2");
+            expect(
+                cList.toggle("c2"),
+                "return false when token is removed"
+            ).toStrictEqual(false);
+        });
+
+        test("adds token with second argument", () => {
+            const element = new TestElement();
+            const cList = element.classList;
+
+            cList.toggle("c1", true);
+            expect(cList.contains("c1"), "adds a token").toBeTruthy();
+
+            expect(
+                cList.toggle("c2", true),
+                "returns true when token is added"
+            ).toStrictEqual(true);
+
+            cList.add("c3");
+            cList.toggle("c3", true);
+
+            expect(
+                cList.contains("c3"),
+                "does not remove a token that is already present"
+            ).toBeTruthy();
+
+            cList.add("c4");
+
+            expect(
+                cList.toggle("c4", true),
+                "returns true when token is already present"
+            ).toStrictEqual(true);
+        });
+
+        test("removes token with second argument", () => {
+            const element = new TestElement();
+            const cList = element.classList;
+
+            cList.add("c1");
+            cList.toggle("c1", false);
+
+            expect(!cList.contains("c1"), "removes a token").toBeTruthy();
+
+            expect(
+                cList.toggle("c2", false),
+                "returns false when token is removed"
+            ).toStrictEqual(false);
+
+            cList.toggle("c3", false);
+
+            expect(
+                !cList.contains("c3"),
+                "does not add a token that is not present"
+            ).toBeTruthy();
+
+            expect(
+                cList.toggle("c4", false),
+                "returns false when token was not present"
+            ).toStrictEqual(false);
+        });
+
+        test("removes duplicated tokens", () => {
+            const element = new TestElement();
+            element.className = "ho ho ho";
+
+            const cList = element.classList;
+            cList.remove("ho");
+            expect(!cList.contains("ho"), "should remove all instances of 'ho'").toBeTruthy();
+            expect(element.className).toStrictEqual("");
+        });
     });
 })

--- a/packages/web-components/fast-ssr/src/dom-shim.ts
+++ b/packages/web-components/fast-ssr/src/dom-shim.ts
@@ -39,24 +39,28 @@ function checkTokenAndGetIndex(classList: DOMTokenList, token: string) {
 /**
  * @beta
  */
-export class DOMTokenList extends Array<string> {
-    constructor(private element: HTMLElement, private attributeName: string) {
-        super();
+export class DOMTokenList {
+    private tokens: string[] = [];
 
+    public constructor(private element: HTMLElement, private attributeName: string) {
         const trimmedClasses = (element.getAttribute(attributeName) || "").trim();
         const classes = trimmedClasses ? trimmedClasses.split(/\s+/) : [];
 
         for (let i = 0, len = classes.length; i < len; i++) {
-            this.push(classes[i]);
+            this.tokens.push(classes[i]);
         }
     }
 
     public item(i: number) {
-        return this[i] || null;
+        return this.tokens[i] || null;
     }
 
     public contains(token: string) {
         return ~checkTokenAndGetIndex(this, token + "");
+    }
+
+    public indexOf(token: string) {
+        return this.tokens.indexOf(token);
     }
 
     public add(...tokens: string[]) {
@@ -68,7 +72,7 @@ export class DOMTokenList extends Array<string> {
             const token = tokens[index] + "";
 
             if (!~checkTokenAndGetIndex(this, token)) {
-                this.push(token);
+                this.tokens.push(token);
                 updated = true;
             }
         } while (++index < length);
@@ -88,7 +92,7 @@ export class DOMTokenList extends Array<string> {
             let result = checkTokenAndGetIndex(this, token);
 
             while (~result) {
-                this.splice(result, 1);
+                this.tokens.splice(result, 1);
                 updated = true;
                 result = checkTokenAndGetIndex(this, token);
             }
@@ -118,13 +122,13 @@ export class DOMTokenList extends Array<string> {
         const index = checkTokenAndGetIndex(this, token + "");
 
         if (~index) {
-            this.splice(index, 1, replacement);
+            this.tokens.splice(index, 1, replacement);
             this.updateClassName();
         }
     }
 
     public toString(): string {
-        return this.join(" ");
+        return this.tokens.join(" ");
     }
 
     private updateClassName() {


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds `classList`, `className`, and `part` properties to the `HTMLElement` shim for SSR.

### 🎫 Issues

* Partial work for #6490  

## 👩‍💻 Reviewer Notes

The main part of this PR is the introduction of an implementation of `DOMTokenList` which is then plugged into `HTMLElement` where appropriate.

## 📑 Test Plan

Tests for `DOMTokenList` were added. Existing tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Explore whether any other shims are needed to enable foundation components to function out of the box.