### PR TITLE
Adds select placeholder feat

### DIFF
--- a/change/@microsoft-fast-foundation-ba3f70b5-c46e-4909-ac90-e174f390ebca.json
+++ b/change/@microsoft-fast-foundation-ba3f70b5-c46e-4909-ac90-e174f390ebca.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "select: adds placeholder feat",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "brian.christopher.brady@gmail.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1800,6 +1800,8 @@ export class FASTSelect extends FormAssociatedSelect {
     // @internal
     protected openChanged(prev: boolean | undefined, next: boolean): void;
     placeholder: string;
+    // (undocumented)
+    placeholderChanged(): void;
     // @internal
     placeholderOption: HTMLOptionElement | null;
     // @internal

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1799,6 +1799,9 @@ export class FASTSelect extends FormAssociatedSelect {
     open: boolean;
     // @internal
     protected openChanged(prev: boolean | undefined, next: boolean): void;
+    placeholder: string;
+    // @internal
+    placeholderOption: HTMLOptionElement | null;
     // @internal
     selectedIndexChanged(prev: number | undefined, next: number): void;
     // @internal @override

--- a/packages/web-components/fast-foundation/src/select/README.md
+++ b/packages/web-components/fast-foundation/src/select/README.md
@@ -136,12 +136,12 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | Name               | Privacy   | Type                  | Default | Description                                          | Inherited From       |
 | ------------------ | --------- | --------------------- | ------- | ---------------------------------------------------- | -------------------- |
 | `open`             | public    | `boolean`             | `false` | The open attribute.                                  |                      |
+| `placeholder`      | public    | `string`              |         | The placeholder attribute.                           |                      |
 | `value`            | public    |                       |         | The value property.                                  |                      |
 | `cleanup`          | public    | `() => void`          |         | Cleanup function for the listbox positioner.         |                      |
 | `displayValue`     | public    | `string`              |         | The value displayed on the button.                   |                      |
 | `proxy`            |           |                       |         |                                                      | FormAssociatedSelect |
 | `multiple`         | public    | `boolean`             |         | Indicates if the listbox is in multi-selection mode. | FASTListboxElement   |
-| `placeholder`      | public    | `string`              |         | The placeholder text.                                |                      |
 | `size`             | public    | `number`              |         | The maximum number of options to display.            | FASTListboxElement   |
 | `length`           | public    | `number`              |         | The number of options.                               | FASTListbox          |
 | `options`          | public    | `FASTListboxOption[]` |         | The list of options.                                 | FASTListbox          |
@@ -168,10 +168,11 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 
 #### Attributes
 
-| Name   | Field    | Inherited From |
-| ------ | -------- | -------------- |
-| `open` | open     |                |
-|        | multiple | FASTListbox    |
+| Name          | Field       | Inherited From |
+| ------------- | ----------- | -------------- |
+| `open`        | open        |                |
+| `placeholder` | placeholder |                |
+|               | multiple    | FASTListbox    |
 
 #### CSS Parts
 

--- a/packages/web-components/fast-foundation/src/select/README.md
+++ b/packages/web-components/fast-foundation/src/select/README.md
@@ -141,6 +141,7 @@ See [listbox-option](/docs/components/listbox-option) for more information.
 | `displayValue`     | public    | `string`              |         | The value displayed on the button.                   |                      |
 | `proxy`            |           |                       |         |                                                      | FormAssociatedSelect |
 | `multiple`         | public    | `boolean`             |         | Indicates if the listbox is in multi-selection mode. | FASTListboxElement   |
+| `placeholder`      | public    | `string`              |         | The placeholder text.                                |                      |
 | `size`             | public    | `number`              |         | The maximum number of options to display.            | FASTListboxElement   |
 | `length`           | public    | `number`              |         | The number of options.                               | FASTListbox          |
 | `options`          | public    | `FASTListboxOption[]` |         | The list of options.                                 | FASTListbox          |

--- a/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
@@ -4,18 +4,15 @@ import type { FASTListboxOption } from "../listbox-option/index.js";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTSelect } from "./select.js";
 
