### PR TITLE
feat: add Context.for() and polish Context

### DIFF
--- a/change/@microsoft-fast-element-603d0ed3-89c6-4505-b1cd-4d26148f994b.json
+++ b/change/@microsoft-fast-element-603d0ed3-89c6-4505-b1cd-4d26148f994b.json
@@ -3,5 +3,5 @@
   "comment": "feat: add Context.for",
   "packageName": "@microsoft/fast-element",
   "email": "rob@bluespire.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-603d0ed3-89c6-4505-b1cd-4d26148f994b.json
+++ b/change/@microsoft-fast-element-603d0ed3-89c6-4505-b1cd-4d26148f994b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: add Context.for",
+  "packageName": "@microsoft/fast-element",
+  "email": "rob@bluespire.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/context.spec.ts
+++ b/packages/web-components/fast-element/src/context.spec.ts
@@ -108,6 +108,26 @@ describe("Context", () => {
         });
     });
 
+    describe("for()", () => {
+        it("returns the same context for successive calls with the same name", () => {
+            const ctx1 = Context.for("test");
+            const ctx2 = Context.for("test");
+
+            expect(ctx1).equals(ctx2);
+            expect(ctx1.name).equals("test");
+            expect(ctx2.name).equals("test");
+        });
+
+        it("returns different context for successive calls with different names", () => {
+            const ctx1 = Context.for("test1");
+            const ctx2 = Context.for("test2");
+
+            expect(ctx1).not.equals(ctx2);
+            expect(ctx1.name).equals("test1");
+            expect(ctx2.name).equals("test2");
+        });
+    });
+
     describe(`get()`, () => {
         it(`gets the value for a context`, () => {
             const value = "hello world";

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -50,7 +50,7 @@ export type TrustedTypesPolicy = {
 
 /**
  * Reverses all readonly members, making them mutable.
- * @internal
+ * @public
  */
 export type Mutable<T> = {
     -readonly [P in keyof T]: T[P];
@@ -197,19 +197,19 @@ export const enum Message {
 
 /**
  * Determines whether or not an object is a function.
- * @internal
+ * @public
  */
 export const isFunction = (object: any): object is Function =>
     typeof object === "function";
 
 /**
  * Determines whether or not an object is a string.
- * @internal
+ * @public
  */
 export const isString = (object: any): object is string => typeof object === "string";
 
 /**
  * A function which does nothing.
- * @internal
+ * @public
  */
 export const noop = () => void 0;

--- a/packages/web-components/fast-element/src/metadata.ts
+++ b/packages/web-components/fast-element/src/metadata.ts
@@ -33,9 +33,11 @@ if (!("metadata" in Reflect)) {
 }
 
 const annotationParamTypesKey = "annotation:paramtypes";
+const designParamTypesKey = "design:paramtypes";
 
 /**
  * Provides basic metadata capabilities used by Context and Dependency Injection.
+ * @public
  */
 export const Metadata = Object.freeze({
     /**
@@ -44,7 +46,7 @@ export const Metadata = Object.freeze({
      * @returns The metadata array or a frozen empty array if no metadata is found.
      */
     getDesignParamTypes: (Type: Constructable) =>
-        ((Reflect as any).getOwnMetadata("design:paramtypes", Type) ??
+        ((Reflect as any).getOwnMetadata(designParamTypesKey, Type) ??
             emptyArray) as readonly any[],
 
     /**


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds a new `Context.for()` API, modeled after the standard `Symbol.for()` JavaScript API. The new API allows you to get a context by name, if it exists, or create one with the provided name if it doesn't. Any created Context will be cached by name and returned by future calls to the API.

As part of this work, the final bit of cleanup on the `Context` feature was done, along with `Metadata` and core interfaces.

### 🎫 Issues

* Relates to issue #6502.

## 👩‍💻 Reviewer Notes

There's not much to this PR. The `Context.for()` API is new and has a pretty simple internal implementation. The rest of the changes are docs and cleanup.

## 📑 Test Plan

All existing tests continue to pass. Two new tests were added for `Context.for()`.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Cleanup and polish for additional areas of `fast-element` as time permits.