### PR TITLE
feat: add displayName to react wrapper

### DIFF
--- a/change/@microsoft-fast-react-wrapper-cf03dab8-c553-4726-abe3-112e2aa326bb.json
+++ b/change/@microsoft-fast-react-wrapper-cf03dab8-c553-4726-abe3-112e2aa326bb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add displayName to react wrapper",
+  "packageName": "@microsoft/fast-react-wrapper",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/utilities/fast-react-wrapper/docs/api-report.md
+++ b/packages/utilities/fast-react-wrapper/docs/api-report.md
@@ -19,7 +19,10 @@ export type ReactEvents<T> = {
 };
 
 // @public
-export type ReactWrapper<TElement extends HTMLElement, TEvents> = Constructable<ReactModule.Component<ReactWrapperProps<TElement, TEvents>>>;
+export interface ReactWrapper<TElement extends HTMLElement, TEvents> extends Constructable<ReactModule.Component<ReactWrapperProps<TElement, TEvents>>> {
+    // (undocumented)
+    displayName: string;
+}
 
 // @public (undocumented)
 export function reactWrapper(React: any, registry?: CustomElementRegistry): {


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR adds a displayName to the react wrapper and makes an adjustment to leverage a single call to `getTagName()` to resolve a consistent name. 

### 🎫 Issues
Would replace #6747, closes #6741

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->