### PR TITLE
feat: picker max suggestions

### DIFF
--- a/change/@microsoft-fast-foundation-04514237-d175-458a-8652-09ba3441e7a2.json
+++ b/change/@microsoft-fast-foundation-04514237-d175-458a-8652-09ba3441e7a2.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "picker max suggestions",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1551,6 +1551,7 @@ export class FASTPicker extends FormAssociatedPicker {
     protected listItemTemplateChanged(): void;
     loadingText: string;
     maxSelected: number | null;
+    maxSuggestions: number | undefined;
     // @internal
     menuConfig: AnchoredRegionConfig;
     // @internal
@@ -1594,6 +1595,7 @@ export class FASTPicker extends FormAssociatedPicker {
     // @internal
     showNoOptions: boolean;
     suggestionsAvailableText: string;
+    trimCount: number;
 }
 
 // @beta

--- a/packages/web-components/fast-foundation/src/picker/README.md
+++ b/packages/web-components/fast-foundation/src/picker/README.md
@@ -202,10 +202,12 @@ export class FASTTextField extends TextField {}
 | `label`                      | public  | `string`                    |                              | Applied to the aria-label attribute of the input element                                                                      |                      |
 | `labelledBy`                 | public  | `string`                    |                              | Applied to the aria-labelledby attribute of the input element                                                                 |                      |
 | `placeholder`                | public  | `string`                    |                              | Applied to the placeholder attribute of the input element                                                                     |                      |
+| `maxSuggestions`             | public  | `number or undefined`       |                              | Limits how many suggestions can be displayed                                                                                  |                      |
 | `menuPlacement`              | public  | `MenuPlacement`             |                              | Controls menu placement                                                                                                       |                      |
 | `showLoading`                | public  | `boolean`                   | `false`                      | Whether to display a loading state if the menu is opened.                                                                     |                      |
 | `listItemTemplate`           | public  | `ViewTemplate`              |                              | Template used to generate selected items. This is used in a repeat directive.                                                 |                      |
 | `defaultListItemTemplate`    | public  | `ViewTemplate or undefined` |                              | Default template to use for selected items (usually specified in the component template). This is used in a repeat directive. |                      |
+| `trimCount`                  | public  | `number`                    | `0`                          | How many suggestions are being trimmed off by max-suggestions                                                                 |                      |
 | `menuOptionTemplate`         | public  | `ViewTemplate`              |                              | Template to use for available options. This is used in a repeat directive.                                                    |                      |
 | `defaultMenuOptionTemplate`  | public  | `ViewTemplate or undefined` |                              | Default template to use for available options (usually specified in the template). This is used in a repeat directive.        |                      |
 | `listItemContentsTemplate`   | public  | `ViewTemplate`              |                              | Template to use for the contents of a selected list item                                                                      |                      |
@@ -254,6 +256,7 @@ export class FASTTextField extends TextField {}
 | `label`                      | label                    |                |
 | `labelledby`                 | labelledBy               |                |
 | `placeholder`                | placeholder              |                |
+| `max-suggestions`            | maxSuggestions           |                |
 | `menu-placement`             | menuPlacement            |                |
 
 <hr/>

--- a/packages/web-components/fast-foundation/src/picker/picker.template.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.template.ts
@@ -125,6 +125,19 @@ export function pickerTemplate<T extends FASTPicker>(
                             </div>
                         `
                     )}
+                    ${when(
+                        x => x.trimCount > 0,
+                        html<T>`
+                            <div
+                                class="trimmed-suggestions-display"
+                                part="trimmed-suggestions-display"
+                            >
+                                <slot name="trimmed-suggestions-region">
+                                    ${x => x.trimmedSuggestionsText}
+                                </slot>
+                            </div>
+                        `
+                    )}
                 </${anchoredRegionTag}>
             `
             )}

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -459,6 +459,13 @@ export class FASTPicker extends FormAssociatedPicker {
      */
     @observable
     public selectedItems: string[] = [];
+    private selectedItemsChanged(): void {
+        if (this.$fastController.isConnected) {
+            if (this.maxSelected && this.selectedItems.length > this.maxSelected) {
+                this.selectedItems.splice(this.maxSelected, this.selectedItems.length);
+            }
+        }
+    }
 
     private optionsPlaceholder: Node;
     private inputElementView: HTMLView | null = null;

--- a/packages/web-components/fast-foundation/src/picker/stories/picker.register.ts
+++ b/packages/web-components/fast-foundation/src/picker/stories/picker.register.ts
@@ -28,10 +28,11 @@ const pickerStyles = css`
         opacity: 1;
         pointer-events: none;
     }
+    .trimmed-suggestions-display,
     .loading-display,
     .no-options-display {
         background: var(--neutral-layer-floating);
-        width: 100%;
+        width: 100% - calc((10 + (var(--design-unit) * 2 * var(--density))) * 1px);
         min-height: calc(
             (var(--base-height-multiplier) + var(--density)) * var(--design-unit) * 1px
         );

--- a/packages/web-components/fast-foundation/src/picker/stories/picker.stories.ts
+++ b/packages/web-components/fast-foundation/src/picker/stories/picker.stories.ts
@@ -11,6 +11,7 @@ const storyTemplate = html<StoryArgs<FASTPicker>>`
         ?filter-selected="${x => x.filterSelected}"
         ?filter-query="${x => x.filterQuery}"
         max-selected="${x => x.maxSelected}"
+        max-suggestions="${x => x.maxSuggestions}"
         no-suggestions-text="${x => x.noSuggestionsText}"
         suggestions-available-text="${x => x.suggestionsAvailableText}"
         loading-text="${x => x.loadingText}"
@@ -35,6 +36,7 @@ export default {
         labelledBy: { control: "text" },
         loadingText: { control: "text" },
         maxSelected: { control: "number" },
+        maxSuggestions: { control: "number" },
         menuPlacement: { control: "select", options: Object.values(MenuPlacement) },
         noSuggestionsText: { control: "text" },
         placeholder: { control: "text" },
@@ -51,4 +53,18 @@ Picker.args = {
     placeholder: "Choose fruit",
     selection: "apple",
     suggestionsAvailableText: "Found some fruit",
+};
+
+export const PickerLimitSuggestions: Story<FASTPicker> = renderComponent(
+    storyTemplate
+).bind({});
+PickerLimitSuggestions.args = {
+    label: "Fruit picker",
+    loadingText: "Loading",
+    noSuggestionsText: "No such fruit",
+    options: "apple, orange, banana, mango, strawberry, raspberry, blueberry",
+    placeholder: "Choose fruit",
+    selection: "apple",
+    suggestionsAvailableText: "Found some fruit",
+    maxSuggestions: 3,
 };


### PR DESCRIPTION
## 📖 Description
While building a picker based ui with larger collections of suggestions I found that I needed to truncate the number of suggestions rendered in the UI "as you type".  Makes sense for picker to enables this internally. This change adds a "max-suggestions" attribute to picker as well as showing a "type for more" message when large suggestion sets are truncated.

![image](https://github.com/microsoft/fast/assets/7649425/6388f15f-36a7-405d-b696-e8b68bcc5831)

Also fixed an issue where max selection could be exceeded programmatically.


### 🎫 Issues
ad hoc

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)