### PR TITLE
fix: accordion "single" expand-mode instances should support defined expanded children

### DIFF
--- a/change/@microsoft-fast-foundation-c597e1e0-fe5a-4e24-8679-a435b94beb03.json
+++ b/change/@microsoft-fast-foundation-c597e1e0-fe5a-4e24-8679-a435b94beb03.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "ensure single expand mode accordions support explicitly expanded items",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -630,15 +630,15 @@ export function endSlotTemplate<TSource extends StartEnd = StartEnd, TParent = a
 
 // @public
 export class FASTAccordion extends FASTElement {
-    // @internal (undocumented)
-    accordionItems: HTMLElement[];
     // (undocumented)
-    protected _accordionItems: Element[];
-    // @internal (undocumented)
-    accordionItemsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]): void;
+    protected accordionItems: Element[];
     expandmode: AccordionExpandMode;
     // @internal (undocumented)
     handleChange(source: any, propertyName: string): void;
+    // @internal (undocumented)
+    slottedAccordionItems: HTMLElement[];
+    // @internal (undocumented)
+    slottedAccordionItemsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]): void;
 }
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
@@ -76,21 +76,20 @@ test.describe("Accordion item", () => {
         await expect(button).toHaveAttribute("aria-expanded", "false");
     });
 
-    test("should set `aria-disabled` property on the internal control equal to the `disabled` property", async () => {
+    test("should set `disabled` attribute on the internal control equal to the `disabled` property", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion-item disabled></fast-accordion-item>
             `;
         });
 
-        await expect(button).toHaveAttribute("aria-disabled", "true");
+        await expect(button).toHaveBooleanAttribute("disabled");
 
         await element.evaluate<void, FASTAccordionItem>(node => {
             node.disabled = false;
         });
 
-        await expect(button).not.toHaveAttribute("aria-disabled", "true");
-        await expect(button).not.toHaveAttribute("aria-disabled", "false");
+        await expect(button).not.toHaveBooleanAttribute("disabled");
     });
 
     test("should set internal properties to match the id when provided", async () => {

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.template.ts
@@ -21,9 +21,9 @@ export function accordionItemTemplate<T extends FASTAccordionItem>(
                 class="button"
                 part="button"
                 ${ref("expandbutton")}
+                ?disabled="${x => (x.disabled ? "true" : void 0)}"
                 aria-expanded="${x => x.expanded}"
                 aria-controls="${x => x.id}-panel"
-                aria-disabled="${x => (x.disabled ? "true" : void 0)}"
                 id="${x => x.id}"
                 @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
             >

--- a/packages/web-components/fast-foundation/src/accordion/README.md
+++ b/packages/web-components/fast-foundation/src/accordion/README.md
@@ -124,10 +124,10 @@ export const myAccordionItem = AccordionItem.compose<AccordionItemOptions>({
 
 #### Fields
 
-| Name              | Privacy   | Type                  | Default | Description                                                                                   | Inherited From |
-| ----------------- | --------- | --------------------- | ------- | --------------------------------------------------------------------------------------------- | -------------- |
-| `expandmode`      | public    | `AccordionExpandMode` |         | Controls the expand mode of the Accordion, either allowing single or multiple item expansion. |                |
-| `_accordionItems` | protected | `Element[]`           |         |                                                                                               |                |
+| Name             | Privacy   | Type                  | Default | Description                                                                                   | Inherited From |
+| ---------------- | --------- | --------------------- | ------- | --------------------------------------------------------------------------------------------- | -------------- |
+| `expandmode`     | public    | `AccordionExpandMode` |         | Controls the expand mode of the Accordion, either allowing single or multiple item expansion. |                |
+| `accordionItems` | protected | `Element[]`           |         |                                                                                               |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -1,6 +1,7 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
+import type { FASTAccordionItem } from "../accordion-item/index.js";
 import { AccordionExpandMode } from "./accordion.options.js";
 
 test.describe("Accordion", () => {
@@ -211,7 +212,7 @@ test.describe("Accordion", () => {
         await expect(thirdItem).not.toHaveBooleanAttribute("expanded");
     });
 
-    test.only("should allow disabled items to be expanded when in single mode", async () => {
+    test("should allow disabled items to be expanded when in single mode", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
@@ -244,6 +245,16 @@ test.describe("Accordion", () => {
         await expect(secondItem).toHaveBooleanAttribute("expanded");
 
         await expect(thirdItem).toHaveBooleanAttribute("expanded");
+
+        await secondItem.evaluate(node => {
+            node.removeAttribute("disabled");
+        });
+
+        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+
+        await expect(secondItem).toHaveBooleanAttribute("expanded");
+
+        await expect(thirdItem).not.toHaveBooleanAttribute("expanded");
     });
 
     test("should ignore `change` events from components other than accordion items", async () => {

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -149,6 +149,103 @@ test.describe("Accordion", () => {
         await expect(secondItem).toHaveBooleanAttribute("expanded");
     });
 
+    test("should set the first item as expanded if no child is expanded by default in single mode", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="single">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
+
+        const items = element.locator("fast-accordion-item");
+
+        const firstItem = items.nth(0);
+
+        const secondItem = items.nth(1);
+
+        await expect(firstItem).toHaveBooleanAttribute("expanded");
+
+        await expect(secondItem).not.toHaveBooleanAttribute("expanded");
+    });
+
+    test("should set the first item with an expanded attribute to expanded in single mode", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="single">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item expanded>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item expanded>
+                        <span slot="heading">Heading 3</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
+
+        const items = element.locator("fast-accordion-item");
+
+        const firstItem = items.nth(0);
+
+        const secondItem = items.nth(1);
+
+        const thirdItem = items.nth(2);
+
+        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+
+        await expect(secondItem).toHaveBooleanAttribute("expanded");
+
+        await expect(thirdItem).not.toHaveBooleanAttribute("expanded");
+    });
+
+    test.only("should allow disabled items to be expanded when in single mode", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="single">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item expanded disabled>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item expanded>
+                        <span slot="heading">Heading 3</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
+
+        const items = element.locator("fast-accordion-item");
+
+        const firstItem = items.nth(0);
+
+        const secondItem = items.nth(1);
+
+        const thirdItem = items.nth(2);
+
+        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+
+        await expect(secondItem).toHaveBooleanAttribute("expanded");
+
+        await expect(thirdItem).toHaveBooleanAttribute("expanded");
+    });
+
     test("should ignore `change` events from components other than accordion items", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -213,6 +213,7 @@ test.describe("Accordion", () => {
     });
 
     test("should allow disabled items to be expanded when in single mode", async () => {
+        test.slow();
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">

--- a/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.template.ts
@@ -8,7 +8,9 @@ import type { FASTAccordion } from "./accordion.js";
 export function accordionTemplate<T extends FASTAccordion>(): ElementViewTemplate<T> {
     return html<T>`
         <template>
-            <slot ${slotted({ property: "accordionItems", filter: elements() })}></slot>
+            <slot
+                ${slotted({ property: "slottedAccordionItems", filter: elements() })}
+            ></slot>
         </template>
     `;
 }

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -67,16 +67,17 @@ export class FASTAccordion extends FASTElement {
         this.$emit("change", this.activeid);
     };
 
-    private findExpandedItem(): FASTAccordionItem | Element {
-        for (let item: number = 0; item < this._accordionItems.length; item++) {
-            if (
-                ((this._accordionItems[item] as unknown) as FASTAccordionItem)
-                    .expanded === true
-            ) {
-                return this._accordionItems[item];
-            }
+    private findExpandedItem(): FASTAccordionItem | Element | null {
+        if (this.accordionItems.length === 0) {
+            return null;
         }
-        return this._accordionItems[0];
+
+        return (
+            this._accordionItems.find(
+                (item: Element | FASTAccordionItem) =>
+                    item instanceof FASTAccordionItem && item.expanded
+            ) ?? this._accordionItems[0]
+        );
     }
 
     private setItems = (): void => {
@@ -118,18 +119,21 @@ export class FASTAccordion extends FASTElement {
     };
 
     private setSingleExpandMode(expandedItem: Element): void {
+        if (this._accordionItems.length === 0) {
+            return;
+        }
         const currentItems = Array.from(this._accordionItems);
         this.activeItemIndex = currentItems.indexOf(expandedItem);
 
         currentItems.forEach((item: FASTAccordionItem, index: number) => {
             if (this.activeItemIndex === index) {
                 item.expanded = true;
-                item.expandbutton.setAttribute("aria-disabled", "true");
+                item.expandbutton.setAttribute("disabled", "");
             } else {
                 item.expanded = false;
 
                 if (!item.hasAttribute("disabled")) {
-                    item.removeAttribute("aria-disabled");
+                    item.expandbutton.removeAttribute("disabled");
                 }
             }
         });

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -99,7 +99,6 @@ export class FASTAccordion extends FASTElement {
         this._accordionItems.forEach((item: HTMLElement, index: number) => {
             if (item instanceof FASTAccordionItem) {
                 item.addEventListener("change", this.activeItemChange);
-                // Observable.getNotifier(item).subscribe(this, "expanded");
             }
 
             const itemId: string | null = this.accordionIds[index];

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -37,14 +37,17 @@ export class FASTAccordion extends FASTElement {
      * @internal
      */
     @observable
-    public accordionItems: HTMLElement[];
+    public slottedAccordionItems: HTMLElement[];
 
-    protected _accordionItems: Element[];
+    protected accordionItems: Element[];
 
     /**
      * @internal
      */
-    public accordionItemsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]): void {
+    public slottedAccordionItemsChanged(
+        oldValue: HTMLElement[],
+        newValue: HTMLElement[]
+    ): void {
         if (this.$fastController.isConnected) {
             this.setItems();
         }
@@ -73,15 +76,15 @@ export class FASTAccordion extends FASTElement {
         }
 
         return (
-            this._accordionItems.find(
+            this.accordionItems.find(
                 (item: Element | FASTAccordionItem) =>
                     item instanceof FASTAccordionItem && item.expanded
-            ) ?? this._accordionItems[0]
+            ) ?? this.accordionItems[0]
         );
     }
 
     private setItems = (): void => {
-        if (this.accordionItems.length === 0) {
+        if (this.slottedAccordionItems.length === 0) {
             return;
         }
 
@@ -93,11 +96,11 @@ export class FASTAccordion extends FASTElement {
             Observable.getNotifier(child).subscribe(this, "disabled")
         );
 
-        this._accordionItems = children.filter(child => !child.hasAttribute("disabled"));
+        this.accordionItems = children.filter(child => !child.hasAttribute("disabled"));
 
         this.accordionIds = this.getItemIds();
 
-        this._accordionItems.forEach((item: HTMLElement, index: number) => {
+        this.accordionItems.forEach((item: HTMLElement, index: number) => {
             if (item instanceof FASTAccordionItem) {
                 item.addEventListener("change", this.activeItemChange);
             }
@@ -119,10 +122,10 @@ export class FASTAccordion extends FASTElement {
     };
 
     private setSingleExpandMode(expandedItem: Element): void {
-        if (this._accordionItems.length === 0) {
+        if (this.accordionItems.length === 0) {
             return;
         }
-        const currentItems = Array.from(this._accordionItems);
+        const currentItems = Array.from(this.accordionItems);
         this.activeItemIndex = currentItems.indexOf(expandedItem);
 
         currentItems.forEach((item: FASTAccordionItem, index: number) => {
@@ -159,7 +162,7 @@ export class FASTAccordion extends FASTElement {
 
         if (!this.isSingleExpandMode()) {
             // setSingleExpandMode sets activeItemIndex on its own
-            this.activeItemIndex = this._accordionItems.indexOf(selectedItem);
+            this.activeItemIndex = this.accordionItems.indexOf(selectedItem);
         } else {
             this.setSingleExpandMode(selectedItem);
         }
@@ -168,7 +171,7 @@ export class FASTAccordion extends FASTElement {
     };
 
     private getItemIds(): Array<string | null> {
-        return this.accordionItems.map((accordionItem: HTMLElement) => {
+        return this.slottedAccordionItems.map((accordionItem: HTMLElement) => {
             return accordionItem.id;
         });
     }
@@ -198,7 +201,7 @@ export class FASTAccordion extends FASTElement {
                 this.focusItem();
                 break;
             case keyEnd:
-                this.activeItemIndex = this._accordionItems.length - 1;
+                this.activeItemIndex = this.accordionItems.length - 1;
                 this.focusItem();
                 break;
         }
@@ -210,7 +213,7 @@ export class FASTAccordion extends FASTElement {
         if (event.target === event.currentTarget) {
             const focusedItem = event.target as HTMLElement;
             const focusedIndex: number = (this.activeItemIndex = Array.from(
-                this._accordionItems
+                this.accordionItems
             ).indexOf(focusedItem));
             if (this.activeItemIndex !== focusedIndex && focusedIndex !== -1) {
                 this.activeItemIndex = focusedIndex;
@@ -222,14 +225,14 @@ export class FASTAccordion extends FASTElement {
     private adjust(adjustment: number): void {
         this.activeItemIndex = wrapInBounds(
             0,
-            this._accordionItems.length - 1,
+            this.accordionItems.length - 1,
             this.activeItemIndex + adjustment
         );
         this.focusItem();
     }
 
     private focusItem(): void {
-        const element: Element = this._accordionItems[this.activeItemIndex];
+        const element: Element = this.accordionItems[this.activeItemIndex];
         if (element instanceof FASTAccordionItem) {
             element.expandbutton.focus();
         }

--- a/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
+++ b/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
@@ -65,3 +65,48 @@ AccordionWithSlottedStartEnd.args = {
         </fast-accordion-item>
     `,
 };
+
+export const AccordionWithExpandedChild: Story<FASTAccordion> = renderComponent(
+    storyTemplate
+).bind({});
+AccordionWithExpandedChild.args = {
+    storyContent: html`
+        <fast-accordion-item>
+            <div slot="heading">Accordion Item 1 Heading</div>
+            Accordion Item 1 Content
+        </fast-accordion-item>
+        <fast-accordion-item>
+            <div slot="heading">Accordion Item 2 Heading</div>
+            <fast-checkbox>A checkbox as content</fast-checkbox>
+        </fast-accordion-item>
+        <fast-accordion-item expanded>
+            <div slot="heading">Accordion Item 3 Heading</div>
+            Accordion Item 3 Content
+        </fast-accordion-item>
+    `,
+};
+
+export const AccordionWithSingleExpandMode: Story<FASTAccordion> = renderComponent(
+    storyTemplate
+).bind({});
+AccordionWithSingleExpandMode.args = {
+    expandmode: "single",
+    storyContent: html`
+        <fast-accordion-item expanded disabled>
+            <div slot="heading">Accordion Item 1 Heading</div>
+            Accordion Item 1 Content
+        </fast-accordion-item>
+        <fast-accordion-item expanded>
+            <div slot="heading">Accordion Item 2 Heading</div>
+            <fast-checkbox>A checkbox as content</fast-checkbox>
+        </fast-accordion-item>
+        <fast-accordion-item>
+            <div slot="heading">Accordion Item 3 Heading</div>
+            Accordion Item 3 Content
+        </fast-accordion-item>
+        <fast-accordion-item>
+            <div slot="heading">Accordion Item 4 Heading</div>
+            Accordion Item 4 Content
+        </fast-accordion-item>
+    `,
+};


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR refactors the behavior associated for "single" expand-mode accordion instances. It also fixes an issue where disabled buttons of accordion items were focusable via tabbing.

### 🎫 Issues
closes #6584
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->