### PR TITLE
Allow using enums for derived DesignToken values

### DIFF
--- a/change/@microsoft-fast-foundation-cafc5ae3-9c3e-4715-b923-5e7542e55091.json
+++ b/change/@microsoft-fast-foundation-cafc5ae3-9c3e-4715-b923-5e7542e55091.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Allow enum types on derived DesignToken values",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "rajsite@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -155,6 +155,19 @@ describe("A DesignToken", () => {
             removeElement(target);
         });
 
+        it("should support getting and setting enumerated values", () => {
+            const target = addElement();
+            const Animal = {
+                cat: 'cat',
+                dog: 'dog'
+            } as const;
+            type Animal = typeof Animal[keyof typeof Animal];
+            const token = DesignToken.create<Animal>("test");
+            token.setValueFor(target, Animal.cat);
+            expect(token.getValueFor(target)).to.equal(Animal.cat);
+            removeElement(target);
+        });
+
         describe("that is a CSSDesignToken", () => {
             it("should set the CSS custom property for the element", async () => {
                 const target = addElement();
@@ -413,6 +426,19 @@ describe("A DesignToken", () => {
                 }
             })
             removeElement(target)
+        });
+
+        it("should support getting and setting enumerated values", () => {
+            const target = addElement();
+            const Animal = {
+                cat: 'cat',
+                dog: 'dog'
+            } as const;
+            type Animal = typeof Animal[keyof typeof Animal];
+            const token = DesignToken.create<Animal>("test");
+            token.setValueFor(target, (): Animal => Animal.cat);
+            expect(token.getValueFor(target)).to.equal(Animal.cat);
+            removeElement(target);
         });
     });
 

--- a/packages/web-components/fast-foundation/src/design-token/interfaces.ts
+++ b/packages/web-components/fast-foundation/src/design-token/interfaces.ts
@@ -3,7 +3,7 @@
  * or arbitrary observable properties.
  * @public
  */
-export type DerivedDesignTokenValue<T> = T extends Function
+export type DerivedDesignTokenValue<T> = [T] extends [Function]
     ? never
     : (target: HTMLElement) => T;
 
@@ -11,7 +11,7 @@ export type DerivedDesignTokenValue<T> = T extends Function
  * A design token value with no observable dependencies
  * @public
  */
-export type StaticDesignTokenValue<T> = T extends Function ? never : T;
+export type StaticDesignTokenValue<T> = [T] extends [Function] ? never : T;
 
 /**
  * The type that a {@link (DesignToken:interface)} can be set to.

--- a/packages/web-components/fast-foundation/src/design-token/interfaces.ts
+++ b/packages/web-components/fast-foundation/src/design-token/interfaces.ts
@@ -11,7 +11,7 @@ export type DerivedDesignTokenValue<T> = [T] extends [Function]
  * A design token value with no observable dependencies
  * @public
  */
-export type StaticDesignTokenValue<T> = [T] extends [Function] ? never : T;
+export type StaticDesignTokenValue<T> = T extends Function ? never : T;
 
 /**
  * The type that a {@link (DesignToken:interface)} can be set to.


### PR DESCRIPTION
# Pull Request

## 📖 Description

Note: This PR only targets `archives/fast-element-1` as the issue does not reproduce in master. The tests might be useful to pull into master to prevent regressions. See Reviewer Notes.

`DerivedDesignTokenValue` were accidentally opting in to [Distributive Conditional Types](https://www.typescriptlang.org/docs/handbook/2/conditional-types.html#distributive-conditional-types) behavior when enum values were used resulting in an enum like:

```ts
const Animal = {
  cat: 'cat',
  dog: 'dog',
} as const;
type Animal = typeof Animal[keyof typeof Animal];
```

Result in requiring a type of:

```ts
(target: HTMLElement) => Animal.cat | (target: HTMLElement) => Animal.dog
```

Instead of the expected type of:
```ts
(target: HTMLElement) => Animal
```

### 🎫 Issues

Fixes #6529.

## 👩‍💻 Reviewer Notes

I opted out of distributive conditional types for the DesignToken value for both the static and derived case. While the static case by chance happens to not have the issue because it just distributes over `T` instead of `() => T`, opting out better conveys the intention.

Edit: I actually ended up just opting out for the derived case. When opting out in the static case you end up down a rabbit hole refactoring the types and turns out master already has that. This issue does not reproduce in master (tested with `@microsoft/fast-foundation@3.0.0-alpha.22`). It may be worth bringing the enum tests into master to prevent future regressions.

## 📑 Test Plan

Added some unit tests for static and derived token values based on enums.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes. - N/A
- [z] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

Pull the tests into master?