### PR TITLE
fix: observe accordion item expanded state to ensure programmatic changes to children are handled in single expand scenarios

### DIFF
--- a/change/@microsoft-fast-foundation-700c2cf4-da3a-492b-8907-db7fa835c422.json
+++ b/change/@microsoft-fast-foundation-700c2cf4-da3a-492b-8907-db7fa835c422.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "observe accordion children to accommodate single expand scenarios with programmatic changes",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
@@ -91,13 +91,13 @@ export class FASTAccordionItem extends FASTElement {
         if (this.disabled) {
             return;
         }
-        this.expanded = !this.expanded;
-        this.change();
+
+        this.$emit("click", e);
     };
 
-    private change = (): void => {
-        this.$emit("change");
-    };
+    // private change = (): void => {
+    //     this.$emit("change");
+    // };
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.ts
@@ -94,10 +94,6 @@ export class FASTAccordionItem extends FASTElement {
 
         this.$emit("click", e);
     };
-
-    // private change = (): void => {
-    //     this.$emit("change");
-    // };
 }
 
 /**

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -263,6 +263,12 @@ test.describe("Accordion", () => {
         await expect(firstItem).toHaveBooleanAttribute("expanded");
 
         await expect(secondItem).not.toHaveBooleanAttribute("expanded");
+
+        await secondItem.evaluate<void>(node => node.setAttribute("expanded", ""));
+
+        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+
+        await expect(secondItem).toHaveBooleanAttribute("expanded");
     });
 
     test("should set the first item with an expanded attribute to expanded in single mode", async () => {

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -191,7 +191,7 @@ export class FASTAccordion extends FASTElement {
     private handleExpandedChange = (item: HTMLElement) => {
         if (item instanceof FASTAccordionItem) {
             this.activeid = item.getAttribute("id");
-            console.log("expanded change called");
+
             if (!this.isSingleExpandMode()) {
                 item.expanded = !item.expanded;
                 // setSingleExpandMode sets activeItemIndex on its own

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -121,7 +121,7 @@ export class FASTAccordion extends FASTElement {
 
         this.accordionItems.forEach((item: HTMLElement, index: number) => {
             if (item instanceof FASTAccordionItem) {
-                item.addEventListener("change", this.activeItemChange);
+                item.addEventListener("click", this.activeItemChange);
             }
 
             const itemId: string | null = this.accordionIds[index];
@@ -164,7 +164,7 @@ export class FASTAccordion extends FASTElement {
     private removeItemListeners = (oldValue: any): void => {
         oldValue.forEach((item: HTMLElement, index: number) => {
             Observable.getNotifier(item).unsubscribe(this, "disabled");
-            item.removeEventListener("change", this.activeItemChange);
+            item.removeEventListener("click", this.activeItemChange);
             item.removeEventListener("keydown", this.handleItemKeyDown);
             item.removeEventListener("focus", this.handleItemFocus);
         });
@@ -181,6 +181,7 @@ export class FASTAccordion extends FASTElement {
 
         if (!this.isSingleExpandMode()) {
             // setSingleExpandMode sets activeItemIndex on its own
+            selectedItem.expanded = !selectedItem.expanded;
             this.activeItemIndex = this.accordionItems.indexOf(selectedItem);
         } else {
             this.setSingleExpandMode(selectedItem);


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR fixes an issue where programmatic changes to a child's expanded property would allow multiple items open in single-expand scenarios. In this update, programmatic changes are observed and only the latest expanded accordion should remain open.

As part of these changes, the API for Accordion Items has changed. The `change` event becomes a specific _click_ event for the click handler. This change removes state handling from the accordion item and moves it into the "parent" accordion as we've done with similar updates to tree view and tree item, menu and menu items.

### 🎫 Issues
#6585

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan
Tests have been updated to accommodate this specific scenario

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->