### PR TITLE
Fix api-extractor doc warnings

### DIFF
--- a/change/@microsoft-fast-foundation-c38c3cfa-235d-4c4c-8f52-450690e62d53.json
+++ b/change/@microsoft-fast-foundation-c38c3cfa-235d-4c4c-8f52-450690e62d53.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix api-extractor doc warnings",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "47367562+bheston@users.noreply.github.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -238,7 +238,7 @@ export class FASTTooltip extends FASTElement {
     })
     public show: boolean | undefined;
     public showChanged(prev: boolean | undefined, next: boolean | undefined): void {
-        this.visible = next;
+        this.setVisible(next);
     }
 
     /**
@@ -254,7 +254,7 @@ export class FASTTooltip extends FASTElement {
      *
      * @internal
      */
-    private set visible(value: boolean | undefined) {
+    private setVisible(value: boolean | undefined) {
         this.controlledVisibility = typeof value === "boolean";
         if (this.controlledVisibility) {
             this.show = value;

--- a/packages/web-components/fast-foundation/src/utilities/template-helpers.ts
+++ b/packages/web-components/fast-foundation/src/utilities/template-helpers.ts
@@ -11,6 +11,7 @@ import type { SyntheticViewTemplate } from "@microsoft/fast-element";
  * @remarks
  * When providing a string, take care to ensure that it is
  * safe and will not enable an XSS attack.
+ * @public
  */
 export type StaticallyComposableHTML<TSource = any, TParent = any> =
     | string

--- a/packages/web-components/fast-foundation/src/utilities/typings.ts
+++ b/packages/web-components/fast-foundation/src/utilities/typings.ts
@@ -1,6 +1,6 @@
 /**
  * Helper for enumerating a type from a const object
- * Example: export type Foo = ValuesOf<typeof Foo>
+ * Example: export type Foo = ValuesOf\<typeof Foo\>
  * @public
  */
 export type ValuesOf<T> = T[keyof T];


### PR DESCRIPTION
# Pull Request

## 📖 Description

API Extractor is throwing some warnings on some doc comments, which also show up in downstream code that references this package.

Cleaned up those issues.

## 👩‍💻 Reviewer Notes

Note that the change in `tooltip` fixes `ae-setter-with-docs` which only wants comments on the getter. Removing the comment from the setter caused it to be removed from the `Fields` list in the `README`. Since that property has split visibility it's probably cleaner like this anyway.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.