### PR TITLE
Allow non-MenuItem-derived types to be indented properly

### DIFF
--- a/change/@microsoft-fast-foundation-b7949ac8-950f-4d90-aae6-0c7134bb95ba.json
+++ b/change/@microsoft-fast-foundation-b7949ac8-950f-4d90-aae6-0c7134bb95ba.json
@@ -1,0 +1,7 @@
+{
+    "type": "patch",
+    "comment": "Allow non-MenuItem-derived types to be indented properly",
+    "packageName": "@microsoft/fast-foundation",
+    "email": "7282195+m-akinc@users.noreply.github.com",
+    "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -178,7 +178,7 @@ export class Menu extends FoundationElement {
         }
 
         e.preventDefault();
-        const changedItem: MenuItem = (e.target as any) as MenuItem;
+        const changedItem: MenuItem = e.target as any as MenuItem;
 
         // closing an expanded item without opening another
         if (
@@ -249,7 +249,7 @@ export class Menu extends FoundationElement {
             item.addEventListener("expanded-change", this.handleExpandedChanged);
             item.addEventListener("focus", this.handleItemFocus);
 
-            if (item instanceof MenuItem) {
+            if ("startColumnCount" in item) {
                 item.startColumnCount = indent;
             }
         });

--- a/packages/web-components/fast-foundation/src/menu/menu.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.ts
@@ -249,7 +249,7 @@ export class Menu extends FoundationElement {
             item.addEventListener("expanded-change", this.handleExpandedChanged);
             item.addEventListener("focus", this.handleItemFocus);
 
-            if ("startColumnCount" in item) {
+            if (item instanceof MenuItem || "startColumnCount" in item) {
                 item.startColumnCount = indent;
             }
         });


### PR DESCRIPTION
# Pull Request

## 📖 Description

We have a design system in which we are implementing an anchor-based menu item. We believe this item should derive from the Foundation `Anchor` rather than the `MenuItem`. The only issue is that the `Menu` has indenting logic that only works for items that are instances of `MenuItem`. Really, all that it needs is for our custom menu item to define `startColumnCount` and handle styling based on that value. This PR simply replaces a call to `item instanceof MenuItem` with `"startColumnCount" in item`.

### 🎫 Issues

None

## 👩‍💻 Reviewer Notes

None

## 📑 Test Plan

Existing tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
