### PR TITLE
fix: add missing picker disabled state

### DIFF
--- a/change/@microsoft-fast-foundation-18c21a13-5985-4fe7-88b6-c1d888f4851f.json
+++ b/change/@microsoft-fast-foundation-18c21a13-5985-4fe7-88b6-c1d888f4851f.json
@@ -3,5 +3,5 @@
   "comment": "add picker disabled state",
   "packageName": "@microsoft/fast-foundation",
   "email": "stephcomeau@msn.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-18c21a13-5985-4fe7-88b6-c1d888f4851f.json
+++ b/change/@microsoft-fast-foundation-18c21a13-5985-4fe7-88b6-c1d888f4851f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add picker disabled state",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1637,7 +1637,7 @@ export class FASTPickerListItem extends FASTElement {
     // @internal (undocumented)
     disconnectedCallback(): void;
     // (undocumented)
-    handleClick(e: MouseEvent): boolean;
+    handleClick(e: MouseEvent): void;
     // (undocumented)
     handleKeyDown(e: KeyboardEvent): boolean;
     value: string;

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1536,6 +1536,10 @@ export class FASTPicker extends FormAssociatedPicker {
     defaultMenuOptionTemplate?: ViewTemplate;
     // (undocumented)
     protected defaultMenuOptionTemplateChanged(): void;
+    // @public
+    disabled: boolean;
+    // (undocumented)
+    disabledChanged(previous: boolean, next: boolean): void;
     // (undocumented)
     disconnectedCallback(): void;
     // @internal
@@ -1626,6 +1630,10 @@ export class FASTPickerListItem extends FASTElement {
     contentsTemplate: ViewTemplate;
     // (undocumented)
     protected contentsTemplateChanged(): void;
+    // @public
+    disabled: boolean;
+    // (undocumented)
+    protected disabledChanged(): void;
     // @internal (undocumented)
     disconnectedCallback(): void;
     // (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -11,6 +11,7 @@ import { Direction } from '@microsoft/fast-web-utilities';
 import type { ElementsFilter } from '@microsoft/fast-element';
 import type { ElementStyles } from '@microsoft/fast-element';
 import type { ElementViewTemplate } from '@microsoft/fast-element';
+import { FASTContext } from '@microsoft/fast-element/context';
 import { FASTElement } from '@microsoft/fast-element';
 import { FASTElementDefinition } from '@microsoft/fast-element';
 import type { HostBehavior } from '@microsoft/fast-element';
@@ -1524,6 +1525,7 @@ export interface FASTNumberField extends StartEnd, DelegatesARIATextbox {
 //
 // @beta
 export class FASTPicker extends FormAssociatedPicker {
+    constructor();
     // @internal
     activeListItemTemplate?: ViewTemplate;
     // @internal
@@ -1598,6 +1600,10 @@ export class FASTPicker extends FormAssociatedPicker {
     // (undocumented)
     protected optionsChanged(): void;
     optionsList: string[];
+    // Warning: (ae-forgotten-export) The symbol "PickerContext" needs to be exported by the entry point index.d.ts
+    //
+    // (undocumented)
+    pickerContext: PickerContext;
     placeholder: string;
     query: string;
     // (undocumented)

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -11,7 +11,7 @@ import { Direction } from '@microsoft/fast-web-utilities';
 import type { ElementsFilter } from '@microsoft/fast-element';
 import type { ElementStyles } from '@microsoft/fast-element';
 import type { ElementViewTemplate } from '@microsoft/fast-element';
-import { FASTContext } from '@microsoft/fast-element/context';
+import { FASTContext } from '@microsoft/fast-element/context.js';
 import { FASTElement } from '@microsoft/fast-element';
 import { FASTElementDefinition } from '@microsoft/fast-element';
 import type { HostBehavior } from '@microsoft/fast-element';

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1525,7 +1525,6 @@ export interface FASTNumberField extends StartEnd, DelegatesARIATextbox {
 //
 // @beta
 export class FASTPicker extends FormAssociatedPicker {
-    constructor();
     // @internal
     activeListItemTemplate?: ViewTemplate;
     // @internal
@@ -1600,17 +1599,13 @@ export class FASTPicker extends FormAssociatedPicker {
     // (undocumented)
     protected optionsChanged(): void;
     optionsList: string[];
-    // Warning: (ae-forgotten-export) The symbol "PickerContext" needs to be exported by the entry point index.d.ts
-    //
-    // (undocumented)
-    pickerContext: PickerContext;
     placeholder: string;
     query: string;
     // (undocumented)
     protected queryChanged(): void;
     // @internal
     region: FASTAnchoredRegion;
-    // @internal (undocumented)
+    // @internal
     selectedItems: string[];
     // @internal
     selectedListTag: string;
@@ -1636,16 +1631,14 @@ export class FASTPickerListItem extends FASTElement {
     contentsTemplate: ViewTemplate;
     // (undocumented)
     protected contentsTemplateChanged(): void;
-    // @public
-    disabled: boolean;
-    // (undocumented)
-    protected disabledChanged(): void;
     // @internal (undocumented)
     disconnectedCallback(): void;
     // (undocumented)
     handleClick(e: MouseEvent): void;
     // (undocumented)
     handleKeyDown(e: KeyboardEvent): boolean;
+    // Warning: (ae-forgotten-export) The symbol "PickerContext" needs to be exported by the entry point index.d.ts
+    pickerContext: PickerContext;
     value: string;
 }
 

--- a/packages/web-components/fast-foundation/src/picker/README.md
+++ b/packages/web-components/fast-foundation/src/picker/README.md
@@ -256,7 +256,7 @@ export class FASTTextField extends TextField {}
 | `no-suggestions-text`        | noSuggestionsText        |                |
 | `suggestions-available-text` | suggestionsAvailableText |                |
 | `loading-text`               | loadingText              |                |
-| `disabled`                   | disabled                 |                |
+|                              | disabled                 |                |
 | `label`                      | label                    |                |
 | `labelledby`                 | labelledBy               |                |
 | `placeholder`                | placeholder              |                |

--- a/packages/web-components/fast-foundation/src/picker/README.md
+++ b/packages/web-components/fast-foundation/src/picker/README.md
@@ -42,13 +42,7 @@ export class FASTTextField extends TextField {}
 
 
 
-### class: `pickerContext`
-
-#### Fields
-
-| Name       | Privacy | Type      | Default | Description | Inherited From |
-| ---------- | ------- | --------- | ------- | ----------- | -------------- |
-| `disabled` | public  | `boolean` | `false` |             |                |
+### class: `DefaultPickerContext`
 
 <hr/>
 
@@ -72,27 +66,25 @@ export class FASTTextField extends TextField {}
 
 #### Fields
 
-| Name               | Privacy | Type           | Default | Description                                               | Inherited From |
-| ------------------ | ------- | -------------- | ------- | --------------------------------------------------------- | -------------- |
-| `value`            | public  | `string`       |         | The underlying string value of the item                   |                |
-| `disabled`         | public  | `boolean`      |         | Disables the picker-list-item.                            |                |
-| `contentsTemplate` | public  | `ViewTemplate` |         | The template used to render the contents of the list item |                |
+| Name               | Privacy | Type            | Default | Description                                               | Inherited From |
+| ------------------ | ------- | --------------- | ------- | --------------------------------------------------------- | -------------- |
+| `pickerContext`    |         | `PickerContext` |         | Context object for the parent picker                      |                |
+| `value`            | public  | `string`        |         | The underlying string value of the item                   |                |
+| `contentsTemplate` | public  | `ViewTemplate`  |         | The template used to render the contents of the list item |                |
 
 #### Methods
 
 | Name                      | Privacy   | Description | Parameters         | Return    | Inherited From |
 | ------------------------- | --------- | ----------- | ------------------ | --------- | -------------- |
-| `disabledChanged`         | protected |             |                    | `void`    |                |
 | `contentsTemplateChanged` | protected |             |                    | `void`    |                |
 | `handleKeyDown`           | public    |             | `e: KeyboardEvent` | `boolean` |                |
 | `handleClick`             | public    |             | `e: MouseEvent`    | `void`    |                |
 
 #### Attributes
 
-| Name       | Field    | Inherited From |
-| ---------- | -------- | -------------- |
-| `value`    | value    |                |
-| `disabled` | disabled |                |
+| Name    | Field | Inherited From |
+| ------- | ----- | -------------- |
+| `value` | value |                |
 
 <hr/>
 
@@ -214,7 +206,6 @@ export class FASTTextField extends TextField {}
 
 | Name                         | Privacy | Type                        | Default                      | Description                                                                                                                   | Inherited From       |
 | ---------------------------- | ------- | --------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------- |
-| `pickerContext`              |         | `PickerContext`             |                              |                                                                                                                               |                      |
 | `selection`                  | public  | `string`                    | `""`                         | Currently selected items. Comma delineated string ie. "apples,oranges".                                                       |                      |
 | `options`                    | public  | `string`                    |                              | Currently available options. Comma delineated string ie. "apples,oranges".                                                    |                      |
 | `filterSelected`             | public  | `boolean`                   | `true`                       | Whether the component should remove an option from the list when it is in the selection                                       |                      |

--- a/packages/web-components/fast-foundation/src/picker/README.md
+++ b/packages/web-components/fast-foundation/src/picker/README.md
@@ -65,7 +65,7 @@ export class FASTTextField extends TextField {}
 | `disabledChanged`         | protected |             |                    | `void`    |                |
 | `contentsTemplateChanged` | protected |             |                    | `void`    |                |
 | `handleKeyDown`           | public    |             | `e: KeyboardEvent` | `boolean` |                |
-| `handleClick`             | public    |             | `e: MouseEvent`    | `boolean` |                |
+| `handleClick`             | public    |             | `e: MouseEvent`    | `void`    |                |
 
 #### Attributes
 

--- a/packages/web-components/fast-foundation/src/picker/README.md
+++ b/packages/web-components/fast-foundation/src/picker/README.md
@@ -42,6 +42,26 @@ export class FASTTextField extends TextField {}
 
 
 
+### class: `pickerContext`
+
+#### Fields
+
+| Name       | Privacy | Type      | Default | Description | Inherited From |
+| ---------- | ------- | --------- | ------- | ----------- | -------------- |
+| `disabled` | public  | `boolean` | `false` |             |                |
+
+<hr/>
+
+### Variables
+
+| Name            | Description | Type |
+| --------------- | ----------- | ---- |
+| `PickerContext` |             |      |
+
+<hr/>
+
+
+
 ### class: `FASTPickerListItem`
 
 #### Superclass
@@ -194,6 +214,7 @@ export class FASTTextField extends TextField {}
 
 | Name                         | Privacy | Type                        | Default                      | Description                                                                                                                   | Inherited From       |
 | ---------------------------- | ------- | --------------------------- | ---------------------------- | ----------------------------------------------------------------------------------------------------------------------------- | -------------------- |
+| `pickerContext`              |         | `PickerContext`             |                              |                                                                                                                               |                      |
 | `selection`                  | public  | `string`                    | `""`                         | Currently selected items. Comma delineated string ie. "apples,oranges".                                                       |                      |
 | `options`                    | public  | `string`                    |                              | Currently available options. Comma delineated string ie. "apples,oranges".                                                    |                      |
 | `filterSelected`             | public  | `boolean`                   | `true`                       | Whether the component should remove an option from the list when it is in the selection                                       |                      |

--- a/packages/web-components/fast-foundation/src/picker/README.md
+++ b/packages/web-components/fast-foundation/src/picker/README.md
@@ -55,21 +55,24 @@ export class FASTTextField extends TextField {}
 | Name               | Privacy | Type           | Default | Description                                               | Inherited From |
 | ------------------ | ------- | -------------- | ------- | --------------------------------------------------------- | -------------- |
 | `value`            | public  | `string`       |         | The underlying string value of the item                   |                |
+| `disabled`         | public  | `boolean`      |         | Disables the picker-list-item.                            |                |
 | `contentsTemplate` | public  | `ViewTemplate` |         | The template used to render the contents of the list item |                |
 
 #### Methods
 
 | Name                      | Privacy   | Description | Parameters         | Return    | Inherited From |
 | ------------------------- | --------- | ----------- | ------------------ | --------- | -------------- |
+| `disabledChanged`         | protected |             |                    | `void`    |                |
 | `contentsTemplateChanged` | protected |             |                    | `void`    |                |
 | `handleKeyDown`           | public    |             | `e: KeyboardEvent` | `boolean` |                |
 | `handleClick`             | public    |             | `e: MouseEvent`    | `boolean` |                |
 
 #### Attributes
 
-| Name    | Field | Inherited From |
-| ------- | ----- | -------------- |
-| `value` | value |                |
+| Name       | Field    | Inherited From |
+| ---------- | -------- | -------------- |
+| `value`    | value    |                |
+| `disabled` | disabled |                |
 
 <hr/>
 
@@ -199,6 +202,7 @@ export class FASTTextField extends TextField {}
 | `noSuggestionsText`          | public  | `string`                    | `"No suggestions available"` | The text to present to assistive technolgies when no suggestions are available.                                               |                      |
 | `suggestionsAvailableText`   | public  | `string`                    | `"Suggestions available"`    | The text to present to assistive technolgies when suggestions are available.                                                  |                      |
 | `loadingText`                | public  | `string`                    | `"Loading suggestions"`      | The text to present to assistive technologies when suggestions are loading.                                                   |                      |
+| `disabled`                   | public  | `boolean`                   |                              | Disables the picker.                                                                                                          |                      |
 | `label`                      | public  | `string`                    |                              | Applied to the aria-label attribute of the input element                                                                      |                      |
 | `labelledBy`                 | public  | `string`                    |                              | Applied to the aria-labelledby attribute of the input element                                                                 |                      |
 | `placeholder`                | public  | `string`                    |                              | Applied to the placeholder attribute of the input element                                                                     |                      |
@@ -217,27 +221,28 @@ export class FASTTextField extends TextField {}
 
 #### Methods
 
-| Name                               | Privacy   | Description                                                   | Parameters         | Return    | Inherited From |
-| ---------------------------------- | --------- | ------------------------------------------------------------- | ------------------ | --------- | -------------- |
-| `selectionChanged`                 | protected |                                                               |                    | `void`    |                |
-| `optionsChanged`                   | protected |                                                               |                    | `void`    |                |
-| `menuPlacementChanged`             | protected |                                                               |                    | `void`    |                |
-| `showLoadingChanged`               | protected |                                                               |                    | `void`    |                |
-| `listItemTemplateChanged`          | protected |                                                               |                    | `void`    |                |
-| `defaultListItemTemplateChanged`   | protected |                                                               |                    | `void`    |                |
-| `menuOptionTemplateChanged`        | protected |                                                               |                    | `void`    |                |
-| `defaultMenuOptionTemplateChanged` | protected |                                                               |                    | `void`    |                |
-| `queryChanged`                     | protected |                                                               |                    | `void`    |                |
-| `filteredOptionsListChanged`       | protected |                                                               |                    | `void`    |                |
-| `flyoutOpenChanged`                | protected |                                                               |                    | `void`    |                |
-| `focus`                            | public    | Move focus to the input element                               |                    |           |                |
-| `handleKeyDown`                    | public    | Handle key down events.                                       | `e: KeyboardEvent` | `boolean` |                |
-| `handleFocusIn`                    | public    | Handle focus in events.                                       | `e: FocusEvent`    | `boolean` |                |
-| `handleFocusOut`                   | public    | Handle focus out events.                                      | `e: FocusEvent`    | `boolean` |                |
-| `handleSelectionChange`            | public    | The list of selected items has changed                        |                    | `void`    |                |
-| `handleRegionLoaded`               | public    | Anchored region is loaded, menu and options exist in the DOM. | `e: Event`         | `void`    |                |
-| `handleItemInvoke`                 | public    | A list item has been invoked.                                 | `e: Event`         | `boolean` |                |
-| `handleOptionInvoke`               | public    | A menu option has been invoked.                               | `e: Event`         | `boolean` |                |
+| Name                               | Privacy   | Description                                                   | Parameters                         | Return    | Inherited From |
+| ---------------------------------- | --------- | ------------------------------------------------------------- | ---------------------------------- | --------- | -------------- |
+| `selectionChanged`                 | protected |                                                               |                                    | `void`    |                |
+| `optionsChanged`                   | protected |                                                               |                                    | `void`    |                |
+| `disabledChanged`                  | public    |                                                               | `previous: boolean, next: boolean` | `void`    |                |
+| `menuPlacementChanged`             | protected |                                                               |                                    | `void`    |                |
+| `showLoadingChanged`               | protected |                                                               |                                    | `void`    |                |
+| `listItemTemplateChanged`          | protected |                                                               |                                    | `void`    |                |
+| `defaultListItemTemplateChanged`   | protected |                                                               |                                    | `void`    |                |
+| `menuOptionTemplateChanged`        | protected |                                                               |                                    | `void`    |                |
+| `defaultMenuOptionTemplateChanged` | protected |                                                               |                                    | `void`    |                |
+| `queryChanged`                     | protected |                                                               |                                    | `void`    |                |
+| `filteredOptionsListChanged`       | protected |                                                               |                                    | `void`    |                |
+| `flyoutOpenChanged`                | protected |                                                               |                                    | `void`    |                |
+| `focus`                            | public    | Move focus to the input element                               |                                    |           |                |
+| `handleKeyDown`                    | public    | Handle key down events.                                       | `e: KeyboardEvent`                 | `boolean` |                |
+| `handleFocusIn`                    | public    | Handle focus in events.                                       | `e: FocusEvent`                    | `boolean` |                |
+| `handleFocusOut`                   | public    | Handle focus out events.                                      | `e: FocusEvent`                    | `boolean` |                |
+| `handleSelectionChange`            | public    | The list of selected items has changed                        |                                    | `void`    |                |
+| `handleRegionLoaded`               | public    | Anchored region is loaded, menu and options exist in the DOM. | `e: Event`                         | `void`    |                |
+| `handleItemInvoke`                 | public    | A list item has been invoked.                                 | `e: Event`                         | `boolean` |                |
+| `handleOptionInvoke`               | public    | A menu option has been invoked.                               | `e: Event`                         | `boolean` |                |
 
 #### Attributes
 
@@ -251,6 +256,7 @@ export class FASTTextField extends TextField {}
 | `no-suggestions-text`        | noSuggestionsText        |                |
 | `suggestions-available-text` | suggestionsAvailableText |                |
 | `loading-text`               | loadingText              |                |
+| `disabled`                   | disabled                 |                |
 | `label`                      | label                    |                |
 | `labelledby`                 | labelledBy               |                |
 | `placeholder`                | placeholder              |                |

--- a/packages/web-components/fast-foundation/src/picker/picker-context.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-context.ts
@@ -1,0 +1,6 @@
+import { observable } from "@microsoft/fast-element";
+
+export class PickerContext {
+    @observable
+    public disabled: boolean = false;
+}

--- a/packages/web-components/fast-foundation/src/picker/picker-context.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-context.ts
@@ -1,6 +1,18 @@
 import { observable } from "@microsoft/fast-element";
+import { Context } from "@microsoft/fast-element/context";
 
-export class PickerContext {
+export interface PickerContext {
+    disabled: boolean;
+}
+
+export const PickerContext = Context.create<PickerContext>("picker-context");
+
+export class DefaultPickerContext implements PickerContext {
+    /**
+     * The disabled state of the picker
+     *
+     * @internal
+     */
     @observable
     public disabled: boolean = false;
 }

--- a/packages/web-components/fast-foundation/src/picker/picker-context.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-context.ts
@@ -1,5 +1,5 @@
 import { observable } from "@microsoft/fast-element";
-import { Context } from "@microsoft/fast-element/context";
+import { Context } from "@microsoft/fast-element/context.js";
 
 export interface PickerContext {
     disabled: boolean;

--- a/packages/web-components/fast-foundation/src/picker/picker-list-item.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list-item.template.ts
@@ -13,6 +13,7 @@ export function pickerListItemTemplate<
         <template
             role="listitem"
             tabindex="0"
+            disabled="${(x, c) => (x.pickerContext.disabled === true ? true : void 0)}"
             @click="${(x, c) => x.handleClick(c.event as MouseEvent)}"
             @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
         >

--- a/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
@@ -1,6 +1,7 @@
 import type { HTMLView, ViewTemplate } from "@microsoft/fast-element";
 import { attr, FASTElement, html, observable } from "@microsoft/fast-element";
 import { keyEnter } from "@microsoft/fast-web-utilities";
+import { PickerContext } from "./picker-context.js";
 
 const defaultContentsTemplate: ViewTemplate<FASTPickerListItem> = html`
     <template>${x => x.value}</template>
@@ -12,6 +13,8 @@ const defaultContentsTemplate: ViewTemplate<FASTPickerListItem> = html`
  * @beta
  */
 export class FASTPickerListItem extends FASTElement {
+    @inject(PickerContext) pickerContext!: PickerContext;
+
     /**
      * The underlying string value of the item
      *
@@ -20,17 +23,6 @@ export class FASTPickerListItem extends FASTElement {
      */
     @attr({ attribute: "value" })
     public value: string;
-
-    /**
-     * Disables the picker-list-item.
-     *
-     * @public
-     * @remarks
-     * HTML Attribute: disabled
-     */
-    @attr({ attribute: "disabled", mode: "boolean" })
-    public disabled: boolean;
-    protected disabledChanged(): void {}
 
     /**
      *  The template used to render the contents of the list item
@@ -63,7 +55,7 @@ export class FASTPickerListItem extends FASTElement {
     }
 
     public handleKeyDown(e: KeyboardEvent): boolean {
-        if (e.defaultPrevented || this.disabled) {
+        if (e.defaultPrevented || this.pickerContext.disabled) {
             return true;
         }
 
@@ -76,7 +68,7 @@ export class FASTPickerListItem extends FASTElement {
     }
 
     public handleClick(e: MouseEvent): void {
-        if (e.defaultPrevented || this.disabled) {
+        if (e.defaultPrevented || this.pickerContext.disabled) {
             return;
         }
         this.handleInvoke();

--- a/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
@@ -13,6 +13,10 @@ const defaultContentsTemplate: ViewTemplate<FASTPickerListItem> = html`
  * @beta
  */
 export class FASTPickerListItem extends FASTElement {
+    /**
+     * Context object for the parent picker
+     *
+     */
     @PickerContext
     pickerContext: PickerContext;
 

--- a/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
@@ -13,7 +13,8 @@ const defaultContentsTemplate: ViewTemplate<FASTPickerListItem> = html`
  * @beta
  */
 export class FASTPickerListItem extends FASTElement {
-    @inject(PickerContext) pickerContext!: PickerContext;
+    @PickerContext
+    pickerContext: PickerContext;
 
     /**
      * The underlying string value of the item

--- a/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
@@ -22,6 +22,17 @@ export class FASTPickerListItem extends FASTElement {
     public value: string;
 
     /**
+     * Disables the picker-list-item.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: disabled
+     */
+    @attr({ attribute: "disabled", mode: "boolean" })
+    public disabled: boolean;
+    protected disabledChanged(): void {}
+
+    /**
      *  The template used to render the contents of the list item
      *
      */
@@ -52,7 +63,7 @@ export class FASTPickerListItem extends FASTElement {
     }
 
     public handleKeyDown(e: KeyboardEvent): boolean {
-        if (e.defaultPrevented) {
+        if (e.defaultPrevented || this.disabled) {
             return false;
         }
 
@@ -65,7 +76,7 @@ export class FASTPickerListItem extends FASTElement {
     }
 
     public handleClick(e: MouseEvent): boolean {
-        if (!e.defaultPrevented) {
+        if (!e.defaultPrevented || !this.disabled) {
             this.handleInvoke();
         }
         return false;

--- a/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker-list-item.ts
@@ -64,7 +64,7 @@ export class FASTPickerListItem extends FASTElement {
 
     public handleKeyDown(e: KeyboardEvent): boolean {
         if (e.defaultPrevented || this.disabled) {
-            return false;
+            return true;
         }
 
         if (e.key === keyEnter) {
@@ -75,11 +75,11 @@ export class FASTPickerListItem extends FASTElement {
         return true;
     }
 
-    public handleClick(e: MouseEvent): boolean {
-        if (!e.defaultPrevented || !this.disabled) {
-            this.handleInvoke();
+    public handleClick(e: MouseEvent): void {
+        if (e.defaultPrevented || this.disabled) {
+            return;
         }
-        return false;
+        this.handleInvoke();
     }
 
     private handleInvoke(): void {

--- a/packages/web-components/fast-foundation/src/picker/picker.spec.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.spec.ts
@@ -176,6 +176,16 @@ describe("Picker", () => {
         await disconnect();
     });
 
+    it("picker 'combobox' should reflect disabled prop on picker", async () => {
+        const { element, connect, disconnect } = await setupPicker();
+        element.disabled = true;
+        await connect();
+
+        expect(element.inputElement?.getAttribute("disabled")).to.equal(true);
+
+        await disconnect();
+    });
+
     it("picker should create a menu element when instanciated", async () => {
         const { element, connect, disconnect } = await setupPicker();
         await connect();
@@ -386,7 +396,7 @@ describe("Picker", () => {
         await disconnect();
     });
 
-    it("picker menu-option emits 'pickeriteminvoked' event on 'Enter'", async () => {
+    it("picker list-item emits 'pickeriteminvoked' event on 'Enter'", async () => {
         const { element, connect, disconnect } = await setupPickerListItem();
 
         let wasInvoked: boolean = false;
@@ -400,6 +410,44 @@ describe("Picker", () => {
         element.dispatchEvent(enterEvent);
 
         expect(wasInvoked).to.equal(true);
+
+        await disconnect();
+    });
+
+    it("picker list-item does not emit 'pickeriteminvoked' event when disabled and clicked", async () => {
+        const { element, connect, disconnect } = await setupPickerListItem();
+
+        let wasInvoked: boolean = false;
+        element.disabled = true;
+
+        element.addEventListener("pickeriteminvoked", e => {
+            wasInvoked = true;
+        });
+
+        await connect();
+
+        element.click();
+
+        expect(wasInvoked).to.equal(false);
+
+        await disconnect();
+    });
+
+    it("picker list-item does not emit 'pickeriteminvoked' event on 'Enter' when disabled", async () => {
+        const { element, connect, disconnect } = await setupPickerListItem();
+
+        let wasInvoked: boolean = false;
+
+        element.disabled = true;
+        element.addEventListener("pickeriteminvoked", e => {
+            wasInvoked = true;
+        });
+
+        await connect();
+
+        element.dispatchEvent(enterEvent);
+
+        expect(wasInvoked).to.equal(false);
 
         await disconnect();
     });

--- a/packages/web-components/fast-foundation/src/picker/picker.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.template.ts
@@ -8,7 +8,7 @@ function defaultListItemTemplate(options: PickerOptions): ViewTemplate {
     const pickerListItemTag = html.partial(tagFor(options.pickerListItem));
     return html`
     <${pickerListItemTag}
-        disabled = "${(x, c) => c.parent.disabled}"
+        ?disabled = "${(x, c) => c.parent.disabled}"
         value="${x => x}"
         :contentsTemplate="${(x, c) => c.parent.listItemContentsTemplate}"
     >

--- a/packages/web-components/fast-foundation/src/picker/picker.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.template.ts
@@ -8,6 +8,7 @@ function defaultListItemTemplate(options: PickerOptions): ViewTemplate {
     const pickerListItemTag = html.partial(tagFor(options.pickerListItem));
     return html`
     <${pickerListItemTag}
+        disabled = "${(x, c) => c.parent.disabled}"
         value="${x => x}"
         :contentsTemplate="${(x, c) => c.parent.listItemContentsTemplate}"
     >

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -9,7 +9,8 @@ import {
     RepeatDirective,
     Updates,
 } from "@microsoft/fast-element";
-import { ViewBehaviorOrchestrator } from "@microsoft/fast-element/utilities.js";
+import { Container, inject } from "@microsoft/fast-element/di";
+import { ViewBehaviorOrchestrator } from "@microsoft/fast-element/utilities";
 import {
     keyArrowDown,
     keyArrowLeft,
@@ -40,6 +41,7 @@ import { FASTPickerMenuOption } from "./picker-menu-option.js";
 import type { FASTPickerMenu } from "./picker-menu.js";
 import { FormAssociatedPicker } from "./picker.form-associated.js";
 import { MenuPlacement } from "./picker.options.js";
+import { PickerContext } from "./picker-context.js";
 
 const pickerInputTemplate: ViewTemplate = html<FASTPicker>`
     <input
@@ -64,6 +66,9 @@ const pickerInputTemplate: ViewTemplate = html<FASTPicker>`
  * @beta
  */
 export class FASTPicker extends FormAssociatedPicker {
+    @inject(PickerContext) pickerContext!: PickerContext;
+    @Container container!: Container;
+
     /**
      * Currently selected items. Comma delineated string ie. "apples,oranges".
      *
@@ -161,6 +166,8 @@ export class FASTPicker extends FormAssociatedPicker {
     @attr({ mode: "boolean" })
     public disabled: boolean;
     public disabledChanged(previous: boolean, next: boolean): void {
+        this.pickerContext.disabled = this.disabled;
+
         if (super.disabledChanged) {
             super.disabledChanged(previous, next);
         }
@@ -457,7 +464,7 @@ export class FASTPicker extends FormAssociatedPicker {
     public region: FASTAnchoredRegion;
 
     /**
-     *
+     * Currently selected items (string)
      *
      * @internal
      */

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -151,6 +151,26 @@ export class FASTPicker extends FormAssociatedPicker {
     public loadingText: string = "Loading suggestions";
 
     /**
+     * Disables the picker.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: disabled
+     */
+    @attr({ mode: "boolean" })
+    public disabled: boolean;
+    public disabledChanged(previous: boolean, next: boolean): void {
+        if (super.disabledChanged) {
+            super.disabledChanged(previous, next);
+        }
+        if (this.$fastController.isConnected) {
+            if (this.disabled) {
+                this.toggleFlyout(false);
+            }
+        }
+    }
+
+    /**
      * Applied to the aria-label attribute of the input element
      *
      * @remarks
@@ -546,7 +566,6 @@ export class FASTPicker extends FormAssociatedPicker {
             "optionsupdated",
             this.handleMenuOptionsUpdated
         );
-
         this.handleSelectionChange();
     }
 
@@ -554,7 +573,7 @@ export class FASTPicker extends FormAssociatedPicker {
      * Toggles the menu flyout
      */
     private toggleFlyout(open: boolean): void {
-        if (this.flyoutOpen === open) {
+        if (this.flyoutOpen === open || (this.disabled && !this.flyoutOpen)) {
             return;
         }
 
@@ -586,6 +605,9 @@ export class FASTPicker extends FormAssociatedPicker {
      * Handle click event from input element
      */
     private handleInputClick = (e: MouseEvent): void => {
+        if (e.defaultPrevented || this.disabled) {
+            return;
+        }
         e.preventDefault();
         this.toggleFlyout(true);
     };
@@ -604,7 +626,7 @@ export class FASTPicker extends FormAssociatedPicker {
      * Handle key down events.
      */
     public handleKeyDown(e: KeyboardEvent): boolean {
-        if (e.defaultPrevented) {
+        if (e.defaultPrevented || this.disabled) {
             return false;
         }
         const activeElement = getRootActiveElement(this);

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -46,6 +46,7 @@ const pickerInputTemplate: ViewTemplate = html<FASTPicker>`
         slot="input-region"
         role="combobox"
         type="text"
+        ?disabled=${x => x.disabled}
         autocapitalize="off"
         autocomplete="off"
         haspopup="list"

--- a/packages/web-components/fast-foundation/src/picker/stories/picker.register.ts
+++ b/packages/web-components/fast-foundation/src/picker/stories/picker.register.ts
@@ -97,6 +97,9 @@ const pickerListStyles = css`
         user-select: none;
         padding: 0 calc(var(--design-unit) * 2px + 1px);
     }
+    ::slotted([role="combobox"][disabled]) {
+        cursor: not-allowed;
+    }
 `;
 
 const pickerListItemStyles = css`

--- a/packages/web-components/fast-foundation/src/picker/stories/picker.register.ts
+++ b/packages/web-components/fast-foundation/src/picker/stories/picker.register.ts
@@ -88,7 +88,6 @@ const pickerListStyles = css`
         height: calc(
             (var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px
         );
-        min-width: 250px;
         width: auto;
         box-sizing: border-box;
         border: none;
@@ -123,12 +122,15 @@ const pickerListItemStyles = css`
         user-select: none;
         white-space: nowrap;
     }
-    :host(:focus-visible),
-    :host(:hover) {
+    :host([disabled]) {
+        cursor: not-allowed;
+    }
+    :host(:focus-visible:not([disabled])),
+    :host(:hover:not([disabled])) {
         background: var(--accent-fill-rest);
         color: var(--foreground-on-accent-rest);
     }
-    :host(:focus-visible) {
+    :host(:focus-visible:not([disabled])) {
         border-color: var(--focus-stroke-outer);
     }
 `;

--- a/packages/web-components/fast-foundation/src/picker/stories/picker.stories.ts
+++ b/packages/web-components/fast-foundation/src/picker/stories/picker.stories.ts
@@ -28,6 +28,7 @@ export default {
         // TODO: These are always true https://github.com/microsoft/fast/issues/6311
         filterQuery: true,
         filterSelected: true,
+        disabled: false,
     },
     argTypes: {
         filterQuery: { control: "boolean" },

--- a/packages/web-components/fast-foundation/src/picker/stories/picker.stories.ts
+++ b/packages/web-components/fast-foundation/src/picker/stories/picker.stories.ts
@@ -10,6 +10,7 @@ const storyTemplate = html<StoryArgs<FASTPicker>>`
         options="${x => x.options}"
         ?filter-selected="${x => x.filterSelected}"
         ?filter-query="${x => x.filterQuery}"
+        ?disabled="${x => x.disabled}"
         max-selected="${x => x.maxSelected}"
         no-suggestions-text="${x => x.noSuggestionsText}"
         suggestions-available-text="${x => x.suggestionsAvailableText}"
@@ -31,6 +32,7 @@ export default {
     argTypes: {
         filterQuery: { control: "boolean" },
         filterSelected: { control: "boolean" },
+        disabled: { control: "boolean" },
         label: { control: "text" },
         labelledBy: { control: "text" },
         loadingText: { control: "text" },
@@ -51,4 +53,5 @@ Picker.args = {
     placeholder: "Choose fruit",
     selection: "apple",
     suggestionsAvailableText: "Found some fruit",
+    disabled: false,
 };


### PR DESCRIPTION
## 📖 Description

Picker was missing a disabled state.  This change adds that functionality.

## 📑 Test Plan
Added some basic tests.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
