### PR TITLE
Prevent keyboard navigation to hidden tab

### DIFF
--- a/change/@microsoft-fast-foundation-7d8d0430-523b-473a-af77-e2bcf0bc6e38.json
+++ b/change/@microsoft-fast-foundation-7d8d0430-523b-473a-af77-e2bcf0bc6e38.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Prevent keyboard navigation to hidden tab",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-7d8d0430-523b-473a-af77-e2bcf0bc6e38.json
+++ b/change/@microsoft-fast-foundation-7d8d0430-523b-473a-af77-e2bcf0bc6e38.json
@@ -1,5 +1,5 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "Prevent keyboard navigation to hidden tab",
   "packageName": "@microsoft/fast-foundation",
   "email": "7282195+m-akinc@users.noreply.github.com",

--- a/change/@microsoft-fast-foundation-7d8d0430-523b-473a-af77-e2bcf0bc6e38.json
+++ b/change/@microsoft-fast-foundation-7d8d0430-523b-473a-af77-e2bcf0bc6e38.json
@@ -3,5 +3,5 @@
   "comment": "Prevent keyboard navigation to hidden tab",
   "packageName": "@microsoft/fast-foundation",
   "email": "7282195+m-akinc@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
@@ -386,4 +386,37 @@ test.describe("Tabs", () => {
 
         await expect(element).toHaveJSProperty("activeid", secondTabId);
     });
+
+    test("should not allow selecting hidden tab using keyboard", async () => {
+        test.slow();
+
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tabs>
+                    <fast-tab>Tab one</fast-tab>
+                    <fast-tab hidden>Tab two</fast-tab>
+                    <fast-tab>Tab three</fast-tab>
+                    <fast-tab-panel>Tab panel one</fast-tab-panel>
+                    <fast-tab-panel>Tab panel two</fast-tab-panel>
+                    <fast-tab-panel>Tab panel three</fast-tab-panel>
+                </fast-tabs>
+            `;
+        });
+
+        const firstTab = tabs.nth(0);
+
+        const thirdTab = tabs.nth(2);
+
+        const firstTabId = (await firstTab.getAttribute("id")) ?? "";
+
+        const thirdTabId = (await thirdTab.getAttribute("id")) ?? "";
+
+        await element.evaluate((node: FASTTabs, firstTabId) => {
+            node.activeid = firstTabId;
+        }, firstTabId);
+
+        await firstTab.press("ArrowRight");
+
+        await expect(element).toHaveJSProperty("activeid", thirdTabId);
+    });
 });

--- a/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
@@ -387,7 +387,7 @@ test.describe("Tabs", () => {
         await expect(element).toHaveJSProperty("activeid", secondTabId);
     });
 
-    test("should not allow selecting hidden tab using keyboard", async () => {
+    test("should not allow selecting hidden tab using arrow keys", async () => {
         test.slow();
 
         await root.evaluate(node => {
@@ -418,5 +418,38 @@ test.describe("Tabs", () => {
         await firstTab.press("ArrowRight");
 
         await expect(element).toHaveJSProperty("activeid", thirdTabId);
+    });
+
+    test("should not allow selecting hidden tab by pressing End", async () => {
+        test.slow();
+
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-tabs>
+                    <fast-tab>Tab one</fast-tab>
+                    <fast-tab>Tab two</fast-tab>
+                    <fast-tab hidden>Tab three</fast-tab>
+                    <fast-tab-panel>Tab panel one</fast-tab-panel>
+                    <fast-tab-panel>Tab panel two</fast-tab-panel>
+                    <fast-tab-panel>Tab panel three</fast-tab-panel>
+                </fast-tabs>
+            `;
+        });
+
+        const firstTab = tabs.nth(0);
+
+        const secondTab = tabs.nth(1);
+
+        const firstTabId = (await firstTab.getAttribute("id")) ?? "";
+
+        const secondTabId = (await secondTab.getAttribute("id")) ?? "";
+
+        await element.evaluate((node: FASTTabs, firstTabId) => {
+            node.activeid = firstTabId;
+        }, firstTabId);
+
+        await firstTab.press("End");
+
+        await expect(element).toHaveJSProperty("activeid", secondTabId);
     });
 });

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -130,8 +130,12 @@ export class FASTTabs extends FASTElement {
         return el.getAttribute("aria-disabled") === "true";
     };
 
+    private isHiddenElement = (el: Element): el is HTMLElement => {
+        return el.getAttribute("hidden") !== null;
+    };
+
     private isFocusableElement = (el: Element): el is HTMLElement => {
-        return !this.isDisabledElement(el);
+        return !this.isDisabledElement(el) && !this.isHiddenElement(el);
     };
 
     private getActiveIndex(): number {

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -131,7 +131,7 @@ export class FASTTabs extends FASTElement {
     };
 
     private isHiddenElement = (el: Element): el is HTMLElement => {
-        return el.getAttribute("hidden") !== null;
+        return el.hasAttribute("hidden");
     };
 
     private isFocusableElement = (el: Element): el is HTMLElement => {

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -276,7 +276,7 @@ export class FASTTabs extends FASTElement {
      * This method allows the active index to be adjusted by numerical increments
      */
     public adjust(adjustment: number): void {
-        const focusableTabs = this.tabs.filter(t => !this.isDisabledElement(t));
+        const focusableTabs = this.tabs.filter(t => this.isFocusableElement(t));
         const currentActiveTabIndex = focusableTabs.indexOf(this.activetab);
 
         const nextTabIndex = limit(


### PR DESCRIPTION
# Pull Request

## 📖 Description

There is a bug in the tabs component where you can use the keyboard (arrows, home/end) to navigate to a hidden tab. None of the tabs will appear as active, but the tab panel for the hidden tab will be displayed.

### 🎫 Issues

NA

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

There is a TODO in the tabs test file for creating tests for keyboard navigation. I have created just two tests to exercise the use cases I fixed.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

I would like this change cherry-picked into the `archives/fast-element-1` branch.