### PR TITLE
Add directives support for `createElementTemplate`

### DIFF
--- a/change/@microsoft-fast-element-83001531-34b6-4220-aaa5-090b6da18111.json
+++ b/change/@microsoft-fast-element-83001531-34b6-4220-aaa5-090b6da18111.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add directives support for createElementTemplate",
+  "packageName": "@microsoft/fast-element",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-83001531-34b6-4220-aaa5-090b6da18111.json
+++ b/change/@microsoft-fast-element-83001531-34b6-4220-aaa5-090b6da18111.json
@@ -3,5 +3,5 @@
   "comment": "add directives support for createElementTemplate",
   "packageName": "@microsoft/fast-element",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/src/templating/render.spec.ts
+++ b/packages/web-components/fast-element/src/templating/render.spec.ts
@@ -11,6 +11,7 @@ import { NodeTemplate, render, RenderBehavior, RenderDirective, RenderInstructio
 import { html, ViewTemplate } from "./template.js";
 import type { SyntheticView } from "./view.js";
 import type { ElementCreateOptions } from "./render.js";
+import { ref } from "./ref.js";
 
 describe("The render", () => {
     const childTemplate = html`Child Template`;
@@ -712,7 +713,7 @@ describe("The render", () => {
     });
 
     context("createElementTemplate function", () => {
-        const childTemplate = html<Child>`This is a template. ${x => x.knownValue}`;
+        const sourceTemplate = html<RenderSource>`This is a template. ${x => x.knownValue}`;
 
         const templateAttributeOptions: ElementCreateOptions = {
             attributes: { id: x => x.id },
@@ -722,7 +723,7 @@ describe("The render", () => {
             content: "foo"
         }
 
-        class Child {
+        class RenderSource {
             id = 'child-1';
             @observable knownValue: string = "value";
             @observable ref: HTMLElement;
@@ -741,7 +742,7 @@ describe("The render", () => {
             );
 
             const targetNode = document.createElement("div");
-            const source = new Child();
+            const source = new RenderSource();
             const view = template.create();
 
             view.bind(source);
@@ -767,12 +768,12 @@ describe("The render", () => {
                 "button",
                 {
                     ...templateAttributeOptions,
-                    content: childTemplate
+                    content: sourceTemplate
                 }
             );
 
             const targetNode = document.createElement("div");
-            const source = new Child();
+            const source = new RenderSource();
             const view = template.create();
 
             view.bind(source);
@@ -787,12 +788,12 @@ describe("The render", () => {
                 "button",
                 {
                     ...templateAttributeOptions,
-                    content: childTemplate
+                    content: sourceTemplate
                 }
             );
 
             const targetNode = document.createElement("div");
-            const source = new Child();
+            const source = new RenderSource();
             const view = template.create();
 
             view.bind(source);
@@ -806,6 +807,28 @@ describe("The render", () => {
             await Updates.next();
 
             expect(toHTML(targetNode.firstElementChild!)).to.equal("This is a template. new-value");
+        });
+
+        it(`creates a template with a ref directive on the host tag.`, async () => {
+            const template = RenderInstruction.createElementTemplate(
+                "button",
+                {
+                    directives: [ref("ref")],
+                    ...templateStaticViewOptions
+                }
+            );
+
+            const targetNode = document.createElement("div");
+            const source = new RenderSource();
+            const view = template.create();
+            view.bind(source);
+            view.appendTo(targetNode);
+
+            expect(view.source).to.equal(source);
+
+            await Updates.next();
+
+            expect(source.ref).to.be.instanceof(HTMLElement);
         });
     });
 });

--- a/packages/web-components/fast-element/src/templating/render.spec.ts
+++ b/packages/web-components/fast-element/src/templating/render.spec.ts
@@ -12,6 +12,8 @@ import { html, ViewTemplate } from "./template.js";
 import type { SyntheticView } from "./view.js";
 import type { ElementCreateOptions } from "./render.js";
 import { ref } from "./ref.js";
+import { children } from "./children.js";
+import { elements } from "./node-observation.js";
 
 describe("The render", () => {
     const childTemplate = html`Child Template`;
@@ -727,6 +729,7 @@ describe("The render", () => {
             id = 'child-1';
             @observable knownValue: string = "value";
             @observable ref: HTMLElement;
+            @observable childElements: Array<HTMLElement>;
         }
 
         it(`creates a template from a tag name`, () => {
@@ -829,6 +832,33 @@ describe("The render", () => {
             await Updates.next();
 
             expect(source.ref).to.be.instanceof(HTMLElement);
+        });
+
+        it(`creates a template with ref and children directives on the host tag`, async () => {
+            const template = RenderInstruction.createElementTemplate(
+                "ul",
+                {
+                    directives: [ref("ref"), children({ property: "childElements", filter: elements() })],
+                    content: html`
+                        <li>item-1</li>
+                        <li>item-1</li>
+                        <li>item-1</li>
+                    `
+                }
+            );
+
+            const targetNode = document.createElement("div");
+            const source = new RenderSource();
+            const view = template.create();
+            view.bind(source);
+            view.appendTo(targetNode);
+
+            expect(view.source).to.equal(source);
+
+            await Updates.next();
+
+            expect(source.ref).to.be.instanceof(HTMLElement);
+            expect(source.childElements).to.have.lengthOf(3);
         });
     });
 });

--- a/packages/web-components/fast-element/src/templating/render.spec.ts
+++ b/packages/web-components/fast-element/src/templating/render.spec.ts
@@ -1,6 +1,6 @@
 import { expect } from "chai";
 import { customElement, FASTElement } from "../components/fast-element.js";
-import { ExecutionContext, Observable, observable } from "../observation/observable.js";
+import { observable } from "../observation/observable.js";
 import { Updates } from "../observation/update-queue.js";
 import { Fake } from "../testing/fakes.js";
 import { uniqueElementName } from "../testing/fixture.js";
@@ -11,9 +11,6 @@ import { NodeTemplate, render, RenderBehavior, RenderDirective, RenderInstructio
 import { html, ViewTemplate } from "./template.js";
 import type { SyntheticView } from "./view.js";
 import type { ElementCreateOptions } from "./render.js";
-import { children } from "./children.js";
-import { elements } from "./node-observation.js";
-import { ref } from "./ref.js";
 
 describe("The render", () => {
     const childTemplate = html`Child Template`;

--- a/packages/web-components/fast-element/src/templating/render.ts
+++ b/packages/web-components/fast-element/src/templating/render.ts
@@ -377,11 +377,7 @@ function createElementTemplate<TSource = any, TParent = any>(
         for (let i = 0, ii = directives.length; i < ii; ++i) {
             const directive = directives[i];
 
-            if (i === 0) {
-                markup.push(" ");
-            } else {
-                markup.push("");
-            }
+            markup.push(i > 0 ? "" : " ");
 
             values.push(directive);
         }

--- a/packages/web-components/fast-element/src/templating/render.ts
+++ b/packages/web-components/fast-element/src/templating/render.ts
@@ -372,13 +372,15 @@ function createElementTemplate<TSource = any, TParent = any>(
     }
 
     if (directives) {
+        markup[markup.length - 1] += " ";
+
         for (let i = 0, ii = directives.length; i < ii; ++i) {
             const directive = directives[i];
 
-            if (i !== 0) {
-                markup.push("");
-            } else {
+            if (i === 0) {
                 markup.push(" ");
+            } else {
+                markup.push("");
             }
 
             values.push(directive);

--- a/packages/web-components/fast-element/src/templating/render.ts
+++ b/packages/web-components/fast-element/src/templating/render.ts
@@ -271,6 +271,23 @@ export type BaseElementRenderOptions<
 };
 
 /**
+ * Render options for directly creating an element with {@link RenderInstruction.createElementTemplate}
+ * @public
+ */
+export type ElementCreateOptions<TSource = any, TParent = any> = Omit<
+    BaseElementRenderOptions,
+    "type" | "name"
+> & {
+    /**
+     * Directives to use when creating the element template. These directives are applied directly to the specified tag.
+     *
+     * @remarks
+     * Directives supported by this API are: `ref`, `children`, `slotted`, or any custom `HTMLDirective` that can be used on a HTML tag.
+     */
+    directives?: TemplateValue<TSource, TParent>[];
+};
+
+/**
  * Render options used to specify an element.
  * @public
  */
@@ -329,16 +346,15 @@ function instructionToTemplate(def: RenderInstruction | undefined) {
 
 function createElementTemplate<TSource = any, TParent = any>(
     tagName: string,
-    attributes?: Record<string, string | TemplateValue<TSource, TParent>>,
-    content?: string | ContentTemplate,
-    policy?: DOMPolicy
+    options?: ElementCreateOptions
 ): ViewTemplate<TSource, TParent> {
     const markup: Array<string> = [];
     const values: Array<TemplateValue<TSource, TParent>> = [];
+    const { attributes, directives, content, policy } = options ?? {};
 
+    markup.push(`<${tagName}`);
     if (attributes) {
         const attrNames = Object.getOwnPropertyNames(attributes);
-        markup.push(`<${tagName}`);
 
         for (let i = 0, ii = attrNames.length; i < ii; ++i) {
             const name = attrNames[i];
@@ -352,10 +368,24 @@ function createElementTemplate<TSource = any, TParent = any>(
             values.push(attributes[name]);
         }
 
-        markup.push(`">`);
-    } else {
-        markup.push(`<${tagName}>`);
+        markup.push(`"`);
     }
+
+    if (directives) {
+        for (let i = 0, ii = directives.length; i < ii; ++i) {
+            const directive = directives[i];
+
+            if (i !== 0) {
+                markup.push("");
+            } else {
+                markup.push(" ");
+            }
+
+            values.push(directive);
+        }
+    }
+
+    markup[markup.length - 1] += ">";
 
     if (content && isFunction((content as any).create)) {
         values.push(content);
@@ -390,12 +420,11 @@ function create(options: any): RenderInstruction {
             }
         }
 
-        template = createElementTemplate(
-            tagName,
-            options.attributes ?? defaultAttributes,
-            options.content,
-            options.policy
-        );
+        if (!options.attributes) {
+            options.attributes = defaultAttributes;
+        }
+
+        template = createElementTemplate(tagName, options);
     } else {
         template = options.template;
     }


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR adds the ability to attach directives to the host element provided to `createElementTemplate` as well as consolidating the function's arguments into a single options object, which affects the `RenderInstruction.create` API.

After this change this is now possible:
```ts
class Model {
  @observable elementRef: HTMLElement;
  handleClick() {}
}

const template = RenderInstruction.createElementTemplate(
  "fast-button",
  {
    attributes: { "@click": x => x.handleClick() },
    directives: [ref("elementRef")], // applies to the "button" element being created
    content: html`<svg slot="start">...</svg> click me!`
  }
);
```

Prior to this change, it was not possible for the `Model` instance to access the `button` element it is bound to. In addition if the `Model` needed the children nodes of the host element, the template would need another `ViewTemplate` passed to as content with the `children` directive on it. Now the `children` directive can be directly applied to the host.

## 👩‍💻 Reviewer Notes
While everything tested locally just fine. I couldn't get the tests to detect when the property for a `ref` or `children` directive was updated. Any suggestions with writing tests for the new behavior would be appreciated.

Feedback on the new options type name and structure is also appreciated.

## 📑 Test Plan
Existing tests pass after this update. See above regarding new tests.

## ✅ Checklist

### General

- [X] I have included a change request file using `$ yarn change`
- [X] I have added tests for my changes.
- [X] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
