### PR TITLE
Fix: picker show no options

### DIFF
--- a/change/@microsoft-fast-foundation-4ed56949-7343-439d-9bd1-4f76b36c9d1d.json
+++ b/change/@microsoft-fast-foundation-4ed56949-7343-439d-9bd1-4f76b36c9d1d.json
@@ -3,5 +3,5 @@
   "comment": "picker show no options",
   "packageName": "@microsoft/fast-foundation",
   "email": "stephcomeau@msn.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-4ed56949-7343-439d-9bd1-4f76b36c9d1d.json
+++ b/change/@microsoft-fast-foundation-4ed56949-7343-439d-9bd1-4f76b36c9d1d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "picker show no options",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -311,10 +311,11 @@ export class FASTPicker extends FormAssociatedPicker {
     public filteredOptionsList: string[] = [];
     protected filteredOptionsListChanged(): void {
         if (this.$fastController.isConnected) {
-            this.showNoOptions =
-                this.filteredOptionsList.length === 0 &&
-                this.menuElement.querySelectorAll('[role="listitem"]').length === 0;
-            this.setFocusedOption(this.showNoOptions ? -1 : 0);
+            Updates.enqueue(() => {
+                this.showNoOptions =
+                    this.menuElement.querySelectorAll('[role="listitem"]').length === 0;
+                this.setFocusedOption(this.showNoOptions ? -1 : 0);
+            });
         }
     }
 


### PR DESCRIPTION
## 📖 Description
Picker "no options" display shows up one keystroke too late because the current detection happens before invalid options based on the last char typed are removed from the dom.

### 🎫 Issues
ad-ho

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