-test.describe("Select", () => {
+test.describe.only("Select", () => {
     let page: Page;
     let element: Locator;
-    let options: Locator;
     let root: Locator;
 
     test.beforeAll(async ({ browser }) => {
         page = await browser.newPage();
 
         element = page.locator("fast-select");
-
-        options = page.locator("fast-option");
 
         root = page.locator("#root");
 
@@ -181,6 +178,8 @@ test.describe("Select", () => {
         await element.evaluate<void, FASTSelect>(node => {
             node.open = true;
         });
+
+        const options = element.locator("fast-option");
         const option = options.nth(0);
 
         expect(

--- a/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
@@ -88,6 +88,52 @@ test.describe("Select", () => {
         await expect(element).toHaveAttribute("aria-required", "true");
     });
 
+    test("should render placeholder option when select is collapsible", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select placeholder="my placeholder">
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
+
+        const option = await page.$(".placeholder");
+
+        expect(option).not.toBeNull();
+    });
+
+    test("should not render placeholder option when the multiple attribute is present", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select multiple placeholder="placeholder">
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
+        const option = await page.$(".placeholder");
+
+        expect(option).toBeNull();
+    });
+
+    test("should not render placeholder option when the size attribute is present", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-select size="3" placeholder="placeholder">
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-select>
+            `;
+        });
+        const option = await page.$(".placeholder");
+
+        expect(option).toBeNull();
+    });
+
     test("should set its value to the first enabled option", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -61,6 +61,14 @@ export function selectTemplate<T extends FASTSelect>(
                 ?hidden="${x => (x.collapsible ? !x.open : false)}"
                 ${ref("listbox")}
             >
+                ${when(
+                    x => x.placeholder,
+                    html<T>`
+                        <option disabled hidden ${ref("placeholderOption")}>
+                            ${x => x.placeholder}
+                        </option>
+                    `
+                )}
                 <slot
                     ${slotted({
                         filter: FASTListbox.slottedOptionFilter,

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -63,7 +63,7 @@ export function selectTemplate<T extends FASTSelect>(
                 ${ref("listbox")}
             >
                 ${when(
-                    x => x.placeholder,
+                    x => x.placeholder && !x.multiple,
                     html<T>`
                         <option disabled hidden ${ref("placeholderOption")}>
                             ${x => x.placeholder}

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -63,7 +63,7 @@ export function selectTemplate<T extends FASTSelect>(
                 ${ref("listbox")}
             >
                 ${when(
-                    x => x.placeholder && !x.multiple,
+                    x => x.placeholder && x.collapsible,
                     html<T>`
                         <option disabled hidden ${ref("placeholderOption")}>
                             ${x => x.placeholder}

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -65,7 +65,13 @@ export function selectTemplate<T extends FASTSelect>(
                 ${when(
                     x => x.placeholder && x.collapsible,
                     html<T>`
-                        <option disabled hidden ${ref("placeholderOption")}>
+                        <option
+                            class="placeholder"
+                            part="placeholder"
+                            disabled
+                            hidden
+                            ${ref("placeholderOption")}
+                        >
                             ${x => x.placeholder}
                         </option>
                     `

--- a/packages/web-components/fast-foundation/src/select/select.template.ts
+++ b/packages/web-components/fast-foundation/src/select/select.template.ts
@@ -19,6 +19,7 @@ export function selectTemplate<T extends FASTSelect>(
             aria-expanded="${x => x.ariaExpanded}"
             aria-haspopup="${x => (x.collapsible ? "listbox" : null)}"
             aria-multiselectable="${x => x.ariaMultiSelectable}"
+            aria-required="${x => (x.required ? "true" : null)}"
             ?open="${x => x.open}"
             role="combobox"
             tabindex="${x => (!x.disabled ? "0" : null)}"

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -58,6 +58,23 @@ export class FASTSelect extends FormAssociatedSelect {
     public open: boolean = false;
 
     /**
+     * The placeholder attribute.
+     *
+     * @public
+     * @remarks
+     * HTML Attribute: placeholder
+     */
+    @attr
+    public placeholder: string;
+
+    /**
+     * The ref to the internal `.control` element.
+     *
+     * @internal
+     */
+    @observable
+    public placeholderOption: HTMLOptionElement | null = null;
+    /**
      * Sets focus and synchronizes ARIA attributes when the open property changes.
      *
      * @param prev - the previous open value
@@ -88,6 +105,10 @@ export class FASTSelect extends FormAssociatedSelect {
 
         this.ariaControls = "";
         this.ariaExpanded = "false";
+    }
+
+    public placeholderChanged(): void {
+        this.updateDisplayValue();
     }
 
     /**
@@ -262,7 +283,7 @@ export class FASTSelect extends FormAssociatedSelect {
      */
     public get displayValue(): string {
         Observable.track(this, "displayValue");
-        return this.firstSelectedOption?.text ?? "";
+        return this.firstSelectedOption?.text ?? this.placeholderOption?.text ?? "";
     }
 
     /**
@@ -463,7 +484,7 @@ export class FASTSelect extends FormAssociatedSelect {
             el => el.hasAttribute("selected") || el.selected || el.value === this.value
         );
 
-        if (selectedIndex !== -1) {
+        if (selectedIndex !== -1 || this.placeholder) {
             this.selectedIndex = selectedIndex;
             return;
         }
@@ -581,7 +602,7 @@ export class FASTSelect extends FormAssociatedSelect {
      * @internal
      */
     private updateDisplayValue(): void {
-        if (this.collapsible) {
+        if (this.$fastController.isConnected && this.collapsible) {
             Observable.notify(this, "displayValue");
         }
     }

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -107,6 +107,11 @@ export class FASTSelect extends FormAssociatedSelect {
         this.ariaExpanded = "false";
     }
 
+    /**
+     * Updates the display value when the placeholder changes.
+     *
+     * @public
+     */
     public placeholderChanged(): void {
         this.updateDisplayValue();
     }

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -108,15 +108,6 @@ export class FASTSelect extends FormAssociatedSelect {
     }
 
     /**
-     * Updates the display value when the placeholder changes.
-     *
-     * @public
-     */
-    public placeholderChanged(): void {
-        this.updateDisplayValue();
-    }
-
-    /**
      * The selectedIndex when the open property is true.
      *
      * @internal

--- a/packages/web-components/fast-foundation/src/select/stories/select.stories.ts
+++ b/packages/web-components/fast-foundation/src/select/stories/select.stories.ts
@@ -9,6 +9,7 @@ const storyTemplate = html<StoryArgs<FASTSelect>>`
         ?open="${x => x.open}"
         ?disabled="${x => x.disabled}"
         ?multiple="${x => x.multiple}"
+        ?required="${x => x.required}"
         placeholder="${x => x.placeholder}"
         size="${x => x.size}"
         value="${x => x.value}"
@@ -22,6 +23,7 @@ export default {
     args: {
         disabled: false,
         multiple: false,
+        required: false,
         open: false,
         storyContent: html<StoryArgs<FASTSelect>>`
             ${repeat(x => x.storyItems, listboxOptionTemplate)}
@@ -76,6 +78,11 @@ SelectDisabled.args = {
 export const SelectPlaceholder: Story<FASTSelect> = Select.bind({});
 SelectPlaceholder.args = {
     placeholder: "Placeholder",
+};
+
+export const SelectRequired: Story<FASTSelect> = Select.bind({});
+SelectRequired.args = {
+    required: true,
 };
 
 export const SelectWithSlottedStartEnd: Story<FASTSelect> = Select.bind({});

--- a/packages/web-components/fast-foundation/src/select/stories/select.stories.ts
+++ b/packages/web-components/fast-foundation/src/select/stories/select.stories.ts
@@ -23,7 +23,6 @@ export default {
         disabled: false,
         multiple: false,
         open: false,
-        placeholder: undefined,
         storyContent: html<StoryArgs<FASTSelect>>`
             ${repeat(x => x.storyItems, listboxOptionTemplate)}
         `,

--- a/packages/web-components/fast-foundation/src/select/stories/select.stories.ts
+++ b/packages/web-components/fast-foundation/src/select/stories/select.stories.ts
@@ -9,6 +9,7 @@ const storyTemplate = html<StoryArgs<FASTSelect>>`
         ?open="${x => x.open}"
         ?disabled="${x => x.disabled}"
         ?multiple="${x => x.multiple}"
+        placeholder="${x => x.placeholder}"
         size="${x => x.size}"
         value="${x => x.value}"
     >
@@ -22,6 +23,7 @@ export default {
         disabled: false,
         multiple: false,
         open: false,
+        placeholder: undefined,
         storyContent: html<StoryArgs<FASTSelect>>`
             ${repeat(x => x.storyItems, listboxOptionTemplate)}
         `,
@@ -51,6 +53,7 @@ export default {
         storyContent: { table: { disable: true } },
         storyItems: { control: "object" },
         value: { control: "text" },
+        placeholder: { control: "text" },
     },
 } as Meta<FASTSelect>;
 
@@ -69,6 +72,11 @@ SelectWithSize.args = {
 export const SelectDisabled: Story<FASTSelect> = Select.bind({});
 SelectDisabled.args = {
     disabled: true,
+};
+
+export const SelectPlaceholder: Story<FASTSelect> = Select.bind({});
+SelectPlaceholder.args = {
+    placeholder: "Placeholder",
 };
 
 export const SelectWithSlottedStartEnd: Story<FASTSelect> = Select.bind({});


### PR DESCRIPTION
# Select Placeholder

##  Description
This PR adds placeholder functionality to the FASTSelect component. The implementation aligns with how native HTML select elements handle placeholder text. Specifically, a hidden and disabled option element is dynamically rendered within the select menu to display the placeholder text.

##  Features
Adds a placeholder attribute to the FASTSelect component.
Dynamically renders a hidden and disabled option containing the placeholder text.
If the placeholder attribute is undefined or empty, the placeholder option will not be rendered.

##  Benefits
Provides a standardized way to display placeholder text in FASTSelect, similar to native HTML select elements.
Enhances the usability of the FASTSelect component by indicating the kind of selection the user should make.

### 🎫 Issues

[<!---
* List and link relevant issues here.
-->](https://github.com/microsoft/fast/issues/6853)

## 📑 Test Plan

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

Adds tests for placeholder feature. The 