### PR TITLE
fix: gracefully handle scenarios where first and last child properties of HTMLView are null

### DIFF
--- a/change/@microsoft-fast-element-b0c50dfe-bb5e-4277-8a77-ab2045909c6d.json
+++ b/change/@microsoft-fast-element-b0c50dfe-bb5e-4277-8a77-ab2045909c6d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update HTMLView to gracefully handle null scenarios for first and last child properties",
+  "packageName": "@microsoft/fast-element",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -520,7 +520,7 @@ export class HTMLView<TSource = any, TParent = any> implements ElementView<TSour
     get event(): Event;
     eventDetail<TDetail>(): TDetail;
     eventTarget<TTarget extends EventTarget>(): TTarget;
-    firstChild: Node;
+    firstChild: Node | null;
     index: number;
     insertBefore(node: Node): void;
     isBound: boolean;
@@ -529,7 +529,7 @@ export class HTMLView<TSource = any, TParent = any> implements ElementView<TSour
     get isInMiddle(): boolean;
     get isLast(): boolean;
     get isOdd(): boolean;
-    lastChild: Node;
+    lastChild: Node | null;
     length: number;
     // (undocumented)
     onUnbind(behavior: {
@@ -829,9 +829,9 @@ export interface SubtreeDirectiveOptions<T = any> extends NodeBehaviorOptions<T>
 
 // @public
 export interface SyntheticView<TSource = any, TParent = any> extends View<TSource, TParent> {
-    readonly firstChild: Node;
+    readonly firstChild: Node | null;
     insertBefore(node: Node): void;
-    readonly lastChild: Node;
+    readonly lastChild: Node | null;
     remove(): void;
 }
 

--- a/packages/web-components/fast-element/src/templating/view.spec.ts
+++ b/packages/web-components/fast-element/src/templating/view.spec.ts
@@ -25,6 +25,20 @@ function startCapturingWarnings() {
 
 describe(`The HTMLView`, () => {
     context("when binding hosts", () => {
+        it("should gracefully handle empty templates", () => {
+            const template = html``;
+
+            const view = template.create(document.createElement('div'));
+
+            expect(() => {
+                view.appendTo(document.body)
+            }).to.not.throw();
+
+            expect(() => {
+                view.remove();
+            }).to.not.throw();
+        });
+
         it("warns on class bindings when host not present", () => {
             const template = html`
                 <template class="foo"></template>

--- a/packages/web-components/fast-element/src/templating/view.ts
+++ b/packages/web-components/fast-element/src/templating/view.ts
@@ -60,12 +60,12 @@ export interface SyntheticView<TSource = any, TParent = any>
     /**
      * The first DOM node in the range of nodes that make up the view.
      */
-    readonly firstChild: Node;
+    readonly firstChild: Node | null;
 
     /**
      * The last DOM node in the range of nodes that make up the view.
      */
-    readonly lastChild: Node;
+    readonly lastChild: Node | null;
 
     /**
      * Inserts the view's DOM nodes before the referenced node.
@@ -210,12 +210,12 @@ export class HTMLView<TSource = any, TParent = any>
     /**
      * The first DOM node in the range of nodes that make up the view.
      */
-    public firstChild: Node;
+    public firstChild: Node | null;
 
     /**
      * The last DOM node in the range of nodes that make up the view.
      */
-    public lastChild: Node;
+    public lastChild: Node | null;
 
     /**
      * Constructs an instance of HTMLView.
@@ -227,8 +227,8 @@ export class HTMLView<TSource = any, TParent = any>
         private factories: ReadonlyArray<CompiledViewBehaviorFactory>,
         public readonly targets: ViewBehaviorTargets
     ) {
-        this.firstChild = fragment.firstChild!;
-        this.lastChild = fragment.lastChild!;
+        this.firstChild = fragment?.firstChild;
+        this.lastChild = fragment?.lastChild;
     }
 
     /**
@@ -269,9 +269,13 @@ export class HTMLView<TSource = any, TParent = any>
      * The nodes are not disposed and the view can later be re-inserted.
      */
     public remove(): void {
+        if (!this.firstChild || !this.lastChild) {
+            return;
+        }
+
         const fragment = this.fragment;
-        const end = this.lastChild!;
-        let current = this.firstChild!;
+        const end = this.lastChild;
+        let current = this.firstChild;
         let next;
 
         while (current !== end) {
@@ -288,6 +292,10 @@ export class HTMLView<TSource = any, TParent = any>
      * Once a view has been disposed, it cannot be inserted or bound again.
      */
     public dispose(): void {
+        if (!this.firstChild || !this.lastChild) {
+            return;
+        }
+
         removeNodeSequence(this.firstChild, this.lastChild);
         this.unbind();
     }
@@ -377,7 +385,14 @@ export class HTMLView<TSource = any, TParent = any>
             return;
         }
 
-        removeNodeSequence(views[0].firstChild, views[views.length - 1].lastChild);
+        const firstChild = views[0].firstChild;
+        const lastChild = views[views.length - 1].lastChild;
+
+        if (!firstChild || !lastChild) {
+            return;
+        }
+
+        removeNodeSequence(firstChild, lastChild);
 
         for (let i = 0, ii = views.length; i < ii; ++i) {
             views[i].unbind();


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR adds null checks and updates the typings for first and last child to handle null scenarios.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
I believe this fixes #6596
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->