### PR TITLE
feat: remove link from avatar

### DIFF
--- a/change/@microsoft-fast-foundation-163d8cc4-4555-4850-bd77-634d114cd95f.json
+++ b/change/@microsoft-fast-foundation-163d8cc4-4555-4850-bd77-634d114cd95f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove link from Avatar",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -753,7 +753,6 @@ export class FASTAnchoredRegion extends FASTElement {
 
 // @public
 export class FASTAvatar extends FASTElement {
-    link: string;
 }
 
 // @public

--- a/packages/web-components/fast-foundation/src/avatar/README.md
+++ b/packages/web-components/fast-foundation/src/avatar/README.md
@@ -105,24 +105,11 @@ This component is built with the expectation that focus is delegated to the anch
 | ------------- | ------ | ----------------------- |
 | `FASTElement` |        | @microsoft/fast-element |
 
-#### Fields
-
-| Name   | Privacy | Type     | Default | Description                               | Inherited From |
-| ------ | ------- | -------- | ------- | ----------------------------------------- | -------------- |
-| `link` | public  | `string` |         | Indicates the Avatar should have url link |                |
-
-#### Attributes
-
-| Name   | Field | Inherited From |
-| ------ | ----- | -------------- |
-| `link` | link  |                |
-
 #### CSS Parts
 
 | Name        | Description                           |
 | ----------- | ------------------------------------- |
 | `backplate` | The wrapping container for the avatar |
-| `link`      | The avatar link                       |
 | `content`   | The default slot                      |
 
 #### Slots

--- a/packages/web-components/fast-foundation/src/avatar/avatar.spec.md
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.spec.md
@@ -12,7 +12,6 @@ A common use case would be to display an image or text (usually initials) of a u
 - A URL for an image can be passed to the component to be displayed in the backplate
 - Badge slot: Able to slot in a badge component
 - Media slot: Accepts an `img` or an `svg`
-- When a `link` is provided an `aria-link` attribute is added
 
 ### Prior Art/Examples
 
@@ -29,14 +28,13 @@ A common use case would be to display an image or text (usually initials) of a u
 - `fast-avatar`
 
 #### Attributes
-|   Name    | Description                                                 | Type                                |
-|-----------|-------------------------------------------------------------|-------------------------------------|
-| `link`    | Accepts a URL for the anchor source                         | `string`                            |
+None
 
 #### Slots
 
 | Name  | Description               | Elements     |
 |-------|---------------------------|--------------|
+|-      | Slot for initials         | text         |
 |`badge`| Slot for fast badge       | `fast-badge` |
 |`media`| Slot for images and icons | `img`, `svg` |
 
@@ -48,14 +46,8 @@ A common use case would be to display an image or text (usually initials) of a u
     class="backplate"
     part="backplate"
 >
-    <a
-        class="link"
-        part="link"
-        href="${x => (x.link ? x.link : void 0)}"
-    >
-        <slot name="media" part="media">${definition.media || ""}</slot>
-        <slot class="content" part="content"></slot>
-    </a>
+    <slot name="media" part="media">${definition.media || ""}</slot>
+    <slot class="content" part="content"></slot>
 </div>
 <slot name="badge" part="badge"></slot>
 ```
@@ -65,15 +57,13 @@ A common use case would be to display an image or text (usually initials) of a u
 ## Implementation
 
 ```html
-<fast-avatar 
-  link="...">
+<fast-avatar>
 </fast-avatar>
 ```
 
 With `fast-badge` Component:
 ```html
-<fast-avatar
-  link="...">
+<fast-avatar>
   <fast-badge slot="badge">&nbsp</fast-badge>
 </fast-avatar>
 ```
@@ -81,8 +71,6 @@ With `fast-badge` Component:
 ### Accessibility
 
 It is important to ensure that when the contrast of text in the backplate meets [1.4.3 Contrast (Minimum)](https://www.w3.org/TR/UNDERSTANDING-WCAG20/visual-audio-contrast-contrast.html).
-
-If there is a link the component should have an `aria-link` attribute.
 
 ### Globalization
 

--- a/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.template.ts
@@ -10,19 +10,10 @@ export function avatarTemplate<T extends FASTAvatar>(
     options: AvatarOptions = {}
 ): ElementViewTemplate<T> {
     return html<T>`
