### PR TITLE
fix: readonly number field should not respond to keyboard or click input

### DIFF
--- a/change/@microsoft-fast-foundation-8ea4460b-0681-4d22-a443-204f622e72dd.json
+++ b/change/@microsoft-fast-foundation-8ea4460b-0681-4d22-a443-204f622e72dd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: prevents incrementing via keyboard and click for disabled AND readonly number field",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/src/number-field/number-field.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.ts
@@ -266,6 +266,10 @@ export class FASTNumberField extends FormAssociatedNumberField {
      * @public
      */
     public stepUp(): void {
+        if (this.disabled || this.readOnly) {
+            return;
+        }
+
         const value = parseFloat(this.value);
         const stepUpValue = !isNaN(value)
             ? value + this.step
@@ -286,6 +290,10 @@ export class FASTNumberField extends FormAssociatedNumberField {
      * @public
      */
     public stepDown(): void {
+        if (this.disabled || this.readOnly) {
+            return;
+        }
+
         const value = parseFloat(this.value);
         const stepDownValue = !isNaN(value)
             ? value - this.step
@@ -362,7 +370,11 @@ export class FASTNumberField extends FormAssociatedNumberField {
      * Handles the internal control's `keydown` event
      * @internal
      */
-    public handleKeyDown(e: KeyboardEvent): boolean {
+    public handleKeyDown(e: KeyboardEvent): void | boolean {
+        if (this.disabled || this.readOnly) {
+            return;
+        }
+
         const key = e.key;
 
         switch (key) {

--- a/packages/web-components/fast-foundation/src/number-field/stories/number-field.stories.ts
+++ b/packages/web-components/fast-foundation/src/number-field/stories/number-field.stories.ts
@@ -96,6 +96,23 @@ export const NumberField: Story<FASTNumberField> = renderComponent(storyTemplate
     {}
 );
 
+export const NumberFieldDisabled: Story<FASTNumberField> = renderComponent(
+    storyTemplate
+).bind({});
+
+NumberFieldDisabled.args = {
+    disabled: true,
+};
+
+export const NumberFieldReadOnly: Story<FASTNumberField> = renderComponent(
+    storyTemplate
+).bind({});
+
+NumberFieldReadOnly.args = {
+    readOnly: true,
+    value: "15",
+};
+
 export const NumberFieldWithSlottedStartEnd: Story<FASTNumberField> = NumberField.bind(
     {}
 );


### PR DESCRIPTION
# Pull Request

## 📖 Description
Ensures that click and keyboard events do not respond to input for readonly or disabled number field

### 🎫 Issues
closes #6712

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->