### PR TITLE
fix: add comment to empty templates to gracefully handle null first/last child for views

### DIFF
--- a/change/@microsoft-fast-element-e0afb613-ce1a-4f4f-95a8-5518772af979.json
+++ b/change/@microsoft-fast-element-e0afb613-ce1a-4f4f-95a8-5518772af979.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: update compiler to ensure first and last child references are defined",
+  "packageName": "@microsoft/fast-element",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-element/src/templating/compiler.spec.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.spec.ts
@@ -73,6 +73,13 @@ describe("The template compiler", () => {
                 childCount: 0,
             },
             {
+                type: "an empty template",
+                html: `<template></template>`,
+                directives: () => [],
+                fragment: ``,
+                childCount: 0,
+            },
+            {
                 type: "a single",
                 html: `${inline(0)}`,
                 directives: () => [binding()],
@@ -181,6 +188,13 @@ describe("The template compiler", () => {
         ];
 
         scenarios.forEach(x => {
+            it(`ensures that first and last child references are not null for ${x.type}`, () => {
+                const { fragment } = compile(x.html, x.directives());
+
+                expect(fragment.firstChild).not.to.be.null;
+                expect(fragment.lastChild).not.to.be.null;
+            })
+
             policies.forEach(y => {
                 it(`handles ${x.type} binding expression(s) with ${y.name} policy`, () => {
                     const directives = x.directives();

--- a/packages/web-components/fast-element/src/templating/compiler.ts
+++ b/packages/web-components/fast-element/src/templating/compiler.ts
@@ -358,8 +358,13 @@ export const Compiler = {
             template = html;
         }
 
+        if (!template.content.firstChild && !template.content.lastChild) {
+            template.content.appendChild(document.createComment(""));
+        }
+
         // https://bugs.chromium.org/p/chromium/issues/detail?id=1111864
         const fragment = document.adoptNode(template.content);
+
         const context = new CompilationContext<TSource, TParent>(
             fragment,
             factories,

--- a/packages/web-components/fast-element/src/templating/view.spec.ts
+++ b/packages/web-components/fast-element/src/templating/view.spec.ts
@@ -36,6 +36,15 @@ describe(`The HTMLView`, () => {
             expect(view.firstChild).not.to.be.null;
             expect(view.lastChild).not.to.be.null;
         });
+        it("gracefully handles empty template literals", () => {
+            const template = html``;
+
+            const view = template.create();
+            view.bind({});
+
+            expect(view.firstChild).not.to.be.null;
+            expect(view.lastChild).not.to.be.null;
+        });
         it("warns on class bindings when host not present", () => {
             const template = html`
                 <template class="foo"></template>

--- a/packages/web-components/fast-element/src/templating/view.spec.ts
+++ b/packages/web-components/fast-element/src/templating/view.spec.ts
@@ -25,6 +25,17 @@ function startCapturingWarnings() {
 
 describe(`The HTMLView`, () => {
     context("when binding hosts", () => {
+        it("gracefully handles empty template elements", () => {
+            const template = html`
+                <template></template>
+            `;
+
+            const view = template.create();
+            view.bind({});
+
+            expect(view.firstChild).not.to.be.null;
+            expect(view.lastChild).not.to.be.null;
+        });
         it("warns on class bindings when host not present", () => {
             const template = html`
                 <template class="foo"></template>


### PR DESCRIPTION
# Pull Request

## 📖 Description
Coming back around to this with @eisenbergeffect's suggestion. This PR checks or null first and last child references in the template compiler and inserts a comment to gracefully handle null scenarios for views.

### 🎫 Issues
closes #6596

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
