### PR TITLE
fix: support multiple ChildrenDirective for the same element

### DIFF
--- a/change/@microsoft-fast-element-34020ef5-64b7-45bf-80d1-d8e1f4db59cd.json
+++ b/change/@microsoft-fast-element-34020ef5-64b7-45bf-80d1-d8e1f4db59cd.json
@@ -1,0 +1,7 @@
+{
+    "type": "prerelease",
+    "comment": "fixes a bug where ChildrenDirective could not be used multiple times for the same element",
+    "packageName": "@microsoft/fast-element",
+    "email": "nicholasrice@users.noreply.github.com",
+    "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-element/src/templating/children.spec.ts
+++ b/packages/web-components/fast-element/src/templating/children.spec.ts
@@ -5,7 +5,7 @@ import { elements } from "./node-observation.js";
 import { Updates } from "../observation/update-queue.js";
 import { Fake } from "../testing/fakes.js";
 import { html } from "./template.js";
-import { ref, RefDirective } from "./ref.js";
+import { ref } from "./ref.js";
 
 describe("The children", () => {
     context("template function", () => {

--- a/packages/web-components/fast-element/src/templating/children.ts
+++ b/packages/web-components/fast-element/src/templating/children.ts
@@ -45,7 +45,7 @@ export type ChildrenDirectiveOptions<T = any> =
 export class ChildrenDirective extends NodeObservationDirective<
     ChildrenDirectiveOptions
 > {
-    private observerProperty = `${this.id}-o`;
+    private observerProperty = Symbol();
 
     /**
      * Creates an instance of ChildrenDirective.


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR fixes a bug where `ChildrenDirective` could not be used more than once for the same target element.

The bug exists because `ChildrenDirective` uses it's `observerProperty` to look up observer instances on a target, and it creates it's `observerProperty` during construction when the `id` property it derives that string from is `undefined` (set by the compiler after construction). This means every instance's `observerProperty` is `"undefined-o"`, which allows incorrect lookup if multiple directives are attached.

That property simply needs to be unique so that the observer can be looked up from the target, so a Symbol is a suitable replacement.
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->