### PR TITLE
chore: remove deprecated APIs from fast-element

### DIFF
--- a/change/@microsoft-fast-element-a8d80d50-029f-4e90-a013-92790032d39c.json
+++ b/change/@microsoft-fast-element-a8d80d50-029f-4e90-a013-92790032d39c.json
@@ -3,5 +3,5 @@
   "comment": "chore: remove deprecated APIs from fast-element",
   "packageName": "@microsoft/fast-element",
   "email": "rob@bluespire.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-a8d80d50-029f-4e90-a013-92790032d39c.json
+++ b/change/@microsoft-fast-element-a8d80d50-029f-4e90-a013-92790032d39c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: remove deprecated APIs from fast-element",
+  "packageName": "@microsoft/fast-element",
+  "email": "rob@bluespire.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/tooling/adaptive-ui-explorer/src/components/color-block.ts
+++ b/packages/tooling/adaptive-ui-explorer/src/components/color-block.ts
@@ -6,6 +6,7 @@ import {
     DOM,
     FASTElement,
     html,
+    Updates,
     ViewTemplate,
     when,
 } from "@microsoft/fast-element";
@@ -532,7 +533,7 @@ export class ColorBlock extends FASTElement {
 
     @attr color: string;
     private colorChanged(): void {
-        DOM.queueUpdate(() => this.updateColor());
+        Updates.enqueue(() => this.updateColor());
     }
 
     @attr({ attribute: "layer-name" })

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -208,9 +208,6 @@ export interface CSSDirectiveDefinition<TType extends Constructable<CSSDirective
     readonly type: TType;
 }
 
-// @public @deprecated (undocumented)
-export const cssPartial: (strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]) => CSSDirective;
-
 // @public
 export type CSSTemplateTag = ((strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]) => ElementStyles) & {
     partial(strings: TemplateStringsArray, ...values: (ComposableStyles | CSSDirective)[]): CSSDirective;
@@ -229,9 +226,6 @@ export interface Disposable {
 
 // @public
 export const DOM: Readonly<{
-    queueUpdate: (callable: Callable) => void;
-    nextUpdate: () => Promise<void>;
-    processUpdates: () => void;
     readonly policy: DOMPolicy;
     setPolicy(value: DOMPolicy): void;
     setAttribute(element: HTMLElement, attributeName: string, value: any): void;

--- a/packages/web-components/fast-element/src/di/di.ts
+++ b/packages/web-components/fast-element/src/di/di.ts
@@ -863,12 +863,6 @@ export const DI = Object.freeze({
     createContext,
 
     /**
-     * @deprecated
-     * Use DI.createContext instead.
-     */
-    createInterface: createContext,
-
-    /**
      * A decorator that specifies what to inject into its target.
      * @param dependencies - The dependencies to inject.
      * @returns The decorator to be applied to the target class.

--- a/packages/web-components/fast-element/src/dom.ts
+++ b/packages/web-components/fast-element/src/dom.ts
@@ -1,5 +1,4 @@
-import { Updates } from "./observation/update-queue.js";
-import { Callable, Message, TrustedTypesPolicy } from "./interfaces.js";
+import { Message, TrustedTypesPolicy } from "./interfaces.js";
 import { FAST } from "./platform.js";
 
 /**
@@ -113,24 +112,6 @@ const fastPolicy = defaultPolicy;
  * @public
  */
 export const DOM = Object.freeze({
-    /**
-     * @deprecated
-     * Use Updates.enqueue().
-     */
-    queueUpdate: Updates.enqueue as (callable: Callable) => void,
-
-    /**
-     * @deprecated
-     * Use Updates.next()
-     */
-    nextUpdate: Updates.next,
-
-    /**
-     * @deprecated
-     * Use Updates.process()
-     */
-    processUpdates: Updates.process,
-
     /**
      * Gets the dom policy used by the templating system.
      */

--- a/packages/web-components/fast-element/src/styles/css.ts
+++ b/packages/web-components/fast-element/src/styles/css.ts
@@ -148,9 +148,3 @@ css.partial = (
     const { styles, behaviors } = collectStyles(strings, values);
     return new CSSPartial(styles, behaviors);
 };
-
-/**
- * @deprecated Use css.partial instead.
- * @public
- */
-export const cssPartial = css.partial;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR removes duplicative deprecated APIs from `fast-element`.

### 🎫 Issues

* Part of [#6502](https://github.com/microsoft/fast/issues/6502)

## 👩‍💻 Reviewer Notes

Just a removal of APIs that were marked deprecated for several releases.

## 📑 Test Plan

Existing tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Continuing a survey of the `fast-element` codebase to see if there is any other polish that is needed in preparation for a release.