### PR TITLE
fix: only add aria orientation for proper role divider

### DIFF
--- a/change/@microsoft-fast-foundation-c935a253-e2ce-42db-a6fd-50b3adbd8839.json
+++ b/change/@microsoft-fast-foundation-c935a253-e2ce-42db-a6fd-50b3adbd8839.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: add aria-orientation to divider only when role equals separator",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/src/divider/divider.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/divider/divider.pw.spec.ts
@@ -70,4 +70,30 @@ test.describe("Divider", () => {
             DividerOrientation.horizontal
         );
     });
+
+    test("should NOT set the `aria-orientation` attribute equal to the `orientation` value if the `role` is presentational", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-divider orientation="vertical"></fast-divider>
+            `;
+        });
+
+        await expect(element).toHaveAttribute(
+            "aria-orientation",
+            DividerOrientation.vertical
+        );
+
+        await element.evaluate((node: FASTDivider, DividerOrientation) => {
+            node.role = DividerRole.presentation;
+        }, DividerOrientation);
+
+        await expect(element).not.toHaveAttribute(
+            "aria-orientation",
+            DividerOrientation.horizontal
+        );
+        await expect(element).not.toHaveAttribute(
+            "aria-orientation",
+            DividerOrientation.vertical
+        );
+    });
 });

--- a/packages/web-components/fast-foundation/src/divider/divider.template.ts
+++ b/packages/web-components/fast-foundation/src/divider/divider.template.ts
@@ -1,5 +1,6 @@
 import { ElementViewTemplate, html } from "@microsoft/fast-element";
 import type { FASTDivider } from "./divider.js";
+import { DividerRole } from "./divider.options.js";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#FASTDivider} component.
@@ -7,7 +8,11 @@ import type { FASTDivider } from "./divider.js";
  */
 export function dividerTemplate<T extends FASTDivider>(): ElementViewTemplate<T> {
     return html<T>`
-        <template role="${x => x.role}" aria-orientation="${x => x.orientation}">
+        <template
+            role="${x => x.role}"
+            aria-orientation="${x =>
+                x.role === DividerRole.separator ? x.orientation : void 0}"
+        >
             <slot></slot>
         </template>
     `;


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR ensures that aria-attributes are allowed for a given role for Divider. In cases where the role is presentation, `aria-orientation` should not be aplied.

### 🎫 Issues
n/a