### PR TITLE
fix: toolbar should not throw if start/end slots do not exist

### DIFF
--- a/change/@microsoft-fast-foundation-240d2dac-2fd1-4e5f-a760-03c9e5505330.json
+++ b/change/@microsoft-fast-foundation-240d2dac-2fd1-4e5f-a760-03c9e5505330.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: toolbar should not throw if start or end is undefined",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
@@ -207,11 +207,10 @@ export class FASTToolbar extends FASTElement {
      * @internal
      */
     protected get allSlottedItems(): (HTMLElement | Node)[] {
-        return [
-            ...this.start.assignedElements(),
-            ...this.slottedItems,
-            ...this.end.assignedElements(),
-        ];
+        const start = this.start?.assignedElements() ?? [];
+        const end = this.end?.assignedElements() ?? [];
+
+        return [...start, ...this.slottedItems, ...end];
     }
 
     /**


### PR DESCRIPTION
# Pull Request

## 📖 Description
Fixes an issue where toolbar would throw if the class were used with a template without start or end slots.

### 🎫 Issues
fixes #6634