### PR TITLE
fix: refactor radio group to better manage disabled state and interactions

### DIFF
--- a/change/@microsoft-fast-foundation-3a1720aa-98a8-4aed-8596-b071ec2d7773.json
+++ b/change/@microsoft-fast-foundation-3a1720aa-98a8-4aed-8596-b071ec2d7773.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix radio group disabled handling",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1627,8 +1627,6 @@ export class FASTProgressRing extends FASTBaseProgress {
 // @public
 export class FASTRadio extends FormAssociatedRadio implements RadioControl {
     constructor();
-    // @beta
-    clickHandler(e: MouseEvent): boolean | void;
     // @internal (undocumented)
     connectedCallback(): void;
     // @internal (undocumented)
@@ -1650,7 +1648,7 @@ export class FASTRadioGroup extends FASTElement {
     // (undocumented)
     childItems: HTMLElement[];
     // @internal (undocumented)
-    clickHandler: (e: MouseEvent) => void;
+    clickHandler: (e: MouseEvent) => void | boolean;
     // @internal (undocumented)
     connectedCallback(): void;
     disabled: boolean;
@@ -1660,6 +1658,8 @@ export class FASTRadioGroup extends FASTElement {
     disconnectedCallback(): void;
     // @internal (undocumented)
     focusOutHandler: (e: FocusEvent) => boolean | void;
+    // @internal (undocumented)
+    handleDisabledClick: (e: MouseEvent) => void | boolean;
     // @internal
     keydownHandler: (e: KeyboardEvent) => boolean | void;
     name: string;

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
@@ -175,28 +175,103 @@ test.describe("Radio Group", () => {
         await expect(element).not.hasAttribute("aria-disabled");
     });
 
-    test("should set all child radio elements to disabled when the `disabled` attribute is present", async () => {
+    test("should NOT modify child radio elements disabled state when the `disabled` attribute is present", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
-                <fast-radio-group disabled>
+                <fast-radio-group>
                     <fast-radio></fast-radio>
-                    <fast-radio></fast-radio>
+                    <fast-radio disabled></fast-radio>
                     <fast-radio></fast-radio>
                 </fast-radio-group>
             `;
         });
 
+        await expect(element).not.toHaveBooleanAttribute("disabled");
+
+        const firstRadio = radios.nth(0);
+        const secondRadio = radios.nth(1);
+        const thirdRadio = radios.nth(2);
+
+        const expectedFirst = await firstRadio.evaluate<boolean, FASTRadio>(node =>
+            node.hasAttribute("disabled")
+        );
+        const expectedSecond = await secondRadio.evaluate<boolean, FASTRadio>(node =>
+            node.hasAttribute("disabled")
+        );
+        const expectedThird = await thirdRadio.evaluate<boolean, FASTRadio>(node =>
+            node.hasAttribute("disabled")
+        );
+
+        expect(
+            await firstRadio.evaluate<boolean, FASTRadio>(radio =>
+                radio.hasAttribute("disabled")
+            )
+        ).toEqual(expectedFirst);
+
+        expect(
+            await secondRadio.evaluate<boolean, FASTRadio>(radio =>
+                radio.hasAttribute("disabled")
+            )
+        ).toEqual(expectedSecond);
+
+        expect(
+            await thirdRadio.evaluate<boolean, FASTRadio>(radio =>
+                radio.hasAttribute("disabled")
+            )
+        ).toEqual(expectedThird);
+
+        element.evaluate<void, FASTRadioGroup>(node => node.setAttribute("disabled", ""));
+
         await expect(element).toHaveBooleanAttribute("disabled");
 
         expect(
-            await radios.evaluateAll<boolean, FASTRadio>(radios =>
-                radios.every(radio => radio.disabled)
+            await firstRadio.evaluate<boolean, FASTRadio>(radio =>
+                radio.hasAttribute("disabled")
             )
-        ).toBeTruthy();
+        ).toEqual(expectedFirst);
 
         expect(
-            await radios.evaluateAll(radios =>
-                radios.every(radio => radio.getAttribute("aria-disabled") === "true")
+            await secondRadio.evaluate<boolean, FASTRadio>(radio =>
+                radio.hasAttribute("disabled")
+            )
+        ).toEqual(expectedSecond);
+
+        expect(
+            await thirdRadio.evaluate<boolean, FASTRadio>(radio =>
+                radio.hasAttribute("disabled")
+            )
+        ).toEqual(expectedThird);
+    });
+
+    test("should NOT be focusable when disabled", async () => {
+        const first: Locator = page.locator("button", { hasText: "First" });
+        const second: Locator = page.locator("button", { hasText: "Second" });
+
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <button>First</button>
+                <fast-radio-group disabled>
+                    <fast-radio></fast-radio>
+                    <fast-radio></fast-radio>
+                    <fast-radio></fast-radio>
+                </fast-radio-group>
+                <button>Second</button>
+            `;
+        });
+
+        await expect(element).toHaveBooleanAttribute("disabled");
+
+        await first.focus();
+
+        await expect(first).toBeFocused();
+
+        await first.press("Tab");
+
+        await expect(second).toBeFocused();
+
+        await expect(
+            element.evaluate<boolean, FASTRadioGroup>(
+                node => node.getAttribute("tabindex") === "-1"
             )
         ).toBeTruthy();
     });

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
@@ -15,6 +15,7 @@ export function radioGroupTemplate<T extends FASTRadioGroup>(): ElementViewTempl
             aria-readonly="${x => x.readOnly}"
             aria-orientation="${x => x.orientation}"
             @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
+            @mousedown="${(x, c) => x.handleDisabledClick(c.event as MouseEvent)}"
             @keydown="${(x, c) => x.keydownHandler(c.event as KeyboardEvent)}"
             @focusout="${(x, c) => x.focusOutHandler(c.event as FocusEvent)}"
         >

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
@@ -10,6 +10,7 @@ export function radioGroupTemplate<T extends FASTRadioGroup>(): ElementViewTempl
     return html<T>`
         <template
             role="radiogroup"
+            tabindex=${x => (x.disabled ? -1 : void 0)}
             aria-disabled="${x => x.disabled}"
             aria-readonly="${x => x.readOnly}"
             aria-orientation="${x => x.orientation}"

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.template.ts
@@ -10,7 +10,7 @@ export function radioGroupTemplate<T extends FASTRadioGroup>(): ElementViewTempl
     return html<T>`
         <template
             role="radiogroup"
-            tabindex=${x => (x.disabled ? -1 : void 0)}
+            tabindex="${x => (x.disabled ? -1 : void 0)}"
             aria-disabled="${x => x.disabled}"
             aria-readonly="${x => x.readOnly}"
             aria-orientation="${x => x.orientation}"

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -53,15 +53,7 @@ export class FASTRadioGroup extends FASTElement {
      */
     @attr({ attribute: "disabled", mode: "boolean" })
     public disabled: boolean;
-    // protected disabledChanged(): void {
-    //     if (this.slottedRadioButtons) {
-    //         this.slottedRadioButtons.forEach((radio: FASTRadio) => {
-    //             if (this.disabled && !this.isInsideFoundationToolbar) {
-    //                 radio.setAttribute("tabindex", "-1")
-    //             }
-    //         });
-    //     }
-    // }
+    protected disabledChanged(): void {}
 
     /**
      * The name of the radio group. Setting this value will set the name value

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -8,6 +8,7 @@ import {
     keyArrowUp,
     keyEnter,
 } from "@microsoft/fast-web-utilities";
+import { FASTRadio } from "../radio/index.js";
 import { getDirection } from "../utilities/direction.js";
 import { RadioGroupOrientation } from "./radio-group.options.js";
 
@@ -33,7 +34,7 @@ export class FASTRadioGroup extends FASTElement {
     public readOnly: boolean;
     protected readOnlyChanged(): void {
         if (this.slottedRadioButtons !== undefined) {
-            this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
+            this.slottedRadioButtons.forEach((radio: FASTRadio) => {
                 if (this.readOnly) {
                     radio.readOnly = true;
                 } else {
@@ -52,17 +53,7 @@ export class FASTRadioGroup extends FASTElement {
      */
     @attr({ attribute: "disabled", mode: "boolean" })
     public disabled: boolean;
-    protected disabledChanged(): void {
-        if (this.slottedRadioButtons !== undefined) {
-            this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
-                if (this.disabled) {
-                    radio.disabled = true;
-                } else {
-                    radio.disabled = false;
-                }
-            });
-        }
-    }
+    protected disabledChanged(): void {}
 
     /**
      * The name of the radio group. Setting this value will set the name value
@@ -76,7 +67,7 @@ export class FASTRadioGroup extends FASTElement {
     public name: string;
     protected nameChanged(): void {
         if (this.slottedRadioButtons) {
-            this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
+            this.slottedRadioButtons.forEach((radio: FASTRadio) => {
                 radio.setAttribute("name", this.name);
             });
         }
@@ -93,7 +84,7 @@ export class FASTRadioGroup extends FASTElement {
     public value: string;
     protected valueChanged(): void {
         if (this.slottedRadioButtons) {
-            this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
+            this.slottedRadioButtons.forEach((radio: FASTRadio) => {
                 if (radio.value === this.value) {
                     radio.checked = true;
                     this.selectedRadio = radio;
@@ -130,8 +121,8 @@ export class FASTRadioGroup extends FASTElement {
         }
     }
 
-    private selectedRadio: HTMLInputElement | null;
-    private focusedRadio: HTMLInputElement | null;
+    private selectedRadio: FASTRadio | null;
+    private focusedRadio: FASTRadio | null;
     private direction: Direction;
 
     private get parentToolbar(): HTMLElement | null {
@@ -156,33 +147,29 @@ export class FASTRadioGroup extends FASTElement {
     }
 
     public disconnectedCallback(): void {
-        this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
+        this.slottedRadioButtons.forEach((radio: FASTRadio) => {
             radio.removeEventListener("change", this.radioChangeHandler);
         });
     }
 
     private setupRadioButtons(): void {
         const checkedRadios: HTMLElement[] = this.slottedRadioButtons.filter(
-            (radio: HTMLInputElement) => {
+            (radio: FASTRadio) => {
                 return radio.hasAttribute("checked");
             }
         );
         const numberOfCheckedRadios: number = checkedRadios ? checkedRadios.length : 0;
         if (numberOfCheckedRadios > 1) {
-            const lastCheckedRadio: HTMLInputElement = checkedRadios[
+            const lastCheckedRadio: FASTRadio = checkedRadios[
                 numberOfCheckedRadios - 1
-            ] as HTMLInputElement;
+            ] as FASTRadio;
             lastCheckedRadio.checked = true;
         }
         let foundMatchingVal: boolean = false;
 
-        this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
+        this.slottedRadioButtons.forEach((radio: FASTRadio) => {
             if (this.name !== undefined) {
                 radio.setAttribute("name", this.name);
-            }
-
-            if (this.disabled) {
-                radio.disabled = true;
             }
 
             if (this.readOnly) {
@@ -206,31 +193,31 @@ export class FASTRadioGroup extends FASTElement {
 
         if (this.value === undefined && this.slottedRadioButtons.length > 0) {
             const checkedRadios: HTMLElement[] = this.slottedRadioButtons.filter(
-                (radio: HTMLInputElement) => {
+                (radio: FASTRadio) => {
                     return radio.hasAttribute("checked");
                 }
             );
             const numberOfCheckedRadios: number =
                 checkedRadios !== null ? checkedRadios.length : 0;
             if (numberOfCheckedRadios > 0 && !foundMatchingVal) {
-                const lastCheckedRadio: HTMLInputElement = checkedRadios[
+                const lastCheckedRadio: FASTRadio = checkedRadios[
                     numberOfCheckedRadios - 1
-                ] as HTMLInputElement;
+                ] as FASTRadio;
                 lastCheckedRadio.checked = true;
                 this.focusedRadio = lastCheckedRadio;
                 lastCheckedRadio.setAttribute("tabindex", "0");
             } else {
                 this.slottedRadioButtons[0].setAttribute("tabindex", "0");
-                this.focusedRadio = this.slottedRadioButtons[0] as HTMLInputElement;
+                this.focusedRadio = this.slottedRadioButtons[0] as FASTRadio;
             }
         }
     }
 
     private radioChangeHandler = (e: CustomEvent): boolean | void => {
-        const changedRadio: HTMLInputElement = e.target as HTMLInputElement;
+        const changedRadio: FASTRadio = e.target as FASTRadio;
 
         if (changedRadio.checked) {
-            this.slottedRadioButtons.forEach((radio: HTMLInputElement) => {
+            this.slottedRadioButtons.forEach((radio: FASTRadio) => {
                 if (radio !== changedRadio) {
                     radio.checked = false;
                     if (!this.isInsideFoundationToolbar) {
@@ -247,11 +234,11 @@ export class FASTRadioGroup extends FASTElement {
     };
 
     private moveToRadioByIndex = (group: HTMLElement[], index: number) => {
-        const radio: HTMLInputElement = group[index] as HTMLInputElement;
+        const radio: FASTRadio = group[index] as FASTRadio;
         if (!this.isInsideToolbar) {
             radio.setAttribute("tabindex", "0");
             if (radio.readOnly) {
-                this.slottedRadioButtons.forEach((nextRadio: HTMLInputElement) => {
+                this.slottedRadioButtons.forEach((nextRadio: FASTRadio) => {
                     if (nextRadio !== radio) {
                         nextRadio.setAttribute("tabindex", "-1");
                     }
@@ -266,11 +253,11 @@ export class FASTRadioGroup extends FASTElement {
     };
 
     private moveRightOffGroup = () => {
-        (this.nextElementSibling as HTMLInputElement)?.focus();
+        (this.nextElementSibling as FASTRadio)?.focus();
     };
 
     private moveLeftOffGroup = () => {
-        (this.previousElementSibling as HTMLInputElement)?.focus();
+        (this.previousElementSibling as FASTRadio)?.focus();
     };
 
     /**
@@ -278,7 +265,7 @@ export class FASTRadioGroup extends FASTElement {
      */
     public focusOutHandler = (e: FocusEvent): boolean | void => {
         const group: HTMLElement[] = this.slottedRadioButtons;
-        const radio: HTMLInputElement | null = e.target as HTMLInputElement;
+        const radio: FASTRadio | null = e.target as FASTRadio;
         const index: number = radio !== null ? group.indexOf(radio) : 0;
         const focusedIndex: number = this.focusedRadio
             ? group.indexOf(this.focusedRadio)
@@ -289,9 +276,9 @@ export class FASTRadioGroup extends FASTElement {
             (focusedIndex === group.length - 1 && focusedIndex === index)
         ) {
             if (!this.selectedRadio) {
-                this.focusedRadio = group[0] as HTMLInputElement;
+                this.focusedRadio = group[0] as FASTRadio;
                 this.focusedRadio.setAttribute("tabindex", "0");
-                group.forEach((nextRadio: HTMLInputElement) => {
+                group.forEach((nextRadio: FASTRadio) => {
                     if (nextRadio !== this.focusedRadio) {
                         nextRadio.setAttribute("tabindex", "-1");
                     }
@@ -301,7 +288,7 @@ export class FASTRadioGroup extends FASTElement {
 
                 if (!this.isInsideFoundationToolbar) {
                     this.selectedRadio.setAttribute("tabindex", "0");
-                    group.forEach((nextRadio: HTMLInputElement) => {
+                    group.forEach((nextRadio: FASTRadio) => {
                         if (nextRadio !== this.selectedRadio) {
                             nextRadio.setAttribute("tabindex", "-1");
                         }
@@ -316,18 +303,19 @@ export class FASTRadioGroup extends FASTElement {
      * @internal
      */
     public clickHandler = (e: MouseEvent): void => {
-        const radio: HTMLInputElement | null = e.target as HTMLInputElement;
-        if (radio) {
-            const group: HTMLElement[] = this.slottedRadioButtons;
-            if (radio.checked || group.indexOf(radio) === 0) {
-                radio.setAttribute("tabindex", "0");
-                this.selectedRadio = radio;
-            } else {
-                radio.setAttribute("tabindex", "-1");
-                this.selectedRadio = null;
-            }
+        if (this.disabled) {
+            return;
+        }
+
+        const radio: FASTRadio | null = e.target as FASTRadio;
+
+        if (radio && radio instanceof FASTRadio && !radio.disabled) {
+            radio.checked = true;
+            radio.setAttribute("tabindex", "0");
+            this.selectedRadio = radio;
             this.focusedRadio = radio;
         }
+
         e.preventDefault();
     };
 
@@ -374,7 +362,7 @@ export class FASTRadioGroup extends FASTElement {
         /* looping to get to next radio that is not disabled */
         /* matching native radio/radiogroup which does not select an item if there is only 1 in the group */
         while (index < group.length && group.length > 1) {
-            if (!(group[index] as HTMLInputElement).disabled) {
+            if (!(group[index] as FASTRadio).disabled) {
                 this.moveToRadioByIndex(group, index);
                 break;
             } else if (this.focusedRadio && index === group.indexOf(this.focusedRadio)) {
@@ -404,7 +392,7 @@ export class FASTRadioGroup extends FASTElement {
         }
         /* looping to get to next radio that is not disabled */
         while (index >= 0 && group.length > 1) {
-            if (!(group[index] as HTMLInputElement).disabled) {
+            if (!(group[index] as FASTRadio).disabled) {
                 this.moveToRadioByIndex(group, index);
                 break;
             } else if (this.focusedRadio && index === group.indexOf(this.focusedRadio)) {

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.ts
@@ -53,7 +53,15 @@ export class FASTRadioGroup extends FASTElement {
      */
     @attr({ attribute: "disabled", mode: "boolean" })
     public disabled: boolean;
-    protected disabledChanged(): void {}
+    // protected disabledChanged(): void {
+    //     if (this.slottedRadioButtons) {
+    //         this.slottedRadioButtons.forEach((radio: FASTRadio) => {
+    //             if (this.disabled && !this.isInsideFoundationToolbar) {
+    //                 radio.setAttribute("tabindex", "-1")
+    //             }
+    //         });
+    //     }
+    // }
 
     /**
      * The name of the radio group. Setting this value will set the name value
@@ -143,6 +151,7 @@ export class FASTRadioGroup extends FASTElement {
     public connectedCallback(): void {
         super.connectedCallback();
         this.direction = getDirection(this);
+
         this.setupRadioButtons();
     }
 
@@ -188,6 +197,7 @@ export class FASTRadioGroup extends FASTElement {
                 }
                 radio.checked = false;
             }
+
             radio.addEventListener("change", this.radioChangeHandler);
         });
 
@@ -302,21 +312,33 @@ export class FASTRadioGroup extends FASTElement {
     /**
      * @internal
      */
-    public clickHandler = (e: MouseEvent): void => {
+    public handleDisabledClick = (e: MouseEvent): void | boolean => {
+        // prevent focus events on items from the click handler when disabled
+        if (this.disabled) {
+            e.preventDefault();
+            return;
+        }
+
+        return true;
+    };
+
+    /**
+     * @internal
+     */
+    public clickHandler = (e: MouseEvent): void | boolean => {
         if (this.disabled) {
             return;
         }
 
+        e.preventDefault();
         const radio: FASTRadio | null = e.target as FASTRadio;
 
-        if (radio && radio instanceof FASTRadio && !radio.disabled) {
+        if (radio && radio instanceof FASTRadio) {
             radio.checked = true;
             radio.setAttribute("tabindex", "0");
             this.selectedRadio = radio;
             this.focusedRadio = radio;
         }
-
-        e.preventDefault();
     };
 
     private shouldMoveOffGroupToTheRight = (
@@ -414,7 +436,7 @@ export class FASTRadioGroup extends FASTElement {
     public keydownHandler = (e: KeyboardEvent): boolean | void => {
         const key = e.key;
 
-        if (key in ArrowKeys && this.isInsideFoundationToolbar) {
+        if (key in ArrowKeys && (this.isInsideFoundationToolbar || this.disabled)) {
             return true;
         }
 

--- a/packages/web-components/fast-foundation/src/radio-group/stories/radio-group.register.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/stories/radio-group.register.ts
@@ -22,6 +22,10 @@ const styles = css`
     :host([orientation="horizontal"]) .positioning-region {
         flex-direction: row;
     }
+
+    :host([disabled]) {
+        opacity: var(--disabled-opacity);
+    }
 `;
 
 FASTRadioGroup.define({

--- a/packages/web-components/fast-foundation/src/radio/README.md
+++ b/packages/web-components/fast-foundation/src/radio/README.md
@@ -125,7 +125,6 @@ export const myRadio = Radio.compose<RadioOptions>({
 | ----------------- | --------- | --------------------------------- | ------------------ | ----------------- | -------------- |
 | `readOnlyChanged` | protected |                                   |                    | `void`            |                |
 | `keypressHandler` | public    | Handles key presses on the radio. | `e: KeyboardEvent` | `boolean or void` |                |
-| `clickHandler`    | public    | Handles clicks on the radio.      | `e: MouseEvent`    | `boolean or void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/radio/radio.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.pw.spec.ts
@@ -168,28 +168,12 @@ test.describe("Radio", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should fire events when clicked and spacebar is pressed", async () => {
+    test("should fire an event when spacebar is pressed", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>Radio</fast-radio>
             `;
         });
-
-        const [wasClicked] = await Promise.all([
-            element.evaluate(
-                (node: FASTRadio) =>
-                    new Promise(resolve =>
-                        node.addEventListener("click", () => resolve(true), {
-                            once: true,
-                        })
-                    )
-            ),
-            element.evaluate(node => {
-                node.dispatchEvent(new MouseEvent("click"));
-            }),
-        ]);
-
-        expect(wasClicked).toBeTruthy();
 
         const [wasPressed] = await Promise.all([
             element.evaluate(
@@ -209,10 +193,36 @@ test.describe("Radio", () => {
         expect(wasPressed).toBeTruthy();
     });
 
+    test("should NOT fire events when clicked", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-radio>Radio</fast-radio>
+            `;
+        });
+
+        const [wasClicked] = await Promise.all([
+            element.evaluate(
+                (node: FASTRadio) =>
+                    new Promise(resolve =>
+                        node.addEventListener("click", () => resolve(false), {
+                            once: true,
+                        })
+                    )
+            ),
+            element.evaluate(node => {
+                node.dispatchEvent(new MouseEvent("click"));
+            }),
+        ]);
+
+        expect(wasClicked).toBeFalsy();
+    });
+
     test("should handle validity when the `required` attribute is present", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
-                <fast-radio required name="name" value="test">Radio</fast-radio>
+                <fast-radio-group>
+                    <fast-radio required name="name" value="test">Radio</fast-radio>
+                <fast-radio-group>
             `;
         });
 

--- a/packages/web-components/fast-foundation/src/radio/radio.template.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.template.ts
@@ -19,7 +19,6 @@ export function radioTemplate<T extends FASTRadio>(
             aria-disabled="${x => x.disabled}"
             aria-readonly="${x => x.readOnly}"
             @keypress="${(x, c) => x.keypressHandler(c.event as KeyboardEvent)}"
-            @click="${(x, c) => x.clickHandler(c.event as MouseEvent)}"
         >
             <div part="control" class="control">
                 <slot name="checked-indicator">

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -144,8 +144,8 @@ export class FASTRadio extends FormAssociatedRadio implements RadioControl {
      * @beta
      */
     public clickHandler(e: MouseEvent): boolean | void {
-        if (!this.disabled && !this.readOnly && !this.checked) {
-            this.checked = true;
-        }
+        // if (!this.disabled && !this.readOnly && !this.checked) {
+        //     this.checked = true;
+        // }
     }
 }

--- a/packages/web-components/fast-foundation/src/radio/radio.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.ts
@@ -1,5 +1,6 @@
 import { attr, observable } from "@microsoft/fast-element";
 import { keySpace } from "@microsoft/fast-web-utilities";
+import { FASTRadioGroup } from "../radio-group/index.js";
 import type { StaticallyComposableHTML } from "../utilities/template-helpers.js";
 import { FormAssociatedRadio } from "./radio.form-associated.js";
 
@@ -137,15 +138,5 @@ export class FASTRadio extends FormAssociatedRadio implements RadioControl {
         }
 
         return true;
-    }
-
-    /**
-     * Handles clicks on the radio.
-     * @beta
-     */
-    public clickHandler(e: MouseEvent): boolean | void {
-        // if (!this.disabled && !this.readOnly && !this.checked) {
-        //     this.checked = true;
-        // }
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR proposes a slight refactor of radio group in order to support the disabling of the radiogroup without modifying the state of individual radio children. This PR does a few things:

1) Removes click handling behavior for the radio itself and manages via the group. Per the APG, radios which are not selected (primarily on page-load scenarios) can be selected via "Space" so that behavior remains in tact.

2) Removes behavior modifying each disabled items `disabled` state. For the sake of ensuring we don't break with future changes to the disabledChanged method, I've left this enumerated as _protected_ for now.

3) Assigns a tabindex of -1 to prevent focus from being brought to the element and its children.

4) To ensure that focus does not pass to the radiogroup when clicked, a mousedown event has been added to prevent focus when disabled.

### 🎫 Issues
fixes #6567 
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan
Tests have been added for most all pertinent scenarios

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->