### PR TITLE
fix: prevent array splice notification on non-mutating splice() calls

### DIFF
--- a/change/@microsoft-fast-element-44cfe95a-1f60-4e2e-a3f1-1d02aba63bab.json
+++ b/change/@microsoft-fast-element-44cfe95a-1f60-4e2e-a3f1-1d02aba63bab.json
@@ -1,0 +1,7 @@
+{
+    "type": "prerelease",
+    "comment": "Prevent notification of array splices when operation does not mutate array values",
+    "packageName": "@microsoft/fast-element",
+    "email": "nicholasrice@users.noreply.github.com",
+    "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-element/src/observation/arrays.spec.ts
+++ b/packages/web-components/fast-element/src/observation/arrays.spec.ts
@@ -442,7 +442,6 @@ describe("The ArrayObserver", () => {
 
         observer.subscribe({
             handleChange(source, args) {
-                console.log(args[0])
                 splices = args
             }
         });

--- a/packages/web-components/fast-element/src/observation/arrays.spec.ts
+++ b/packages/web-components/fast-element/src/observation/arrays.spec.ts
@@ -433,6 +433,26 @@ describe("The ArrayObserver", () => {
 
         expect(wasCalled).to.be.false;
     })
+
+    it("should not deliver splices for .splice() when .splice() does not change the items in the array", async () => {
+        ArrayObserver.enable();
+        const array = [1,2,3,4,5];
+        const observer = Observable.getNotifier(array);
+        let splices;
+
+        observer.subscribe({
+            handleChange(source, args) {
+                console.log(args[0])
+                splices = args
+            }
+        });
+
+        array.splice(0, array.length, ...array);
+
+        await Updates.next();
+
+        expect(splices.length).to.equal(0);
+    })
 });
 
 describe("The array length observer", () => {

--- a/packages/web-components/fast-element/src/observation/arrays.ts
+++ b/packages/web-components/fast-element/src/observation/arrays.ts
@@ -611,7 +611,7 @@ let defaultSpliceStrategy: SpliceStrategy = Object.freeze({
             if (changes === void 0) {
                 return emptyArray;
             }
-            return changes.length > 1 ? project(current, changes) : changes;
+            return project(current, changes);
         }
 
         return resetSplices;


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description
This PR fixes a bug where array observer would notify a splice when the mutation that occurred did not alter the array values. It appears in FE2 migration, an attempt to optimize for single-splice processing short-cut the projection process, which would detect non-mutation scenarios like splicing an array with the same values. 

This issue has significant impact of the `repeat` directive, causing it to disconnect and re-connect views un-necessarily. 
<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

### 🎫 Issues
fixes ##6431

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->