### PR TITLE
fix: RtlScrollConverter test on high dpi systems in fast-web-utilities

### DIFF
--- a/change/@microsoft-fast-web-utilities-14b2f190-1571-4498-ba72-68bbafb26a20.json
+++ b/change/@microsoft-fast-web-utilities-14b2f190-1571-4498-ba72-68bbafb26a20.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix RtlScrollConverter test for high dpi systems",
+  "packageName": "@microsoft/fast-web-utilities",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/utilities/fast-web-utilities/src/rtl-scroll-converter.spec.ts
+++ b/packages/utilities/fast-web-utilities/src/rtl-scroll-converter.spec.ts
@@ -103,12 +103,13 @@ describe("RtlScrollConverter", (): void => {
     });
 
     it("invertedGetRtlScrollConverter returns correct value", () => {
+        const scale = window.devicePixelRatio;
         const testElement: HTMLDivElement = getDummyDiv();
         document.body.appendChild(testElement);
         testElement.scrollLeft = 1;
 
         expect(RtlScrollConverter["invertedGetRtlScrollConverter"](testElement)).to.equal(
-            -1
+            -1 / scale
         );
     });
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes an intermittently failing test that seems to be affected by the device pixel ratio.

## 👩‍💻 Reviewer Notes

This test returns `0.5` on my Macbook Pro, since the test environment gets the same device pixel ratio as my screen (`2`).

## 📑 Test Plan

The `RtlScrollConverter` test should pass in all environments.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

I encountered this bug while testing #6847, but it's present on the main branch as well. Perhaps there's a way to override the behavior that's causing the test runner to use the host's display properties?