-    <div
-        class="backplate"
-        part="backplate"
-    >
-        <a
-            class="link"
-            part="link"
-            href="${x => (x.link ? x.link : void 0)}"
-        >
+        <div class="backplate" part="backplate">
             <slot name="media">${staticallyCompose(options.media)}</slot>
-            <slot><slot>
-        </a>
-    </div>
-    <slot name="badge"></slot>
+            <slot></slot>
+        </div>
+        <slot name="badge"></slot>
     `;
 }

--- a/packages/web-components/fast-foundation/src/avatar/avatar.ts
+++ b/packages/web-components/fast-foundation/src/avatar/avatar.ts
@@ -1,4 +1,4 @@
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { FASTElement } from "@microsoft/fast-element";
 import type { StaticallyComposableHTML } from "../utilities/template-helpers.js";
 
 /**
@@ -16,18 +16,8 @@ export type AvatarOptions = {
  * @slot - The default slot for avatar text, commonly a name or initials
  * @slot badge - Used to provide a badge, such as a status badge
  * @csspart backplate - The wrapping container for the avatar
- * @csspart link - The avatar link
  * @csspart content - The default slot
  *
  * @public
  */
-export class FASTAvatar extends FASTElement {
-    /**
-     * Indicates the Avatar should have url link
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: link
-     */
-    @attr public link: string;
-}
+export class FASTAvatar extends FASTElement {}

--- a/packages/web-components/fast-foundation/src/avatar/stories/avatar.register.ts
+++ b/packages/web-components/fast-foundation/src/avatar/stories/avatar.register.ts
@@ -11,25 +11,18 @@ const styles = css`
         height: var(--avatar-size, var(--avatar-size-default));
         max-width: var(--avatar-size, var(--avatar-size-default));
         position: relative;
+        color: var(--foreground-on-accent-rest);
     }
 
     :host([hidden]) {
         display: none;
     }
 
-    .link {
-        align-items: center;
-        color: var(--foreground-on-accent-rest);
-        display: flex;
-        flex-direction: row;
-        justify-content: center;
-        min-width: 100%;
-        text-decoration: none;
-    }
-
     .backplate {
         display: flex;
         position: relative;
+        align-items: center;
+        justify-content: center;
         border-radius: 100%;
         min-width: 100%;
         overflow: hidden;

--- a/packages/web-components/fast-foundation/src/avatar/stories/avatar.stories.ts
+++ b/packages/web-components/fast-foundation/src/avatar/stories/avatar.stories.ts
@@ -4,7 +4,7 @@ import { renderComponent } from "../../__test__/helpers.js";
 import type { FASTAvatar } from "../avatar.js";
 
 const storyTemplate = html<StoryArgs<FASTAvatar>>`
-    <fast-avatar link="${x => x.link}">
+    <fast-avatar>
         ${x => x.storyContent}
     </fast-avatar>
 `;
@@ -12,7 +12,6 @@ const storyTemplate = html<StoryArgs<FASTAvatar>>`
 export default {
     title: "Avatar",
     argTypes: {
-        link: { control: "text" },
         storyContent: { table: { disable: true } },
     },
     decorators: [


### PR DESCRIPTION
# Pull Request

## 📖 Description

Many uses of an `Avatar` do not require `link` functionality. Often when it does it's beneficial to have other visual indications like hover and active indication. This update to `Avatar` allows it to be a general container for an combination of a profile image, initials, and a badge. If it requires click or link functionality it should be used within a `Button` or `Anchor`.

## 👩‍💻 Reviewer Notes

Reviewed under Storybook examples. Might have styling impacts if the `<a>` was expected for layout purposes.

## 📑 Test Plan

Test styling of any custom `Avatar` components.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [x] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)