### PR TITLE
fix: remove deprecation notice for display helper utility

### DIFF
--- a/change/@microsoft-fast-foundation-5a3886ec-6b78-4daf-b7dd-fc42d9ca6149.json
+++ b/change/@microsoft-fast-foundation-5a3886ec-6b78-4daf-b7dd-fc42d9ca6149.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove deprecation notice from display helpers",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -314,7 +314,7 @@ export interface CSSDesignTokenConfiguration extends DesignTokenConfiguration {
     cssCustomPropertyName: string;
 }
 
-// @public @deprecated
+// @public
 export type CSSDisplayPropertyValue = "block" | "contents" | "flex" | "grid" | "inherit" | "initial" | "inline" | "inline-block" | "inline-flex" | "inline-grid" | "inline-table" | "list-item" | "none" | "run-in" | "table" | "table-caption" | "table-cell" | "table-column" | "table-column-group" | "table-footer-group" | "table-header-group" | "table-row" | "table-row-group";
 
 // @public
@@ -602,7 +602,7 @@ export const disabledCursor = "not-allowed";
 // @public
 export function disclosureTemplate<T extends FASTDisclosure>(): ElementViewTemplate<T>;
 
-// @public @deprecated
+// @public
 export function display(displayValue: CSSDisplayPropertyValue): string;
 
 // @public
@@ -2292,7 +2292,7 @@ export type GenerateHeaderOptions = ValuesOf<typeof GenerateHeaderOptions>;
 // @public
 export const getDirection: (rootNode: HTMLElement) => Direction;
 
-// @public @deprecated
+// @public
 export const hidden = ":host([hidden]){display:none}";
 
 // @public

--- a/packages/web-components/fast-foundation/src/utilities/style/display.ts
+++ b/packages/web-components/fast-foundation/src/utilities/style/display.ts
@@ -1,7 +1,6 @@
 /**
  * Define all possible CSS display values.
  * @public
- * @deprecated - fast-foundation is removing styling utilities
  */
 export type CSSDisplayPropertyValue =
     | "block"
@@ -31,7 +30,6 @@ export type CSSDisplayPropertyValue =
 /**
  * A CSS fragment to set `display: none;` when the host is hidden using the [hidden] attribute.
  * @public
- * @deprecated - fast-foundation is removing styling utilities
  */
 export const hidden = `:host([hidden]){display:none}`;
 
@@ -40,7 +38,6 @@ export const hidden = `:host([hidden]){display:none}`;
  * Also adds CSS rules to not display the element when the [hidden] attribute is applied to the element.
  * @param display - The CSS display property value
  * @public
- * @deprecated - fast-foundation is removing styling utilities
  */
 export function display(displayValue: CSSDisplayPropertyValue): string {
     return `${hidden}:host{display:${displayValue}}`;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
While Foundation doesn't export component styles, it does export several helpers for creating design systems. The specific helpers here make sense to continue to share with the community in order to provide common patterns which can be shared rather than duplicated across implementations. This simply removes the deprecation notice for this helper in favor of continuing support.

### 🎫 Issues
n/a
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
