### PR TITLE
Fix focus issue for some custom menu item elements in menu

### DIFF
--- a/change/@microsoft-fast-foundation-1ba75c0b-83bf-492d-abdb-55636ef3d18c.json
+++ b/change/@microsoft-fast-foundation-1ba75c0b-83bf-492d-abdb-55636ef3d18c.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Support custom elements with delegatesFocus=true in submenus",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/menu/menu.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.spec.ts
@@ -15,6 +15,21 @@ const FASTMenuItem = MenuItem.compose({
     template: itemTemplate,
 })
 
+class AnchorMenuItem extends MenuItem {}
+
+const FASTAnchorMenuItem = AnchorMenuItem.compose({
+    baseName: "anchor-menu-item",
+    template: html`
+        <template role="menuitem">
+            <a href="#">
+                <slot></slot>
+            </a>
+        </template>`,
+    shadowOptions: {
+        delegatesFocus: true
+    }
+});
+
 const arrowUpEvent = new KeyboardEvent("keydown", {
     key: keyArrowUp,
     bubbles: true,
@@ -26,7 +41,7 @@ const arrowDownEvent = new KeyboardEvent("keydown", {
 } as KeyboardEventInit);
 
 async function setup() {
-    const { element, connect, disconnect } = await fixture([FASTMenu(), FASTMenuItem()]);
+    const { element, connect, disconnect } = await fixture([FASTMenu(), FASTMenuItem(), FASTAnchorMenuItem()]);
 
     const menuItem1 = document.createElement("fast-menu-item");
     (menuItem1 as MenuItem).textContent = "Foo";
@@ -44,12 +59,17 @@ async function setup() {
     (menuItem4 as MenuItem).textContent = "Bat";
     (menuItem4 as MenuItem).id = "id4";
 
+    const menuItem5 = document.createElement("fast-anchor-menu-item");
+    (menuItem5 as MenuItem).textContent = "Bap";
+    (menuItem5 as MenuItem).id = "id5";
+
     element.appendChild(menuItem1);
     element.appendChild(menuItem2);
     element.appendChild(menuItem3);
     element.appendChild(menuItem4);
+    element.appendChild(menuItem5);
 
-    return { element, connect, disconnect, menuItem1, menuItem2, menuItem3, menuItem4 };
+    return { element, connect, disconnect, menuItem1, menuItem2, menuItem3, menuItem4, menuItem5 };
 }
 
 describe("Menu", () => {
@@ -124,6 +144,19 @@ describe("Menu", () => {
         await DOM.nextUpdate();
 
         expect(document.getElementById("not-an-item")?.hasAttribute("tabindex")).to.equal(false);
+
+        await disconnect();
+    });
+
+    it("should set tabindex in shadow DOM for custom menu item with delegatesFocus", async () => {
+        const { element, connect, disconnect } = await setup();
+
+        await connect();
+
+        await DOM.nextUpdate();
+
+        expect(document.getElementById("id5")?.hasAttribute("tabindex")).to.equal(false);
+        expect(document.getElementById("id5")?.shadowRoot?.querySelector('[tabindex]')).to.not.equal(null);
 
         await disconnect();
     });
@@ -343,6 +376,12 @@ describe("Menu", () => {
         expect(document.activeElement?.id).to.equal("id4");
 
         document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id5");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id5");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
         expect(document.activeElement?.id).to.equal("id4");
 
         document.activeElement?.dispatchEvent(arrowUpEvent);
@@ -389,6 +428,12 @@ describe("Menu", () => {
         expect(document.activeElement?.id).to.equal("id4");
 
         document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id5");
+
+        document.activeElement?.dispatchEvent(arrowDownEvent);
+        expect(document.activeElement?.id).to.equal("id5");
+
+        document.activeElement?.dispatchEvent(arrowUpEvent);
         expect(document.activeElement?.id).to.equal("id4");
 
         document.activeElement?.dispatchEvent(arrowUpEvent);

--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -146,9 +146,9 @@ export class Menu extends FoundationElement {
             // find our first focusable element
             const focusIndex: number = this.menuItems.findIndex(this.isFocusableElement);
             // set the current focus index's tabindex to -1
-            this.menuItems[this.focusIndex].setAttribute("tabindex", "-1");
+            this.setTabIndex(this.menuItems[this.focusIndex], "-1");
             // set the first focusable element tabindex to 0
-            this.menuItems[focusIndex].setAttribute("tabindex", "0");
+            this.setTabIndex(this.menuItems[focusIndex], "0");
             // set the focus index
             this.focusIndex = focusIndex;
         }
@@ -161,9 +161,9 @@ export class Menu extends FoundationElement {
             this.menuItems !== undefined &&
             targetItem !== this.menuItems[this.focusIndex]
         ) {
-            this.menuItems[this.focusIndex].setAttribute("tabindex", "-1");
+            this.setTabIndex(this.menuItems[this.focusIndex], "-1");
             this.focusIndex = this.menuItems.indexOf(targetItem);
-            targetItem.setAttribute("tabindex", "0");
+            this.setTabIndex(targetItem, "0");
         }
     };
 
@@ -194,10 +194,10 @@ export class Menu extends FoundationElement {
             if (this.expandedItem !== null && this.expandedItem !== changedItem) {
                 this.expandedItem.expanded = false;
             }
-            this.menuItems[this.focusIndex].setAttribute("tabindex", "-1");
+            this.setTabIndex(this.menuItems[this.focusIndex], "-1");
             this.expandedItem = changedItem;
             this.focusIndex = this.menuItems.indexOf(changedItem);
-            changedItem.setAttribute("tabindex", "0");
+            this.setTabIndex(changedItem, "0");
         }
     };
 
@@ -245,7 +245,7 @@ export class Menu extends FoundationElement {
         }, 0);
 
         menuItems.forEach((item: HTMLElement, index: number) => {
-            item.setAttribute("tabindex", index === 0 ? "0" : "-1");
+            this.setTabIndex(item, index === 0 ? "0" : "-1");
             item.addEventListener("expanded-change", this.handleExpandedChanged);
             item.addEventListener("focus", this.handleItemFocus);
 
@@ -335,14 +335,14 @@ export class Menu extends FoundationElement {
                     this.focusIndex > -1 &&
                     this.menuItems.length >= this.focusIndex - 1
                 ) {
-                    this.menuItems[this.focusIndex].setAttribute("tabindex", "-1");
+                    this.setTabIndex(this.menuItems[this.focusIndex], "-1");
                 }
 
                 // update the focus index
                 this.focusIndex = focusIndex;
 
                 // update the tabindex of next focusable element
-                child.setAttribute("tabindex", "0");
+                this.setTabIndex(child, "0");
 
                 // focus the element
                 child.focus();
@@ -351,6 +351,17 @@ export class Menu extends FoundationElement {
             }
 
             focusIndex += adjustment;
+        }
+    }
+
+    private setTabIndex(item: Element, value: string): void {
+        // If the item is a custom element that delegates focus, setting the tabindex on
+        // the host would trigger the inner element to lose focus, which will close the
+        // submenu, if it is in one.
+        if (item.shadowRoot?.delegatesFocus) {
+            item.shadowRoot?.firstElementChild?.setAttribute("tabindex", value);
+        } else {
+            item.setAttribute("tabindex", value);
         }
     }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

We have implemented a design system and are attempting to add a menu item that is actually an anchor. This anchor menu item component has a native anchor in its `shadowRoot`. The component sets `delegatesFocus` to true so that interactions occur directly with the native anchor. We are mostly able to make this work, except that the menu code manages `tabindex` on the menu items, and this causes problems for anchor menu items in submenus. Specifically, when the inner native anchor has focus, and the menu sets `tabindex` on the host element, the native anchor loses focus. This `focusout` event bubbles up and triggers the submenu to close. This makes it impossible to use up/down arrow to navigate across an anchor menu item. It also prevents clicks from working (i.e. triggering page navigation).

The proposed solution is to check whether the menu item has a `shadowRoot` with `delegatesFocus=true` before attempting to set `tabindex`. If the item does, then set `tabindex` on the first element child of the `shadowRoot`, otherwise continue as before and set it on the menu item element.

### 🎫 Issues

None

## 👩‍💻 Reviewer Notes

None

## 📑 Test Plan

Existing tests related to setting the `tabindex` continue to pass. Added one new test.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.