### PR TITLE
sync archives branch after failed push during publish

### DIFF
--- a/change/@microsoft-fast-foundation-9eda75c8-6106-407b-9040-5989faee48ab.json
+++ b/change/@microsoft-fast-foundation-9eda75c8-6106-407b-9040-5989faee48ab.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "hidden horizontal-scroll fix",
-  "packageName": "@microsoft/fast-foundation",
-  "email": "robarb@microsoft.com",
-  "dependentChangeType": "prerelease"
-}

--- a/packages/tooling/fast-figma-plugin-msft/package.json
+++ b/packages/tooling/fast-figma-plugin-msft/package.json
@@ -54,6 +54,6 @@
     "@microsoft/fast-colors": "^5.3.0",
     "@microsoft/fast-components": "^2.30.6",
     "@microsoft/fast-element": "^1.11.0",
-    "@microsoft/fast-react-wrapper": "^0.3.15"
+    "@microsoft/fast-react-wrapper": "^0.3.16-0"
   }
 }

--- a/packages/utilities/fast-react-wrapper/CHANGELOG.json
+++ b/packages/utilities/fast-react-wrapper/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/fast-react-wrapper",
   "entries": [
     {
+      "date": "Mon, 28 Nov 2022 18:28:05 GMT",
+      "tag": "@microsoft/fast-react-wrapper_v0.3.16-0",
+      "version": "0.3.16-0",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "beachball",
+            "package": "@microsoft/fast-react-wrapper",
+            "comment": "Bump @microsoft/fast-foundation to v2.47.1-0",
+            "commit": "1538e4766a95811301309cd33b4eb78c53db9aeb"
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 25 Oct 2022 03:07:31 GMT",
       "tag": "@microsoft/fast-react-wrapper_v0.3.15",
       "version": "0.3.15",

--- a/packages/utilities/fast-react-wrapper/CHANGELOG.md
+++ b/packages/utilities/fast-react-wrapper/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @microsoft/fast-react-wrapper
 
-This log was last generated on Tue, 25 Oct 2022 03:07:31 GMT and should not be manually modified.
+This log was last generated on Mon, 28 Nov 2022 18:28:05 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 0.3.16-0
+
+Mon, 28 Nov 2022 18:28:05 GMT
+
+### Changes
+
+- Bump @microsoft/fast-foundation to v2.47.1-0
 
 ## 0.3.15
 

--- a/packages/utilities/fast-react-wrapper/package.json
+++ b/packages/utilities/fast-react-wrapper/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/fast-react-wrapper",
   "description": "A utility for wrapping web components for use in React.",
   "sideEffects": false,
-  "version": "0.3.15",
+  "version": "0.3.16-0",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"
@@ -87,7 +87,7 @@
   },
   "dependencies": {
     "@microsoft/fast-element": "^1.11.0",
-    "@microsoft/fast-foundation": "^2.47.0"
+    "@microsoft/fast-foundation": "^2.47.1-0"
   },
   "peerDependencies": {
     "react": ">=16.9.0"

--- a/packages/web-components/fast-foundation/CHANGELOG.json
+++ b/packages/web-components/fast-foundation/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/fast-foundation",
   "entries": [
     {
+      "date": "Mon, 28 Nov 2022 18:28:05 GMT",
+      "tag": "@microsoft/fast-foundation_v2.47.1-0",
+      "version": "2.47.1-0",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "robarb@microsoft.com",
+            "package": "@microsoft/fast-foundation",
+            "commit": "1538e4766a95811301309cd33b4eb78c53db9aeb",
+            "comment": "hidden horizontal-scroll fix"
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 25 Oct 2022 03:07:31 GMT",
       "tag": "@microsoft/fast-foundation_v2.47.0",
       "version": "2.47.0",

--- a/packages/web-components/fast-foundation/CHANGELOG.md
+++ b/packages/web-components/fast-foundation/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @microsoft/fast-foundation
 
-This log was last generated on Tue, 25 Oct 2022 03:07:31 GMT and should not be manually modified.
+This log was last generated on Mon, 28 Nov 2022 18:28:05 GMT and should not be manually modified.
 
 <!-- Start content -->
+
+## 2.47.1-0
+
+Mon, 28 Nov 2022 18:28:05 GMT
+
+### Changes
+
+- hidden horizontal-scroll fix (robarb@microsoft.com)
 
 ## 2.47.0
 

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/fast-foundation",
   "description": "A library of Web Component building blocks",
   "sideEffects": false,
-  "version": "2.47.0",
+  "version": "2.47.1-0",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"

--- a/sites/fast-color-explorer/package.json
+++ b/sites/fast-color-explorer/package.json
@@ -57,7 +57,7 @@
     "@microsoft/fast-colors": "^5.3.0",
     "@microsoft/fast-components": "^2.30.6",
     "@microsoft/fast-element": "^1.11.0",
-    "@microsoft/fast-foundation": "^2.47.0",
+    "@microsoft/fast-foundation": "^2.47.1-0",
     "@microsoft/fast-web-utilities": "^5.4.1"
   }
 }

--- a/sites/fast-website/package.json
+++ b/sites/fast-website/package.json
@@ -12,7 +12,7 @@
     "@fluentui/svg-icons": "^1.1.139",
     "@microsoft/fast-components": "^2.30.6",
     "@microsoft/fast-element": "^1.11.0",
-    "@microsoft/fast-foundation": "^2.47.0",
+    "@microsoft/fast-foundation": "^2.47.1-0",
     "@microsoft/fast-web-utilities": "^5.4.1",
     "@microsoft/site-utilities": "^0.9.0",
     "@rollup/plugin-alias": "^3.1.1",


### PR DESCRIPTION
Syncs the repo with the post-publish state after the publish failed to push back to the `archives/fast-element-1` branch.