### PR TITLE
fix: change public static methods for listbox and data grid to not be fat arrow fns

### DIFF
--- a/change/@microsoft-fast-foundation-cb62e613-5e97-4272-8609-bba0f2f41056.json
+++ b/change/@microsoft-fast-foundation-cb62e613-5e97-4272-8609-bba0f2f41056.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: change public static methods for listbox and data grid to not be fat arrow fns",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1005,7 +1005,7 @@ export class FASTDataGrid extends FASTElement {
     disconnectedCallback(): void;
     focusColumnIndex: number;
     focusRowIndex: number;
-    static generateColumns: (row: object) => ColumnDefinition[];
+    static generateColumns(row: object): ColumnDefinition[];
     generateHeader: GenerateHeaderOptions;
     gridTemplateColumns: string;
     // (undocumented)
@@ -1257,7 +1257,7 @@ export abstract class FASTListbox extends FASTElement {
     protected setSelectedOptions(): void;
     // @internal
     protected shouldSkipFocus: boolean;
-    static slottedOptionFilter: (n: HTMLElement) => boolean;
+    static slottedOptionFilter(n: HTMLElement): boolean;
     // @internal
     slottedOptions: Element[];
     // @internal

--- a/packages/web-components/fast-foundation/src/combobox/README.md
+++ b/packages/web-components/fast-foundation/src/combobox/README.md
@@ -102,12 +102,6 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | ---------------- | --------------------------------------- | ------- |
 | `FormAssociated` | /src/form-associated/form-associated.js |         |
 
-#### Static Fields
-
-| Name                  | Privacy | Type | Default | Description                                         | Inherited From |
-| --------------------- | ------- | ---- | ------- | --------------------------------------------------- | -------------- |
-| `slottedOptionFilter` | public  |      |         | A static filter to include only selectable options. | FASTListbox    |
-
 #### Fields
 
 | Name               | Privacy   | Type                  | Default | Description                           | Inherited From |
@@ -154,12 +148,6 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | Name                     | Module                                    | Package |
 | ------------------------ | ----------------------------------------- | ------- |
 | `FormAssociatedCombobox` | /src/combobox/combobox.form-associated.js |         |
-
-#### Static Fields
-
-| Name                  | Privacy | Type | Default | Description                                         | Inherited From |
-| --------------------- | ------- | ---- | ------- | --------------------------------------------------- | -------------- |
-| `slottedOptionFilter` | public  |      |         | A static filter to include only selectable options. | FASTListbox    |
 
 #### Fields
 

--- a/packages/web-components/fast-foundation/src/data-grid/README.md
+++ b/packages/web-components/fast-foundation/src/data-grid/README.md
@@ -230,12 +230,6 @@ export const myDataGrid = DataGrid.compose({
 | ------------- | ------ | ----------------------- |
 | `FASTElement` |        | @microsoft/fast-element |
 
-#### Static Fields
-
-| Name              | Privacy | Type | Default | Description                                                      | Inherited From |
-| ----------------- | ------- | ---- | ------- | ---------------------------------------------------------------- | -------------- |
-| `generateColumns` | public  |      |         | generates a basic column definition by examining sample row data |                |
-
 #### Fields
 
 | Name                     | Privacy | Type                                                | Default | Description                                                                                                                                                                                                                                                                                     | Inherited From |

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -116,14 +116,14 @@ export class FASTDataGrid extends FASTElement {
     /**
      *  generates a basic column definition by examining sample row data
      */
-    public static generateColumns = (row: object): ColumnDefinition[] => {
+    public static generateColumns(row: object): ColumnDefinition[] {
         return Object.getOwnPropertyNames(row).map((property: string, index: number) => {
             return {
                 columnDataKey: property,
                 gridColumn: `${index}`,
             };
         });
-    };
+    }
 
     /**
      *  generates a gridTemplateColumns based on columndefinitions

--- a/packages/web-components/fast-foundation/src/listbox/README.md
+++ b/packages/web-components/fast-foundation/src/listbox/README.md
@@ -68,12 +68,6 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | ------------- | ----------------------- | ------- |
 | `FASTListbox` | /src/listbox/listbox.js |         |
 
-#### Static Fields
-
-| Name                  | Privacy | Type | Default | Description                                         | Inherited From |
-| --------------------- | ------- | ---- | ------- | --------------------------------------------------- | -------------- |
-| `slottedOptionFilter` | public  |      |         | A static filter to include only selectable options. | FASTListbox    |
-
 #### Fields
 
 | Name               | Privacy   | Type                  | Default | Description                                          | Inherited From |
@@ -112,12 +106,6 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | Name          | Module | Package                 |
 | ------------- | ------ | ----------------------- |
 | `FASTElement` |        | @microsoft/fast-element |
-
-#### Static Fields
-
-| Name                  | Privacy | Type | Default | Description                                         | Inherited From |
-| --------------------- | ------- | ---- | ------- | --------------------------------------------------- | -------------- |
-| `slottedOptionFilter` | public  |      |         | A static filter to include only selectable options. |                |
 
 #### Fields
 

--- a/packages/web-components/fast-foundation/src/listbox/listbox.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.ts
@@ -127,8 +127,9 @@ export abstract class FASTListbox extends FASTElement {
      * @param n - element to filter
      * @public
      */
-    public static slottedOptionFilter = (n: HTMLElement) =>
-        isListboxOption(n) && !n.hidden;
+    public static slottedOptionFilter(n: HTMLElement) {
+        return isListboxOption(n) && !n.hidden;
+    }
 
     /**
      * The default slotted elements.

--- a/packages/web-components/fast-foundation/src/select/README.md
+++ b/packages/web-components/fast-foundation/src/select/README.md
@@ -92,12 +92,6 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | ---------------- | --------------------------------------- | ------- |
 | `FormAssociated` | /src/form-associated/form-associated.js |         |
 
-#### Static Fields
-
-| Name                  | Privacy | Type | Default | Description                                         | Inherited From |
-| --------------------- | ------- | ---- | ------- | --------------------------------------------------- | -------------- |
-| `slottedOptionFilter` | public  |      |         | A static filter to include only selectable options. | FASTListbox    |
-
 #### Fields
 
 | Name               | Privacy   | Type                  | Default | Description                                          | Inherited From     |
@@ -136,12 +130,6 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | Name                   | Module                                | Package |
 | ---------------------- | ------------------------------------- | ------- |
 | `FormAssociatedSelect` | /src/select/select.form-associated.js |         |
-
-#### Static Fields
-
-| Name                  | Privacy | Type | Default | Description                                         | Inherited From |
-| --------------------- | ------- | ---- | ------- | --------------------------------------------------- | -------------- |
-| `slottedOptionFilter` | public  |      |         | A static filter to include only selectable options. | FASTListbox    |
 
 #### Fields
 


### PR DESCRIPTION
# Pull Request

## 📖 Description
This PR changes static methods which are fat arrow functions to normal methods.

### 🎫 Issues
Part of #6809