### PR TITLE
fix: missing quote on Picker template

### DIFF
--- a/change/@microsoft-fast-foundation-783a779e-e845-401e-b3b0-a1752e3595e3.json
+++ b/change/@microsoft-fast-foundation-783a779e-e845-401e-b3b0-a1752e3595e3.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix missing quote on Picker",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/change/@microsoft-fast-foundation-783a779e-e845-401e-b3b0-a1752e3595e3.json
+++ b/change/@microsoft-fast-foundation-783a779e-e845-401e-b3b0-a1752e3595e3.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Fix missing quote on Picker",
+  "comment": "Fix Picker template missing quote and dependent tag names",
   "packageName": "@microsoft/fast-foundation",
   "email": "47367562+bheston@users.noreply.github.com",
   "dependentChangeType": "prerelease"

--- a/packages/web-components/fast-foundation/src/picker/picker.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.template.ts
@@ -51,8 +51,8 @@ export function pickerTemplate<T extends FASTPicker>(
     options: PickerOptions
 ): ElementViewTemplate<T> {
     const anchoredRegionTag = html.partial(tagFor(options.anchoredRegion));
-    const pickerMenuTag = html.partial(tagFor(options.pickerMenu));
-    const pickerListTag = html.partial(tagFor(options.pickerList));
+    const pickerMenuTag = tagFor(options.pickerMenu);
+    const pickerListTag = tagFor(options.pickerList);
     const progressRingTag = html.partial(tagFor(options.progressRing));
 
     return html<T>`

--- a/packages/web-components/fast-foundation/src/picker/picker.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.template.ts
@@ -117,7 +117,7 @@ export function pickerTemplate<T extends FASTPicker>(
                                 <slot name="loading-region">
                                     <${progressRingTag}
                                         part="loading-progress"
-                                        class="loading-progress
+                                        class="loading-progress"
                                         slot="loading-region"
                                     ></${progressRingTag}>
                                         ${x => x.loadingText}

--- a/packages/web-components/fast-foundation/src/picker/stories/picker.register.ts
+++ b/packages/web-components/fast-foundation/src/picker/stories/picker.register.ts
@@ -11,13 +11,15 @@ import { FASTPicker } from "../picker.js";
 import { pickerTemplate } from "../picker.template.js";
 
 const pickerStyles = css`
+    :host([hidden]) {
+        display: none;
+    }
     :host {
+        display: inline-flex;
         box-sizing: border-box;
     }
-
     fast-anchored-region {
         z-index: 1000;
-        overflow: auto;
         display: flex;
         font-family: var(--body-font);
         font-size: var(--type-ramp-base-font-size);
@@ -62,30 +64,38 @@ const pickerListStyles = css`
         row-gap: calc(var(--design-unit) * 1px);
         flex-wrap: wrap;
         box-sizing: border-box;
-    }
-
-    ::slotted([role="combobox"]) {
-        min-width: 260px;
-        width: auto;
-        box-sizing: border-box;
-        color: var(--neutral-foreground-rest);
         background: var(--neutral-fill-input-rest);
         border-radius: calc(var(--control-corner-radius) * 1px);
         border: calc(var(--stroke-width) * 1px) solid var(--accent-fill-rest);
         font-family: var(--body-font);
-        outline: none;
-        user-select: none;
         font-size: var(--type-ramp-base-font-size);
         line-height: var(--type-ramp-base-line-height);
-        padding: 0 calc(var(--design-unit) * 2px + 1px);
+        padding: calc(var(--design-unit) * 1px) calc(var(--design-unit) * 2px);
     }
-    ::slotted([role="combobox"]:active) {
+    :host(:not([disabled]):hover) {
         background: var(--neutral-fill-input-hover);
+        border-color: var(--accent-fill-hover);
+    }
+    :host(:not([disabled]):active) {
+        background: var(--neutral-fill-input-active);
         border-color: var(--accent-fill-active);
     }
-    ::slotted([role="combobox"]:focus-within) {
+    :host(:not([disabled]):focus-within) {
         border-color: var(--focus-stroke-outer);
         box-shadow: 0 0 0 1px var(--focus-stroke-outer) inset;
+    }
+    ::slotted([role="combobox"]) {
+        height: calc(
+            (var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px
+        );
+        min-width: 250px;
+        width: auto;
+        box-sizing: border-box;
+        border: none;
+        color: var(--neutral-foreground-rest);
+        outline: none;
+        user-select: none;
+        padding: 0 calc(var(--design-unit) * 2px + 1px);
     }
 `;
 
@@ -115,7 +125,7 @@ const pickerListItemStyles = css`
     :host(:focus-visible),
     :host(:hover) {
         background: var(--accent-fill-rest);
-        color: var(--neutral-foreground-rest);
+        color: var(--foreground-on-accent-rest);
     }
     :host(:focus-visible) {
         border-color: var(--focus-stroke-outer);
@@ -126,7 +136,6 @@ const pickerMenuStyles = css`
     :host {
         margin: calc(var(--design-unit) * 1px) 0;
         background: var(--neutral-layer-floating);
-        --elevation: 11;
         z-index: 1000;
         display: flex;
         width: 100%;
@@ -138,6 +147,7 @@ const pickerMenuStyles = css`
         border-radius: calc(var(--control-corner-radius) * 1px);
         padding: calc(var(--design-unit) * 1px) 0;
         border: calc(var(--stroke-width) * 1px) solid transparent;
+        box-shadow: var(--elevation-shadow);
     }
     .suggestions-available-alert {
         height: 0;
@@ -181,7 +191,7 @@ const pickerMenuOptionStyles = css`
     }
     :host([aria-selected="true"]) {
         background: var(--accent-fill-rest);
-        color: var(--neutral-foreground-rest);
+        color: var(--foreground-on-accent-rest);
     }
 `;
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds a quote missing in the `Picker` template.
Fixed template binding for tags that are passed in to the component, not rendered in the template.
Cleaned up the styling.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.