### PR TITLE
Fix design token CSS variable inheritance bug

### DIFF
--- a/change/@microsoft-fast-foundation-54b02727-a454-4ca3-aff7-ea01225c6088.json
+++ b/change/@microsoft-fast-foundation-54b02727-a454-4ca3-aff7-ea01225c6088.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix design token inheritance bug",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -1081,7 +1081,6 @@ describe("A DesignToken", () => {
             await DOM.nextUpdate();
 
             expect(styles.getPropertyValue(token.cssCustomProperty)).to.equal("12");
-            console.log('----------------------------------------------------');
             DesignToken.unregisterRoot();
 
             await DOM.nextUpdate();

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -798,8 +798,8 @@ class DesignTokenNode implements Behavior, Subscriber {
             return;
         }
 
-        this.updateCSSTokenReflection(this.store, token);
         this.hydrate(token, this.getRaw(token));
+        this.updateCSSTokenReflection(this.store, token);
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/design-token/design-token.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.ts
@@ -556,26 +556,29 @@ class DesignTokenNode implements Behavior, Subscriber {
             if (token) {
                 // Notify any token subscribers
                 token.notify(this.target);
-
-                if (DesignTokenImpl.isCSSDesignToken(token)) {
-                    const parent = this.parent;
-                    const reflecting = this.isReflecting(token);
-
-                    if (parent) {
-                        const parentValue = parent.get(token);
-                        const sourceValue = source.get(token);
-                        if (parentValue !== sourceValue && !reflecting) {
-                            this.reflectToCSS(token);
-                        } else if (parentValue === sourceValue && reflecting) {
-                            this.stopReflectToCSS(token);
-                        }
-                    } else if (!reflecting) {
-                        this.reflectToCSS(token);
-                    }
-                }
+                this.updateCSSTokenReflection(source, token);
             }
         },
     };
+
+    private updateCSSTokenReflection(source: Store, token: DesignTokenImpl<any>): void {
+        if (DesignTokenImpl.isCSSDesignToken(token)) {
+            const parent = this.parent;
+            const reflecting = this.isReflecting(token);
+
+            if (parent) {
+                const parentValue = parent.get(token);
+                const sourceValue = source.get(token);
+                if (parentValue !== sourceValue && !reflecting) {
+                    this.reflectToCSS(token);
+                } else if (parentValue === sourceValue && reflecting) {
+                    this.stopReflectToCSS(token);
+                }
+            } else if (!reflecting) {
+                this.reflectToCSS(token);
+            }
+        }
+    }
 
     constructor(public readonly target: HTMLElement | (HTMLElement & FASTElement)) {
         nodeCache.set(target, this);
@@ -795,6 +798,7 @@ class DesignTokenNode implements Behavior, Subscriber {
             return;
         }
 
+        this.updateCSSTokenReflection(this.store, token);
         this.hydrate(token, this.getRaw(token));
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This fixes a bug where a design token value is incorrectly inherited.

### 🎫 Issues

#6864 

## 👩‍💻 Reviewer Notes

I pulled some code for updating CSS reflection into a separate function to reuse. It is now called in response to changes in parent token values.

I added a couple test cases and fixed some formatting and other minor issues with the existing tests.

## 📑 Test Plan

Unit tests pass.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
