### PR TITLE
fix: correct types for a break in TypeScript 5 legacy decorators

### DIFF
--- a/change/@microsoft-fast-element-207108f3-8e5f-4e90-82d4-3a1590ac5ad9.json
+++ b/change/@microsoft-fast-element-207108f3-8e5f-4e90-82d4-3a1590ac5ad9.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: correct types for a break in TypeScript 5 legacy decorators",
+  "packageName": "@microsoft/fast-element",
+  "email": "rob@bluespire.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-207108f3-8e5f-4e90-82d4-3a1590ac5ad9.json
+++ b/change/@microsoft-fast-element-207108f3-8e5f-4e90-82d4-3a1590ac5ad9.json
@@ -3,5 +3,5 @@
   "comment": "fix: correct types for a break in TypeScript 5 legacy decorators",
   "packageName": "@microsoft/fast-element",
   "email": "rob@bluespire.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/src/context.ts
+++ b/packages/web-components/fast-element/src/context.ts
@@ -1,4 +1,4 @@
-import { Constructable, Message } from "./interfaces.js";
+import { Constructable, Message, ParameterDecorator } from "./interfaces.js";
 import { Metadata } from "./metadata.js";
 import { FAST } from "./platform.js";
 

--- a/packages/web-components/fast-element/src/interfaces.ts
+++ b/packages/web-components/fast-element/src/interfaces.ts
@@ -57,6 +57,16 @@ export type Mutable<T> = {
 };
 
 /**
+ * A temporary type as a workaround for the TS compiler's erroneous built-in ParameterDecorator type.
+ * @public
+ */
+export type ParameterDecorator = (
+    target: Object,
+    propertyKey: string | undefined,
+    parameterIndex: number
+) => void;
+
+/**
  * The FAST global.
  * @public
  */


### PR DESCRIPTION
# Pull Request

## 📖 Description

TypeScript broke legacy parameter decorators by changing the compiler without updating their distributed types. This PR adds our own version of the `ParameterDecorator` type, to get around TypeScript's "oopsie". Without this fix, certain code will not compile in TS 5. I hope we can remove this after a future TypeScript 5 release.

### 🎫 Issues

No associated issue.

## 👩‍💻 Reviewer Notes

This is only a types change. No change to actual behavior.

## 📑 Test Plan

All tests continue to pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

I plan to continue review and polish in preparation for release.