### PR TITLE
fixes bug in Webkit adoptedStyleSheets implementation

### DIFF
--- a/change/@microsoft-fast-element-b964400d-bbe0-4401-bd6a-12b1f459d3b2.json
+++ b/change/@microsoft-fast-element-b964400d-bbe0-4401-bd6a-12b1f459d3b2.json
@@ -3,5 +3,5 @@
   "comment": "Update adoptedStyleSheets strategy to use push/splice when available to fix Safari 16.4 bug",
   "packageName": "@microsoft/fast-element",
   "email": "nicholasrice@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-element-b964400d-bbe0-4401-bd6a-12b1f459d3b2.json
+++ b/change/@microsoft-fast-element-b964400d-bbe0-4401-bd6a-12b1f459d3b2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update adoptedStyleSheets strategy to use push/splice when available to fix Safari 16.4 bug",
+  "packageName": "@microsoft/fast-element",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/components/element-controller.ts
+++ b/packages/web-components/fast-element/src/components/element-controller.ts
@@ -550,9 +550,9 @@ ElementController.setStrategy(ElementController);
  * @param target
  * @returns
  */
-function normalizeStyleTarget(target: StyleTarget): StyleTarget {
+function normalizeStyleTarget(target: StyleTarget): Required<StyleTarget> {
     if ("adoptedStyleSheets" in target) {
-        return target;
+        return target as Required<StyleTarget>;
     } else {
         return (
             (getShadowRoot(target as any) as null | StyleTarget) ??
@@ -595,16 +595,11 @@ export class AdoptedStyleSheetsStrategy implements StyleStrategy {
     }
 
     public addStylesTo(target: StyleTarget): void {
-        const t = normalizeStyleTarget(target);
-        t.adoptedStyleSheets = [...t.adoptedStyleSheets!, ...this.sheets];
+        addAdoptedStyleSheets(normalizeStyleTarget(target), this.sheets);
     }
 
     public removeStylesFrom(target: StyleTarget): void {
-        const t = normalizeStyleTarget(target);
-        const sheets = this.sheets;
-        t.adoptedStyleSheets = t.adoptedStyleSheets!.filter(
-            (x: CSSStyleSheet) => sheets.indexOf(x) === -1
-        );
+        removeAdoptedStyleSheets(normalizeStyleTarget(target), this.sheets);
     }
 }
 

--- a/packages/web-components/fast-element/src/components/element-controller.ts
+++ b/packages/web-components/fast-element/src/components/element-controller.ts
@@ -644,10 +644,17 @@ export class StyleElementStrategy implements StyleStrategy {
     }
 }
 
-type StylesheetMutator = (target: Required<StyleTarget>, sheets: CSSStyleSheet[]) => void;
-let addAdoptedStyleSheets: StylesheetMutator;
-let removeAdoptedStyleSheets: StylesheetMutator;
-
+let addAdoptedStyleSheets = (target: Required<StyleTarget>, sheets: CSSStyleSheet[]) => {
+    target.adoptedStyleSheets = [...target.adoptedStyleSheets!, ...sheets];
+};
+let removeAdoptedStyleSheets = (
+    target: Required<StyleTarget>,
+    sheets: CSSStyleSheet[]
+) => {
+    target.adoptedStyleSheets = target.adoptedStyleSheets!.filter(
+        (x: CSSStyleSheet) => sheets.indexOf(x) === -1
+    );
+};
 if (ElementStyles.supportsAdoptedStyleSheets) {
     try {
         // Test if browser implementation uses FrozenArray.
@@ -669,22 +676,8 @@ if (ElementStyles.supportsAdoptedStyleSheets) {
             }
         };
     } catch (e) {
-        // Fallback to array assignment, which is compatible with the
-        // FrozenArray implementation
-        addAdoptedStyleSheets = (
-            target: Required<StyleTarget>,
-            sheets: CSSStyleSheet[]
-        ) => {
-            target.adoptedStyleSheets = [...target.adoptedStyleSheets!, ...sheets];
-        };
-        removeAdoptedStyleSheets = (
-            target: Required<StyleTarget>,
-            sheets: CSSStyleSheet[]
-        ) => {
-            target.adoptedStyleSheets = target.adoptedStyleSheets!.filter(
-                (x: CSSStyleSheet) => sheets.indexOf(x) === -1
-            );
-        };
+        // Do nothing if an error is thrown, the default
+        // case handles FrozenArray.
     }
 
     ElementStyles.setDefaultStrategy(AdoptedStyleSheetsStrategy);

--- a/packages/web-components/fast-element/src/components/element-controller.ts
+++ b/packages/web-components/fast-element/src/components/element-controller.ts
@@ -649,17 +649,9 @@ export class StyleElementStrategy implements StyleStrategy {
     }
 }
 
-let addAdoptedStyleSheets = (target: Required<StyleTarget>, sheets: CSSStyleSheet[]) => {
-    target.adoptedStyleSheets = [...target.adoptedStyleSheets!, ...sheets];
-};
-let removeAdoptedStyleSheets = (
-    target: Required<StyleTarget>,
-    sheets: CSSStyleSheet[]
-) => {
-    target.adoptedStyleSheets = target.adoptedStyleSheets!.filter(
-        (x: CSSStyleSheet) => sheets.indexOf(x) === -1
-    );
-};
+type StylesheetMutator = (target: Required<StyleTarget>, sheets: CSSStyleSheet[]) => void;
+let addAdoptedStyleSheets: StylesheetMutator;
+let removeAdoptedStyleSheets: StylesheetMutator;
 
 if (ElementStyles.supportsAdoptedStyleSheets) {
     try {
@@ -682,8 +674,22 @@ if (ElementStyles.supportsAdoptedStyleSheets) {
             }
         };
     } catch (e) {
-        // Do nothing if this fails, the initial implementation
-        // handles adoptedStyleSheets being a FrozenArray
+        // Fallback to array assignment, which is compatible with the
+        // FrozenArray implementation
+        addAdoptedStyleSheets = (
+            target: Required<StyleTarget>,
+            sheets: CSSStyleSheet[]
+        ) => {
+            target.adoptedStyleSheets = [...target.adoptedStyleSheets!, ...sheets];
+        };
+        removeAdoptedStyleSheets = (
+            target: Required<StyleTarget>,
+            sheets: CSSStyleSheet[]
+        ) => {
+            target.adoptedStyleSheets = target.adoptedStyleSheets!.filter(
+                (x: CSSStyleSheet) => sheets.indexOf(x) === -1
+            );
+        };
     }
 
     ElementStyles.setDefaultStrategy(AdoptedStyleSheetsStrategy);


### PR DESCRIPTION


<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
Safari 16.4 released support of adoptedStyleSheets and constructable style sheets. It appears there is a bug in the implementation though, causing intermittent removal of sheets when new sheets are added. In our testing, it appears that using this implementation circumvents the bug.

This PR updates FAST's constructableStyleSheet strategy to use push/splice instead of new array assignment when the browser's adoptedStyleSheet implementation does not use a FrozenArray. Since initial implementation of this code, the CSSOM spec has been [updated to define using an ObservableArray](https://www.w3.org/TR/cssom-1/#ref-for-dom-documentorshadowroot-adoptedstylesheets) for adoptedStyleSheets. This code falls back to array assignment if push and splice are not supported.

I've also filed a [bug against Webkit](https://bugs.webkit.org/show_bug.cgi?id=254844).
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->