### PR TITLE
fix: Safari 16 adoptNode issue

### DIFF
--- a/change/@microsoft-fast-element-6cd8429d-8362-443b-b70d-b125b2146c1b.json
+++ b/change/@microsoft-fast-element-6cd8429d-8362-443b-b70d-b125b2146c1b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix Safari 16 issue",
+  "packageName": "@microsoft/fast-element",
+  "email": "mahwy.asdf@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-6cd8429d-8362-443b-b70d-b125b2146c1b.json
+++ b/change/@microsoft-fast-element-6cd8429d-8362-443b-b70d-b125b2146c1b.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
-  "comment": "Fix Safari 16 issue",
-  "packageName": "@microsoft/fast-element",
-  "email": "mahwy.asdf@gmail.com",
-  "dependentChangeType": "patch"
+    "type": "patch",
+    "comment": "Fix Safari 16 adoptNode issue",
+    "packageName": "@microsoft/fast-element",
+    "email": "mahwy.asdf@gmail.com",
+    "dependentChangeType": "patch"
 }

--- a/packages/web-components/fast-element/src/templating/compiler.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.ts
@@ -357,7 +357,15 @@ export const Compiler = {
         }
 
         // https://bugs.chromium.org/p/chromium/issues/detail?id=1111864
-        const fragment = document.adoptNode(template.content);
+        let fragment = document.adoptNode(template.content);
+
+        // Safari 16 introduced breaking changes with adoptNode.
+        // If fragment was not adopted, then use importNode
+        // https://github.com/microsoft/fast/issues/6537#issuecomment-1328513375
+        if (fragment.ownerDocument !== document) {
+            fragment = document.importNode(fragment, true)
+        }
+
         const context = new CompilationContext<TSource, TParent>(
             fragment,
             factories,


### PR DESCRIPTION
# Pull Request

## 📖 Description

Safari 16+ introduced a breaking change with `adoptNode`. It's providing a fix by calling `importNode` in case the adoptNode returned [preemptively](https://github.com/web-platform-tests/wpt/pull/16348) without adopting a given fragment.


### 🎫 Issues

- https://github.com/microsoft/fast/issues/6537
- https://github.com/aurelia/framework/issues/1003

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
