### PR TITLE
bug: unmatched div tag in menu-item.template.ts

### DIFF
--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -21,72 +21,76 @@ export function menuItemTemplate<T extends FASTMenuItem>(
     options: MenuItemOptions = {}
 ): ElementViewTemplate<T> {
     return html<T>`
-    <template
-        aria-haspopup="${x => (x.hasSubmenu ? "menu" : void 0)}"
-        aria-checked="${x => (x.role !== MenuItemRole.menuitem ? x.checked : void 0)}"
-        aria-disabled="${x => x.disabled}"
-        aria-expanded="${x => x.expanded}"
-        @keydown="${(x, c) => x.handleMenuItemKeyDown(c.event as KeyboardEvent)}"
-        @click="${(x, c) => x.handleMenuItemClick(c.event as MouseEvent)}"
-        @mouseover="${(x, c) => x.handleMouseOver(c.event as MouseEvent)}"
-        @mouseout="${(x, c) => x.handleMouseOut(c.event as MouseEvent)}"
-    >
-            ${when(
-                x => x.role === MenuItemRole.menuitemcheckbox,
-                html<FASTMenuItem>`
-                    <div part="input-container" class="input-container">
-                        <span part="checkbox" class="checkbox">
-                            <slot name="checkbox-indicator">
-                                ${staticallyCompose(options.checkboxIndicator)}
-                            </slot>
-                        </span>
-                    </div>
-                `
-            )}
-            ${when(
-                x => x.role === MenuItemRole.menuitemradio,
-                html<FASTMenuItem>`
-                    <div part="input-container" class="input-container">
-                        <span part="radio" class="radio">
-                            <slot name="radio-indicator">
-                                ${staticallyCompose(options.radioIndicator)}
-                            </slot>
-                        </span>
-                    </div>
-                `
-            )}
-        </div>
-        ${startSlotTemplate(options)}
-        <span class="content" part="content">
-            <slot></slot>
-        </span>
-        ${endSlotTemplate(options)}
-        ${when(
-            x => x.hasSubmenu,
-            html<T>`
-                <div
-                    part="expand-collapse-glyph-container"
-                    class="expand-collapse-glyph-container"
-                >
-                    <span part="expand-collapse" class="expand-collapse">
-                        <slot name="expand-collapse-indicator">
-                            ${staticallyCompose(options.expandCollapseGlyph)}
-                        </slot>
-                    </span>
-                </div>
-            `
-        )}
-        <span
-            ?hidden="${x => !x.expanded}"
-            class="submenu-container"
-            part="submenu-container"
-            ${ref("submenuContainer")}
+        <template
+            aria-haspopup="${x => (x.hasSubmenu ? "menu" : void 0)}"
+            aria-checked="${x => (x.role !== MenuItemRole.menuitem ? x.checked : void 0)}"
+            aria-disabled="${x => x.disabled}"
+            aria-expanded="${x => x.expanded}"
+            @keydown="${(x, c) => x.handleMenuItemKeyDown(c.event as KeyboardEvent)}"
+            @click="${(x, c) => x.handleMenuItemClick(c.event as MouseEvent)}"
+            @mouseover="${(x, c) => x.handleMouseOver(c.event as MouseEvent)}"
+            @mouseout="${(x, c) => x.handleMouseOut(c.event as MouseEvent)}"
         >
-            <slot name="submenu" ${slotted({
-                property: "slottedSubmenu",
-                filter: elements("[role='menu']"),
-            })}></slot>
-        </span>
-    </template>
+            <div>
+                ${when(
+                    x => x.role === MenuItemRole.menuitemcheckbox,
+                    html<FASTMenuItem>`
+                        <div part="input-container" class="input-container">
+                            <span part="checkbox" class="checkbox">
+                                <slot name="checkbox-indicator">
+                                    ${staticallyCompose(options.checkboxIndicator)}
+                                </slot>
+                            </span>
+                        </div>
+                    `
+                )}
+                ${when(
+                    x => x.role === MenuItemRole.menuitemradio,
+                    html<FASTMenuItem>`
+                        <div part="input-container" class="input-container">
+                            <span part="radio" class="radio">
+                                <slot name="radio-indicator">
+                                    ${staticallyCompose(options.radioIndicator)}
+                                </slot>
+                            </span>
+                        </div>
+                    `
+                )}
+            </div>
+            ${startSlotTemplate(options)}
+            <span class="content" part="content">
+                <slot></slot>
+            </span>
+            ${endSlotTemplate(options)}
+            ${when(
+                x => x.hasSubmenu,
+                html<T>`
+                    <div
+                        part="expand-collapse-glyph-container"
+                        class="expand-collapse-glyph-container"
+                    >
+                        <span part="expand-collapse" class="expand-collapse">
+                            <slot name="expand-collapse-indicator">
+                                ${staticallyCompose(options.expandCollapseGlyph)}
+                            </slot>
+                        </span>
+                    </div>
+                `
+            )}
+            <span
+                ?hidden="${x => !x.expanded}"
+                class="submenu-container"
+                part="submenu-container"
+                ${ref("submenuContainer")}
+            >
+                <slot
+                    name="submenu"
+                    ${slotted({
+                        property: "slottedSubmenu",
+                        filter: elements("[role='menu']"),
+                    })}
+                ></slot>
+            </span>
+        </template>
     `;
 }

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts
@@ -31,32 +31,30 @@ export function menuItemTemplate<T extends FASTMenuItem>(
             @mouseover="${(x, c) => x.handleMouseOver(c.event as MouseEvent)}"
             @mouseout="${(x, c) => x.handleMouseOut(c.event as MouseEvent)}"
         >
-            <div>
-                ${when(
-                    x => x.role === MenuItemRole.menuitemcheckbox,
-                    html<FASTMenuItem>`
-                        <div part="input-container" class="input-container">
-                            <span part="checkbox" class="checkbox">
-                                <slot name="checkbox-indicator">
-                                    ${staticallyCompose(options.checkboxIndicator)}
-                                </slot>
-                            </span>
-                        </div>
-                    `
-                )}
-                ${when(
-                    x => x.role === MenuItemRole.menuitemradio,
-                    html<FASTMenuItem>`
-                        <div part="input-container" class="input-container">
-                            <span part="radio" class="radio">
-                                <slot name="radio-indicator">
-                                    ${staticallyCompose(options.radioIndicator)}
-                                </slot>
-                            </span>
-                        </div>
-                    `
-                )}
-            </div>
+            ${when(
+                x => x.role === MenuItemRole.menuitemcheckbox,
+                html<FASTMenuItem>`
+                    <div part="input-container" class="input-container">
+                        <span part="checkbox" class="checkbox">
+                            <slot name="checkbox-indicator">
+                                ${staticallyCompose(options.checkboxIndicator)}
+                            </slot>
+                        </span>
+                    </div>
+                `
+            )}
+            ${when(
+                x => x.role === MenuItemRole.menuitemradio,
+                html<FASTMenuItem>`
+                    <div part="input-container" class="input-container">
+                        <span part="radio" class="radio">
+                            <slot name="radio-indicator">
+                                ${staticallyCompose(options.radioIndicator)}
+                            </slot>
+                        </span>
+                    </div>
+                `
+            )}
             ${startSlotTemplate(options)}
             <span class="content" part="content">
                 <slot></slot>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

There was an unmatched div in on [line](https://github.com/microsoft/fast/blob/6091f89a6a0b8bf3baa4cd4ed2aae1078ba9865b/packages/web-components/fast-foundation/src/menu-item/menu-item.template.ts#L58) , This pull request is to address the same bug 

### 🎫 Issues

This pull request is to address the issue [#6840](https://github.com/microsoft/fast/issues/6840)

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
