### PR TITLE
docs: fix typo on vite integration example file

### DIFF
--- a/packages/web-components/fast-foundation/docs/integrations/vite.md
+++ b/packages/web-components/fast-foundation/docs/integrations/vite.md
@@ -61,7 +61,7 @@ In the root of your project folder, you will see a `tsconfig.js` file.  Replace 
     "forceConsistentCasingInFileNames": true,
     "useDefineForClassFields": false
   },
-  "include": ["src/*/.ts"]
+  "include": ["src/*.ts"]
 }
 ```
 

--- a/sites/website/versioned_docs/version-legacy/integrations/vite.md
+++ b/sites/website/versioned_docs/version-legacy/integrations/vite.md
@@ -60,7 +60,7 @@ In the root of your project folder, you will see a `tsconfig.js` file.  Replace 
     "forceConsistentCasingInFileNames": true,
     "useDefineForClassFields": false
   },
-  "include": ["src/*/.ts"]
+  "include": ["src/*.ts"]
 }
 ```
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

There is a typo on [Vite Integration Section](https://www.fast.design/docs/integrations/vite), in the _tsconfig.js_ file example.

### 🎫 Issues

Needs to change a typo on _tsconfig.js_ file example.

## 👩‍💻 Reviewer Notes

Searching on the entire project I found two results where changing the typo, one on sites folder and the other on packages.

## ✅ Checklist

### General

- [ x] I have correct the typo for the `tsconfig.js` example on sites docs
- [ x] I have correct the typo for the `tsconfig.js` example on packages
- [ x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
