### PR TITLE
fix: use push/splice for adoptedStyleSheet mutation when available

### DIFF
--- a/change/@microsoft-fast-element-abaf8433-027c-4daf-a871-2b516797920b.json
+++ b/change/@microsoft-fast-element-abaf8433-027c-4daf-a871-2b516797920b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use push and splice for adoptedStyleSheet mutation when available to avoid Safari 16.4 bug",
+  "packageName": "@microsoft/fast-element",
+  "email": "nicholasrice@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/styles/element-styles.ts
+++ b/packages/web-components/fast-element/src/styles/element-styles.ts
@@ -133,6 +133,45 @@ function reduceBehaviors(
             return prev.concat(curr);
         }, null as Behavior[] | null);
 }
+let addAdoptedStyleSheets = (
+    target: Required<StyleTarget>,
+    sheets: CSSStyleSheet[]
+): void => {
+    target.adoptedStyleSheets = [...target.adoptedStyleSheets!, ...sheets];
+};
+let removeAdoptedStyleSheets = (
+    target: Required<StyleTarget>,
+    sheets: CSSStyleSheet[]
+): void => {
+    target.adoptedStyleSheets = target.adoptedStyleSheets!.filter(
+        (x: CSSStyleSheet) => sheets.indexOf(x) === -1
+    );
+};
+if (DOM.supportsAdoptedStyleSheets) {
+    try {
+        // Test if browser implementation uses FrozenArray.
+        // If not, use push / splice to alter the stylesheets
+        // in place. This circumvents a bug in Safari 16.4 where
+        // periodically, assigning the array would previously
+        // cause sheets to be removed.
+        (document as any).adoptedStyleSheets.push();
+        (document as any).adoptedStyleSheets.splice();
+        addAdoptedStyleSheets = (target, sheets) => {
+            target.adoptedStyleSheets.push(...sheets);
+        };
+        removeAdoptedStyleSheets = (target, sheets) => {
+            for (const sheet of sheets) {
+                const index = target.adoptedStyleSheets.indexOf(sheet);
+                if (index !== -1) {
+                    target.adoptedStyleSheets.splice(index, 1);
+                }
+            }
+        };
+    } catch (e) {
+        // Do nothing if an error is thrown, the default
+        // case handles FrozenArray.
+    }
+}
 
 /**
  * https://wicg.github.io/construct-stylesheets/
@@ -177,16 +216,13 @@ export class AdoptedStyleSheetsStyles extends ElementStyles {
         this.behaviors = reduceBehaviors(styles);
     }
 
-    public addStylesTo(target: StyleTarget): void {
-        target.adoptedStyleSheets = [...target.adoptedStyleSheets!, ...this.styleSheets];
+    public addStylesTo(target: Required<StyleTarget>): void {
+        addAdoptedStyleSheets(target, this.styleSheets);
         super.addStylesTo(target);
     }
 
-    public removeStylesFrom(target: StyleTarget): void {
-        const sourceSheets = this.styleSheets;
-        target.adoptedStyleSheets = target.adoptedStyleSheets!.filter(
-            (x: CSSStyleSheet) => sourceSheets.indexOf(x) === -1
-        );
+    public removeStylesFrom(target: Required<StyleTarget>): void {
+        removeAdoptedStyleSheets(target, this.styleSheets);
         super.removeStylesFrom(target);
     }
 }

--- a/packages/web-components/fast-element/src/styles/styles.spec.ts
+++ b/packages/web-components/fast-element/src/styles/styles.spec.ts
@@ -21,10 +21,10 @@ if (DOM.supportsAdoptedStyleSheets) {
                     adoptedStyleSheets: [],
                 };
 
-                sheet.addStylesTo(target as StyleTarget);
+                sheet.addStylesTo(target as Required<StyleTarget>);
                 expect(target.adoptedStyleSheets!.length).to.equal(1);
 
-                sheet.removeStylesFrom(target as StyleTarget);
+                sheet.removeStylesFrom(target as Required<StyleTarget>);
                 expect(target.adoptedStyleSheets!.length).to.equal(0);
             });
 
@@ -35,12 +35,12 @@ if (DOM.supportsAdoptedStyleSheets) {
                 const target: Pick<StyleTarget, "adoptedStyleSheets"> = {
                     adoptedStyleSheets: [style],
                 };
-                sheet.addStylesTo(target as StyleTarget);
+                sheet.addStylesTo(target as Required<StyleTarget>);
 
                 expect(target.adoptedStyleSheets!.length).to.equal(2);
                 expect(target.adoptedStyleSheets).to.contain(cache.get("test"));
 
-                sheet.removeStylesFrom(target as StyleTarget);
+                sheet.removeStylesFrom(target as Required<StyleTarget>);
 
                 expect(target.adoptedStyleSheets!.length).to.equal(1);
                 expect(target.adoptedStyleSheets).not.to.contain(cache.get("test"));
@@ -52,7 +52,7 @@ if (DOM.supportsAdoptedStyleSheets) {
                 const elementStyles = new AdoptedStyleSheetsStyles([styles], cache);
                 const target = {
                     adoptedStyleSheets: [],
-                } as unknown as StyleTarget;
+                } as unknown as Required<StyleTarget>;
 
                 expect(elementStyles.isAttachedTo(target as StyleTarget)).to.equal(false)
 
@@ -71,8 +71,8 @@ if (DOM.supportsAdoptedStyleSheets) {
                     adoptedStyleSheets: [],
                 };
 
-                red.addStylesTo(target as StyleTarget);
-                green.addStylesTo(target as StyleTarget);
+                red.addStylesTo(target as Required<StyleTarget>);
+                green.addStylesTo(target as Required<StyleTarget>);
 
                 expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
                 expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));
@@ -84,7 +84,7 @@ if (DOM.supportsAdoptedStyleSheets) {
                     adoptedStyleSheets: [],
                 };
 
-                red.addStylesTo(target as StyleTarget);
+                red.addStylesTo(target as Required<StyleTarget>);
 
                 expect((target.adoptedStyleSheets![0])).to.equal(cache.get('r'));
                 expect((target.adoptedStyleSheets![1])).to.equal(cache.get('g'));


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
Safari 16.4 released support of adoptedStyleSheets and constructable style sheets. It appears there is a bug in the implementation though, causing intermittent removal of sheets when new sheets are added. In our testing, it appears that using this implementation circumvents the bug.

This PR updates FAST's AdoptedStyleSheetsStyles to use push/splice instead of new array assignment when the browser's adoptedStyleSheet implementation does not use a FrozenArray. Since initial implementation of this code, the CSSOM spec has been [updated to define using an ObservableArray](https://www.w3.org/TR/cssom-1/#ref-for-dom-documentorshadowroot-adoptedstylesheets) for adoptedStyleSheets. This code falls back to array assignment if push and splice are not supported.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->