### PR TITLE
feat: (proposed) add support for date type inputs to text field

### DIFF
--- a/change/@microsoft-fast-foundation-ca3f2e42-edc3-4b8a-a90c-fed25810c053.json
+++ b/change/@microsoft-fast-foundation-ca3f2e42-edc3-4b8a-a90c-fed25810c053.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add date type",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2049,9 +2049,15 @@ export class FASTTextField extends FormAssociatedTextField {
     list: string;
     // (undocumented)
     protected listChanged(): void;
+    max: string;
+    // (undocumented)
+    maxChanged(): void;
     maxlength: number;
     // (undocumented)
     protected maxlengthChanged(): void;
+    min: string;
+    // (undocumented)
+    minChanged(): void;
     minlength: number;
     // (undocumented)
     protected minlengthChanged(): void;
@@ -2774,6 +2780,7 @@ export const TextFieldType: {
     readonly tel: "tel";
     readonly text: "text";
     readonly url: "url";
+    readonly date: "date";
 };
 
 // @public

--- a/packages/web-components/fast-foundation/src/text-field/README.md
+++ b/packages/web-components/fast-foundation/src/text-field/README.md
@@ -86,9 +86,9 @@ This component is built with the expectation that focus is delegated to the inpu
 
 ### Variables
 
-| Name            | Description          | Type                                                                              |
-| --------------- | -------------------- | --------------------------------------------------------------------------------- |
-| `TextFieldType` | Text field sub-types | `{ email: "email", password: "password", tel: "tel", text: "text", url: "url", }` |
+| Name            | Description          | Type                                                                                            |
+| --------------- | -------------------- | ----------------------------------------------------------------------------------------------- |
+| `TextFieldType` | Text field sub-types | `{ email: "email", password: "password", tel: "tel", text: "text", url: "url", date: "date", }` |
 
 <hr/>
 
@@ -111,6 +111,8 @@ This component is built with the expectation that focus is delegated to the inpu
 | `placeholder` | public  | `string`        |         | Sets the placeholder value of the element, generally used to provide a hint to the user.                                                                                                                                    |                         |
 | `type`        | public  | `TextFieldType` |         | Allows setting a type or mode of text.                                                                                                                                                                                      |                         |
 | `list`        | public  | `string`        |         | Allows associating a [datalist](https://developer.mozilla.org/en-US/docs/Web/HTML/Element/datalist) to the element by https://developer.mozilla.org/en-US/docs/Web/API/Element/id.                                      |                         |
+| `max`         | public  | `string`        |         | The maximum the value can be (applies to date)                                                                                                                                                                              |                         |
+| `min`         | public  | `string`        |         | The minimum the value can be (applies to date)                                                                                                                                                                              |                         |
 | `maxlength`   | public  | `number`        |         | The maximum number of characters a user can enter.                                                                                                                                                                          |                         |
 | `minlength`   | public  | `number`        |         | The minimum number of characters a user can enter.                                                                                                                                                                          |                         |
 | `pattern`     | public  | `string`        |         | A regular expression that the value must match to pass validation.                                                                                                                                                          |                         |
@@ -126,6 +128,8 @@ This component is built with the expectation that focus is delegated to the inpu
 | `autofocusChanged`   | protected |                                                   |            | `void` |                |
 | `placeholderChanged` | protected |                                                   |            | `void` |                |
 | `listChanged`        | protected |                                                   |            | `void` |                |
+| `maxChanged`         | public    |                                                   |            | `void` |                |
+| `minChanged`         | public    |                                                   |            | `void` |                |
 | `maxlengthChanged`   | protected |                                                   |            | `void` |                |
 | `minlengthChanged`   | protected |                                                   |            | `void` |                |
 | `patternChanged`     | protected |                                                   |            | `void` |                |
@@ -149,6 +153,8 @@ This component is built with the expectation that focus is delegated to the inpu
 | `placeholder` | placeholder |                |
 | `type`        | type        |                |
 | `list`        | list        |                |
+|               | max         |                |
+| `min`         | min         |                |
 |               | maxlength   |                |
 |               | minlength   |                |
 | `pattern`     | pattern     |                |

--- a/packages/web-components/fast-foundation/src/text-field/stories/text-field.register.ts
+++ b/packages/web-components/fast-foundation/src/text-field/stories/text-field.register.ts
@@ -44,6 +44,10 @@ const styles = css`
         line-height: var(--type-ramp-base-line-height);
     }
 
+    input[type="date"]::-webkit-calendar-picker-indicator {
+        filter: invert(0.5);
+    }
+
     .control:hover,
     .control:focus-visible,
     .control:disabled,

--- a/packages/web-components/fast-foundation/src/text-field/stories/text-field.register.ts
+++ b/packages/web-components/fast-foundation/src/text-field/stories/text-field.register.ts
@@ -44,7 +44,9 @@ const styles = css`
         line-height: var(--type-ramp-base-line-height);
     }
 
