### PR TITLE
fix: acccordion expand mode changes should update the UI as expected

### DIFF
--- a/change/@microsoft-fast-foundation-630834ad-b6a7-4fb5-82e8-f9a49fa2ec98.json
+++ b/change/@microsoft-fast-foundation-630834ad-b6a7-4fb5-82e8-f9a49fa2ec98.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fixes an issue where accordion expand-mode changes were not reflected in the component",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -642,6 +642,8 @@ export class FASTAccordion extends FASTElement {
     // (undocumented)
     protected accordionItems: Element[];
     expandmode: AccordionExpandMode;
+    // (undocumented)
+    expandmodeChanged(prev: AccordionExpandMode, next: AccordionExpandMode): void;
     // @internal (undocumented)
     handleChange(source: any, propertyName: string): void;
     // @internal (undocumented)

--- a/packages/web-components/fast-foundation/src/accordion/README.md
+++ b/packages/web-components/fast-foundation/src/accordion/README.md
@@ -129,6 +129,12 @@ export const myAccordionItem = AccordionItem.compose<AccordionItemOptions>({
 | `expandmode`     | public    | `AccordionExpandMode` |         | Controls the expand mode of the Accordion, either allowing single or multiple item expansion. |                |
 | `accordionItems` | protected | `Element[]`           |         |                                                                                               |                |
 
+#### Methods
+
+| Name                | Privacy | Description | Parameters                                             | Return | Inherited From |
+| ------------------- | ------- | ----------- | ------------------------------------------------------ | ------ | -------------- |
+| `expandmodeChanged` | public  |             | `prev: AccordionExpandMode, next: AccordionExpandMode` |        |                |
+
 #### Events
 
 | Name     | Type | Description                                                | Inherited From |

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -1,8 +1,8 @@
 import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
-import type { FASTAccordionItem } from "../accordion-item/index.js";
 import { AccordionExpandMode } from "./accordion.options.js";
+import type { FASTAccordion } from "./accordion.js";
 
 test.describe("Accordion", () => {
     let page: Page;
@@ -148,6 +148,78 @@ test.describe("Accordion", () => {
         await expect(firstItem).not.toHaveBooleanAttribute("expanded");
 
         await expect(secondItem).toHaveBooleanAttribute("expanded");
+    });
+
+    test("should set the expanded items' button to disabled when in single expand mode", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="single">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
+
+        const items = element.locator("fast-accordion-item");
+
+        const firstItem = items.nth(0);
+
+        const secondItem = items.nth(1);
+
+        await firstItem.click();
+
+        await expect(firstItem).toHaveBooleanAttribute("expanded");
+
+        await expect(firstItem.locator("button")).toHaveBooleanAttribute("disabled");
+
+        await secondItem.click();
+
+        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+
+        await expect(firstItem.locator("button")).not.toHaveBooleanAttribute("disabled");
+
+        await expect(secondItem).toHaveBooleanAttribute("expanded");
+
+        await expect(secondItem.locator("button")).toHaveBooleanAttribute("disabled");
+    });
+
+    test.only("should remove an expanded items' expandbutton disabled attribute when expand mode changes from single to multi", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="single">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
+
+        const items = element.locator("fast-accordion-item");
+
+        const firstItem = items.nth(0);
+
+        await firstItem.click();
+
+        await expect(firstItem).toHaveBooleanAttribute("expanded");
+
+        await expect(firstItem.locator("button")).toHaveBooleanAttribute("disabled");
+
+        await element.evaluate(node => {
+            node.setAttribute("expand-mode", "multi");
+        });
+
+        await expect(firstItem.locator("button")).not.toHaveBooleanAttribute("disabled");
     });
 
     test("should set the first item as expanded if no child is expanded by default in single mode", async () => {

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -150,7 +150,7 @@ test.describe("Accordion", () => {
         await expect(secondItem).toHaveBooleanAttribute("expanded");
     });
 
-    test("should set the expanded items' button to disabled when in single expand mode", async () => {
+    test("should set the expanded items' button to aria-disabled when in single expand mode", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
@@ -176,13 +176,23 @@ test.describe("Accordion", () => {
 
         await expect(firstItem).toHaveBooleanAttribute("expanded");
 
-        await expect(firstItem.locator("button")).toHaveBooleanAttribute("disabled");
+        await expect(firstItem.locator("button")).toHaveAttribute(
+            "aria-disabled",
+            "true"
+        );
 
         await secondItem.click();
 
         await expect(firstItem).not.toHaveBooleanAttribute("expanded");
 
-        await expect(firstItem.locator("button")).not.hasAttribute("aria-disabled");
+        await expect(firstItem.locator("button")).not.toHaveAttribute(
+            "aria-disabled",
+            "true"
+        );
+        await expect(firstItem.locator("button")).not.toHaveAttribute(
+            "aria-disabled",
+            "false"
+        );
 
         await expect(secondItem).toHaveBooleanAttribute("expanded");
 
@@ -192,7 +202,7 @@ test.describe("Accordion", () => {
         );
     });
 
-    test.only("should remove an expanded items' expandbutton aria-disabled attribute when expand mode changes from single to multi", async () => {
+    test("should remove an expanded items' expandbutton aria-disabled attribute when expand mode changes from single to multi", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -182,14 +182,17 @@ test.describe("Accordion", () => {
 
         await expect(firstItem).not.toHaveBooleanAttribute("expanded");
 
-        await expect(firstItem.locator("button")).not.toHaveBooleanAttribute("disabled");
+        await expect(firstItem.locator("button")).not.hasAttribute("aria-disabled");
 
         await expect(secondItem).toHaveBooleanAttribute("expanded");
 
-        await expect(secondItem.locator("button")).toHaveBooleanAttribute("disabled");
+        await expect(secondItem.locator("button")).toHaveAttribute(
+            "aria-disabled",
+            "true"
+        );
     });
 
-    test.only("should remove an expanded items' expandbutton disabled attribute when expand mode changes from single to multi", async () => {
+    test.only("should remove an expanded items' expandbutton aria-disabled attribute when expand mode changes from single to multi", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
@@ -213,13 +216,16 @@ test.describe("Accordion", () => {
 
         await expect(firstItem).toHaveBooleanAttribute("expanded");
 
-        await expect(firstItem.locator("button")).toHaveBooleanAttribute("disabled");
+        await expect(firstItem.locator("button")).toHaveAttribute(
+            "aria-disabled",
+            "true"
+        );
 
         await element.evaluate(node => {
             node.setAttribute("expand-mode", "multi");
         });
 
-        await expect(firstItem.locator("button")).not.toHaveBooleanAttribute("disabled");
+        await expect(firstItem.locator("button")).not.hasAttribute("aria-disabled");
     });
 
     test("should set the first item as expanded if no child is expanded by default in single mode", async () => {

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -44,7 +44,9 @@ export class FASTAccordion extends FASTElement {
         }
 
         if (next !== AccordionExpandMode.single) {
-            (expandedItem as FASTAccordionItem)?.expandbutton.removeAttribute("disabled");
+            (expandedItem as FASTAccordionItem)?.expandbutton.removeAttribute(
+                "aria-disabled"
+            );
         } else {
             this.setSingleExpandMode(expandedItem);
         }
@@ -148,12 +150,12 @@ export class FASTAccordion extends FASTElement {
         currentItems.forEach((item: FASTAccordionItem, index: number) => {
             if (this.activeItemIndex === index) {
                 item.expanded = true;
-                item.expandbutton.setAttribute("disabled", "");
+                item.expandbutton.setAttribute("aria-disabled", "true");
             } else {
                 item.expanded = false;
 
                 if (!item.hasAttribute("disabled")) {
-                    item.expandbutton.removeAttribute("disabled");
+                    item.expandbutton.removeAttribute("aria-disabled");
                 }
             }
         });

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -32,6 +32,24 @@ export class FASTAccordion extends FASTElement {
      */
     @attr({ attribute: "expand-mode" })
     public expandmode: AccordionExpandMode = AccordionExpandMode.multi;
+    public expandmodeChanged(prev: AccordionExpandMode, next: AccordionExpandMode) {
+        if (!this.$fastController.isConnected) {
+            return;
+        }
+
+        const expandedItem = this.findExpandedItem();
+
+        if (!expandedItem) {
+            return;
+        }
+
+        if (next !== AccordionExpandMode.single) {
+            console.log(next, "next");
+            (expandedItem as FASTAccordionItem)?.expandbutton.removeAttribute("disabled");
+        } else {
+            this.setSingleExpandMode(expandedItem);
+        }
+    }
 
     /**
      * @internal

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -44,7 +44,6 @@ export class FASTAccordion extends FASTElement {
         }
 
         if (next !== AccordionExpandMode.single) {
-            console.log(next, "next");
             (expandedItem as FASTAccordionItem)?.expandbutton.removeAttribute("disabled");
         } else {
             this.setSingleExpandMode(expandedItem);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
Fixes an issue where swapping expand modes did not trigger the proper updates to the accordion component. This also goes back to setting an item's expand button to aria-disabled attribute vs. disabled.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
fixes #6586
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->