### PR TITLE
fix: rtl scroll converter test asserting incorrect values

### DIFF
--- a/change/@microsoft-fast-web-utilities-14b2f190-1571-4498-ba72-68bbafb26a20.json
+++ b/change/@microsoft-fast-web-utilities-14b2f190-1571-4498-ba72-68bbafb26a20.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "fix RtlScrollConverter test for high dpi systems",
-  "packageName": "@microsoft/fast-web-utilities",
-  "email": "863023+radium-v@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-web-utilities-3092275f-0c7e-4bf4-be96-424047357621.json
+++ b/change/@microsoft-fast-web-utilities-3092275f-0c7e-4bf4-be96-424047357621.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix RtlScrollConverter test",
+  "packageName": "@microsoft/fast-web-utilities",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/utilities/fast-web-utilities/karma.conf.ts
+++ b/packages/utilities/fast-web-utilities/karma.conf.ts
@@ -16,6 +16,7 @@ const commonChromeFlags = [
     "--disable-extensions",
     "--disable-infobars",
     "--disable-translate",
+    "--force-device-scale-factor=1",
 ];
 
 module.exports = function (config: any) {

--- a/packages/utilities/fast-web-utilities/src/rtl-scroll-converter.spec.ts
+++ b/packages/utilities/fast-web-utilities/src/rtl-scroll-converter.spec.ts
@@ -102,14 +102,14 @@ describe("RtlScrollConverter", (): void => {
         );
     });
 
-    it("invertedGetRtlScrollConverter returns correct value", () => {
+    it("invertedGetRtlScrollConverter returns a value <= 0", () => {
         const testElement: HTMLDivElement = getDummyDiv();
         document.body.appendChild(testElement);
         testElement.scrollLeft = 1;
 
-        expect(RtlScrollConverter["invertedGetRtlScrollConverter"](testElement)).to.equal(
-            -1
-        );
+        expect(
+            RtlScrollConverter["invertedGetRtlScrollConverter"](testElement)
+        ).to.be.lessThanOrEqual(0);
     });
 
     it("reverseGetRtlScrollConverter returns correct value", () => {

--- a/packages/utilities/fast-web-utilities/src/rtl-scroll-converter.spec.ts
+++ b/packages/utilities/fast-web-utilities/src/rtl-scroll-converter.spec.ts
@@ -103,13 +103,12 @@ describe("RtlScrollConverter", (): void => {
     });
 
     it("invertedGetRtlScrollConverter returns correct value", () => {
-        const scale = window.devicePixelRatio;
         const testElement: HTMLDivElement = getDummyDiv();
         document.body.appendChild(testElement);
         testElement.scrollLeft = 1;
 
         expect(RtlScrollConverter["invertedGetRtlScrollConverter"](testElement)).to.equal(
-            -1 / scale
+            -1
         );
     });
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Changes the `invertedGetRtlScrollConverter returns correct value` test to pass when any value < 0 is returned.

### 🎫 Issues

This PR reverts #6857.

## 👩‍💻 Reviewer Notes

The behavior seems to be related to this Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1324251

It's something called "zoom for DSF" on MacOS, which leads to inaccurate value reporting:

|browser|value|
|-|-|
|Chrome 119.0.6045.107 (Headless/Karma) on Windows 11|`1`|
|Chrome 119.0.6045.123 on Mac (MBP M1, MacOS 14.0)|`0.5`|
|Webkit Nightly|`0`|
|Firefox Nightly|`0`|

So while I do still think that screen DPI is partly to blame for Chrome returning `0.5`, it seems that setting `scrollLeft` to `1` when in rtl mode and receiving anything other than `0` is a bug.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.