### PR TITLE
feat: remove status messages from switch

### DIFF
--- a/change/@microsoft-fast-foundation-30bb7b36-e241-4543-b762-09555f2be889.json
+++ b/change/@microsoft-fast-foundation-30bb7b36-e241-4543-b762-09555f2be889.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "remove status messages from switch template",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/src/switch/stories/switch.register.ts
+++ b/packages/web-components/fast-foundation/src/switch/stories/switch.register.ts
@@ -60,16 +60,6 @@ const styles = css`
         border-radius: calc(var(--control-corner-radius) * 1px);
         transition: all 0.2s ease-in-out;
     }
-    .status-message {
-        color: var(--neutral-foreground-rest);
-        cursor: pointer;
-        font-size: var(--type-ramp-base-font-size);
-        line-height: var(--typeRamp-base-line-height);
-    }
-    :host([disabled]) .status-message,
-    :host([readonly]) .status-message {
-        cursor: var(--disabled-cursor);
-    }
     .label {
         color: var(--neutral-foreground-rest);
         margin-inline-end: calc(var(--design-unit) * 2px + 2px);
@@ -80,10 +70,6 @@ const styles = css`
     .label__hidden {
         display: none;
         visibility: hidden;
-    }
-    ::slotted([slot="checked-message"]),
-    ::slotted([slot="unchecked-message"]) {
-        margin-inline-start: calc(var(--design-unit) * 2px + 2px);
     }
     :host([aria-checked="true"]) .checked-indicator {
         background: var(--foreground-on-accent-rest);
@@ -109,19 +95,6 @@ const styles = css`
     :host([aria-checked="true"]:focus-visible:not([disabled])) .switch {
         box-shadow: 0 0 0 2px var(--fill-color), 0 0 0 4px var(--focus-stroke-outer);
     }
-    .unchecked-message {
-        display: block;
-    }
-    .checked-message {
-        display: none;
-    }
-    :host([aria-checked="true"]) .unchecked-message {
-        display: none;
-    }
-    :host([aria-checked="true"]) .checked-message {
-        display: block;
-    }
-
     .checked-indicator {
         left: 5px;
         right: calc(((var(--height-number) / 2) + 1) * 1px);

--- a/packages/web-components/fast-foundation/src/switch/stories/switch.stories.ts
+++ b/packages/web-components/fast-foundation/src/switch/stories/switch.stories.ts
@@ -35,16 +35,6 @@ export default {
 
 export const Switch = renderComponent(storyTemplate).bind({});
 
-export const SwitchWithSlottedMessages: Story<FASTSwitch> = renderComponent(
-    storyTemplate
-).bind({});
-SwitchWithSlottedMessages.args = {
-    storyContent: html`
-        <span slot="checked-message">Checked</span>
-        <span slot="unchecked-message">Unchecked</span>
-    `,
-};
-
 export const SwitchInForm: Story<FASTSwitch> = renderComponent(
     html<StoryArgs<FASTSwitch>>`
         <form @submit="${() => false}">
@@ -58,7 +48,5 @@ SwitchInForm.args = {
     required: true,
     storyContent: html`
         Sign up for our newsletter?
-        <div slot="checked-message">Yes, I would like to receive your newsletter</div>
-        <div slot="unchecked-message">do not sign me up</div>
     `,
 };

--- a/packages/web-components/fast-foundation/src/switch/switch.template.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.template.ts
@@ -31,14 +31,6 @@ export function switchTemplate<T extends FASTSwitch>(
             <div part="switch" class="switch">
                 <slot name="switch">${staticallyCompose(options.switch)}</slot>
             </div>
-            <span class="status-message" part="status-message">
-                <span class="checked-message" part="checked-message">
-                    <slot name="checked-message"></slot>
-                </span>
-                <span class="unchecked-message" part="unchecked-message">
-                    <slot name="unchecked-message"></slot>
-                </span>
-            </span>
         </template>
     `;
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR removes the status messages from switch. While initially these were thought to bring value to the switch state, switches have become commonplace in modern UI and status specific messages rarely accompany them (see all of iOS settings as an example of this). In an effort to provide "foundational" building blocks of common controls we should remove this excess as part of the component template. Moving the status messages from within the template doesn't prevent the switch from being composed as part of another template and likely enables folks to better associate using ARIA attributes if necessary, whereas that was previously not possible with these baked into the template.

@bheston and @falkicon as FYI.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
n/a
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->