### PR TITLE
Use close watcher when supported in place of escape key handlers

### DIFF
--- a/change/@microsoft-fast-foundation-82cb2686-8df8-4bdc-a688-f0dab9cb1651.json
+++ b/change/@microsoft-fast-foundation-82cb2686-8df8-4bdc-a688-f0dab9cb1651.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Use close watcher when supported in place of escape key handlers",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "luke@warlow.dev",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/close-watcher.d.ts
+++ b/packages/web-components/fast-foundation/src/close-watcher.d.ts
@@ -1,0 +1,19 @@
+interface CloseWatcher extends EventTarget {
+    new (options?: CloseWatcherOptions): CloseWatcher;
+    requestClose(): void;
+    close(): void;
+    destroy(): void;
+
+    oncancel: (event: Event) => any | null;
+    onclose: (event: Event) => any | null;
+}
+
+declare const CloseWatcher: CloseWatcher;
+
+interface CloseWatcherOptions {
+    signal: AbortSignal;
+}
+
+declare interface Window {
+    CloseWatcher?: CloseWatcher;
+}

--- a/packages/web-components/fast-foundation/src/dialog/dialog.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.ts
@@ -103,9 +103,6 @@ export class FASTDialog extends FASTElement {
      */
     private notifier: Notifier;
 
-    /**
-     * @internal
-     */
     private closeWatcher: CloseWatcher | null = null;
 
     /**

--- a/packages/web-components/fast-foundation/src/picker/picker.ts
+++ b/packages/web-components/fast-foundation/src/picker/picker.ts
@@ -445,6 +445,8 @@ export class FASTPicker extends FormAssociatedPicker {
     private inputElementView: HTMLView | null = null;
     private behaviorOrchestrator: ViewBehaviorOrchestrator | null = null;
 
+    private closeWatcher: CloseWatcher | null = null;
+
     /**
      * @internal
      */
@@ -558,6 +560,9 @@ export class FASTPicker extends FormAssociatedPicker {
 
         if (open && this.getRootActiveElement() === this.inputElement) {
             this.flyoutOpen = open;
+            this.closeWatcher?.destroy();
+            this.closeWatcher = new CloseWatcher();
+            this.closeWatcher.onclose = () => this.toggleFlyout(false);
             Updates.enqueue(() => {
                 if (this.menuElement !== undefined) {
                     this.setFocusedOption(0);
@@ -570,6 +575,7 @@ export class FASTPicker extends FormAssociatedPicker {
 
         this.flyoutOpen = false;
         this.disableMenu();
+        this.closeWatcher?.destroy();
         return;
     }
 
@@ -660,6 +666,9 @@ export class FASTPicker extends FormAssociatedPicker {
             }
 
             case keyEscape: {
+                if (this.closeWatcher) {
+                    return true;
+                }
                 this.toggleFlyout(false);
                 return false;
             }

--- a/packages/web-components/fast-foundation/src/select/select.ts
+++ b/packages/web-components/fast-foundation/src/select/select.ts
@@ -57,6 +57,8 @@ export class FASTSelect extends FormAssociatedSelect {
     @attr({ attribute: "open", mode: "boolean" })
     public open: boolean = false;
 
+    private closeWatcher: CloseWatcher | null = null;
+
     /**
      * Sets focus and synchronizes ARIA attributes when the open property changes.
      *
@@ -78,10 +80,16 @@ export class FASTSelect extends FormAssociatedSelect {
             this.focusAndScrollOptionIntoView();
             this.indexWhenOpened = this.selectedIndex;
 
+            this.closeWatcher?.destroy();
+            this.closeWatcher = new CloseWatcher();
+            this.closeWatcher.onclose = () => (this.open = false);
+
             // focus is directed to the element when `open` is changed programmatically
             Updates.enqueue(() => this.focus());
 
             return;
+        } else {
+            this.closeWatcher?.destroy();
         }
 
         this.cleanup?.();
@@ -523,7 +531,7 @@ export class FASTSelect extends FormAssociatedSelect {
             }
 
             case keyEscape: {
-                if (this.collapsible && this.open) {
+                if (this.collapsible && this.open && !this.closeWatcher) {
                     e.preventDefault();
                     this.open = false;
                 }

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -89,9 +89,6 @@ export class FASTTooltip extends FASTElement {
     @observable
     private controlledVisibility: boolean = false;
 
-    /**
-     * @internal
-     */
     private closeWatcher: CloseWatcher | null = null;
 
     /**

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -90,6 +90,11 @@ export class FASTTooltip extends FASTElement {
     private controlledVisibility: boolean = false;
 
     /**
+     * @internal
+     */
+    private closeWatcher: CloseWatcher | null = null;
+
+    /**
      * Switches between controlled and uncontrolled visibility.
      *
      * @param prev - the previous forced visibility state
@@ -311,7 +316,9 @@ export class FASTTooltip extends FASTElement {
         this.addEventListener("mouseout", this.mouseoutAnchorHandler);
         this.addEventListener("mouseover", this.mouseoverAnchorHandler);
 
-        document.addEventListener("keydown", this.keydownDocumentHandler);
+        if (!("CloseWatcher" in window)) {
+            document.addEventListener("keydown", this.keydownDocumentHandler);
+        }
     }
 
     public connectedCallback(): void {
@@ -337,6 +344,7 @@ export class FASTTooltip extends FASTElement {
     public hideTooltip(): void {
         this._visible = false;
         this.cleanup?.();
+        this.closeWatcher?.destroy();
     }
 
     /**
@@ -446,5 +454,8 @@ export class FASTTooltip extends FASTElement {
     private showTooltip(): void {
         this._visible = true;
         Updates.enqueue(() => this.setPositioning());
+        this.closeWatcher?.destroy();
+        this.closeWatcher = new CloseWatcher();
+        this.closeWatcher.onclose = () => this.dismiss();
     }
 }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

This PR uses the CloseWatcher API [1][2] in place of escape key listeners where it's supported. This allows components such as dialog to be dismissed using extra close signals (e.g. Android back gesture)

[1] https://html.spec.whatwg.org/multipage/interaction.html#the-closewatcher-interface
[2] https://developer.chrome.com/blog/new-in-chrome-120#close-watcher

### 🎫 Issues

https://github.com/microsoft/fast/issues/6878

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

Need to test all changed components to ensure they correctly dismiss when escape key is pressed both in Chrome and a non Chromium browser (e.g. Safari or Firefox).

Additionally can test these components on Android and see the back gesture now correctly dismisses rather than unexpected navigating.

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->