### PR TITLE
fix: clean up toJSON noop on core fast-element types

### DIFF
--- a/change/@microsoft-fast-element-59331653-4600-45fc-b598-6087e3bfd94e.json
+++ b/change/@microsoft-fast-element-59331653-4600-45fc-b598-6087e3bfd94e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: clean up toJSON noop on core fast-element types",
+  "packageName": "@microsoft/fast-element",
+  "email": "rob@bluespire.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-59331653-4600-45fc-b598-6087e3bfd94e.json
+++ b/change/@microsoft-fast-element-59331653-4600-45fc-b598-6087e3bfd94e.json
@@ -3,5 +3,5 @@
   "comment": "fix: clean up toJSON noop on core fast-element types",
   "packageName": "@microsoft/fast-element",
   "email": "rob@bluespire.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -175,16 +175,6 @@ export interface ContentView {
     unbind(): void;
 }
 
-// Warning: (ae-internal-missing-underscore) The name "createMetadataLocator" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export function createMetadataLocator<TMetadata>(): (target: {}) => TMetadata[];
-
-// Warning: (ae-internal-missing-underscore) The name "createTypeRegistry" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export function createTypeRegistry<TDefinition extends TypeDefinition>(): TypeRegistry<TDefinition>;
-
 // @public
 export const css: CSSTemplateTag;
 
@@ -276,8 +266,6 @@ export class ElementController<TElement extends HTMLElement = HTMLElement> exten
     readonly source: TElement;
     get template(): ElementViewTemplate<TElement> | null;
     set template(value: ElementViewTemplate<TElement> | null);
-    // @internal
-    toJSON: () => undefined;
     readonly view: ElementView<TElement> | null;
 }
 
@@ -538,8 +526,6 @@ export class HTMLView<TSource = any, TParent = any> implements ElementView<TSour
     readonly sourceLifetime: SourceLifetime;
     // (undocumented)
     readonly targets: ViewBehaviorTargets;
-    // @internal
-    toJSON: () => undefined;
     unbind(): void;
 }
 
@@ -784,8 +770,6 @@ export abstract class StatelessAttachedAttributeDirective<TOptions> implements H
     createHTML(add: AddViewBehaviorFactory): string;
     // (undocumented)
     protected options: TOptions;
-    // @internal
-    toJSON: () => undefined;
 }
 
 // @public
@@ -845,26 +829,6 @@ export type TrustedTypesPolicy = {
     createHTML(html: string): string;
 };
 
-// Warning: (ae-internal-missing-underscore) The name "TypeDefinition" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export interface TypeDefinition {
-    // (undocumented)
-    type: Function;
-}
-
-// Warning: (ae-internal-missing-underscore) The name "TypeRegistry" should be prefixed with an underscore because the declaration is marked as @internal
-//
-// @internal
-export interface TypeRegistry<TDefinition extends TypeDefinition> {
-    // (undocumented)
-    getByType(key: Function): TDefinition | undefined;
-    // (undocumented)
-    getForInstance(object: any): TDefinition | undefined;
-    // (undocumented)
-    register(definition: TDefinition): boolean;
-}
-
 // @public
 export interface UpdateQueue {
     enqueue(callable: Callable): void;
@@ -923,8 +887,6 @@ export class ViewTemplate<TSource = any, TParent = any> implements ElementViewTe
     readonly html: string | HTMLTemplateElement;
     inline(): CaptureType<TSource, TParent>;
     render(source: TSource, host: Node, hostBindingTarget?: Element): HTMLView<TSource, TParent>;
-    // @internal
-    toJSON: () => undefined;
     withPolicy(policy: DOMPolicy): this;
 }
 

--- a/packages/web-components/fast-element/src/components/element-controller.ts
+++ b/packages/web-components/fast-element/src/components/element-controller.ts
@@ -1,7 +1,7 @@
-import { Message, Mutable, noop } from "../interfaces.js";
+import { Message, Mutable } from "../interfaces.js";
 import { PropertyChangeNotifier } from "../observation/notifier.js";
 import { Observable, SourceLifetime } from "../observation/observable.js";
