### PR TITLE
[archive] Fix usage with TypeScript 4.8+

### DIFF
--- a/change/@microsoft-fast-foundation-673f775c-c439-46ef-93ae-7bd51076ce27.json
+++ b/change/@microsoft-fast-foundation-673f775c-c439-46ef-93ae-7bd51076ce27.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix typings for Typescript 4.8+",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "fcollonval@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -143,7 +143,7 @@ class DesignTokenImpl<T extends { createCSS?(): string }> extends CSSDirective
         return [...this._appliedTo];
     }
 
-    public static from<T>(
+    public static from<T extends { createCSS?(): string }>(
         nameOrConfig: string | DesignTokenConfiguration
     ): DesignTokenImpl<T> {
         return new DesignTokenImpl<T>({
@@ -157,9 +157,17 @@ class DesignTokenImpl<T extends { createCSS?(): string }> extends CSSDirective
         });
     }
 
-    public static isCSSDesignToken<T>(
-        token: DesignToken<T> | CSSDesignToken<T>
-    ): token is CSSDesignToken<T> {
+    public static isCSSDesignToken<
+        T extends
+            | string
+            | number
+            | boolean
+            | symbol
+            | any[]
+            | Uint8Array
+            | ({ createCSS?(): string } & Record<PropertyKey, any>)
+            | null
+    >(token: DesignToken<T> | CSSDesignToken<T>): token is CSSDesignToken<T> {
         return typeof (token as CSSDesignToken<T>).cssCustomProperty === "string";
     }
 
@@ -349,7 +357,7 @@ class CustomPropertyReflector {
  * A light wrapper around BindingObserver to handle value caching and
  * token notification
  */
-class DesignTokenBindingObserver<T> {
+class DesignTokenBindingObserver<T extends { createCSS?(): string }> {
     public readonly dependencies = new Set<DesignTokenImpl<any>>();
     private observer: BindingObserver<HTMLElement, DerivedDesignTokenValue<T>>;
     constructor(
@@ -394,19 +402,24 @@ class DesignTokenBindingObserver<T> {
  */
 class Store {
     private values = new Map<DesignTokenImpl<any>, any>();
-    set<T>(token: DesignTokenImpl<T>, value: StaticDesignTokenValue<T>) {
+    set<T extends { createCSS?(): string }>(
+        token: DesignTokenImpl<T>,
+        value: StaticDesignTokenValue<T>
+    ) {
         if (this.values.get(token) !== value) {
             this.values.set(token, value);
             Observable.getNotifier(this).notify(token.id);
         }
     }
 
-    get<T>(token: DesignTokenImpl<T>): StaticDesignTokenValue<T> | undefined {
+    get<T extends { createCSS?(): string }>(
+        token: DesignTokenImpl<T>
+    ): StaticDesignTokenValue<T> | undefined {
         Observable.track(this, token.id);
         return this.values.get(token);
     }
 
-    delete<T>(token: DesignTokenImpl<T>) {
+    delete<T extends { createCSS?(): string }>(token: DesignTokenImpl<T>) {
         this.values.delete(token);
     }
 
@@ -471,7 +484,7 @@ class DesignTokenNode implements Behavior, Subscriber {
      * @param start - The node to start looking for value assignment
      * @returns
      */
-    public static findClosestAssignedNode<T>(
+    public static findClosestAssignedNode<T extends { createCSS?(): string }>(
         token: DesignTokenImpl<T>,
         start: DesignTokenNode
     ): DesignTokenNode | null {
@@ -581,7 +594,7 @@ class DesignTokenNode implements Behavior, Subscriber {
      * Checks if a token has been assigned an explicit value the node.
      * @param token - the token to check.
      */
-    public has<T>(token: DesignTokenImpl<T>): boolean {
+    public has<T extends { createCSS?(): string }>(token: DesignTokenImpl<T>): boolean {
         return this.assignedValues.has(token);
     }
 
@@ -590,7 +603,9 @@ class DesignTokenNode implements Behavior, Subscriber {
      * @param token - The token to retrieve the value for
      * @returns
      */
-    public get<T>(token: DesignTokenImpl<T>): StaticDesignTokenValue<T> | undefined {
+    public get<T extends { createCSS?(): string }>(
+        token: DesignTokenImpl<T>
+    ): StaticDesignTokenValue<T> | undefined {
         const value = this.store.get(token);
 
         if (value !== undefined) {
@@ -610,7 +625,9 @@ class DesignTokenNode implements Behavior, Subscriber {
      * @param token - The token to retrieve a raw value for
      * @returns
      */
-    public getRaw<T>(token: DesignTokenImpl<T>): DesignTokenValue<T> | undefined {
+    public getRaw<T extends { createCSS?(): string }>(
+        token: DesignTokenImpl<T>
+    ): DesignTokenValue<T> | undefined {
         if (this.assignedValues.has(token)) {
             return this.assignedValues.get(token);
         }
@@ -623,7 +640,10 @@ class DesignTokenNode implements Behavior, Subscriber {
      * @param token - The token to set
      * @param value - The value to set the token to
      */
-    public set<T>(token: DesignTokenImpl<T>, value: DesignTokenValue<T>): void {
+    public set<T extends { createCSS?(): string }>(
+        token: DesignTokenImpl<T>,
+        value: DesignTokenValue<T>
+    ): void {
         if (DesignTokenImpl.isDerivedDesignTokenValue(this.assignedValues.get(token))) {
             this.tearDownBindingObserver(token);
         }
@@ -641,7 +661,7 @@ class DesignTokenNode implements Behavior, Subscriber {
      * Deletes a token value for the node.
      * @param token - The token to delete the value for
      */
-    public delete<T>(token: DesignTokenImpl<T>): void {
+    public delete<T extends { createCSS?(): string }>(token: DesignTokenImpl<T>): void {
         this.assignedValues.delete(token);
         this.tearDownBindingObserver(token);
         const upstream = this.getRaw(token);
@@ -783,7 +803,10 @@ class DesignTokenNode implements Behavior, Subscriber {
      * @param token - The token to hydrate
      * @param value - The value to hydrate
      */
-    public hydrate<T>(token: DesignTokenImpl<T>, value: DesignTokenValue<T>) {
+    public hydrate<T extends { createCSS?(): string }>(
+        token: DesignTokenImpl<T>,
+        value: DesignTokenValue<T>
+    ) {
         if (!this.has(token)) {
             const observer = this.bindingObservers.get(token);
 
@@ -815,7 +838,7 @@ class DesignTokenNode implements Behavior, Subscriber {
      * @param token - The token to notify when the binding updates
      * @param source - The binding source
      */
-    private setupBindingObserver<T>(
+    private setupBindingObserver<T extends { createCSS?(): string }>(
         token: DesignTokenImpl<T>,
         source: DerivedDesignTokenValue<T>
     ): DesignTokenBindingObserver<T> {
@@ -828,7 +851,9 @@ class DesignTokenNode implements Behavior, Subscriber {
     /**
      * Tear down a binding observer for a token.
      */
-    private tearDownBindingObserver<T>(token: DesignTokenImpl<T>): boolean {
+    private tearDownBindingObserver<T extends { createCSS?(): string }>(
+        token: DesignTokenImpl<T>
+    ): boolean {
         if (this.bindingObservers.has(token)) {
             this.bindingObservers.get(token)!.disconnect();
             this.bindingObservers.delete(token);
@@ -845,13 +870,35 @@ function create<T extends Function>(
 function create<T extends undefined | void>(
     nameOrConfig: string | DesignTokenConfiguration
 ): never;
-function create<T>(nameOrConfig: string): CSSDesignToken<T>;
-function create<T>(
+function create<
+    T extends
+        | string
+        | number
+        | boolean
+        | symbol
+        | any[]
+        | Uint8Array
+        | ({ createCSS?(): string } & Record<PropertyKey, any>)
+        | null
+>(nameOrConfig: string): CSSDesignToken<T>;
+function create<
+    T extends
+        | string
+        | number
+        | boolean
+        | symbol
+        | any[]
+        | Uint8Array
+        | ({ createCSS?(): string } & Record<PropertyKey, any>)
+        | null
+>(
     nameOrConfig:
         | Omit<DesignTokenConfiguration, "cssCustomPropertyName">
         | (DesignTokenConfiguration & Record<"cssCustomPropertyName", string>)
 ): CSSDesignToken<T>;
-function create<T>(
+function create<
+    T extends string | number | boolean | symbol | {} | any[] | Uint8Array | null
+>(
     nameOrConfig: DesignTokenConfiguration & Record<"cssCustomPropertyName", null>
 ): DesignToken<T>;
 function create<T>(nameOrConfig: string | DesignTokenConfiguration): any {

--- a/packages/web-components/fast-foundation/src/di/di.ts
+++ b/packages/web-components/fast-foundation/src/di/di.ts
@@ -1721,7 +1721,7 @@ export class ContainerImpl implements Container {
             }
         }
 
-        throw new Error(`Unable to resolve key: ${key}`);
+        throw new Error(`Unable to resolve key: ${String(key)}`);
     }
 
     public getAll<K extends Key>(

--- a/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.spec.ts
@@ -42,7 +42,7 @@ async function setup() {
     const [tabPanel1, tabPanel2, tabPanel3] = Array.from(
         element.querySelectorAll("fast-tab-panel")
     );
-    const [tab1, tab2, tab3] = Array.from(element.querySelectorAll("fast-tab"));
+    const [tab1, tab2, tab3] = Array.from<HTMLElement>(element.querySelectorAll("fast-tab"));
 
     return {
         element,


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
Add typing to template variable to remove error seen in code consuming fast-foundation with TypeScript 4.8+

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
Fixes #6365 


## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

I'm not sure how to test for this. I force locally a TypeScript update to 4.9.5 and fixed the error mentioned in `@microsoft/fast-foundation`.

There are also error in `@microsoft/fast-router` but this does not fix them.

<details><summary>Errors in @microsoft/fast-router</summary>
<pre>
src/configuration.ts(49,9): error TS2322: Type 'DefaultRouteRecognizer<unknown>' is not assignable to type 'RouteRecognizer<TSettings>'.
  The types returned by 'recognize(...)' are incompatible between these types.
    Type 'Promise<RecognizedRoute<unknown> | null>' is not assignable to type 'Promise<RecognizedRoute<TSettings> | null>'.
      Type 'RecognizedRoute<unknown> | null' is not assignable to type 'RecognizedRoute<TSettings> | null'.
        Type 'RecognizedRoute<unknown>' is not assignable to type 'RecognizedRoute<TSettings>'.
          Type 'unknown' is not assignable to type 'TSettings'.
            'TSettings' could be instantiated with an arbitrary type which could be unrelated to 'unknown'.
src/recognizer.ts(271,17): error TS18047: 'segmentA' is possibly 'null'.
src/recognizer.ts(271,33): error TS18047: 'segmentB' is possibly 'null'.
src/recognizer.ts(275,17): error TS18047: 'segmentA' is possibly 'null'.
src/recognizer.ts(275,33): error TS18047: 'segmentB' is possibly 'null'.
src/router.ts(201,13): error TS2322: Type 'unknown' is not assignable to type 'Router<any> | null | undefined'.
</pre>
</details>

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->