### PR TITLE
Fix: data-grid with no rows should still render header

### DIFF
--- a/change/@microsoft-fast-foundation-3f5da524-dd71-4e14-bae8-982e36915731.json
+++ b/change/@microsoft-fast-foundation-3f5da524-dd71-4e14-bae8-982e36915731.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "data grid header fix",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-3f5da524-dd71-4e14-bae8-982e36915731.json
+++ b/change/@microsoft-fast-foundation-3f5da524-dd71-4e14-bae8-982e36915731.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "data grid header fix",
   "packageName": "@microsoft/fast-foundation",
   "email": "stephcomeau@msn.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -115,7 +115,7 @@ export class FASTDataGrid extends FASTElement {
     };
 
     /**
-     *  generates a gridTemplateColumns based on columndata array
+     *  generates a gridTemplateColumns based on columndefinitions
      */
     private static generateTemplateColumns(
         columnDefinitions: ColumnDefinition[]
@@ -222,8 +222,7 @@ export class FASTDataGrid extends FASTElement {
     @observable
     public columnDefinitions: ColumnDefinition[] | null = null;
     protected columnDefinitionsChanged(): void {
-        if (this.columnDefinitions === null) {
-            this.generatedGridTemplateColumns = "";
+        if (!this.columnDefinitions) {
             return;
         }
         this.generatedGridTemplateColumns = FASTDataGrid.generateTemplateColumns(
@@ -560,9 +559,10 @@ export class FASTDataGrid extends FASTElement {
         const focusColumnIndex = Math.max(0, Math.min(cells.length - 1, columnIndex));
 
         const focusTarget: HTMLElement = cells[focusColumnIndex] as HTMLElement;
-
-        focusTarget.scrollIntoView({ block: alignment });
-        focusTarget.focus();
+        if (focusTarget) {
+            focusTarget.scrollIntoView({ block: alignment });
+            focusTarget.focus();
+        }
     };
 
     private queueFocusUpdate(): void {
@@ -590,8 +590,7 @@ export class FASTDataGrid extends FASTElement {
         }
 
         if (
-            this.generateHeader !== GenerateHeaderOptions.none &&
-            this.rowsData.length > 0
+            this.generateHeader !== GenerateHeaderOptions.none
         ) {
             const generatedHeaderElement: HTMLElement = document.createElement(
                 this.rowElementTag

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -589,7 +589,11 @@ export class FASTDataGrid extends FASTElement {
             this.generatedHeader = null;
         }
 
-        if (this.generateHeader !== GenerateHeaderOptions.none) {
+        if (
+            this.generateHeader !== GenerateHeaderOptions.none &&
+            this.columnDefinitions &&
+            this.columnDefinitions.length
+        ) {
             const generatedHeaderElement: HTMLElement = document.createElement(
                 this.rowElementTag
             );

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -589,9 +589,7 @@ export class FASTDataGrid extends FASTElement {
             this.generatedHeader = null;
         }
 
-        if (
-            this.generateHeader !== GenerateHeaderOptions.none
-        ) {
+        if (this.generateHeader !== GenerateHeaderOptions.none) {
             const generatedHeaderElement: HTMLElement = document.createElement(
                 this.rowElementTag
             );

--- a/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.stories.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.stories.ts
@@ -1,11 +1,12 @@
 import { html } from "@microsoft/fast-element";
 import type { Meta, Story, StoryArgs } from "../../__test__/helpers.js";
 import { renderComponent } from "../../__test__/helpers.js";
-import { FASTDataGrid, GenerateHeaderOptions } from "../data-grid.js";
+import type { FASTDataGrid } from "../data-grid.js";
 
 const storyTemplate = html<StoryArgs<FASTDataGrid>>`
     <fast-data-grid
         style="${x => x.style}"
+        :columnDefinitions="${x => x.columnDefinitions ? x.columnDefinitions : null}"
         :rowsData="${x => x.rowsData}"
         no-tabbing="${x => x.noTabbing}"
         generate-header="${x => x.generateHeader}"
@@ -35,7 +36,7 @@ function newDataSet(rowCount: number): any[] {
 export default {
     title: "Data Grid",
     args: {
-        rowsData: newDataSet(100),
+        rowsData: newDataSet(20),
     },
     argTypes: {
         style: {
@@ -55,6 +56,9 @@ export default {
         gridTemplateColumns: {
             control: { type: "text" },
         },
+        columnDefinitions: {
+            control: { type: "object" },
+        }
     },
 } as Meta<FASTDataGrid>;
 
@@ -65,4 +69,12 @@ export const DataGridFixedHeight: Story<FASTDataGrid> = renderComponent(
 ).bind({});
 DataGridFixedHeight.args = {
     style: "height: 200px; overflow-y: scroll;",
+};
+
+export const DataGridColumnDefinitions: Story<FASTDataGrid> = renderComponent(
+    storyTemplate
+).bind({});
+DataGridColumnDefinitions.args = {
+    style: "height: 200px; overflow-y: scroll;",
+    columnDefinitions: [{ columnDataKey: "rowId" }, { columnDataKey: "item1" },  { columnDataKey: "item2" }],
 };

--- a/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.stories.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.stories.ts
@@ -6,7 +6,7 @@ import type { FASTDataGrid } from "../data-grid.js";
 const storyTemplate = html<StoryArgs<FASTDataGrid>>`
     <fast-data-grid
         style="${x => x.style}"
-        :columnDefinitions="${x => x.columnDefinitions ? x.columnDefinitions : null}"
+        :columnDefinitions="${x => (x.columnDefinitions ? x.columnDefinitions : null)}"
         :rowsData="${x => x.rowsData}"
         no-tabbing="${x => x.noTabbing}"
         generate-header="${x => x.generateHeader}"
@@ -58,7 +58,7 @@ export default {
         },
         columnDefinitions: {
             control: { type: "object" },
-        }
+        },
     },
 } as Meta<FASTDataGrid>;
 
@@ -76,5 +76,9 @@ export const DataGridColumnDefinitions: Story<FASTDataGrid> = renderComponent(
 ).bind({});
 DataGridColumnDefinitions.args = {
     style: "height: 200px; overflow-y: scroll;",
-    columnDefinitions: [{ columnDataKey: "rowId" }, { columnDataKey: "item1" },  { columnDataKey: "item2" }],
+    columnDefinitions: [
+        { columnDataKey: "rowId" },
+        { columnDataKey: "item1" },
+        { columnDataKey: "item2" },
+    ],
 };


### PR DESCRIPTION
# Pull Request

## 📖 Description
Data grid wouldn't render a header element when there is no rows in the data.  Obviously automatic generation of columns needs data, but not when columnDefinitions are provided.  Also fixed a minor bug with scrolling to elements when no data and added a "with columnDefintions" story.

### 🎫 Issues
ad-hoc


## ✅ Checklist

### General
- [ x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
