### PR TITLE
fix: picker filter should be case insensitive

### DIFF
--- a/change/@microsoft-fast-foundation-0f870b93-d388-4f3a-abb6-7fe71502d122.json
+++ b/change/@microsoft-fast-foundation-0f870b93-d388-4f3a-abb6-7fe71502d122.json
@@ -3,5 +3,5 @@
   "comment": "picker filter ignores case",
   "packageName": "@microsoft/fast-foundation",
   "email": "stephcomeau@msn.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-0f870b93-d388-4f3a-abb6-7fe71502d122.json
+++ b/change/@microsoft-fast-foundation-0f870b93-d388-4f3a-abb6-7fe71502d122.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "picker filter ignores case",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -1002,8 +1002,10 @@ export class FASTPicker extends FormAssociatedPicker {
             );
         }
         if (this.filterQuery && this.query !== "" && this.query !== undefined) {
+            // compare case-insensitive
+            const filterQuery = this.query.toLowerCase();
             this.filteredOptionsList = this.filteredOptionsList.filter(
-                el => el.indexOf(this.query) !== -1
+                el => el.toLowerCase().indexOf(filterQuery) !== -1
             );
         }
     }


### PR DESCRIPTION
# Pull Request

## 📖 Description
Picker option filtering should be case insensitive.  We could consider adding customizability later, but the default should be permissive.

### 🎫 Issues
ad-hoc

## ✅ Checklist

### General
- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
