### PR TITLE
fix children directive rebind bug

### DIFF
--- a/change/@microsoft-fast-element-e03719ce-131a-4254-a882-d9bc399664dc.json
+++ b/change/@microsoft-fast-element-e03719ce-131a-4254-a882-d9bc399664dc.json
@@ -1,0 +1,7 @@
+{
+    "type": "prerelease",
+    "comment": "fixed a bug where re-binding a ChildrenDirective instance would throw a runtime exception from the mutation handler",
+    "packageName": "@microsoft/fast-element",
+    "email": "nicholasrice@users.noreply.github.com",
+    "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-element/src/templating/children.spec.ts
+++ b/packages/web-components/fast-element/src/templating/children.spec.ts
@@ -6,6 +6,7 @@ import { Updates } from "../observation/update-queue.js";
 import { Fake } from "../testing/fakes.js";
 import { html } from "./template.js";
 import { ref } from "./ref.js";
+import { computedState } from "../state/state.js";
 
 describe("The children", () => {
     context("template function", () => {
@@ -184,6 +185,27 @@ describe("The children", () => {
             await Updates.next();
 
             expect(model.nodes).members([]);
+        });
+        it("re-watches when re-bound", async () => {
+            const { host, children, targets, nodeId } = createDOM("foo-bar");
+            const behavior = new ChildrenDirective({
+                property: "nodes",
+            });
+            behavior.targetNodeId = nodeId;
+            const model = new Model();
+            const controller = Fake.viewController(targets, behavior);
+
+            controller.bind(model);
+
+            behavior.unbind(controller);
+            behavior.bind(controller);
+
+            const element = document.createElement("div");
+            host.appendChild(element);
+
+            await Updates.next();
+
+            expect(model.nodes.includes(element)).to.equal(true)
         });
 
         it("should not throw if DOM stringified", () => {

--- a/packages/web-components/fast-element/src/templating/children.ts
+++ b/packages/web-components/fast-element/src/templating/children.ts
@@ -66,10 +66,10 @@ export class ChildrenDirective extends NodeObservationDirective<
         if (!observer) {
             observer = new MutationObserver(this.handleEvent);
             observer.toJSON = noop;
-            observer.target = target;
             target[this.observerProperty] = observer;
         }
 
+        observer.target = target;
         observer.observe(target, this.options);
     }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR fixes a runtime exception that would occur when a re-bound `ChildrenDirective` would observe a DOM mutation.

This exception occurs because the `disconnect()` method would null-out the target reference on the observer that is using within the mutation handler. That property was only assigned during initial creation of the observer, so re-binding would skip the assign step and following code would throw when trying to access properties of the null reference. 

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
fixes #6740
<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->