### PR TITLE
Fix for #6837

### DIFF
--- a/packages/web-components/fast-foundation/src/dialog/dialog.template.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.template.ts
@@ -11,6 +11,9 @@ export function dialogTemplate<T extends FASTDialog>(): ElementViewTemplate<T> {
             ${when(
                 x => x.modal,
                 html<T>`
+                    <div class="overlay" part="overlay" role="presentation"></div>
+                `,
+                html<T>`
                     <div
                         class="overlay"
                         part="overlay"


### PR DESCRIPTION
Proposed fix for #6837.

# Pull Request

## 📖 Description

It corrects the issue where a modal dialog is dismissable when it should not be. It corrects the reversed behavior of the modal parameter to match expectations as per MDN.

_dialog.template.ts_ is changed.

### 🎫 Issues

#6837 

## 👩‍💻 Reviewer Notes

The styling of the overlay is assumed to be the same for modal and non-modal dialogs. The current implementation does create an overlay div when modal is set to true. 

## 📑 Test Plan


## ✅ Checklist

### General

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [X] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [X] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [X] I have modified an existing component

## ⏭ Next Steps

N/A