### PR TITLE
Fix svg imports path resolution for stories

### DIFF
--- a/change/@microsoft-fast-foundation-e6af9a51-bb59-49a5-9fa6-38d6749c9ac1.json
+++ b/change/@microsoft-fast-foundation-e6af9a51-bb59-49a5-9fa6-38d6749c9ac1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix svg imports path resolution for stories",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-foundation/src/__test__/custom.d.ts
+++ b/packages/web-components/fast-foundation/src/__test__/custom.d.ts
@@ -1,0 +1,4 @@
+declare module "*.svg" {
+    const content: any;
+    export default content;
+}

--- a/packages/web-components/fast-foundation/src/__test__/global.d.ts
+++ b/packages/web-components/fast-foundation/src/__test__/global.d.ts
@@ -8,8 +8,3 @@ declare global {
 }
 
 export {};
-
-declare module "*.svg" {
-    const content: any;
-    export default content;
-}


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes the squiggles for SVG paths in `*.register.ts` and `*.stories.ts` files.

## 👩‍💻 Reviewer Notes

It seems that combining the `PlaywrightTest` namespace extension with the `"*.svg"` module declaration caused the latter to not be picked up, which caused synthetic paths to SVGs to be seen as errors. Splitting `global.d.ts` into two separate modules fixes this minor inconvenience.

## 📑 Test Plan

This change should not affect any build or test process.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
