### PR TITLE
[archive] feat: Add case-sensitive search to Combobox

### DIFF
--- a/change/@microsoft-fast-foundation-b10b34da-26f8-4667-87cc-571876afa903.json
+++ b/change/@microsoft-fast-foundation-b10b34da-26f8-4667-87cc-571876afa903.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add case-sensitive search to Combobox",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "aaronburro@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -441,6 +441,7 @@ export interface ColumnDefinition {
 // @public
 export class Combobox extends FormAssociatedCombobox {
     autocomplete: ComboboxAutocomplete | undefined;
+    caseSensitive: boolean;
     // @internal
     clickHandler(e: MouseEvent): boolean | void;
     // (undocumented)

--- a/packages/web-components/fast-foundation/src/combobox/README.md
+++ b/packages/web-components/fast-foundation/src/combobox/README.md
@@ -117,6 +117,7 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | Name                | Privacy   | Type                                  | Default | Description                                                                                                                                                                         | Inherited From         |
 | ------------------- | --------- | ------------------------------------- | ------- | ----------------------------------------------------------------------------------------------------------------------------------------------------------------------------------- | ---------------------- |
 | `autocomplete`      | public    | `ComboboxAutocomplete or undefined`   |         | The autocomplete attribute.                                                                                                                                                         |                        |
+| `caseSensitive`     | public    | `boolean`                             | `false` | Attribute which controls whether the component uses a case-sensitive search                                                                                                         |                        |
 | `filteredOptions`   | public    | `ListboxOption[]`                     | `[]`    | The collection of currently filtered options.                                                                                                                                       |                        |
 | `open`              | public    | `boolean`                             | `false` | The open attribute.                                                                                                                                                                 |                        |
 | `options`           | public    | `ListboxOption[]`                     |         | The list of options.                                                                                                                                                                | Listbox                |
@@ -155,13 +156,14 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 #### Attributes
 
-| Name           | Field             | Inherited From |
-| -------------- | ----------------- | -------------- |
-| `autocomplete` | autocomplete      |                |
-| `open`         | open              |                |
-| `placeholder`  | placeholder       |                |
-| `position`     | positionAttribute |                |
-|                | disabled          | Listbox        |
+| Name             | Field             | Inherited From |
+| ---------------- | ----------------- | -------------- |
+| `autocomplete`   | autocomplete      |                |
+| `case-sensitive` | caseSensitive     |                |
+| `open`           | open              |                |
+| `placeholder`    | placeholder       |                |
+| `position`       | positionAttribute |                |
+|                  | disabled          | Listbox        |
 
 #### CSS Parts
 

--- a/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.spec.ts
@@ -561,4 +561,37 @@ describe("Combobox", () => {
 
         expect((element as Combobox).control.value).to.eq("three");
     });
+
+    it("should perform case-sensitive search when case-sensitive attribute is TRUE", async () => {
+        const { connect, element, option3 } = await setup();
+
+        await connect();
+
+        element.caseSensitive = true;
+        element.value = "THREE";
+
+        await DOM.nextUpdate();
+
+        expect(element.control).to.exist;
+
+        // make sure lowercase value was NOT selected
+        expect((element as Combobox).control.value).to.eq("THREE");
+        expect(option3.selected).to.be.false;
+    });
+
+    it("should perform case-insensitive search by default", async () => {
+        const { connect, element, option3 } = await setup();
+
+        await connect();
+
+        element.value = "THREE";
+
+        await DOM.nextUpdate();
+
+        expect(element.control).to.exist;
+
+        // make sure lowercase value was selected
+        expect((element as Combobox).control.value).to.eq("three");
+        expect(option3.selected).to.be.true;
+    });
 });

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -56,6 +56,16 @@ export class Combobox extends FormAssociatedCombobox {
     autocomplete: ComboboxAutocomplete | undefined;
 
     /**
+     * Attribute which controls whether the component uses a case-sensitive search
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: case-sensitive
+     */
+    @attr({ attribute: "case-sensitive", mode: "boolean" })
+    public caseSensitive: boolean = false;
+
+    /**
      * Reference to the internal text input element.
      *
      * @internal
@@ -245,10 +255,11 @@ export class Combobox extends FormAssociatedCombobox {
         const prev = `${this._value}`;
 
         if (this.$fastController.isConnected && this.options) {
-            const selectedIndex = this.options.findIndex(
-                el => el.text.toLowerCase() === next.toLowerCase()
-            );
+            const predicate: (value: ListboxOption) => boolean = this.caseSensitive
+                ? el => el.text === next
+                : el => el.text.toLowerCase() === next.toLowerCase();
 
+            const selectedIndex = this.options.findIndex(predicate);
             const prevSelectedValue = this.options[this.selectedIndex]?.text;
             const nextSelectedValue = this.options[selectedIndex]?.text;
 
@@ -335,10 +346,12 @@ export class Combobox extends FormAssociatedCombobox {
             this.filter = "";
         }
 
-        const filter = this.filter.toLowerCase();
-
+        const filterTransform: (s: string) => string = this.caseSensitive
+            ? s => s
+            : s => s?.toLowerCase();
+        const filter = filterTransform(this.filter);
         this.filteredOptions = this._options.filter(o =>
-            o.text.toLowerCase().startsWith(this.filter.toLowerCase())
+            filterTransform(o.text)?.startsWith(filter)
         );
 
         if (this.isAutocompleteList) {


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
Adds `case-sensitive` attribute to `archives/fast-element-1` `Combobox` to allow case-sensitive searching of the items when `value` is set.
Default behaviour is case-insensitive search, which is what exists today. Feature is opt-in.
This helps use-cases where items may be in the list which differ only by case and need to be programmatically selected. Without this change, when setting `Combobox.value`. the first item which matches in a case-insensitive manner will be selected, even if the value matches the case of another item.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

Changes are contained to:
packages/web-components/fast-foundation/src/combobox/

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Added two new tests to `combobox.spec.ts`
- Test case-insensitive search (default)
- Test case-sensitive search

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->
Will also place these changes into master, if they are acceptable.