### PR TITLE
fix: block cell nav events w internal focus queue active

### DIFF
--- a/change/@microsoft-fast-foundation-8be8ec30-b786-4058-b066-dacf147547af.json
+++ b/change/@microsoft-fast-foundation-8be8ec30-b786-4058-b066-dacf147547af.json
@@ -3,5 +3,5 @@
   "comment": "block cell nav events",
   "packageName": "@microsoft/fast-foundation",
   "email": "stephcomeau@msn.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-8be8ec30-b786-4058-b066-dacf147547af.json
+++ b/change/@microsoft-fast-foundation-8be8ec30-b786-4058-b066-dacf147547af.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "block cell nav events",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -264,12 +264,12 @@ export function checkboxTemplate<T extends FASTCheckbox>(options?: CheckboxOptio
 
 // @public
 export interface ColumnDefinition {
-    cellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement;
+    cellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement | null;
     cellInternalFocusQueue?: boolean;
     cellTemplate?: ViewTemplate | SyntheticViewTemplate;
     columnDataKey: string;
     gridColumn?: string;
-    headerCellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement;
+    headerCellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement | null;
     headerCellInternalFocusQueue?: boolean;
     headerCellTemplate?: ViewTemplate | SyntheticViewTemplate;
     isRowHeader?: boolean;
@@ -411,6 +411,9 @@ export const DayFormat: {
 
 // @public
 export type DayFormat = ValuesOf<typeof DayFormat>;
+
+// @public (undocumented)
+export const defaultCellFocusTargetCallback: (cell: FASTDataGridCell) => HTMLElement | null;
 
 // Warning: (ae-different-release-tags) This symbol has another declaration with a different release tag
 // Warning: (ae-internal-mixed-release-tag) Mixed release tags are not allowed for "DelegatesARIAButton" because one of its declarations is marked as @internal

--- a/packages/web-components/fast-foundation/src/data-grid/README.md
+++ b/packages/web-components/fast-foundation/src/data-grid/README.md
@@ -144,6 +144,14 @@ export const myDataGrid = DataGrid.compose({
 
 <hr/>
 
+### Functions
+
+| Name                             | Description | Parameters               | Return                |
+| -------------------------------- | ----------- | ------------------------ | --------------------- |
+| `defaultCellFocusTargetCallback` |             | `cell: FASTDataGridCell` | `HTMLElement or null` |
+
+<hr/>
+
 
 
 ### class: `FASTDataGridRow`
@@ -277,6 +285,44 @@ export const myDataGrid = DataGrid.compose({
 | Name | Description                              |
 | ---- | ---------------------------------------- |
 |      | The default slot for custom row elements |
+
+<hr/>
+
+
+
+### class: `ComplexCell`
+
+#### Superclass
+
+| Name          | Module | Package                 |
+| ------------- | ------ | ----------------------- |
+| `FASTElement` |        | @microsoft/fast-element |
+
+#### Fields
+
+| Name            | Privacy | Type                | Default | Description | Inherited From |
+| --------------- | ------- | ------------------- | ------- | ----------- | -------------- |
+| `buttonA`       | public  | `HTMLButtonElement` |         |             |                |
+| `buttonB`       | public  | `HTMLButtonElement` |         |             |                |
+| `handleFocus`   | public  |                     |         |             |                |
+| `handleKeyDown` | public  |                     |         |             |                |
+
+<hr/>
+
+### Variables
+
+| Name                | Description | Type |
+| ------------------- | ----------- | ---- |
+| `complexCellStyles` |             |      |
+
+<hr/>
+
+### Functions
+
+| Name                  | Description | Parameters | Return                   |
+| --------------------- | ----------- | ---------- | ------------------------ |
+| `registerComplexCell` |             |            |                          |
+| `complexCellTemplate` |             |            | `ElementViewTemplate<T>` |
 
 <hr/>
 

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
@@ -16,6 +16,7 @@ import {
     keyPageDown,
     keyPageUp,
 } from "@microsoft/fast-web-utilities";
+import { isFocusable } from "tabbable";
 import type { ColumnDefinition } from "./data-grid.js";
 import { DataGridCellTypes } from "./data-grid.options.js";
 
@@ -47,8 +48,10 @@ const defaultHeaderCellContentsTemplate: ViewTemplate<FASTDataGridCell> = html`
 export const defaultCellFocusTargetCallback = (
     cell: FASTDataGridCell
 ): HTMLElement | null => {
-    if (cell.children.length && cell.children[0] instanceof HTMLElement) {
-        return cell.children[0] as HTMLElement;
+    for (let i = 0; i < cell.children.length; i++) {
+        if (isFocusable(cell.children[i])) {
+            return cell.children[i] as HTMLElement;
+        }
     }
     return null;
 };

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
@@ -4,9 +4,17 @@ import {
     eventFocusIn,
     eventFocusOut,
     eventKeyDown,
+    keyArrowDown,
+    keyArrowLeft,
+    keyArrowRight,
+    keyArrowUp,
+    keyEnd,
     keyEnter,
     keyEscape,
     keyFunction2,
+    keyHome,
+    keyPageDown,
+    keyPageUp,
 } from "@microsoft/fast-web-utilities";
 import type { ColumnDefinition } from "./data-grid.js";
 import { DataGridCellTypes } from "./data-grid.options.js";
@@ -34,6 +42,16 @@ const defaultHeaderCellContentsTemplate: ViewTemplate<FASTDataGridCell> = html`
                 : x.columnDefinition.title}
     </template>
 `;
+
+// basic focusTargetCallback that returns the first child of the cell
+export const defaultCellFocusTargetCallback = (
+    cell: FASTDataGridCell
+): HTMLElement | null => {
+    if (cell.children.length && cell.children[0] instanceof HTMLElement) {
+        return cell.children[0] as HTMLElement;
+    }
+    return null;
+};
 
 /**
  * A Data Grid Cell Custom HTML Element.
@@ -151,7 +169,7 @@ export class FASTDataGridCell extends FASTElement {
                         "function"
                 ) {
                     // move focus to the focus target
-                    const focusTarget: HTMLElement =
+                    const focusTarget: HTMLElement | null =
                         this.columnDefinition.headerCellFocusTargetCallback(this);
                     if (focusTarget !== null) {
                         focusTarget.focus();
@@ -166,7 +184,7 @@ export class FASTDataGridCell extends FASTElement {
                     typeof this.columnDefinition.cellFocusTargetCallback === "function"
                 ) {
                     // move focus to the focus target
-                    const focusTarget: HTMLElement =
+                    const focusTarget: HTMLElement | null =
                         this.columnDefinition.cellFocusTargetCallback(this);
                     if (focusTarget !== null) {
                         focusTarget.focus();
@@ -184,25 +202,37 @@ export class FASTDataGridCell extends FASTElement {
         }
     }
 
+    private hasInternalFocusQueue(): boolean {
+        if (this.columnDefinition === null) {
+            return false;
+        }
+        if (
+            (this.cellType === DataGridCellTypes.default &&
+                this.columnDefinition.cellInternalFocusQueue) ||
+            (this.cellType === DataGridCellTypes.columnHeader &&
+                this.columnDefinition.headerCellInternalFocusQueue)
+        ) {
+            return true;
+        }
+        return false;
+    }
+
     public handleKeydown(e: KeyboardEvent): void {
+        // if the cell does not have an internal focus queue we can ignore keystrokes
         if (
             e.defaultPrevented ||
             this.columnDefinition === null ||
-            (this.cellType === DataGridCellTypes.default &&
-                this.columnDefinition.cellInternalFocusQueue !== true) ||
-            (this.cellType === DataGridCellTypes.columnHeader &&
-                this.columnDefinition.headerCellInternalFocusQueue !== true)
+            !this.hasInternalFocusQueue()
         ) {
             return;
         }
 
+        const rootActiveElement: Element | null = this.getRootActiveElement();
+
         switch (e.key) {
             case keyEnter:
             case keyFunction2:
-                if (
-                    this.contains(document.activeElement) &&
-                    document.activeElement !== this
-                ) {
+                if (this.contains(rootActiveElement) && rootActiveElement !== this) {
                     return;
                 }
 
@@ -212,7 +242,7 @@ export class FASTDataGridCell extends FASTElement {
                             this.columnDefinition.headerCellFocusTargetCallback !==
                             undefined
                         ) {
-                            const focusTarget: HTMLElement =
+                            const focusTarget: HTMLElement | null =
                                 this.columnDefinition.headerCellFocusTargetCallback(this);
                             if (focusTarget !== null) {
                                 focusTarget.focus();
@@ -223,7 +253,7 @@ export class FASTDataGridCell extends FASTElement {
 
                     default:
                         if (this.columnDefinition.cellFocusTargetCallback !== undefined) {
-                            const focusTarget: HTMLElement =
+                            const focusTarget: HTMLElement | null =
                                 this.columnDefinition.cellFocusTargetCallback(this);
                             if (focusTarget !== null) {
                                 focusTarget.focus();
@@ -235,15 +265,38 @@ export class FASTDataGridCell extends FASTElement {
                 break;
 
             case keyEscape:
-                if (
-                    this.contains(document.activeElement) &&
-                    document.activeElement !== this
-                ) {
+                if (this.contains(rootActiveElement) && rootActiveElement !== this) {
                     this.focus();
                     e.preventDefault();
                 }
                 break;
+
+            // stop any unhandled grid nav events that may bubble from the cell
+            // when internal navigation is active.
+            // note: preventDefault would also block arrow keys in input elements
+            case keyArrowDown:
+            case keyArrowLeft:
+            case keyArrowRight:
+            case keyArrowUp:
+            case keyEnd:
+            case keyHome:
+            case keyPageDown:
+            case keyPageUp:
+                if (this.contains(rootActiveElement) && rootActiveElement !== this) {
+                    e.stopPropagation();
+                }
+                break;
         }
+    }
+
+    private getRootActiveElement(): Element | null {
+        const rootNode = this.getRootNode();
+
+        if (rootNode instanceof ShadowRoot) {
+            return rootNode.activeElement;
+        }
+
+        return document.activeElement;
     }
 
     private updateCellView(): void {

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -78,7 +78,7 @@ export interface ColumnDefinition {
      * focus directly to the checkbox.
      * When headerCellInternalFocusQueue is true this function is called when the user hits Enter or F2
      */
-    headerCellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement;
+    headerCellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement | null;
 
     /**
      * cell template
@@ -98,7 +98,7 @@ export interface ColumnDefinition {
      * When cellInternalFocusQueue is true this function is called when the user hits Enter or F2
      */
 
-    cellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement;
+    cellFocusTargetCallback?: (cell: FASTDataGridCell) => HTMLElement | null;
 
     /**
      * Whether this column is the row header

--- a/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.register.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.register.ts
@@ -1,6 +1,7 @@
 import { css } from "@microsoft/fast-element";
 import { FASTDataGrid } from "../data-grid.js";
 import { dataGridTemplate } from "../data-grid.template.js";
+import { registerComplexCell } from "./examples/complex-cell.js";
 
 const styles = css`
     :host {
@@ -19,3 +20,5 @@ FASTDataGrid.define({
     }),
     styles,
 });
+
+registerComplexCell();

--- a/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.stories.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.stories.ts
@@ -113,6 +113,7 @@ DataGridColumnDefinitions.args = {
 const editCellTemplate = html`
     <template>
         <fast-text-field
+            tabIndex="-1"
             value="${x => x.rowData[x.columnDefinition.columnDataKey]}"
         ></fast-text-field>
     </template>

--- a/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.stories.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/stories/data-grid.stories.ts
@@ -1,6 +1,7 @@
 import { html } from "@microsoft/fast-element";
 import type { Meta, Story, StoryArgs } from "../../__test__/helpers.js";
 import { renderComponent } from "../../__test__/helpers.js";
+import { defaultCellFocusTargetCallback } from "../data-grid-cell.js";
 import {
     DataGridSelectionBehavior,
     DataGridSelectionMode,
@@ -106,5 +107,53 @@ DataGridColumnDefinitions.args = {
         { columnDataKey: "rowId" },
         { columnDataKey: "item1" },
         { columnDataKey: "item2" },
+    ],
+};
+
+const editCellTemplate = html`
+    <template>
+        <fast-text-field
+            value="${x => x.rowData[x.columnDefinition.columnDataKey]}"
+        ></fast-text-field>
+    </template>
+`;
+
+const checkboxCellTemplate = html`
+    <template>
+        <fast-checkbox>${x => x.rowData[x.columnDefinition.columnDataKey]}</fast-checkbox>
+    </template>
+`;
+
+const complexCellTemplate = html`
+  <template>
+    <complex-cell
+        tabIndex="-1"
+    ></complexCell>
+  </template>
+`;
+
+export const DataGridEditBoxes: Story<FASTDataGrid> = renderComponent(storyTemplate).bind(
+    {}
+);
+DataGridEditBoxes.args = {
+    columnDefinitions: [
+        { columnDataKey: "rowId" },
+        {
+            columnDataKey: "item1",
+            cellTemplate: checkboxCellTemplate,
+            cellFocusTargetCallback: defaultCellFocusTargetCallback,
+        },
+        {
+            columnDataKey: "item2",
+            cellInternalFocusQueue: true,
+            cellTemplate: editCellTemplate,
+            cellFocusTargetCallback: defaultCellFocusTargetCallback,
+        },
+        {
+            columnDataKey: "item3",
+            cellInternalFocusQueue: true,
+            cellTemplate: complexCellTemplate,
+            cellFocusTargetCallback: defaultCellFocusTargetCallback,
+        },
     ],
 };

--- a/packages/web-components/fast-foundation/src/data-grid/stories/examples/complex-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/stories/examples/complex-cell.ts
@@ -1,0 +1,72 @@
+import {
+    css,
+    ElementViewTemplate,
+    FASTElement,
+    html,
+    ref,
+} from "@microsoft/fast-element";
+import { eventFocus, keyArrowLeft, keyArrowRight } from "@microsoft/fast-web-utilities";
+
+export function registerComplexCell() {
+    ComplexCell.define({
+        name: "complex-cell",
+        template: complexCellTemplate(),
+        styles: complexCellStyles,
+    });
+}
+
+export class ComplexCell extends FASTElement {
+    public buttonA: HTMLButtonElement;
+    public buttonB: HTMLButtonElement;
+
+    public connectedCallback(): void {
+        super.connectedCallback();
+        this.addEventListener(eventFocus, this.handleFocus);
+    }
+
+    public disconnectedCallback(): void {
+        super.disconnectedCallback();
+    }
+
+    public handleFocus = (e: FocusEvent): void => {
+        this.buttonA.focus();
+    };
+
+    public handleKeyDown = (e: KeyboardEvent): boolean => {
+        if (e.key !== keyArrowLeft && e.key !== keyArrowRight) {
+            return true;
+        }
+        if (e.target === this.buttonA) {
+            this.buttonB.focus();
+        } else {
+            this.buttonA.focus();
+        }
+        return false;
+    };
+}
+
+export function complexCellTemplate<T extends ComplexCell>(): ElementViewTemplate<T> {
+    return html<T>`
+        <template>
+            <button
+                ${ref("buttonA")}
+                tabindex="-1"
+                @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
+            >
+                A
+            </button>
+            <button
+                ${ref("buttonB")}
+                tabindex="-1"
+                @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
+            >
+                B
+            </button>
+        </template>
+    `;
+}
+
+export const complexCellStyles = css`
+    :host {
+    }
+`;

--- a/packages/web-components/fast-foundation/src/data-grid/stories/examples/complex-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/stories/examples/complex-cell.ts
@@ -48,20 +48,20 @@ export class ComplexCell extends FASTElement {
 export function complexCellTemplate<T extends ComplexCell>(): ElementViewTemplate<T> {
     return html<T>`
         <template>
-            <button
+            <fast-button
                 ${ref("buttonA")}
                 tabindex="-1"
                 @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
             >
                 A
-            </button>
-            <button
+            </fast-button>
+            <fast-button
                 ${ref("buttonB")}
                 tabindex="-1"
                 @keydown="${(x, c) => x.handleKeyDown(c.event as KeyboardEvent)}"
             >
                 B
-            </button>
+            </fast-button>
         </template>
     `;
 }


### PR DESCRIPTION
## 📖 Description
Keyboard events emitted from a data grid cell when a cell's internal navigation is active can incorrectly move focus in the parent grid.  Rather than rely on authors to intercept these events the cell component can prevent their propagation.

Additionally, this change adds 
- a simple 'defaultCellFocusTargetCallback` function that authors can use to move focus to the first element of a cell.
- an example of a grid with cells with internal focus targets and internal nav queue
- fixes code that detects the current active element to work within shadow doms

## 📑 Test Plan
Current tests all work

## ✅ Checklist

### General
- [ x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
