### PR TITLE
Replaced `principals` with `principles`

### DIFF
--- a/sites/website/src/docs/introduction.md
+++ b/sites/website/src/docs/introduction.md
@@ -83,7 +83,7 @@ FAST is a collection of technologies built on Web Components and modern Web Stan
 
 ### How does FAST leverage Web Components?
 
-One of FAST's driving principals is "strive to adopt open, web standards-based approaches as much as possible." To that end, FAST is built directly on the W3C Web Component standards mentioned above, and does not create its own component model. This allows components built with FAST to function the same as built-in, native HTML elements. You do not need a framework to use FAST components, but you can use them in combination with any framework or library of your choice.
+One of FAST's driving principles is "strive to adopt open, web standards-based approaches as much as possible." To that end, FAST is built directly on the W3C Web Component standards mentioned above, and does not create its own component model. This allows components built with FAST to function the same as built-in, native HTML elements. You do not need a framework to use FAST components, but you can use them in combination with any framework or library of your choice.
 
 ### How can FAST help me?
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Closes https://github.com/microsoft/fast/issues/6738

The introduction page has the following line of text:

> One of FAST's driving principals is "strive to adopt open, web standards-based approaches as much as possible."

I believe the line is referring to `principles` as opposed to `principals`.

As a solution, I have just replaced the word `principals` with `principles`.

### 🎫 Issues

* https://github.com/microsoft/fast/issues/6738

## 👩‍💻 Reviewer Notes

This is a simple content change. Just make sure the new copy makes sense and the change looks correct.

## 📑 Test Plan

- [x] `principals` has been replaced with `principles`

<details>
  <summary>Test Case</summary>

  1. Open the documentation site and navigate to the introduction page `/docs/introduction/`
  2. Confirm that the text `One of FAST's driving principals is` has been changed to `One of FAST's driving principles is`

</details>

## ✅ Checklist

### General

- [x] I have searched open/closed issues before submitting
- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

Not applicable