-    input[type="date"]::-webkit-calendar-picker-indicator {
+    input[type="date"]::-webkit-calendar-picker-indicator,
+    input[type="week"]::-webkit-calendar-picker-indicator,
+    input[type="month"]::-webkit-calendar-picker-indicator {
         filter: invert(0.5);
     }
 

--- a/packages/web-components/fast-foundation/src/text-field/stories/text-field.stories.ts
+++ b/packages/web-components/fast-foundation/src/text-field/stories/text-field.stories.ts
@@ -11,6 +11,10 @@ const storyTemplate = html<StoryArgs<FASTTextField>>`
         ?required="${x => x.required}"
         ?spellcheck="${x => x.spellcheck}"
         list="${x => x.list}"
+        max="${x => x.max}"
+        ,
+        min="${x => x.min}"
+        ,
         maxlength="${x => x.maxlength}"
         minlength="${x => x.minlength}"
         name="${x => x.name}"
@@ -59,6 +63,8 @@ export default {
         autofocus: { control: "boolean" },
         disabled: { control: "boolean" },
         list: { control: "text" },
+        max: { control: "text" },
+        min: { control: "text" },
         maxlength: { control: "number" },
         minlength: { control: "number" },
         name: { control: "text" },

--- a/packages/web-components/fast-foundation/src/text-field/text-field.options.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.options.ts
@@ -29,6 +29,11 @@ export const TextFieldType = {
      * A URL TextField
      */
     url: "url",
+
+    /**
+     * A date TextField
+     */
+    date: "date",
 } as const;
 
 /**

--- a/packages/web-components/fast-foundation/src/text-field/text-field.options.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.options.ts
@@ -34,6 +34,16 @@ export const TextFieldType = {
      * A date TextField
      */
     date: "date",
+
+    /**
+     * A month TextField
+     */
+    month: "month",
+
+    /**
+     * A week TextField
+     */
+    week: "week",
 } as const;
 
 /**

--- a/packages/web-components/fast-foundation/src/text-field/text-field.spec.md
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.spec.md
@@ -13,6 +13,8 @@ Used anywhere an author might otherwise use:
 - input[type="tel"]
 - input[type="url"]
 - input[type="date"]
+- input[type="week"]
+- input[type="month"]
 
 ### Features
 

--- a/packages/web-components/fast-foundation/src/text-field/text-field.spec.md
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.spec.md
@@ -12,6 +12,7 @@ Used anywhere an author might otherwise use:
 - input[type="password"]
 - input[type="tel"]
 - input[type="url"]
+- input[type="date"]
 
 ### Features
 

--- a/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.template.ts
@@ -40,6 +40,8 @@ export function textFieldTemplate<T extends FASTTextField>(
                 maxlength="${x => x.maxlength}"
                 name="${x => x.name}"
                 minlength="${x => x.minlength}"
+                min="${x => x.min}"
+                max="${x => x.max}"
                 pattern="${x => x.pattern}"
                 placeholder="${x => x.placeholder}"
                 ?readonly="${x => x.readOnly}"

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -116,7 +116,7 @@ export class FASTTextField extends FormAssociatedTextField {
      */
     @attr
     public max: string;
-    public maxChanged(): void {
+    protected maxChanged(): void {
         if (this.proxy instanceof HTMLInputElement) {
             this.proxy.max = this.max;
             this.validate();
@@ -131,7 +131,7 @@ export class FASTTextField extends FormAssociatedTextField {
      */
     @attr
     public min: string;
-    public minChanged(): void {
+    protected minChanged(): void {
         if (this.proxy instanceof HTMLInputElement) {
             this.proxy.min = this.min;
             this.validate();

--- a/packages/web-components/fast-foundation/src/text-field/text-field.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.ts
@@ -109,6 +109,36 @@ export class FASTTextField extends FormAssociatedTextField {
     }
 
     /**
+     * The maximum the value can be (applies to date as yyyy-mm-dd)
+     * @public
+     * @remarks
+     * HTMLAttribute: max
+     */
+    @attr
+    public max: string;
+    public maxChanged(): void {
+        if (this.proxy instanceof HTMLInputElement) {
+            this.proxy.max = this.max;
+            this.validate();
+        }
+    }
+
+    /**
+     * The minimum the value can be (applies to date as yyyy-mm-dd)
+     * @public
+     * @remarks
+     * HTMLAttribute: min
+     */
+    @attr
+    public min: string;
+    public minChanged(): void {
+        if (this.proxy instanceof HTMLInputElement) {
+            this.proxy.min = this.min;
+            this.validate();
+        }
+    }
+
+    /**
      * The maximum number of characters a user can enter.
      * @public
      * @remarks


### PR DESCRIPTION
## 📖 Description

This PR proposes to add support for `type=date` inputs to the FAST text-field component as well as support for min/max dates.

Authors who use this should expect to get the native date input UI at runtime.  

It should be noted that the native control doesn't offer much control over styling the calendar icon:

![image](https://github.com/microsoft/fast/assets/7649425/33ba9694-4a7a-48cd-8a51-7038cf4d7792)

`
    input[type="date"]::-webkit-calendar-picker-indicator {
        filter: invert(0.5);
    }
`

### 🎫 Issues
This has been discussed in discord forums.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
