### PR TITLE
fix: refactor handleEvent method on ChildrenDirective

### DIFF
--- a/change/@microsoft-fast-element-39704f2b-aa47-4125-9e15-2b4bb2083b1f.json
+++ b/change/@microsoft-fast-element-39704f2b-aa47-4125-9e15-2b4bb2083b1f.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "fix: refactor handleEvent method on ChildrenDirective",
+  "packageName": "@microsoft/fast-element",
+  "email": "marco.zambrano@thomsonreuters.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/src/templating/children.ts
+++ b/packages/web-components/fast-element/src/templating/children.ts
@@ -62,7 +62,13 @@ export class ChildrenDirective extends NodeObservationDirective<ChildrenDirectiv
         let observer = target[this.observerProperty];
 
         if (!observer) {
-            observer = new MutationObserver(this.handleEvent);
+            observer = new MutationObserver(
+                () =>
+                    void this.updateTarget(
+                        this.getSource(target),
+                        this.computeNodes(target)
+                    )
+            );
             observer.toJSON = noop;
             target[this.observerProperty] = observer;
         }
@@ -92,11 +98,6 @@ export class ChildrenDirective extends NodeObservationDirective<ChildrenDirectiv
 
         return Array.from(target.childNodes);
     }
-
-    private handleEvent = (mutations: MutationRecord[], observer: any): void => {
-        const target = observer.target;
-        this.updateTarget(this.getSource(target), this.computeNodes(target));
-    };
 }
 
 HTMLDirective.define(ChildrenDirective);


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

This is a refactor, not a change in behavior. The intention is to maintain the same functionality while preventing a runtime error that occurs when working with **Angular** and **Zone.js**.

You can reproduce the error here: https://stackblitz.com/edit/angular-fast-marco-nctc7f?file=src%2Fapp%2Fapp.component.html

On the file: `src/polyfills.ts` you can toggle between the bugged **tree-item** component and the right one.

Also please feel free to tell me if this is doable, and that's because I don't have a lot of context for this **ChildrenDirective** class like you. Right now this fixes our **Angular** and **Zone.js** problems but we don't want to mess with the current behavior.

Thank you.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->
- https://github.com/microsoft/fast/issues/6740

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->