### PR TITLE
feat: add derive to FASTElementDefinition for overriding existing FAST element definition properties

### DIFF
--- a/change/@microsoft-fast-element-02440c30-fe57-49a9-90cd-40f62310510e.json
+++ b/change/@microsoft-fast-element-02440c30-fe57-49a9-90cd-40f62310510e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "split custom element name into prefix and basename",
+  "packageName": "@microsoft/fast-element",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-02440c30-fe57-49a9-90cd-40f62310510e.json
+++ b/change/@microsoft-fast-element-02440c30-fe57-49a9-90cd-40f62310510e.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "split custom element name into prefix and basename",
+  "comment": "add derive method to FASTElementDefinition for creating new definitions from existing instances.",
   "packageName": "@microsoft/fast-element",
   "email": "32497422+KingOfTac@users.noreply.github.com",
   "dependentChangeType": "prerelease"

--- a/change/@microsoft-fast-element-02440c30-fe57-49a9-90cd-40f62310510e.json
+++ b/change/@microsoft-fast-element-02440c30-fe57-49a9-90cd-40f62310510e.json
@@ -3,5 +3,5 @@
   "comment": "split custom element name into prefix and basename",
   "packageName": "@microsoft/fast-element",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -426,15 +426,14 @@ export const FASTElement: {
 export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>> {
     readonly attributeLookup: Record<string, AttributeDefinition>;
     readonly attributes: ReadonlyArray<AttributeDefinition>;
-    readonly baseName: string;
     static compose<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(type: TType, nameOrDef?: string | PartialFASTElementDefinition): FASTElementDefinition<TType>;
     define(registry?: CustomElementRegistry): this;
+    derive(nameOrConfig: string | PartialFASTElementDefinition): FASTElementDefinition<TType>;
     readonly elementOptions: ElementDefinitionOptions;
     static readonly getByType: (key: Function) => FASTElementDefinition<Constructable<HTMLElement>> | undefined;
     static readonly getForInstance: (object: any) => FASTElementDefinition<Constructable<HTMLElement>> | undefined;
     get isDefined(): boolean;
-    get name(): string;
-    prefix: string;
+    readonly name: string;
     readonly propertyLookup: Record<string, AttributeDefinition>;
     // @internal
     static registerBaseType(type: Function): void;

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -426,13 +426,15 @@ export const FASTElement: {
 export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>> {
     readonly attributeLookup: Record<string, AttributeDefinition>;
     readonly attributes: ReadonlyArray<AttributeDefinition>;
+    readonly baseName: string;
     static compose<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(type: TType, nameOrDef?: string | PartialFASTElementDefinition): FASTElementDefinition<TType>;
     define(registry?: CustomElementRegistry): this;
     readonly elementOptions: ElementDefinitionOptions;
     static readonly getByType: (key: Function) => FASTElementDefinition<Constructable<HTMLElement>> | undefined;
     static readonly getForInstance: (object: any) => FASTElementDefinition<Constructable<HTMLElement>> | undefined;
     get isDefined(): boolean;
-    readonly name: string;
+    get name(): string;
+    prefix: string;
     readonly propertyLookup: Record<string, AttributeDefinition>;
     // @internal
     static registerBaseType(type: Function): void;

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -428,8 +428,9 @@ export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Co
     readonly attributes: ReadonlyArray<AttributeDefinition>;
     static compose<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(type: TType, nameOrDef?: string | PartialFASTElementDefinition): FASTElementDefinition<TType>;
     define(registry?: CustomElementRegistry): this;
-    derive(nameOrConfig: string | PartialFASTElementDefinition): FASTElementDefinition<TType>;
+    derive: Function | undefined;
     readonly elementOptions: ElementDefinitionOptions;
+    freeze(): Readonly<Omit<FASTElementDefinition, "derive">>;
     static readonly getByType: (key: Function) => FASTElementDefinition<Constructable<HTMLElement>> | undefined;
     static readonly getForInstance: (object: any) => FASTElementDefinition<Constructable<HTMLElement>> | undefined;
     get isDefined(): boolean;

--- a/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
@@ -129,7 +129,7 @@ describe("FASTElementDefinition", () => {
         it("new definitions can be derived from an instance", () => {;
             const name = uniqueElementName();
             const def = FASTElementDefinition.compose(MyElement, `my-${name}`);
-            const derivedDef = def.derive(`foo-${name}`);
+            const derivedDef = def.derive?.(`foo-${name}`);
 
             expect(derivedDef.isDefined).to.be.false;
 
@@ -148,7 +148,7 @@ describe("FASTElementDefinition", () => {
 
             expect(def.isDefined).to.be.true;
 
-            const derivedDef = def.derive(`foo-${name}`);
+            const derivedDef = def.derive?.(`foo-${name}`);
 
             expect(derivedDef.isDefined).to.be.false;
 
@@ -166,12 +166,20 @@ describe("FASTElementDefinition", () => {
                 styles: styles
             });
 
-            const derivedDef = def.derive({
+            const derivedDef = def.derive?.({
                 name: `foo-${name}`,
                 styles: overrideStyles
             });
 
             expect(def.styles).to.not.equal(derivedDef.styles);
+        });
+
+        it("a derived instance cannot be created from a frozen instance", () => {
+            const name = uniqueElementName();
+            const def = FASTElementDefinition.compose(MyElement, `my-${name}`).freeze();
+
+            expect(def["derive"]).to.be.undefined;
+            expect(def).to.not.be.extensible;
         });
     });
 

--- a/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
@@ -156,6 +156,23 @@ describe("FASTElementDefinition", () => {
 
             expect(derivedDef.isDefined).to.be.true;
         });
+
+        it("a derived instance should replace properties passed through new definition configuration", () => {
+            const name = uniqueElementName();
+            const styles = new ElementStyles([".class { color: red; }"]);
+            const overrideStyles = new ElementStyles([".class { color: blue }"]);
+            const def = FASTElementDefinition.compose(MyElement, {
+                name: `my-${name}`,
+                styles: styles
+            });
+
+            const derivedDef = def.derive({
+                name: `foo-${name}`,
+                styles: overrideStyles
+            });
+
+            expect(def.styles).to.not.equal(derivedDef.styles);
+        });
     });
 
     context("compose", () => {

--- a/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.spec.ts
@@ -125,6 +125,37 @@ describe("FASTElementDefinition", () => {
 
             expect(def.isDefined).to.be.true;
         });
+
+        it("new definitions can be derived from an instance", () => {;
+            const name = uniqueElementName();
+            const def = FASTElementDefinition.compose(MyElement, `my-${name}`);
+            const derivedDef = def.derive(`foo-${name}`);
+
+            expect(derivedDef.isDefined).to.be.false;
+
+            derivedDef.define();
+
+            expect(derivedDef.isDefined).to.be.true;
+        });
+
+        it("an instance and a derived instance can both be defined", () => {
+            const name = uniqueElementName();
+            const def = FASTElementDefinition.compose(MyElement, `my-${name}`);
+
+            expect(def.isDefined).to.be.false;
+
+            def.define();
+
+            expect(def.isDefined).to.be.true;
+
+            const derivedDef = def.derive(`foo-${name}`);
+
+            expect(derivedDef.isDefined).to.be.false;
+
+            derivedDef.define();
+
+            expect(derivedDef.isDefined).to.be.true;
+        });
     });
 
     context("compose", () => {

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -95,9 +95,22 @@ export class FASTElementDefinition<
     }
 
     /**
+     * The prefix of the custom element's name
+     */
+    public prefix: string;
+
+    /**
+     * The base name of the custom element.
+     * Combined with the prefix, this creates the element name that is registered with the platform.
+     */
+    public readonly baseName: string;
+
+    /**
      * The name of the custom element.
      */
-    public readonly name: string;
+    public get name(): string {
+        return `${this.prefix}-${this.baseName}`;
+    }
 
     /**
      * The custom attributes of the custom element.
@@ -148,7 +161,10 @@ export class FASTElementDefinition<
         }
 
         this.type = type;
-        this.name = nameOrConfig.name;
+
+        const nameSeparatorIndex = nameOrConfig.name.indexOf("-");
+        this.prefix = nameOrConfig.name.substring(0, nameSeparatorIndex);
+        this.baseName = nameOrConfig.name.substring(nameSeparatorIndex + 1);
         this.template = nameOrConfig.template;
         this.registry = nameOrConfig.registry ?? customElements;
 

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -148,7 +148,6 @@ export class FASTElementDefinition<
         }
 
         this.type = type;
-
         this.name = nameOrConfig.name;
         this.template = nameOrConfig.template;
         this.registry = nameOrConfig.registry ?? customElements;

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -95,22 +95,9 @@ export class FASTElementDefinition<
     }
 
     /**
-     * The prefix of the custom element's name
-     */
-    public prefix: string;
-
-    /**
-     * The base name of the custom element.
-     * Combined with the prefix, this creates the element name that is registered with the platform.
-     */
-    public readonly baseName: string;
-
-    /**
      * The name of the custom element.
      */
-    public get name(): string {
-        return `${this.prefix}-${this.baseName}`;
-    }
+    public readonly name: string;
 
     /**
      * The custom attributes of the custom element.
@@ -162,9 +149,7 @@ export class FASTElementDefinition<
 
         this.type = type;
 
-        const nameSeparatorIndex = nameOrConfig.name.indexOf("-");
-        this.prefix = nameOrConfig.name.substring(0, nameSeparatorIndex);
-        this.baseName = nameOrConfig.name.substring(nameSeparatorIndex + 1);
+        this.name = nameOrConfig.name;
         this.template = nameOrConfig.template;
         this.registry = nameOrConfig.registry ?? customElements;
 
@@ -223,6 +208,30 @@ export class FASTElementDefinition<
         }
 
         return this;
+    }
+
+    /**
+     * Derives a FASTElementDefinition from an existing instance.
+     * @param nameOrConfig - The new name or overrides to create a new definition from.
+     */
+    public derive(nameOrConfig: string | PartialFASTElementDefinition) {
+        if (isString(nameOrConfig)) {
+            nameOrConfig = { name: nameOrConfig };
+        }
+
+        nameOrConfig = {
+            ...this,
+            ...nameOrConfig,
+        };
+
+        if (
+            fastElementBaseTypes.has(this.type) ||
+            fastElementRegistry.getByType(this.type)
+        ) {
+            return new FASTElementDefinition(class extends this.type {}, nameOrConfig);
+        } else {
+            return new FASTElementDefinition(this.type, nameOrConfig);
+        }
     }
 
     /**

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -223,14 +223,7 @@ export class FASTElementDefinition<
             ...nameOrConfig,
         };
 
-        if (
-            fastElementBaseTypes.has(this.type) ||
-            fastElementRegistry.getByType(this.type)
-        ) {
-            return new FASTElementDefinition(class extends this.type {}, nameOrConfig);
-        } else {
-            return new FASTElementDefinition(this.type, nameOrConfig);
-        }
+        return FASTElementDefinition.compose(this.type, nameOrConfig);
     }
 
     /**

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -212,8 +212,11 @@ export class FASTElementDefinition<
     /**
      * Derives a FASTElementDefinition from an existing instance.
      * @param nameOrConfig - The new name or overrides to create a new definition from.
+     * @remarks This API is only available if a FASTElementDefinition instance has not been frozen.
      */
-    public derive(nameOrConfig: string | PartialFASTElementDefinition) {
+    public derive: Function | undefined = (
+        nameOrConfig: string | PartialFASTElementDefinition
+    ): FASTElementDefinition<TType> => {
         if (isString(nameOrConfig)) {
             nameOrConfig = { name: nameOrConfig };
         }
@@ -224,6 +227,14 @@ export class FASTElementDefinition<
         };
 
         return FASTElementDefinition.compose(this.type, nameOrConfig);
+    };
+
+    /**
+     * Removes the derive API and returns a frozen version of a FASTElementDefinition instance.
+     */
+    public freeze(): Readonly<Omit<FASTElementDefinition, "derive">> {
+        this.derive = undefined;
+        return Object.freeze(this);
     }
 
     /**


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
~~This PR is a proposal to split the name property on `FASTElementDefinition` in a prefix and baseName. While building multiple web component libraries that build on top of `fast-element` and `fast-foundation` I have noticed cases where library consumers sometimes need to change the element prefix _after_ a definition has already been composed. This adds a prefix property that can be changed and a readonly baseName property. The name is now a readonly getter that combines the prefix and baseName.~~

edit: Based on feedback, this PR now adds a `derive` method to `FASTElementDefinition` which uses the compose API under the hood. This enables consumers of libraries that export definitions to still override and customize the element definitions before defining them with the platform.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
~~Tests continue to pass. This shouldn't be a breaking change due to the name getter still returning the same result as before and the arguments passed to `FASTElementDefinition` have not changed.~~

Added tests for the new derive method. Existing tests continue to pass.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [X] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [X] I have tested my changes.
- [X] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->