-import { FAST } from "../platform.js";
+import { FAST, makeSerializationNoop } from "../platform.js";
 import { ElementStyles } from "../styles/element-styles.js";
 import type { HostBehavior, HostController } from "../styles/host.js";
 import type { StyleStrategy, StyleTarget } from "../styles/style-strategy.js";
@@ -439,12 +439,6 @@ export class ElementController<TElement extends HTMLElement = HTMLElement>
         return false;
     }
 
-    /**
-     * Opts out of JSON stringification.
-     * @internal
-     */
-    toJSON = noop;
-
     private renderTemplate(template: ElementViewTemplate | null | undefined): void {
         // When getting the host to render to, we start by looking
         // up the shadow root. If there isn't one, then that means
@@ -509,6 +503,8 @@ export class ElementController<TElement extends HTMLElement = HTMLElement>
         elementControllerStrategy = strategy;
     }
 }
+
+makeSerializationNoop(ElementController);
 
 // Set default strategy for ElementController
 ElementController.setStrategy(ElementController);

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -7,7 +7,13 @@ export type {
     FASTGlobal,
     TrustedTypesPolicy,
 } from "./interfaces.js";
-export * from "./platform.js";
+
+export {
+    FAST,
+    emptyArray
+} from "./platform.js";
+
+// DOM
 export * from "./dom.js";
 
 // Observation

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -8,10 +8,7 @@ export type {
     TrustedTypesPolicy,
 } from "./interfaces.js";
 
-export {
-    FAST,
-    emptyArray
-} from "./platform.js";
+export { FAST, emptyArray } from "./platform.js";
 
 // DOM
 export * from "./dom.js";

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -380,7 +380,7 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
         }
     }
 
-    makeSerializationNoop(ExpressionNotifierImplementation)
+    makeSerializationNoop(ExpressionNotifierImplementation);
 
     return Object.freeze({
         /**

--- a/packages/web-components/fast-element/src/observation/observable.ts
+++ b/packages/web-components/fast-element/src/observation/observable.ts
@@ -6,7 +6,7 @@ import {
     Message,
     noop,
 } from "../interfaces.js";
-import { createMetadataLocator, FAST } from "../platform.js";
+import { createMetadataLocator, FAST, makeSerializationNoop } from "../platform.js";
 import { Updates } from "./update-queue.js";
 import { PropertyChangeNotifier, SubscriberSet } from "./notifier.js";
 import type { Notifier, Subscriber } from "./notifier.js";
@@ -255,11 +255,6 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
             super(expression, initialSubscriber);
         }
 
-        /**
-         * Opts out of JSON stringification.
-         */
-        toJSON = noop;
-
         public setMode(isAsync: boolean): void {
             this.isAsync = this.needsQueue = isAsync;
         }
@@ -384,6 +379,8 @@ export const Observable = FAST.getById(KernelServiceId.observable, () => {
             }
         }
     }
+
+    makeSerializationNoop(ExpressionNotifierImplementation)
 
     return Object.freeze({
         /**

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -1,4 +1,4 @@
-import type { FASTGlobal } from "./interfaces.js";
+import { FASTGlobal, noop } from "./interfaces.js";
 import "./polyfills.js";
 
 // ensure FAST global - duplicated debug.ts
@@ -132,4 +132,13 @@ export function createMetadataLocator<TMetadata>(): (target: {}) => TMetadata[] 
 
         return metadata;
     };
+}
+
+/**
+ * Makes a type noop for JSON serialization.
+ * @param type - The type to make noop for JSON serialization.
+ * @internal
+ */
+export function makeSerializationNoop(type: { readonly prototype: any }) {
+    type.prototype.toJSON = noop;
 }

--- a/packages/web-components/fast-element/src/templating/binding-signal.ts
+++ b/packages/web-components/fast-element/src/templating/binding-signal.ts
@@ -3,9 +3,10 @@ import type {
     ExpressionController,
     ExpressionObserver,
 } from "../observation/observable.js";
-import { isString, noop } from "../interfaces.js";
+import { isString } from "../interfaces.js";
 import type { Subscriber } from "../observation/notifier.js";
 import type { DOMPolicy } from "../dom.js";
+import { makeSerializationNoop } from "../platform.js";
 import type { HTMLBindingDirective } from "./binding.js";
 import { Binding } from "./html-directive.js";
 
@@ -79,12 +80,6 @@ class SignalObserver<TSource = any, TReturn = any, TParent = any> implements Sub
         this.subscriber.handleChange(this.dataBinding.evaluate, this);
     }
 
-    /**
-     * Opts out of JSON stringification.
-     * @internal
-     */
-    toJSON = noop;
-
     private getSignal(controller: ExpressionController<TSource, TParent>): string {
         const options = this.dataBinding.options;
         return isString(options)
@@ -92,6 +87,8 @@ class SignalObserver<TSource = any, TReturn = any, TParent = any> implements Sub
             : options(controller.source, controller.context);
     }
 }
+
+makeSerializationNoop(SignalObserver);
 
 class SignalBinding<TSource = any, TReturn = any, TParent = any> extends Binding<
     TSource,

--- a/packages/web-components/fast-element/src/templating/binding-two-way.ts
+++ b/packages/web-components/fast-element/src/templating/binding-two-way.ts
@@ -1,5 +1,5 @@
 import type { DOMPolicy } from "../dom.js";
-import { isString, Message, noop } from "../interfaces.js";
+import { isString, Message } from "../interfaces.js";
 import type { Subscriber } from "../observation/notifier.js";
 import {
     ExecutionContext,
@@ -9,7 +9,7 @@ import {
     Observable,
     ObservationRecord,
 } from "../observation/observable.js";
-import { FAST } from "../platform.js";
+import { FAST, makeSerializationNoop } from "../platform.js";
 import type { HTMLBindingDirective } from "./binding.js";
 import { Binding } from "./html-directive.js";
 
@@ -134,13 +134,9 @@ class TwoWayObserver<TSource = any, TReturn = any, TParent = any>
             value
         );
     }
