### PR TITLE
docs: Fix some deadlinks and missing import in docs

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -81,7 +81,7 @@ Packages are located within the `packages` folder of the repository. Each packag
 If you'd like to contribute by fixing a bug, implementing a feature, or even correcting typos in our documentation, you'll want to submit a pull request. Before submitting a pull request, be sure to [rebase](https://www.atlassian.com/git/tutorials/merging-vs-rebasing) your branch (typically from master) or use the *merge* button provided by GitHub.
 
 :::note
-For additional details on branch management, read the [branch guide](../community/branch-guide.md) documentation.
+For additional details on branch management, read the [branch guide](./BRANCH_GUIDE.md) documentation.
 :::
 
 #### Change Files

--- a/packages/web-components/fast-element/docs/guide/declaring-templates.md
+++ b/packages/web-components/fast-element/docs/guide/declaring-templates.md
@@ -171,7 +171,7 @@ Properties can also be set directly on an HTML element. To do so, prepend the pr
 :::warning
 Avoid scenarios that require you to directly set HTML, especially when the content is coming from an external source. If you must do this, you should always sanitize the HTML.
 
-The best way to accomplish HTML sanitization is to configure [a trusted types policy](https://w3c.github.io/webappsec-trusted-types/dist/spec/) with FASTElement's template engine. FASTElement ensures that all HTML strings pass through the configured policy. Also, by leveraging the platform's trusted types capabilities, you get native enforcement of the policy through CSP headers. Here's an example of how to configure a custom policy to sanitize HTML:
+The best way to accomplish HTML sanitization is to configure [a trusted types policy](https://w3c.github.io/trusted-types/dist/spec/) with FASTElement's template engine. FASTElement ensures that all HTML strings pass through the configured policy. Also, by leveraging the platform's trusted types capabilities, you get native enforcement of the policy through CSP headers. Here's an example of how to configure a custom policy to sanitize HTML:
 
 ```ts
 import { DOM } from '@microsoft/fast-element';

--- a/packages/web-components/fast-foundation/docs/integrations/rollup.md
+++ b/packages/web-components/fast-foundation/docs/integrations/rollup.md
@@ -42,7 +42,7 @@ npm install @microsoft/fast-components @microsoft/fast-element tslib --save
 We also need to install the Rollup build tooling:
 
 ```shell
-npm install rollup typescript @rollup/plugin-typescript @rollup/plugin-node-resolve rollup-plugin-cleaner rollup-plugin-copy rollup-plugin-serve rollup-plugin-terser --save-dev
+npm install rollup typescript @rollup/plugin-typescript @rollup/plugin-node-resolve rollup-plugin-cleaner rollup-plugin-copy rollup-plugin-serve rollup-plugin-terser rollup-plugin-transform-tagged-template --save-dev
 ```
 
 ## Adding configuration and source
@@ -200,7 +200,7 @@ There's nothing special about the HTML yet, other than the `script` tag in the `
 
 ## Using the components
 
-With all the basic pieces in place, let's run our app with `npm run build`. 
+With all the basic pieces in place, let's run our app with `npm run build`.
 
 Rollup should build your project and open your default browser with your `index.html` page. Right now, it should be blank, since we haven't added any code or interesting HTML. Let's change that.
 
@@ -220,7 +220,7 @@ provideFASTDesignSystem()
   );
 ```
 
-This code uses the FAST Design System to register the `<fast-card>` and `<fast-button>` components. To get some UI showing, we need to write some HTML that uses our components. 
+This code uses the FAST Design System to register the `<fast-card>` and `<fast-button>` components. To get some UI showing, we need to write some HTML that uses our components.
 
 Replace the contents of the `<body>` in your `index.html` file with the following markup:
 

--- a/sites/website/versioned_docs/version-legacy/fast-element/declaring-templates.md
+++ b/sites/website/versioned_docs/version-legacy/fast-element/declaring-templates.md
@@ -173,7 +173,7 @@ Properties can also be set directly on an HTML element. To do so, prepend the pr
 :::warning
 Avoid scenarios that require you to directly set HTML, especially when the content is coming from an external source. If you must do this, you should always sanitize the HTML.
 
-The best way to accomplish HTML sanitization is to configure [a trusted types policy](https://w3c.github.io/webappsec-trusted-types/dist/spec/) with FASTElement's template engine. FASTElement ensures that all HTML strings pass through the configured policy. Also, by leveraging the platform's trusted types capabilities, you get native enforcement of the policy through CSP headers. Here's an example of how to configure a custom policy to sanitize HTML:
+The best way to accomplish HTML sanitization is to configure [a trusted types policy](https://w3c.github.io/trusted-types/dist/spec/) with FASTElement's template engine. FASTElement ensures that all HTML strings pass through the configured policy. Also, by leveraging the platform's trusted types capabilities, you get native enforcement of the policy through CSP headers. Here's an example of how to configure a custom policy to sanitize HTML:
 
 ```ts
 import { DOM } from '@microsoft/fast-element';


### PR DESCRIPTION
# Pull Request

## 📖 Description
I'm exploring the FAST framework and have found a few things in the docs that seem incorrect. To make them better for myself and others, I wanted to create a PR to update them.
- There are a few broken links.
    - branch doc link
    - W3C trusted type link
- The docs for rollup seem to be missing a plugin from the example install script 

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

N/A

## 📑 Test Plan

N/A

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

N/A

## ⏭ Next Steps

N/A