### PR TITLE
feat: update exports from fast-element to be explicit

### DIFF
--- a/change/@microsoft-fast-element-2af3bb19-b65c-49a5-82f8-06ebb38e48cd.json
+++ b/change/@microsoft-fast-element-2af3bb19-b65c-49a5-82f8-06ebb38e48cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "update fast-element exports to be explicit",
+  "packageName": "@microsoft/fast-element",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -11,46 +11,140 @@ export type {
 export { FAST, emptyArray } from "./platform.js";
 
 // DOM
-export * from "./dom.js";
+export { DOMAspect, DOMSink, DOMPolicy, DOM } from "./dom.js";
 
 // Observation
-export * from "./observation/observable.js";
-export * from "./observation/notifier.js";
-export * from "./observation/arrays.js";
-export * from "./observation/update-queue.js";
+export {
+    Accessor,
+    Expression,
+    ExecutionContext,
+    ExpressionController,
+    ExpressionObserver,
+    ExpressionNotifier,
+    Observable,
+    observable,
+    ObservationRecord,
+    SourceLifetime,
+    volatile,
+} from "./observation/observable.js";
+export {
+    Notifier,
+    PropertyChangeNotifier,
+    Subscriber,
+    SubscriberSet,
+} from "./observation/notifier.js";
+export {
+    ArrayObserver,
+    LengthObserver,
+    lengthOf,
+    Splice,
+    SpliceStrategy,
+    SpliceStrategySupport,
+} from "./observation/arrays.js";
+export { UpdateQueue } from "./observation/update-queue.js";
 
 // Binding
-export * from "./binding/binding.js";
-export * from "./binding/one-way.js";
-export * from "./binding/one-time.js";
-export * from "./binding/normalize.js";
+export { Binding, BindingDirective } from "./binding/binding.js";
+export { listener, oneWay } from "./binding/one-way.js";
+export { oneTime } from "./binding/one-time.js";
+export { normalizeBinding } from "./binding/normalize.js";
 
 // Styles
-export * from "./styles/element-styles.js";
-export * from "./styles/css.js";
-export * from "./styles/css-directive.js";
-export * from "./styles/host.js";
-export * from "./styles/style-strategy.js";
-export * from "./styles/css-binding-directive.js";
+export {
+    ComposableStyles,
+    ConstructibleStyleStrategy,
+    ElementStyles,
+} from "./styles/element-styles.js";
+export { css, CSSTemplateTag, CSSValue } from "./styles/css.js";
+export {
+    AddBehavior,
+    cssDirective,
+    CSSDirective,
+    CSSDirectiveDefinition,
+} from "./styles/css-directive.js";
+export { HostController, HostBehavior } from "./styles/host.js";
+export { StyleStrategy, StyleTarget } from "./styles/style-strategy.js";
+export { CSSBindingDirective } from "./styles/css-binding-directive.js";
 
 // Templating
-export * from "./templating/template.js";
-export * from "./templating/compiler.js";
+export {
+    CaptureType,
+    ElementViewTemplate,
+    html,
+    HTMLTemplateCompilationResult,
+    HTMLTemplateTag,
+    InlineTemplateDirective,
+    SyntheticViewTemplate,
+    TemplateValue,
+    ViewTemplate,
+} from "./templating/template.js";
+export { CompilationStrategy, Compiler } from "./templating/compiler.js";
 export { Markup, Parser } from "./templating/markup.js";
-export * from "./templating/html-binding-directive.js";
-export * from "./templating/html-directive.js";
-export * from "./templating/ref.js";
-export * from "./templating/when.js";
-export * from "./templating/repeat.js";
-export * from "./templating/slotted.js";
-export * from "./templating/children.js";
-export * from "./templating/view.js";
-export * from "./templating/node-observation.js";
+export {
+    ContentTemplate,
+    ContentView,
+    HTMLBindingDirective,
+} from "./templating/html-binding-directive.js";
+export {
+    AddViewBehaviorFactory,
+    Aspected,
+    CompiledViewBehaviorFactory,
+    htmlDirective,
+    HTMLDirective,
+    HTMLDirectiveDefinition,
+    PartialHTMLDirectiveDefinition,
+    StatelessAttachedAttributeDirective,
+    ViewBehavior,
+    ViewBehaviorFactory,
+    ViewBehaviorTargets,
+    ViewController,
+} from "./templating/html-directive.js";
+export { ref, RefDirective } from "./templating/ref.js";
+export { when } from "./templating/when.js";
+export {
+    repeat,
+    RepeatBehavior,
+    RepeatDirective,
+    RepeatOptions,
+} from "./templating/repeat.js";
+export {
+    slotted,
+    SlottedDirective,
+    SlottedDirectiveOptions,
+} from "./templating/slotted.js";
+export {
+    children,
+    ChildrenDirective,
+    ChildrenDirectiveOptions,
+    ChildListDirectiveOptions,
+    SubtreeDirectiveOptions,
+} from "./templating/children.js";
+export { ElementView, HTMLView, SyntheticView, View } from "./templating/view.js";
+export {
+    elements,
+    ElementsFilter,
+    NodeBehaviorOptions,
+    NodeObservationDirective,
+} from "./templating/node-observation.js";
 
 // Components
-export * from "./components/fast-element.js";
-export * from "./components/fast-definitions.js";
-export * from "./components/attributes.js";
+export { customElement, FASTElement } from "./components/fast-element.js";
+export {
+    FASTElementDefinition,
+    PartialFASTElementDefinition,
+    ShadowRootOptions,
+} from "./components/fast-definitions.js";
+export {
+    attr,
+    AttributeConfiguration,
+    AttributeDefinition,
+    AttributeMode,
+    booleanConverter,
+    DecoratorAttributeConfiguration,
+    nullableBooleanConverter,
+    nullableNumberConverter,
+    ValueConverter,
+} from "./components/attributes.js";
 export {
     ElementController,
     ElementControllerStrategy,

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -41,7 +41,7 @@ export {
     SpliceStrategy,
     SpliceStrategySupport,
 } from "./observation/arrays.js";
-export { UpdateQueue } from "./observation/update-queue.js";
+export { UpdateQueue, Updates } from "./observation/update-queue.js";
 
 // Binding
 export { Binding, BindingDirective } from "./binding/binding.js";


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR updates exports from fast-element to be explicitly defined. Certain tooling doesn't support name-spaced exports. This PR attempts to provide explicit exports for fast-element to better support a broad range of tooling.

### 🎫 Issues
N/AA

## 👩‍💻 Reviewer Notes
IF the API report doesn't show a change and the build passes, we should be good!