### PR TITLE
fix: update types for default slotted content

### DIFF
--- a/change/@microsoft-fast-element-cea330c6-ce4b-4acd-a125-744d3eee9ed2.json
+++ b/change/@microsoft-fast-element-cea330c6-ce4b-4acd-a125-744d3eee9ed2.json
@@ -3,5 +3,5 @@
   "comment": "update return type for dangerousHTML to DangerousHTMLDirective",
   "packageName": "@microsoft/fast-element",
   "email": "chhol@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-cea330c6-ce4b-4acd-a125-744d3eee9ed2.json
+++ b/change/@microsoft-fast-element-cea330c6-ce4b-4acd-a125-744d3eee9ed2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update return type for dangerousHTML to DangerousHTMLDirective",
+  "packageName": "@microsoft/fast-element",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-a3cf3a8d-5ef5-4b9f-a1ff-a5adfffb5f09.json
+++ b/change/@microsoft-fast-foundation-a3cf3a8d-5ef5-4b9f-a1ff-a5adfffb5f09.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "updates types for default slotted content to remove string and support DangerousHTMLDirective",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -220,7 +220,7 @@ export type CSSTemplateTag = ((strings: TemplateStringsArray, ...values: (Compos
 export function customElement(nameOrDef: string | PartialFASTElementDefinition): (type: Constructable<HTMLElement>) => void;
 
 // @public
-export function dangerousHTML<TSource = any, TParent = any>(html: string): CaptureType<TSource, TParent>;
+export function dangerousHTML<TSource = any, TParent = any>(html: string): DangerousHTMLDirective;
 
 // @public
 export class DangerousHTMLDirective implements HTMLDirective {

--- a/packages/web-components/fast-element/src/templating/dangerous-html.ts
+++ b/packages/web-components/fast-element/src/templating/dangerous-html.ts
@@ -22,6 +22,6 @@ HTMLDirective.define(DangerousHTMLDirective);
  */
 export function dangerousHTML<TSource = any, TParent = any>(
     html: string
-): CaptureType<TSource, TParent> {
+): DangerousHTMLDirective {
     return new DangerousHTMLDirective(html);
 }

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -7,6 +7,7 @@
 import type { CaptureType } from '@microsoft/fast-element';
 import { Constructable } from '@microsoft/fast-element';
 import { CSSDirective } from '@microsoft/fast-element';
+import { DangerousHTMLDirective } from '@microsoft/fast-element';
 import { Direction } from '@microsoft/fast-web-utilities';
 import type { ElementsFilter } from '@microsoft/fast-element';
 import { ElementStyles } from '@microsoft/fast-element';
@@ -31,8 +32,8 @@ export type AccordionExpandMode = typeof AccordionExpandMode[keyof typeof Accord
 
 // @public
 export type AccordionItemOptions = StartEndOptions & {
-    expandedIcon?: string | SyntheticViewTemplate;
-    collapsedIcon?: string | SyntheticViewTemplate;
+    expandedIcon?: DangerousHTMLDirective | SyntheticViewTemplate;
+    collapsedIcon?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -128,7 +129,7 @@ export type AutoUpdateMode = typeof AutoUpdateMode[keyof typeof AutoUpdateMode];
 
 // @public
 export type AvatarOptions = {
-    media?: string | SyntheticViewTemplate;
+    media?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -159,7 +160,7 @@ export function badgeTemplate<T extends FASTBadge>(): ElementViewTemplate<T>;
 
 // @public
 export type BreadcrumbItemOptions = StartEndOptions & {
-    separator?: string | SyntheticViewTemplate;
+    separator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -258,8 +259,8 @@ export type CheckableFormAssociatedElement = FormAssociatedElement & CheckableFo
 
 // @public
 export type CheckboxOptions = {
-    checkedIndicator?: string | SyntheticViewTemplate;
-    indeterminateIndicator?: string | SyntheticViewTemplate;
+    checkedIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
+    indeterminateIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -292,7 +293,7 @@ export type ComboboxAutocomplete = typeof ComboboxAutocomplete[keyof typeof Comb
 
 // @public
 export type ComboboxOptions = StartEndOptions & {
-    indicator?: string | SyntheticViewTemplate;
+    indicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -619,7 +620,7 @@ export function dividerTemplate<T extends FASTDivider>(): ElementViewTemplate<T>
 
 // @public
 export type EndOptions = {
-    end?: string | SyntheticViewTemplate;
+    end?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2176,8 +2177,8 @@ export type FlipperDirection = typeof FlipperDirection[keyof typeof FlipperDirec
 
 // @public
 export type FlipperOptions = {
-    next?: string | SyntheticViewTemplate;
-    previous?: string | SyntheticViewTemplate;
+    next?: DangerousHTMLDirective | SyntheticViewTemplate;
+    previous?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2373,9 +2374,9 @@ export type MediaQueryListListener = (this: MediaQueryList, ev?: MediaQueryListE
 
 // @public
 export type MenuItemOptions = StartEndOptions & {
-    checkboxIndicator?: string | SyntheticViewTemplate;
-    expandCollapseGlyph?: string | SyntheticViewTemplate;
-    radioIndicator?: string | SyntheticViewTemplate;
+    checkboxIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
+    expandCollapseGlyph?: DangerousHTMLDirective | SyntheticViewTemplate;
+    radioIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2434,8 +2435,8 @@ export function noninteractiveCalendarTemplate<T extends FASTCalendar>(options: 
 
 // @public
 export type NumberFieldOptions = StartEndOptions & {
-    stepDownGlyph?: string | SyntheticViewTemplate;
-    stepUpGlyph?: string | SyntheticViewTemplate;
+    stepDownGlyph?: DangerousHTMLDirective | SyntheticViewTemplate;
+    stepUpGlyph?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2478,13 +2479,13 @@ export function pickerTemplate<T extends FASTPicker>(options: PickerOptions): El
 
 // @public
 export type ProgressOptions = {
-    indeterminateIndicator1?: string | SyntheticViewTemplate;
-    indeterminateIndicator2?: string | SyntheticViewTemplate;
+    indeterminateIndicator1?: DangerousHTMLDirective | SyntheticViewTemplate;
+    indeterminateIndicator2?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
 export type ProgressRingOptions = {
-    indeterminateIndicator?: string | SyntheticViewTemplate;
+    indeterminateIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2521,7 +2522,7 @@ export function radioGroupTemplate<T extends FASTRadioGroup>(): ElementViewTempl
 
 // @public
 export type RadioOptions = {
-    checkedIndicator?: string | SyntheticViewTemplate;
+    checkedIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2556,7 +2557,7 @@ export function searchTemplate<T extends FASTSearch>(options?: SearchOptions): E
 
 // @public
 export type SelectOptions = StartEndOptions & {
-    indicator?: string | SyntheticViewTemplate;
+    indicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2601,7 +2602,7 @@ export type SliderMode = typeof SliderMode[keyof typeof SliderMode];
 
 // @public
 export type SliderOptions = {
-    thumb?: string | SyntheticViewTemplate;
+    thumb?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2620,7 +2621,7 @@ export type StartEndOptions = StartOptions & EndOptions;
 
 // @public
 export type StartOptions = {
-    start?: string | SyntheticViewTemplate;
+    start?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2634,7 +2635,7 @@ export const supportsElementInternals: boolean;
 
 // @public
 export type SwitchOptions = {
-    switch?: string | SyntheticViewTemplate;
+    switch?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public
@@ -2742,7 +2743,7 @@ export function tooltipTemplate<T extends FASTTooltip>(options: TooltipOptions):
 
 // @public
 export type TreeItemOptions = StartEndOptions & {
-    expandCollapseGlyph?: string | SyntheticViewTemplate;
+    expandCollapseGlyph?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 // @public

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
@@ -1,5 +1,6 @@
 import {
     attr,
+    DangerousHTMLDirective,
     FASTElement,
     nullableNumberConverter,
     SyntheticViewTemplate,
@@ -12,8 +13,8 @@ import { applyMixins } from "../utilities/apply-mixins.js";
  * @public
  */
 export type AccordionItemOptions = StartEndOptions & {
-    expandedIcon?: string | SyntheticViewTemplate;
-    collapsedIcon?: string | SyntheticViewTemplate;
+    expandedIcon?: DangerousHTMLDirective | SyntheticViewTemplate;
+    collapsedIcon?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/avatar/avatar.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.ts
@@ -1,11 +1,16 @@
-import { attr, FASTElement, SyntheticViewTemplate } from "@microsoft/fast-element";
+import {
+    attr,
+    DangerousHTMLDirective,
+    FASTElement,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 
 /**
  * Avatar configuration options
  * @public
  */
 export type AvatarOptions = {
-    media?: string | SyntheticViewTemplate;
+    media?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.ts
@@ -1,4 +1,8 @@
-import { observable, SyntheticViewTemplate } from "@microsoft/fast-element";
+import {
+    DangerousHTMLDirective,
+    observable,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 import { DelegatesARIALink, FASTAnchor } from "../anchor/anchor.js";
 import { StartEnd, StartEndOptions } from "../patterns/index.js";
 import { applyMixins } from "../utilities/apply-mixins.js";
@@ -14,7 +18,7 @@ import { applyMixins } from "../utilities/apply-mixins.js";
  * @public
  */
 export type BreadcrumbItemOptions = StartEndOptions & {
-    separator?: string | SyntheticViewTemplate;
+    separator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.ts
@@ -1,4 +1,9 @@
-import { attr, observable, SyntheticViewTemplate } from "@microsoft/fast-element";
+import {
+    attr,
+    DangerousHTMLDirective,
+    observable,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 import { keySpace } from "@microsoft/fast-web-utilities";
 import { FormAssociatedCheckbox } from "./checkbox.form-associated.js";
 
@@ -7,8 +12,8 @@ import { FormAssociatedCheckbox } from "./checkbox.form-associated.js";
  * @public
  */
 export type CheckboxOptions = {
-    checkedIndicator?: string | SyntheticViewTemplate;
-    indeterminateIndicator?: string | SyntheticViewTemplate;
+    checkedIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
+    indeterminateIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/checkbox/stories/checkbox.register.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/stories/checkbox.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTCheckbox } from "../checkbox.js";
 import { checkboxTemplate } from "../checkbox.template.js";
@@ -132,7 +133,7 @@ const styles = css`
 FASTCheckbox.define({
     name: "fast-checkbox",
     template: checkboxTemplate({
-        checkedIndicator: /* html */ `
+        checkedIndicator: /* html */ html`
             <svg
                 part="checked-indicator"
                 class="checked-indicator"
@@ -146,7 +147,7 @@ FASTCheckbox.define({
                 />
             </svg>
         `,
-        indeterminateIndicator: /* html */ `
+        indeterminateIndicator: /* html */ html`
             <div part="indeterminate-indicator" class="indeterminate-indicator"></div>
         `,
     }),

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -1,6 +1,7 @@
 import { autoUpdate, computePosition, flip, hide, size } from "@floating-ui/dom";
 import {
     attr,
+    DangerousHTMLDirective,
     Observable,
     observable,
     SyntheticViewTemplate,
@@ -19,7 +20,7 @@ import { ComboboxAutocomplete } from "./combobox.options.js";
  * @public
  */
 export type ComboboxOptions = StartEndOptions & {
-    indicator?: string | SyntheticViewTemplate;
+    indicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/combobox/stories/combobox.register.ts
+++ b/packages/web-components/fast-foundation/src/combobox/stories/combobox.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTCombobox } from "../combobox.js";
 import { comboboxTemplate } from "../combobox.template.js";
@@ -205,7 +206,7 @@ const styles = css`
 FASTCombobox.define({
     name: "fast-combobox",
     template: comboboxTemplate({
-        indicator: /* html */ `
+        indicator: /* html */ html`
             <svg
                 class="select-indicator"
                 part="select-indicator"

--- a/packages/web-components/fast-foundation/src/flipper/flipper.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.ts
@@ -1,6 +1,7 @@
 import {
     attr,
     booleanConverter,
+    DangerousHTMLDirective,
     FASTElement,
     SyntheticViewTemplate,
 } from "@microsoft/fast-element";
@@ -13,8 +14,8 @@ export { FlipperDirection };
  * @public
  */
 export type FlipperOptions = {
-    next?: string | SyntheticViewTemplate;
-    previous?: string | SyntheticViewTemplate;
+    next?: DangerousHTMLDirective | SyntheticViewTemplate;
+    previous?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/flipper/stories/flipper.register.ts
+++ b/packages/web-components/fast-foundation/src/flipper/stories/flipper.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTFlipper } from "../flipper.js";
 import { flipperTemplate } from "../flipper.template.js";
@@ -85,14 +86,14 @@ const styles = css`
 FASTFlipper.define({
     name: "fast-flipper",
     template: flipperTemplate({
-        next: /* html */ `
+        next: /* html */ html`
             <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
                 <path
                     d="M4.023 15.273L11.29 8 4.023.727l.704-.704L12.71 8l-7.984 7.977-.704-.704z"
                 />
             </svg>
         `,
-        previous: /* html */ `
+        previous: /* html */ html`
             <svg viewBox="0 0 16 16" xmlns="http://www.w3.org/2000/svg">
                 <path
                     d="M11.273 15.977L3.29 8 11.273.023l.704.704L4.71 8l7.266 7.273-.704.704z"

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.ts
@@ -2,6 +2,7 @@ import type { Placement } from "@floating-ui/dom";
 import { autoUpdate, computePosition, flip, shift, size } from "@floating-ui/dom";
 import {
     attr,
+    DangerousHTMLDirective,
     FASTElement,
     observable,
     SyntheticViewTemplate,
@@ -26,9 +27,9 @@ export { MenuItemRole, roleForMenuItem };
  * @public
  */
 export type MenuItemOptions = StartEndOptions & {
-    checkboxIndicator?: string | SyntheticViewTemplate;
-    expandCollapseGlyph?: string | SyntheticViewTemplate;
-    radioIndicator?: string | SyntheticViewTemplate;
+    checkboxIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
+    expandCollapseGlyph?: DangerousHTMLDirective | SyntheticViewTemplate;
+    radioIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.register.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/stories/menu-item.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTMenuItem } from "../menu-item.js";
 import { menuItemTemplate } from "../menu-item.template.js";
@@ -201,27 +202,33 @@ export const styles = css`
 FASTMenuItem.define({
     name: "fast-menu-item",
     template: menuItemTemplate({
-        checkboxIndicator: /* html */ `
+        checkboxIndicator: /* html */ html`
             <svg
                 part="checkbox-indicator"
                 class="checkbox-indicator"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
             >
-                <path fill-rule="evenodd" clip-rule="evenodd" d="m8.1 12.7 7.1-8.2 1.6 1.4-8.6 9.9-4.4-4.5 1.5-1.5L8 12.7Z"/>
+                <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="m8.1 12.7 7.1-8.2 1.6 1.4-8.6 9.9-4.4-4.5 1.5-1.5L8 12.7Z"
+                />
             </svg>
         `,
-        expandCollapseGlyph: /* html */ `
+        expandCollapseGlyph: /* html */ html`
             <svg
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
                 class="expand-collapse-glyph"
                 part="expand-collapse-glyph"
             >
-                <path d="M5 12.3a1 1 0 0 0 1.6.8L11 8.8a1.5 1.5 0 0 0 0-2.3L6.6 2.2A1 1 0 0 0 5 3v9.3Z"/>
+                <path
+                    d="M5 12.3a1 1 0 0 0 1.6.8L11 8.8a1.5 1.5 0 0 0 0-2.3L6.6 2.2A1 1 0 0 0 5 3v9.3Z"
+                />
             </svg>
         `,
-        radioIndicator: /* html */ `
+        radioIndicator: /* html */ html`
             <span part="radio-indicator" class="radio-indicator"></span>
         `,
     }),

--- a/packages/web-components/fast-foundation/src/menu/stories/menu.register.ts
+++ b/packages/web-components/fast-foundation/src/menu/stories/menu.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { attr } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTMenuItem, MenuItemRole, menuItemTemplate } from "../../menu-item/index.js";
@@ -122,28 +123,33 @@ FancyMenu.define({
 FancyMenuItem.define({
     name: "fancy-menu-item",
     template: menuItemTemplate({
-        anchoredRegion: "fast-anchored-region",
-        checkboxIndicator: /* html */ `
+        checkboxIndicator: /* html */ html`
             <svg
                 part="checkbox-indicator"
                 class="checkbox-indicator"
                 viewBox="0 0 20 20"
                 xmlns="http://www.w3.org/2000/svg"
             >
-                <path fill-rule="evenodd" clip-rule="evenodd" d="m8.1 12.7 7.1-8.2 1.6 1.4-8.6 9.9-4.4-4.5 1.5-1.5L8 12.7Z"/>
+                <path
+                    fill-rule="evenodd"
+                    clip-rule="evenodd"
+                    d="m8.1 12.7 7.1-8.2 1.6 1.4-8.6 9.9-4.4-4.5 1.5-1.5L8 12.7Z"
+                />
             </svg>
         `,
-        expandCollapseGlyph: /* html */ `
+        expandCollapseGlyph: /* html */ html`
             <svg
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"
                 class="expand-collapse-glyph"
                 part="expand-collapse-glyph"
             >
-                <path d="M5 12.3a1 1 0 0 0 1.6.8L11 8.8a1.5 1.5 0 0 0 0-2.3L6.6 2.2A1 1 0 0 0 5 3v9.3Z"/>
+                <path
+                    d="M5 12.3a1 1 0 0 0 1.6.8L11 8.8a1.5 1.5 0 0 0 0-2.3L6.6 2.2A1 1 0 0 0 5 3v9.3Z"
+                />
             </svg>
         `,
-        radioIndicator: /* html */ `
+        radioIndicator: /* html */ html`
             <span part="radio-indicator" class="radio-indicator"></span>
         `,
     }),

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -1,5 +1,6 @@
 import {
     attr,
+    DangerousHTMLDirective,
     nullableNumberConverter,
     observable,
     SyntheticViewTemplate,
@@ -16,8 +17,8 @@ import { FormAssociatedNumberField } from "./number-field.form-associated.js";
  * @public
  */
 export type NumberFieldOptions = StartEndOptions & {
-    stepDownGlyph?: string | SyntheticViewTemplate;
-    stepUpGlyph?: string | SyntheticViewTemplate;
+    stepDownGlyph?: DangerousHTMLDirective | SyntheticViewTemplate;
+    stepUpGlyph?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/number-field/stories/number-field.register.ts
+++ b/packages/web-components/fast-foundation/src/number-field/stories/number-field.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTNumberField } from "../number-field.js";
 import { numberFieldTemplate } from "../number-field.template.js";
@@ -165,8 +166,12 @@ FASTNumberField.define({
     name: "fast-number-field",
     styles,
     template: numberFieldTemplate({
-        stepDownGlyph: /* html */ `<span class="step-down-glyph" part="step-down-glyph"></span>`,
-        stepUpGlyph: /* html */ `<span class="step-up-glyph" part="step-up-glyph"></span>`,
+        stepDownGlyph: /* html */ html`
+            <span class="step-down-glyph" part="step-down-glyph"></span>
+        `,
+        stepUpGlyph: /* html */ html`
+            <span class="step-up-glyph" part="step-up-glyph"></span>
+        `,
     }),
     shadowOptions: {
         delegatesFocus: true,

--- a/packages/web-components/fast-foundation/src/patterns/start-end.ts
+++ b/packages/web-components/fast-foundation/src/patterns/start-end.ts
@@ -1,11 +1,17 @@
-import { html, ref, SyntheticViewTemplate, ViewTemplate } from "@microsoft/fast-element";
+import {
+    html,
+    DangerousHTMLDirective,
+    ref,
+    SyntheticViewTemplate,
+    ViewTemplate,
+} from "@microsoft/fast-element";
 
 /**
  * Start configuration options
  * @public
  */
 export type StartOptions = {
-    start?: string | SyntheticViewTemplate;
+    start?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**
@@ -13,7 +19,7 @@ export type StartOptions = {
  * @public
  */
 export type EndOptions = {
-    end?: string | SyntheticViewTemplate;
+    end?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/patterns/start-end.ts
+++ b/packages/web-components/fast-foundation/src/patterns/start-end.ts
@@ -1,6 +1,6 @@
 import {
-    html,
     DangerousHTMLDirective,
+    html,
     ref,
     SyntheticViewTemplate,
     ViewTemplate,

--- a/packages/web-components/fast-foundation/src/progress-ring/progress-ring.options.ts
+++ b/packages/web-components/fast-foundation/src/progress-ring/progress-ring.options.ts
@@ -1,9 +1,12 @@
-import type { SyntheticViewTemplate } from "@microsoft/fast-element";
+import type {
+    DangerousHTMLDirective,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 
 /**
  * ProgressRing configuration options
  * @public
  */
 export type ProgressRingOptions = {
-    indeterminateIndicator?: string | SyntheticViewTemplate;
+    indeterminateIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };

--- a/packages/web-components/fast-foundation/src/progress-ring/stories/progress-ring.register.ts
+++ b/packages/web-components/fast-foundation/src/progress-ring/stories/progress-ring.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTProgressRing } from "../progress-ring.js";
 import { progressRingTemplate } from "../progress-ring.template.js";
@@ -72,7 +73,7 @@ const styles = css`
 FASTProgressRing.define({
     name: "fast-progress-ring",
     template: progressRingTemplate({
-        indeterminateIndicator: /* html */ `
+        indeterminateIndicator: /* html */ html`
             <svg class="progress" part="progress" viewBox="0 0 16 16">
                 <circle
                     class="background"

--- a/packages/web-components/fast-foundation/src/progress/progress.options.ts
+++ b/packages/web-components/fast-foundation/src/progress/progress.options.ts
@@ -1,10 +1,13 @@
-import type { SyntheticViewTemplate } from "@microsoft/fast-element";
+import type {
+    DangerousHTMLDirective,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 
 /**
  * Progress configuration options
  * @public
  */
 export type ProgressOptions = {
-    indeterminateIndicator1?: string | SyntheticViewTemplate;
-    indeterminateIndicator2?: string | SyntheticViewTemplate;
+    indeterminateIndicator1?: DangerousHTMLDirective | SyntheticViewTemplate;
+    indeterminateIndicator2?: DangerousHTMLDirective | SyntheticViewTemplate;
 };

--- a/packages/web-components/fast-foundation/src/progress/stories/progress.register.ts
+++ b/packages/web-components/fast-foundation/src/progress/stories/progress.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTProgress } from "../progress.js";
 import { progressTemplate } from "../progress.template.js";
@@ -109,11 +110,17 @@ const styles = css`
 FASTProgress.define({
     name: "fast-progress",
     template: progressTemplate({
-        indeterminateIndicator1: /* html */ `
-            <span class="indeterminate-indicator-1" part="indeterminate-indicator-1"></span>
+        indeterminateIndicator1: /* html */ html`
+            <span
+                class="indeterminate-indicator-1"
+                part="indeterminate-indicator-1"
+            ></span>
         `,
-        indeterminateIndicator2: /* html */ `
-            <span class="indeterminate-indicator-2" part="indeterminate-indicator-2"></span>
+        indeterminateIndicator2: /* html */ html`
+            <span
+                class="indeterminate-indicator-2"
+                part="indeterminate-indicator-2"
+            ></span>
         `,
     }),
     styles,

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -1,4 +1,9 @@
-import { attr, observable, SyntheticViewTemplate } from "@microsoft/fast-element";
+import {
+    attr,
+    DangerousHTMLDirective,
+    observable,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 import { keySpace } from "@microsoft/fast-web-utilities";
 import { FormAssociatedRadio } from "./radio.form-associated.js";
 
@@ -16,7 +21,7 @@ export type RadioControl = Pick<
  * @public
  */
 export type RadioOptions = {
-    checkedIndicator?: string | SyntheticViewTemplate;
+    checkedIndicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/radio/stories/radio.register.ts
+++ b/packages/web-components/fast-foundation/src/radio/stories/radio.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTRadio } from "../radio.js";
 import { radioTemplate } from "../radio.template.js";
@@ -136,7 +137,7 @@ const styles = css`
 FASTRadio.define({
     name: "fast-radio",
     template: radioTemplate({
-        checkedIndicator: /* html */ `
+        checkedIndicator: /* html */ html`
             <div part="checked-indicator" class="checked-indicator"></div>
         `,
     }),

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -1,6 +1,7 @@
 import { autoUpdate, computePosition, flip, hide, size } from "@floating-ui/dom";
 import {
     attr,
+    DangerousHTMLDirective,
     Observable,
     observable,
     SyntheticViewTemplate,
@@ -29,7 +30,7 @@ import { FormAssociatedSelect } from "./select.form-associated.js";
  * @public
  */
 export type SelectOptions = StartEndOptions & {
-    indicator?: string | SyntheticViewTemplate;
+    indicator?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/select/stories/select.register.ts
+++ b/packages/web-components/fast-foundation/src/select/stories/select.register.ts
@@ -1,4 +1,4 @@
-import { css, ElementStyles } from "@microsoft/fast-element";
+import { css, html, ElementStyles } from "@microsoft/fast-element";
 import { FASTSelect } from "../select.js";
 import { selectTemplate } from "../select.template.js";
 
@@ -209,7 +209,7 @@ export class Select extends FASTSelect {
 Select.define({
     name: "fast-select",
     template: selectTemplate({
-        indicator: /* html */ `
+        indicator: /* html */ html`
             <svg
                 class="select-indicator"
                 part="select-indicator"

--- a/packages/web-components/fast-foundation/src/select/stories/select.register.ts
+++ b/packages/web-components/fast-foundation/src/select/stories/select.register.ts
@@ -1,4 +1,4 @@
-import { css, html, ElementStyles } from "@microsoft/fast-element";
+import { css, ElementStyles, html } from "@microsoft/fast-element";
 import { FASTSelect } from "../select.js";
 import { selectTemplate } from "../select.template.js";
 

--- a/packages/web-components/fast-foundation/src/slider/slider.options.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.options.ts
@@ -1,4 +1,7 @@
-import type { SyntheticViewTemplate } from "@microsoft/fast-element";
+import type {
+    DangerousHTMLDirective,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 import type { Direction, Orientation } from "@microsoft/fast-web-utilities";
 
 /**
@@ -32,5 +35,5 @@ export interface SliderConfiguration {
  * @public
  */
 export type SliderOptions = {
-    thumb?: string | SyntheticViewTemplate;
+    thumb?: DangerousHTMLDirective | SyntheticViewTemplate;
 };

--- a/packages/web-components/fast-foundation/src/slider/stories/slider.register.ts
+++ b/packages/web-components/fast-foundation/src/slider/stories/slider.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTSlider } from "../slider.js";
 import { sliderTemplate } from "../slider.template.js";
@@ -126,7 +127,9 @@ const styles = css`
 FASTSlider.define({
     name: "fast-slider",
     template: sliderTemplate({
-        thumb: /* html */ `<div class="thumb-cursor"></div>`,
+        thumb: /* html */ html`
+            <div class="thumb-cursor"></div>
+        `,
     }),
     styles,
 });

--- a/packages/web-components/fast-foundation/src/switch/stories/switch.register.ts
+++ b/packages/web-components/fast-foundation/src/switch/stories/switch.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTSwitch } from "../switch.js";
 import { switchTemplate } from "../switch.template.js";
@@ -134,7 +135,7 @@ const styles = css`
 FASTSwitch.define({
     name: "fast-switch",
     template: switchTemplate({
-        switch: /* html */ `
+        switch: /* html */ html`
             <span class="checked-indicator" part="checked-indicator"></span>
         `,
     }),

--- a/packages/web-components/fast-foundation/src/switch/switch.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.ts
@@ -1,4 +1,9 @@
-import { attr, observable, SyntheticViewTemplate } from "@microsoft/fast-element";
+import {
+    attr,
+    DangerousHTMLDirective,
+    observable,
+    SyntheticViewTemplate,
+} from "@microsoft/fast-element";
 import { keyEnter, keySpace } from "@microsoft/fast-web-utilities";
 import { FormAssociatedSwitch } from "./switch.form-associated.js";
 
@@ -7,7 +12,7 @@ import { FormAssociatedSwitch } from "./switch.form-associated.js";
  * @public
  */
 export type SwitchOptions = {
-    switch?: string | SyntheticViewTemplate;
+    switch?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**

--- a/packages/web-components/fast-foundation/src/tree-item/stories/tree-item.register.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/stories/tree-item.register.ts
@@ -1,3 +1,4 @@
+import { html } from "@microsoft/fast-element";
 import { css } from "@microsoft/fast-element";
 import { FASTTreeItem } from "../tree-item.js";
 import { treeItemTemplate } from "../tree-item.template.js";
@@ -204,7 +205,7 @@ FASTTreeItem.define({
     name: "fast-tree-item",
     styles,
     template: treeItemTemplate({
-        expandCollapseGlyph: /* html */ `
+        expandCollapseGlyph: /* html */ html`
             <svg
                 viewBox="0 0 16 16"
                 xmlns="http://www.w3.org/2000/svg"

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.ts
@@ -1,5 +1,6 @@
 import {
     attr,
+    DangerousHTMLDirective,
     FASTElement,
     observable,
     SyntheticViewTemplate,
@@ -23,7 +24,7 @@ export function isTreeItemElement(el: Element): el is HTMLElement {
  * @public
  */
 export type TreeItemOptions = StartEndOptions & {
-    expandCollapseGlyph?: string | SyntheticViewTemplate;
+    expandCollapseGlyph?: DangerousHTMLDirective | SyntheticViewTemplate;
 };
 
 /**


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR updates the return type for the `dangerousHTML()` helper to `DangerousHTMLDirective` and updates the typings in FAST Foundation usage for default slotted content options.

### 🎫 Issues
n/a
