### PR TITLE
fix: data-grid: clean-up header on disconnect

### DIFF
--- a/change/@microsoft-fast-foundation-320b3755-1115-4abf-860a-95a6ac9a9327.json
+++ b/change/@microsoft-fast-foundation-320b3755-1115-4abf-860a-95a6ac9a9327.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "clean up header on disconnect",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-320b3755-1115-4abf-860a-95a6ac9a9327.json
+++ b/change/@microsoft-fast-foundation-320b3755-1115-4abf-860a-95a6ac9a9327.json
@@ -3,5 +3,5 @@
   "comment": "clean up header on disconnect",
   "packageName": "@microsoft/fast-foundation",
   "email": "stephcomeau@msn.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -391,9 +391,12 @@ export class FASTDataGrid extends FASTElement {
         this.removeEventListener(eventKeyDown, this.handleKeydown);
         this.removeEventListener(eventFocusOut, this.handleFocusOut);
 
-        // disconnect observer
         this.observer.disconnect();
-        this.generatedHeader = null;
+
+        if (this.generatedHeader !== null) {
+            this.removeChild(this.generatedHeader);
+            this.generatedHeader = null;
+        }
     }
 
     /**


### PR DESCRIPTION
## 📖 Description
Data-grid was not properly cleaning up generated header on disconnect, so in disconnect/reconnect scenarios the extra row in the dom would create multiple problems.

### 🎫 Issues
closes https://github.com/microsoft/fast/issues/6564

## 📑 Test Plan
Straightforward fix, did not create new tests.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)