### PR TITLE
fix: call super.disconnected callback in form associated base class

### DIFF
--- a/change/@microsoft-fast-foundation-6460ce7b-2806-47d5-8604-308d3b8151d3.json
+++ b/change/@microsoft-fast-foundation-6460ce7b-2806-47d5-8604-308d3b8151d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: call super.disconnectedCallback in form associated base class",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "chhol@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.ts
@@ -524,6 +524,8 @@ export function FormAssociated<T extends ConstructableFormAssociated>(BaseCtor: 
          * @internal
          */
         public disconnectedCallback(): void {
+            super.disconnectedCallback();
+
             this.proxyEventsToBlock.forEach(name =>
                 this.proxy.removeEventListener(name, this.stopPropagation)
             );


### PR DESCRIPTION
# Pull Request

## 📖 Description
Fixes an issue where super.disconnectedCallback is not called within the form associated base class

### 🎫 Issues

<!---
* List and link relevant issues here.
-->