-
-    /**
-     * Opts out of JSON stringification.
-     * @internal
-     */
-    toJSON = noop;
 }
+
+makeSerializationNoop(TwoWayObserver);
 
 class TwoWayBinding<TSource = any, TReturn = any, TParent = any> extends Binding<
     TSource,

--- a/packages/web-components/fast-element/src/templating/binding.ts
+++ b/packages/web-components/fast-element/src/templating/binding.ts
@@ -1,5 +1,5 @@
 import type { Subscriber } from "../index.js";
-import { isFunction, Message, noop } from "../interfaces.js";
+import { isFunction, Message } from "../interfaces.js";
 import {
     ExecutionContext,
     Expression,
@@ -7,7 +7,7 @@ import {
     ExpressionObserver,
     Observable,
 } from "../observation/observable.js";
-import { FAST } from "../platform.js";
+import { FAST, makeSerializationNoop } from "../platform.js";
 import { DOM, DOMAspect, DOMPolicy } from "../dom.js";
 import {
     AddViewBehaviorFactory,
@@ -43,13 +43,9 @@ class OneTimeBinding<TSource = any, TReturn = any, TParent = any>
     bind(controller: ExpressionController): TReturn {
         return this.evaluate(controller.source, controller.context);
     }
-
-    /**
-     * Opts out of JSON stringification.
-     * @internal
-     */
-    toJSON = noop;
 }
+
+makeSerializationNoop(OneTimeBinding);
 
 type UpdateTarget = (
     this: HTMLBindingDirective,

--- a/packages/web-components/fast-element/src/templating/html-directive.ts
+++ b/packages/web-components/fast-element/src/templating/html-directive.ts
@@ -1,12 +1,12 @@
 import { DOMAspect, DOMPolicy } from "../dom.js";
-import { Constructable, Mutable, noop } from "../interfaces.js";
+import type { Constructable, Mutable } from "../interfaces.js";
 import type { Subscriber } from "../observation/notifier.js";
 import type {
     Expression,
     ExpressionController,
     ExpressionObserver,
 } from "../observation/observable.js";
-import { createTypeRegistry } from "../platform.js";
+import { createTypeRegistry, makeSerializationNoop } from "../platform.js";
 import { Markup } from "./markup.js";
 
 /**
@@ -274,12 +274,6 @@ export abstract class Binding<TSource = any, TReturn = any, TParent = any> {
 export abstract class StatelessAttachedAttributeDirective<TOptions>
     implements HTMLDirective, ViewBehaviorFactory, ViewBehavior {
     /**
-     * Opts out of JSON stringification.
-     * @internal
-     */
-    toJSON = noop;
-
-    /**
      * Creates an instance of RefDirective.
      * @param options - The options to use in configuring the directive.
      */
@@ -309,3 +303,5 @@ export abstract class StatelessAttachedAttributeDirective<TOptions>
      */
     public abstract bind(controller: ViewController): void;
 }
+
+makeSerializationNoop(StatelessAttachedAttributeDirective);

--- a/packages/web-components/fast-element/src/templating/template.ts
+++ b/packages/web-components/fast-element/src/templating/template.ts
@@ -1,7 +1,7 @@
 import type { DOMPolicy } from "../dom.js";
-import { isFunction, isString, Message, noop } from "../interfaces.js";
+import { isFunction, isString, Message } from "../interfaces.js";
 import type { Expression } from "../observation/observable.js";
-import { FAST } from "../platform.js";
+import { FAST, makeSerializationNoop } from "../platform.js";
 import { bind, HTMLBindingDirective, oneTime } from "./binding.js";
 import { Compiler } from "./compiler.js";
 import {
@@ -247,12 +247,6 @@ export class ViewTemplate<TSource = any, TParent = any>
     }
 
     /**
-     * Opts out of JSON stringification.
-     * @internal
-     */
-    toJSON = noop;
-
-    /**
      * Creates a template based on a set of static strings and dynamic values.
      * @param strings - The static strings to create the template with.
      * @param values - The dynamic values to create the template with.
@@ -309,6 +303,8 @@ export class ViewTemplate<TSource = any, TParent = any>
         );
     }
 }
+
+makeSerializationNoop(ViewTemplate);
 
 /**
  * Transforms a template literal string into a ViewTemplate.

--- a/packages/web-components/fast-element/src/templating/view.ts
+++ b/packages/web-components/fast-element/src/templating/view.ts
@@ -1,9 +1,10 @@
-import { Disposable, noop } from "../interfaces.js";
+import type { Disposable } from "../interfaces.js";
 import {
     ExecutionContext,
     Observable,
     SourceLifetime,
 } from "../observation/observable.js";
+import { makeSerializationNoop } from "../platform.js";
 import type {
     CompiledViewBehaviorFactory,
     ViewBehavior,
@@ -352,12 +353,6 @@ export class HTMLView<TSource = any, TParent = any>
         this.isBound = false;
     }
 
-    /**
-     * Opts out of JSON stringification.
-     * @internal
-     */
-    toJSON = noop;
-
     private evaluateUnbindables() {
         const unbindables = this.unbindables;
 
@@ -385,5 +380,6 @@ export class HTMLView<TSource = any, TParent = any>
     }
 }
 
+makeSerializationNoop(HTMLView);
 Observable.defineProperty(HTMLView.prototype, "index");
 Observable.defineProperty(HTMLView.prototype, "length");


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR continues the work of cleaning up and polishing `fast-element` in preparation for release. It removes the `toJSON` noop from the public API surface and shifts the logic to an internal utility function.

### 🎫 Issues

* Part of #6502 

## 👩‍💻 Reviewer Notes

This is a small cleanup PR that centralizes logic and removes some clutter from type definitions.

## 📑 Test Plan

No changes to functionality. All tests continue to pass.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

More PRs coming as part of the general cleanup/polish work.