### PR TITLE
chore: lock lerna version for CI

### DIFF
--- a/.github/workflows/cd-deploy-www-production.yml
+++ b/.github/workflows/cd-deploy-www-production.yml
@@ -19,7 +19,7 @@ jobs:
       uses: actions/checkout@master
 
     - name: Install Lerna
-      run: yarn global add lerna
+      run: yarn global add lerna@5.5.2
 
     - name: Install package dependencies / prepare workspaces
       run: yarn install --frozen-lockfile

--- a/.github/workflows/cd-deploy-www-staging.yml
+++ b/.github/workflows/cd-deploy-www-staging.yml
@@ -41,7 +41,7 @@ jobs:
       uses: actions/checkout@master
 
     - name: Install Lerna
-      run: yarn global add lerna
+      run: yarn global add lerna@5.5.2
 
     - name: Install package dependencies / prepare workspaces
       run: yarn install --frozen-lockfile

--- a/.github/workflows/cd-release-npm.yml
+++ b/.github/workflows/cd-release-npm.yml
@@ -22,7 +22,7 @@ jobs:
         token: ${{ secrets.GH_TOKEN }}
 
     - name: Add or Update packages
-      run: sudo yarn global add lerna
+      run: sudo yarn global add lerna@5.5.2
 
     - name: Set Git User
       run: |

--- a/.github/workflows/testing/ci-daily-local.yml
+++ b/.github/workflows/testing/ci-daily-local.yml
@@ -17,7 +17,7 @@ jobs:
         sudo apt-get update
         sudo apt-get install yarn
         sudo yarn global upgrade typescript
-        sudo yarn global add lerna
+        sudo yarn global add lerna@5.5.2
 
     - name: Install package dependencies / prepare workspaces
       run: yarn install --frozen-lockfile

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -19,7 +19,7 @@ npm install -g yarn
 The second tool you'll need is Lerna, which can be installed with this command:
 
 ```bash
-yarn global add lerna
+yarn global add lerna@5.5.2
 ```
 
 :::important

--- a/sites/website/versioned_docs/version-legacy/community/contributor-guide.md
+++ b/sites/website/versioned_docs/version-legacy/community/contributor-guide.md
@@ -27,7 +27,7 @@ npm install -g yarn
 The second tool you'll need is Lerna, which can be installed with this command:
 
 ```bash
-yarn global add lerna
+yarn global add lerna@5.5.2
 ```
 
 :::important


### PR DESCRIPTION
# Pull Request

## 📖 Description
A lerna update seemed to recently cause an issue when running the publish CI for the archive branch. This led to realizing that the most recent versions of lerna have been being installed on CI. This locks the version to a known, working version to prevent breaks.