### PR TITLE
DRAFT: Data-grid context?

### DIFF
--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
@@ -8,7 +8,7 @@ import {
     keyEscape,
     keyFunction2,
 } from "@microsoft/fast-web-utilities";
-import type { ColumnDefinition } from "./data-grid.js";
+import type { ColumnDefinition } from "./data-grid.options.js";
 import { DataGridCellTypes } from "./data-grid.options.js";
 import { DataGridContext } from "./data-grid-context.js";
 

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
@@ -10,6 +10,7 @@ import {
 } from "@microsoft/fast-web-utilities";
 import type { ColumnDefinition } from "./data-grid.js";
 import { DataGridCellTypes } from "./data-grid.options.js";
+import { DataGridContext } from "./data-grid-context.js";
 
 export { DataGridCellTypes };
 
@@ -43,6 +44,14 @@ const defaultHeaderCellContentsTemplate: ViewTemplate<FASTDataGridCell> = html`
  * @public
  */
 export class FASTDataGridCell extends FASTElement {
+    /**
+     * Context for the parent data grid
+     *
+     * @public
+     */
+    @DataGridContext
+    dataGridContext: DataGridContext;
+
     /**
      * The type of cell
      *

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-context.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-context.ts
@@ -1,8 +1,9 @@
 import { observable } from "@microsoft/fast-element";
 import { Context } from "@microsoft/fast-element/context";
-import { DataGridSelectionBehavior } from "./data-grid.options.js";
+import { ColumnDefinition, DataGridSelectionBehavior } from "./data-grid.options.js";
 
 export interface DataGridContext {
+    columnDefinitions: ColumnDefinition[] | [];
     gridTemplateColumns: string;
     selectionBehavior: DataGridSelectionBehavior;
 }
@@ -25,4 +26,12 @@ export class DefaultDataGridContext implements DataGridContext {
      */
     @observable
     public selectionBehavior: DataGridSelectionBehavior = DataGridSelectionBehavior.auto;
+
+    /**
+     * The column definitions of the grid
+     *
+     * @internal
+     */
+    @observable
+    public columnDefinitions: ColumnDefinition[] = [];
 }

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-context.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-context.ts
@@ -1,0 +1,28 @@
+import { observable } from "@microsoft/fast-element";
+import { Context } from "@microsoft/fast-element/context";
+import { DataGridSelectionBehavior } from "./data-grid.options.js";
+
+export interface DataGridContext {
+    gridTemplateColumns: string;
+    selectionBehavior: DataGridSelectionBehavior;
+}
+
+export const DataGridContext = Context.create<DataGridContext>("data-grid-context");
+
+export class DefaultDataGridContext implements DataGridContext {
+    /**
+     * The disabled state of the picker
+     *
+     * @internal
+     */
+    @observable
+    public gridTemplateColumns: string;
+
+    /**
+     * Selection behavior
+     *
+     * @internal
+     */
+    @observable
+    public selectionBehavior: DataGridSelectionBehavior = DataGridSelectionBehavior.auto;
+}

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-context.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-context.ts
@@ -21,7 +21,7 @@ export class DefaultDataGridContext implements DataGridContext {
     public rowsData: object[] = [];
 
     /**
-     * The disabled state of the picker
+     * The grid-template-columns value to be applied to rows
      *
      * @internal
      */

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-context.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-context.ts
@@ -5,12 +5,21 @@ import { ColumnDefinition, DataGridSelectionBehavior } from "./data-grid.options
 export interface DataGridContext {
     columnDefinitions: ColumnDefinition[] | [];
     gridTemplateColumns: string;
+    rowsData: object[];
     selectionBehavior: DataGridSelectionBehavior;
 }
 
 export const DataGridContext = Context.create<DataGridContext>("data-grid-context");
 
 export class DefaultDataGridContext implements DataGridContext {
+    /**
+     * The data being displayed in the grid
+     *
+     * @internal
+     */
+    @observable
+    public rowsData: object[] = [];
+
     /**
      * The disabled state of the picker
      *

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.template.ts
@@ -8,7 +8,7 @@ import {
 import type { ViewTemplate } from "@microsoft/fast-element";
 import { tagFor, TemplateElementDependency } from "../patterns/index.js";
 import type { FASTDataGridRow } from "./data-grid-row.js";
-import type { ColumnDefinition } from "./data-grid.js";
+import type { ColumnDefinition } from "./data-grid.options.js";
 
 /**
  * Options for data grid cells.

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
@@ -17,7 +17,6 @@ import {
     keyHome,
     keySpace,
 } from "@microsoft/fast-web-utilities";
-import type { ColumnDefinition } from "./data-grid.js";
 import {
     DataGridRowTypes,
     DataGridSelectionBehavior,
@@ -69,14 +68,6 @@ export class FASTDataGridRow extends FASTElement {
             return;
         }
     }
-
-    /**
-     * The column definitions of the row
-     *
-     * @public
-     */
-    @observable
-    public columnDefinitions: ColumnDefinition[] | null = null;
 
     /**
      * The template used to render cells in generated rows.
@@ -185,7 +176,7 @@ export class FASTDataGridRow extends FASTElement {
             this.$fastController.addBehavior(this.behaviorOrchestrator);
             this.behaviorOrchestrator.addBehaviorFactory(
                 new RepeatDirective<FASTDataGridRow>(
-                    oneWay(x => x.columnDefinitions),
+                    oneWay(x => x.dataGridContext.columnDefinitions),
                     oneWay(x => x.activeCellItemTemplate),
                     { positioning: true }
                 ),

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.ts
@@ -23,6 +23,7 @@ import {
     DataGridSelectionBehavior,
     DataGridSelectionChangeDetail,
 } from "./data-grid.options.js";
+import { DataGridContext } from "./data-grid-context.js";
 
 /**
  * A Data Grid Row Custom HTML Element.
@@ -33,19 +34,12 @@ import {
  */
 export class FASTDataGridRow extends FASTElement {
     /**
-     * String that gets applied to the the css gridTemplateColumns attribute for the row
+     * Context for the parent data grid
      *
      * @public
-     * @remarks
-     * HTML Attribute: grid-template-columns
      */
-    @attr({ attribute: "grid-template-columns" })
-    public gridTemplateColumns: string;
-    protected gridTemplateColumnsChanged(): void {
-        if (this.$fastController.isConnected) {
-            this.updateRowStyle();
-        }
-    }
+    @DataGridContext
+    public dataGridContext: DataGridContext;
 
     /**
      * The type of row
@@ -165,13 +159,6 @@ export class FASTDataGridRow extends FASTElement {
     public selected: boolean;
 
     /**
-     * Selection behavior
-     *
-     * @internal
-     */
-    public selectionBehavior: DataGridSelectionBehavior = DataGridSelectionBehavior.auto;
-
-    /**
      * @internal
      */
     public slottedCellElements: HTMLElement[];
@@ -210,8 +197,6 @@ export class FASTDataGridRow extends FASTElement {
         this.addEventListener(eventFocusOut, this.handleFocusout);
         this.addEventListener(eventKeyDown, this.handleKeydown);
         this.addEventListener(eventClick, this.handleClick);
-
-        this.updateRowStyle();
 
         if (this.refocusOnLoad) {
             // if focus was on the row when data changed try to refocus on same cell
@@ -304,7 +289,8 @@ export class FASTDataGridRow extends FASTElement {
             case keySpace:
                 if (
                     this.selected !== undefined &&
-                    this.selectionBehavior !== DataGridSelectionBehavior.programmatic
+                    this.dataGridContext.selectionBehavior !==
+                        DataGridSelectionBehavior.programmatic
                 ) {
                     e.preventDefault();
                     this.toggleSelected({
@@ -328,7 +314,7 @@ export class FASTDataGridRow extends FASTElement {
     public handleClick(e: MouseEvent): void {
         if (
             e.defaultPrevented ||
-            this.selectionBehavior !== DataGridSelectionBehavior.auto ||
+            this.dataGridContext.selectionBehavior !== DataGridSelectionBehavior.auto ||
             this.selected === undefined
         ) {
             return;
@@ -354,8 +340,4 @@ export class FASTDataGridRow extends FASTElement {
                 ? this.headerCellItemTemplate
                 : this.defaultHeaderCellItemTemplate;
     }
-
-    private updateRowStyle = (): void => {
-        this.style.gridTemplateColumns = this.gridTemplateColumns;
-    };
 }

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.options.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.options.ts
@@ -1,4 +1,6 @@
+import type { SyntheticViewTemplate, ViewTemplate } from "@microsoft/fast-element";
 import type { ValuesOf } from "../utilities/index.js";
+import type { FASTDataGridCell } from "./data-grid-cell.js";
 
 /**
  * Enumerates the data grid auto generated header options
@@ -142,3 +144,72 @@ export const DataGridSelectionBehavior = {
  * @public
  */
 export type DataGridSelectionBehavior = ValuesOf<typeof DataGridSelectionBehavior>;
+
+/**
+ * Defines a column in the grid
+ *
+ * @public
+ */
+export interface ColumnDefinition {
+    /**
+     * Identifies the data item to be displayed in this column
+     * (i.e. how the data item is labelled in each row)
+     */
+    columnDataKey: string;
+
+    /**
+     * Sets the css grid-column property on the cell which controls its placement in
+     * the parent row. If left unset the cells will set this value to match the index
+     * of their column in the parent collection of ColumnDefinitions.
+     */
+    gridColumn?: string;
+
+    /**
+     *  Column title, if not provided columnDataKey is used as title
+     */
+    title?: string;
+
+    /**
+     *  Header cell template
+     */
+    headerCellTemplate?: ViewTemplate | SyntheticViewTemplate;
+
+    /**
+     * Whether the header cell has an internal focus queue
+     */
+    headerCellInternalFocusQueue?: boolean;
+
+    /**
+     * Callback function that returns the element to focus in a custom cell.
+     * When headerCellInternalFocusQueue is false this function is called when the cell is first focused
+     * to immediately move focus to a cell element, for example a cell that is a checkbox could move
+     * focus directly to the checkbox.
+     * When headerCellInternalFocusQueue is true this function is called when the user hits Enter or F2
+     */
+    headerCellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement;
+
+    /**
+     * cell template
+     */
+    cellTemplate?: ViewTemplate | SyntheticViewTemplate;
+
+    /**
+     * Whether the cell has an internal focus queue
+     */
+    cellInternalFocusQueue?: boolean;
+
+    /**
+     * Callback function that returns the element to focus in a custom cell.
+     * When cellInternalFocusQueue is false this function is called when the cell is first focused
+     * to immediately move focus to a cell element, for example a cell that is a checkbox could move
+     * focus directly to the checkbox.
+     * When cellInternalFocusQueue is true this function is called when the user hits Enter or F2
+     */
+
+    cellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement;
+
+    /**
+     * Whether this column is the row header
+     */
+    isRowHeader?: boolean;
+}

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.options.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.options.ts
@@ -1,6 +1,5 @@
 import type { SyntheticViewTemplate, ViewTemplate } from "@microsoft/fast-element";
 import type { ValuesOf } from "../utilities/index.js";
-import type { FASTDataGridCell } from "./data-grid-cell.js";
 
 /**
  * Enumerates the data grid auto generated header options
@@ -186,7 +185,7 @@ export interface ColumnDefinition {
      * focus directly to the checkbox.
      * When headerCellInternalFocusQueue is true this function is called when the user hits Enter or F2
      */
-    headerCellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement;
+    headerCellFocusTargetCallback?: (cell: HTMLElement) => HTMLElement;
 
     /**
      * cell template
@@ -206,7 +205,7 @@ export interface ColumnDefinition {
      * When cellInternalFocusQueue is true this function is called when the user hits Enter or F2
      */
 
-    cellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement;
+    cellFocusTargetCallback?: (cell: HTMLElement) => HTMLElement;
 
     /**
      * Whether this column is the row header

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -235,6 +235,7 @@ export class FASTDataGrid extends FASTElement {
             this.columnDefinitions = FASTDataGrid.generateColumns(this.rowsData[0]);
         }
         if (this.$fastController.isConnected) {
+            this.dataGridContext.rowsData = this.rowsData;
             this.toggleGeneratedHeader();
             this.deselectAllRows();
         }
@@ -407,6 +408,7 @@ export class FASTDataGrid extends FASTElement {
     public connectedCallback(): void {
         super.connectedCallback();
         this.updateGridTemplateColumns();
+        this.dataGridContext.rowsData = this.rowsData;
         this.dataGridContext.selectionBehavior = this.selectionBehavior;
 
         this.dataGridContext.columnDefinitions = this.columnDefinitions || [];
@@ -881,8 +883,6 @@ export class FASTDataGrid extends FASTElement {
                 this.rowElementTag
             );
             this.generatedHeader = (generatedHeaderElement as unknown) as FASTDataGridRow;
-            this.generatedHeader.columnDefinitions = this.columnDefinitions;
-            // this.generatedHeader.gridTemplateColumns = this.gridTemplateColumns;
             this.generatedHeader.rowType =
                 this.generateHeader === GenerateHeaderOptions.sticky
                     ? DataGridRowTypes.stickyHeader
@@ -904,17 +904,6 @@ export class FASTDataGrid extends FASTElement {
     ): void => {
         this.deselectAllRows();
         if (mutations && mutations.length) {
-            mutations.forEach((mutation: MutationRecord): void => {
-                mutation.addedNodes.forEach((newNode: Node): void => {
-                    if (
-                        newNode.nodeType === 1 &&
-                        (newNode as Element).getAttribute("role") === "row"
-                    ) {
-                        (newNode as FASTDataGridRow).columnDefinitions = this.columnDefinitions;
-                    }
-                });
-            });
-
             this.queueRowIndexUpdate();
         }
     };

--- a/packages/web-components/fast-foundation/src/data-grid/stories/data-grid-row.register.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/stories/data-grid-row.register.ts
@@ -2,8 +2,9 @@ import { css } from "@microsoft/fast-element";
 import { FASTDataGridRow } from "../data-grid-row.js";
 import { dataGridRowTemplate } from "../data-grid-row.template.js";
 
-const styles = css`
+const styles = css<FASTDataGridRow>`
     :host {
+        grid-template-columns: ${x => x.dataGridContext.gridTemplateColumns};
         display: grid;
         padding: 1px 0;
         box-sizing: border-box;


### PR DESCRIPTION
## 📖 Description

Experimenting with the idea of the data-grid component having a context to see if it's worth doing and if I'm doing it right.  This pr is just for discussion purposes at this point.

Pros:
- reduce how much setting of row props we do on index updates, use bindings to context instead
- cells can use context to access data for all rows, not just parent row.
- removes some "internal" interfaces from components (ie. authors shouldn't set "gridTemplateColumns" on a row since the parent grid overwrites it)

Cons:
- subcomponents may become dependent on context (but technically rows should always be children of grids).

