### PR TITLE
Fix bug in toolbar click handler when a slotted element has child elements

### DIFF
--- a/change/@microsoft-fast-foundation-2ada25c3-3fb4-48ba-893d-e64d11f7f095.json
+++ b/change/@microsoft-fast-foundation-2ada25c3-3fb4-48ba-893d-e64d11f7f095.json
@@ -3,5 +3,5 @@
   "comment": "Fix bug in toolbar click handler when a slotted element has child elements",
   "packageName": "@microsoft/fast-foundation",
   "email": "20542556+mollykreis@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-2ada25c3-3fb4-48ba-893d-e64d11f7f095.json
+++ b/change/@microsoft-fast-foundation-2ada25c3-3fb4-48ba-893d-e64d11f7f095.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix bug with nested elements in toolbar click handler",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "20542556+mollykreis@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-2ada25c3-3fb4-48ba-893d-e64d11f7f095.json
+++ b/change/@microsoft-fast-foundation-2ada25c3-3fb4-48ba-893d-e64d11f7f095.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Fix bug with nested elements in toolbar click handler",
+  "comment": "Fix bug in toolbar click handler when a slotted element has child elements",
   "packageName": "@microsoft/fast-foundation",
   "email": "20542556+mollykreis@users.noreply.github.com",
   "dependentChangeType": "patch"

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.pw.spec.ts
@@ -388,7 +388,10 @@ test.describe("Toolbar", () => {
                 <fast-toolbar>
                     <button slot="start">Start Slot Button</button>
                     <button>Button 1</button>
-                    <button>Button 2 <div>more button content</div></button>
+                    <button>
+                        Button 2
+                        <div>more button content</div>
+                    </button>
                     <button>Button 3</button>
                     <button slot="end">End Slot Button</button>
                 </fast-toolbar>
@@ -397,7 +400,7 @@ test.describe("Toolbar", () => {
 
         const button2 = element.locator("button", { hasText: "Button 2" });
 
-        const button2InnerContent = button2.locator("div", { hasText: "more button content" });
+        const button2InnerContent = button2.locator("div");
 
         const startSlotButton = element.locator("button", {
             hasText: "Start Slot Button",

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.pw.spec.ts
@@ -349,4 +349,70 @@ test.describe("Toolbar", () => {
 
         await expect(element).toHaveJSProperty("activeIndex", 0);
     });
+
+    test("should update activeIndex when an element within the toolbar is clicked", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-toolbar>
+                    <button slot="start">Start Slot Button</button>
+                    <button>Button 1</button>
+                    <button>Button 2</button>
+                    <button>Button 3</button>
+                    <button slot="end">End Slot Button</button>
+                </fast-toolbar>
+            `;
+        });
+
+        const button2 = element.locator("button", { hasText: "Button 2" });
+
+        const startSlotButton = element.locator("button", {
+            hasText: "Start Slot Button",
+        });
+
+        await element.focus();
+
+        await expect(startSlotButton).toBeFocused();
+
+        await expect(element).toHaveJSProperty("activeIndex", 0);
+
+        await button2.click();
+
+        await expect(button2).toBeFocused();
+
+        await expect(element).toHaveJSProperty("activeIndex", 2);
+    });
+
+    test("should update activeIndex when a nested element within the toolbar is clicked", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-toolbar>
+                    <button slot="start">Start Slot Button</button>
+                    <button>Button 1</button>
+                    <button>Button 2 <div>more button content</div></button>
+                    <button>Button 3</button>
+                    <button slot="end">End Slot Button</button>
+                </fast-toolbar>
+            `;
+        });
+
+        const button2 = element.locator("button", { hasText: "Button 2" });
+
+        const button2InnerContent = button2.locator("div", { hasText: "more button content" });
+
+        const startSlotButton = element.locator("button", {
+            hasText: "Start Slot Button",
+        });
+
+        await element.focus();
+
+        await expect(startSlotButton).toBeFocused();
+
+        await expect(element).toHaveJSProperty("activeIndex", 0);
+
+        await button2InnerContent.click();
+
+        await expect(button2).toBeFocused();
+
+        await expect(element).toHaveJSProperty("activeIndex", 2);
+    });
 });

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
@@ -122,7 +122,7 @@ export class FASTToolbar extends FASTElement {
      * @internal
      */
     public clickHandler(e: MouseEvent): boolean | void {
-        const activeIndex = this.focusableElements?.indexOf(e.target as HTMLElement);
+        const activeIndex = this.focusableElements?.findIndex(x => x.contains(e.target as HTMLElement));
         if (activeIndex > -1 && this.activeIndex !== activeIndex) {
             this.setFocusedElement(activeIndex);
         }

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
@@ -122,7 +122,9 @@ export class FASTToolbar extends FASTElement {
      * @internal
      */
     public clickHandler(e: MouseEvent): boolean | void {
-        const activeIndex = this.focusableElements?.findIndex(x => x.contains(e.target as HTMLElement));
+        const activeIndex = this.focusableElements?.findIndex(x =>
+            x.contains(e.target as HTMLElement)
+        );
         if (activeIndex > -1 && this.activeIndex !== activeIndex) {
             this.setFocusedElement(activeIndex);
         }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Resolves #6819 

When an element in the toolbar is clicked, the toolbar's `activeIndex` should update to be the index of that clicked item. However, there is a bug where this does not happen if a child element within the slotted element is clicked. This PR is intended to resolve that bug.

### 🎫 Issues

#6819 

## 👩‍💻 Reviewer Notes

I've updated the `clickHandler` for the toolbar to search `focusableElements` for an entry that _contains_ the clicked element rather than an entry that _is_ the clicked element. No other logic has changed.

## 📑 Test Plan

I've added two additional tests for the toolbar:
1. Ensure that the toolbar's `activeIndex` updates when an element slotted into the toolbar is clicked (passed with & without this change)
2. Ensure that the toolbar's `activeIndex` updates when a nested element within an element slotted into the toolbar is clicked (failed without this change & passes with this change)

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

N/A