### PR TITLE
adds disabled attribute to FASTAccordionItem

### DIFF
--- a/change/@microsoft-fast-foundation-012e9466-7b19-4417-b3e1-10b617cc49fc.json
+++ b/change/@microsoft-fast-foundation-012e9466-7b19-4417-b3e1-10b617cc49fc.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "adds disabled state to accordion item",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "email not defined",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -642,6 +642,7 @@ export class FASTAccordion extends FASTElement {
 export class FASTAccordionItem extends FASTElement {
     // @internal (undocumented)
     clickHandler: (e: MouseEvent) => void;
+    disabled: boolean;
     // @internal (undocumented)
     expandbutton: HTMLElement;
     expanded: boolean;

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -32,7 +32,7 @@ export function accordionItemTemplate<T extends FASTAccordionItem>(
             </button>
             ${startSlotTemplate(options)}
             ${endSlotTemplate(options)}
-            <span class="icon" part="icon" aria-hidden="true" >
+            <span class="icon" part="icon" aria-hidden="true">
                 <slot name="expanded-icon">
                     ${options.expandedIcon ?? ""}
                 </slot>

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -24,6 +24,7 @@ export function accordionItemTemplate<T extends FASTAccordionItem>(
                 aria-controls="${x => x.id}-panel"
                 id="${x => x.id}"
                 @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
+                tabindex="${x => (x.disabled ? "-1" : "0")}"
             >
                 <span class="heading-content" part="heading-content">
                     <slot name="heading"></slot>
@@ -31,7 +32,7 @@ export function accordionItemTemplate<T extends FASTAccordionItem>(
             </button>
             ${startSlotTemplate(options)}
             ${endSlotTemplate(options)}
-            <span class="icon" part="icon" aria-hidden="true">
+            <span class="icon" part="icon" aria-hidden="true" >
                 <slot name="expanded-icon">
                     ${options.expandedIcon ?? ""}
                 </slot>

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
@@ -63,6 +63,16 @@ export class FASTAccordionItem extends FASTElement {
     public expanded: boolean = false;
 
     /**
+     * Disables the item.
+     *
+     * @public
+     * @remarks
+     * HTML attribute: disabled
+     */
+    @attr({ mode: "boolean" })
+    public disabled: boolean = false;
+
+    /**
      * The item ID
      *
      * @public
@@ -81,6 +91,7 @@ export class FASTAccordionItem extends FASTElement {
      * @internal
      */
     public clickHandler = (e: MouseEvent) => {
+        if (this.disabled) return;
         this.expanded = !this.expanded;
         this.change();
     };

--- a/packages/web-components/fast-foundation/src/accordion/README.md
+++ b/packages/web-components/fast-foundation/src/accordion/README.md
@@ -164,6 +164,7 @@ export const myAccordionItem = AccordionItem.compose<AccordionItemOptions>({
 | -------------- | ------- | ---------------------------- | ------- | -------------------------------------------------------------------------------------------------- | -------------- |
 | `headinglevel` | public  | `1 or 2 or 3 or 4 or 5 or 6` | `2`     | Configures the [level](https://www.w3.org/TR/wai-aria-1.1/#aria-level) of the heading element. |                |
 | `expanded`     | public  | `boolean`                    | `false` | Expands or collapses the item.                                                                     |                |
+| `disabled`     | public  | `boolean`                    | `false` | Disables the item.                                                                                 |                |
 | `id`           | public  | `string`                     |         | The item ID                                                                                        |                |
 
 #### Events
@@ -178,6 +179,7 @@ export const myAccordionItem = AccordionItem.compose<AccordionItemOptions>({
 | --------------- | ------------ | -------------- |
 | `heading-level` | headinglevel |                |
 |                 | expanded     |                |
+|                 | disabled     |                |
 | `id`            | id           |                |
 
 #### CSS Parts

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -56,13 +56,22 @@ export class FASTAccordion extends FASTElement {
         this.$emit("change", this.activeid);
     };
 
-    private findExpandedItem(): FASTAccordionItem | null {
+    private findActiveItem(): FASTAccordionItem | null {
         for (let item: number = 0; item < this.accordionItems.length; item++) {
-            if (this.accordionItems[item].getAttribute("expanded") === "true") {
+            if (!this.accordionItems[item].hasAttribute("disabled")) {
                 return this.accordionItems[item] as FASTAccordionItem;
             }
         }
         return null;
+    }
+
+    private findExpandedItem(): FASTAccordionItem | null {
+        for (let item: number = 0; item < this.accordionItems.length; item++) {
+            if (this.accordionItems[item].hasAttribute("expanded")) {
+                return this.accordionItems[item] as FASTAccordionItem;
+            }
+        }
+        return this.findActiveItem();
     }
 
     private setItems = (): void => {
@@ -74,7 +83,10 @@ export class FASTAccordion extends FASTElement {
             if (item instanceof FASTAccordionItem) {
                 item.addEventListener("change", this.activeItemChange);
                 if (this.isSingleExpandMode()) {
-                    this.activeItemIndex !== index
+                    if (item.disabled) {
+                        this.activeItemIndex++;
+                    }
+                    this.activeItemIndex !== index || item.disabled
                         ? (item.expanded = false)
                         : (item.expanded = true);
                 }
@@ -89,9 +101,10 @@ export class FASTAccordion extends FASTElement {
             item.addEventListener("focus", this.handleItemFocus);
         });
         if (this.isSingleExpandMode()) {
-            const expandedItem: FASTAccordionItem | null =
-                this.findExpandedItem() ?? (this.accordionItems[0] as FASTAccordionItem);
-            expandedItem.setAttribute("aria-disabled", "true");
+            const expandedItem: FASTAccordionItem | null = this.findExpandedItem();
+            if (expandedItem) {
+                expandedItem.setAttribute("aria-disabled", "true");
+            }
         }
     };
 

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -83,12 +83,10 @@ export class FASTAccordion extends FASTElement {
             if (item instanceof FASTAccordionItem) {
                 item.addEventListener("change", this.activeItemChange);
                 if (this.isSingleExpandMode()) {
-                    if (item.disabled) {
-                        this.activeItemIndex++;
+                    const expandedItem: FASTAccordionItem | null = this.findExpandedItem();
+                    if (expandedItem) {
+                        expandedItem.expanded = true;
                     }
-                    this.activeItemIndex !== index || item.disabled
-                        ? (item.expanded = false)
-                        : (item.expanded = true);
                 }
             }
             const itemId: string | null = this.accordionIds[index];
@@ -101,9 +99,10 @@ export class FASTAccordion extends FASTElement {
             item.addEventListener("focus", this.handleItemFocus);
         });
         if (this.isSingleExpandMode()) {
-            const expandedItem: FASTAccordionItem | null =
-                this.findExpandedItem() ?? (this.accordionItems[0] as FASTAccordionItem);
-            expandedItem.setAttribute("aria-disabled", "true");
+            const expandedItem: FASTAccordionItem | null = this.findExpandedItem();
+            if (expandedItem) {
+                expandedItem.setAttribute("aria-disabled", "true");
+            }
         }
     };
 

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -101,10 +101,9 @@ export class FASTAccordion extends FASTElement {
             item.addEventListener("focus", this.handleItemFocus);
         });
         if (this.isSingleExpandMode()) {
-            const expandedItem: FASTAccordionItem | null = this.findExpandedItem();
-            if (expandedItem) {
-                expandedItem.setAttribute("aria-disabled", "true");
-            }
+            const expandedItem: FASTAccordionItem | null =
+                this.findExpandedItem() ?? (this.accordionItems[0] as FASTAccordionItem);
+            expandedItem.setAttribute("aria-disabled", "true");
         }
     };
 

--- a/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
+++ b/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
@@ -5,7 +5,7 @@ import { FASTAccordion } from "../accordion.js";
 import { AccordionExpandMode } from "../accordion.options.js";
 
 const storyTemplate = html<StoryArgs<FASTAccordion>>`
-    <fast-accordion expand-mode="${x => x.expandmode}">
+    <fast-accordion expand-mode="single">
         ${x => x.storyContent}
     </fast-accordion>
 `;
@@ -25,9 +25,13 @@ export default {
 export const Accordion: Story<FASTAccordion> = renderComponent(storyTemplate).bind({});
 Accordion.args = {
     storyContent: html`
-        <fast-accordion-item>
+        <fast-accordion-item disabled>
             <div slot="heading">Accordion Item 1 Heading</div>
             Accordion Item 1 Content
+        </fast-accordion-item>
+        <fast-accordion-item disabled>
+            <div slot="heading">Accordion Item 2 Heading</div>
+            <fast-checkbox>A checkbox as content</fast-checkbox>
         </fast-accordion-item>
         <fast-accordion-item>
             <div slot="heading">Accordion Item 2 Heading</div>

--- a/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
+++ b/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
@@ -5,7 +5,7 @@ import { FASTAccordion } from "../accordion.js";
 import { AccordionExpandMode } from "../accordion.options.js";
 
 const storyTemplate = html<StoryArgs<FASTAccordion>>`
-    <fast-accordion expand-mode="single">
+    <fast-accordion expand-mode="${x => x.expandmode}">
         ${x => x.storyContent}
     </fast-accordion>
 `;
@@ -25,13 +25,9 @@ export default {
 export const Accordion: Story<FASTAccordion> = renderComponent(storyTemplate).bind({});
 Accordion.args = {
     storyContent: html`
-        <fast-accordion-item disabled>
+        <fast-accordion-item>
             <div slot="heading">Accordion Item 1 Heading</div>
             Accordion Item 1 Content
-        </fast-accordion-item>
-        <fast-accordion-item disabled>
-            <div slot="heading">Accordion Item 2 Heading</div>
-            <fast-checkbox>A checkbox as content</fast-checkbox>
         </fast-accordion-item>
         <fast-accordion-item>
             <div slot="heading">Accordion Item 2 Heading</div>


### PR DESCRIPTION
# Adds disabled attribute to FASTAccordionItem

## 📖 Description

We need to support disabled accordion items in our design system and the keyboarding interaction model doesn't provide support for that. This adds the disabled state as a disabled Boolean on the FASTAccordionItem and modifies Accordion class features to account for single expand mode.


### 🎫 Issues

[feat: add support for disabled state in Accordion Items](https://github.com/microsoft/fast/issues/6568
)

## 👩‍💻 Reviewer Notes

This PR is currently in a draft state. I'm looking for feedback on my approach.

## 📑 Test Plan

WIP

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps