### PR TITLE
fix: Tabs fn should be overrideable

### DIFF
--- a/change/@microsoft-fast-foundation-879984ab-c986-4ae7-93f2-bbebf4530962.json
+++ b/change/@microsoft-fast-foundation-879984ab-c986-4ae7-93f2-bbebf4530962.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "tabs fn cleanup",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "quic_scomeau@qualcomm.com",
+  "dependentChangeType": "prerelease"
+}

--- a/change/@microsoft-fast-foundation-879984ab-c986-4ae7-93f2-bbebf4530962.json
+++ b/change/@microsoft-fast-foundation-879984ab-c986-4ae7-93f2-bbebf4530962.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "tabs fn cleanup",
+  "comment": "fix: allow tabs `setTabs` method to be extended",
   "packageName": "@microsoft/fast-foundation",
   "email": "quic_scomeau@qualcomm.com",
   "dependentChangeType": "prerelease"

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1965,7 +1965,6 @@ export class FASTTabs extends FASTElement {
     orientation: TabsOrientation;
     // @internal (undocumented)
     orientationChanged(): void;
-    // (undocumented)
     protected setTabs(): void;
     // @internal (undocumented)
     tabpanels: HTMLElement[];

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1966,7 +1966,7 @@ export class FASTTabs extends FASTElement {
     // @internal (undocumented)
     orientationChanged(): void;
     // (undocumented)
-    protected setTabs: () => void;
+    protected setTabs(): void;
     // @internal (undocumented)
     tabpanels: HTMLElement[];
     // @internal (undocumented)

--- a/packages/web-components/fast-foundation/src/tabs/README.md
+++ b/packages/web-components/fast-foundation/src/tabs/README.md
@@ -134,10 +134,10 @@ export const myTabs = Tabs.compose({
 
 #### Methods
 
-| Name      | Privacy   | Description                    | Parameters           | Return | Inherited From |
-| --------- | --------- | ------------------------------ | -------------------- | ------ | -------------- |
-| `setTabs` | protected |                                |                      | `void` |                |
-| `adjust`  | public    | The adjust method for FASTTabs | `adjustment: number` | `void` |                |
+| Name      | Privacy   | Description                                                                       | Parameters           | Return | Inherited From |
+| --------- | --------- | --------------------------------------------------------------------------------- | -------------------- | ------ | -------------- |
+| `setTabs` | protected | Function that is invoked whenever the selected tab or the tab collection changes. |                      | `void` |                |
+| `adjust`  | public    | The adjust method for FASTTabs                                                    | `adjustment: number` | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/tabs/README.md
+++ b/packages/web-components/fast-foundation/src/tabs/README.md
@@ -134,10 +134,10 @@ export const myTabs = Tabs.compose({
 
 #### Methods
 
-| Name      | Privacy   | Description                                                                       | Parameters           | Return | Inherited From |
-| --------- | --------- | --------------------------------------------------------------------------------- | -------------------- | ------ | -------------- |
-| `setTabs` | protected | Function that is invoked whenever the selected tab or the tab collection changes. |                      | `void` |                |
-| `adjust`  | public    | The adjust method for FASTTabs                                                    | `adjustment: number` | `void` |                |
+| Name      | Privacy | Description                                                                       | Parameters           | Return | Inherited From |
+| --------- | ------- | --------------------------------------------------------------------------------- | -------------------- | ------ | -------------- |
+| `setTabs` | public  | Function that is invoked whenever the selected tab or the tab collection changes. |                      | `void` |                |
+| `adjust`  | public  | The adjust method for FASTTabs                                                    | `adjustment: number` | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/tabs/README.md
+++ b/packages/web-components/fast-foundation/src/tabs/README.md
@@ -126,18 +126,18 @@ export const myTabs = Tabs.compose({
 
 #### Fields
 
-| Name          | Privacy   | Type              | Default | Description                   | Inherited From |
-| ------------- | --------- | ----------------- | ------- | ----------------------------- | -------------- |
-| `orientation` | public    | `TabsOrientation` |         | The orientation               |                |
-| `activeid`    | public    | `string`          |         | The id of the active tab      |                |
-| `activetab`   | public    | `HTMLElement`     |         | A reference to the active tab |                |
-| `setTabs`     | protected |                   |         |                               |                |
+| Name          | Privacy | Type              | Default | Description                   | Inherited From |
+| ------------- | ------- | ----------------- | ------- | ----------------------------- | -------------- |
+| `orientation` | public  | `TabsOrientation` |         | The orientation               |                |
+| `activeid`    | public  | `string`          |         | The id of the active tab      |                |
+| `activetab`   | public  | `HTMLElement`     |         | A reference to the active tab |                |
 
 #### Methods
 
-| Name     | Privacy | Description                    | Parameters           | Return | Inherited From |
-| -------- | ------- | ------------------------------ | -------------------- | ------ | -------------- |
-| `adjust` | public  | The adjust method for FASTTabs | `adjustment: number` | `void` |                |
+| Name      | Privacy   | Description                    | Parameters           | Return | Inherited From |
+| --------- | --------- | ------------------------------ | -------------------- | ------ | -------------- |
+| `setTabs` | protected |                                |                      | `void` |                |
+| `adjust`  | public    | The adjust method for FASTTabs | `adjustment: number` | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, ref, slotted, when } from "@microsoft/fast-element";
+import { ElementViewTemplate, html, slotted } from "@microsoft/fast-element";
 import { endSlotTemplate, startSlotTemplate } from "../patterns/index.js";
 import type { FASTTabs } from "./tabs.js";
 import type { TabsOptions } from "./tabs.options.js";

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -145,6 +145,11 @@ export class FASTTabs extends FASTElement {
         }
     }
 
+    /**
+     * Function that is invoked whenever the selected tab or the tab collection changes.
+     *
+     * @protected
+     */
     protected setTabs(): void {
         const gridHorizontalProperty: string = "gridColumn";
         const gridVerticalProperty: string = "gridRow";

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -148,7 +148,7 @@ export class FASTTabs extends FASTElement {
     /**
      * Function that is invoked whenever the selected tab or the tab collection changes.
      *
-     * @protected
+     * @public
      */
     protected setTabs(): void {
         const gridHorizontalProperty: string = "gridColumn";

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -41,7 +41,6 @@ export class FASTTabs extends FASTElement {
     public orientationChanged(): void {
         if (this.$fastController.isConnected) {
             this.setTabs();
-            this.setTabPanels();
         }
     }
     /**
@@ -65,7 +64,6 @@ export class FASTTabs extends FASTElement {
                 (item: HTMLElement) => item.id === oldValue
             );
             this.setTabs();
-            this.setTabPanels();
         }
     }
 
@@ -86,7 +84,6 @@ export class FASTTabs extends FASTElement {
             this.tabpanelIds = this.getTabPanelIds();
 
             this.setTabs();
-            this.setTabPanels();
         }
     }
 
@@ -107,7 +104,6 @@ export class FASTTabs extends FASTElement {
             this.tabpanelIds = this.getTabPanelIds();
 
             this.setTabs();
-            this.setTabPanels();
         }
     }
 
@@ -149,7 +145,7 @@ export class FASTTabs extends FASTElement {
         }
     }
 
-    protected setTabs = (): void => {
+    protected setTabs(): void {
         const gridHorizontalProperty: string = "gridColumn";
         const gridVerticalProperty: string = "gridRow";
         const gridProperty: string = this.isHorizontal()
@@ -186,9 +182,10 @@ export class FASTTabs extends FASTElement {
                 ? tab.classList.add("vertical")
                 : tab.classList.remove("vertical");
         });
-    };
+        this.setTabPanels();
+    }
 
-    private setTabPanels = (): void => {
+    private setTabPanels(): void {
         this.tabpanels.forEach((tabpanel: HTMLElement, index: number) => {
             const tabId: string = this.tabIds[index];
             const tabpanelId: string = this.tabpanelIds[index];
@@ -198,7 +195,7 @@ export class FASTTabs extends FASTElement {
                 ? tabpanel.setAttribute("hidden", "")
                 : tabpanel.removeAttribute("hidden");
         });
-    };
+    }
 
     private getTabIds(): Array<string> {
         return this.tabs.map((tab: HTMLElement) => {
@@ -293,7 +290,7 @@ export class FASTTabs extends FASTElement {
         }
     }
 
-    private adjustForward = (e: KeyboardEvent): void => {
+    private adjustForward(e: KeyboardEvent): void {
         const group: HTMLElement[] = this.tabs;
         let index: number = 0;
 
@@ -314,9 +311,9 @@ export class FASTTabs extends FASTElement {
                 index += 1;
             }
         }
-    };
+    }
 
-    private adjustBackward = (e: KeyboardEvent): void => {
+    private adjustBackward(e: KeyboardEvent): void {
         const group: HTMLElement[] = this.tabs;
         let index: number = 0;
 
@@ -333,16 +330,16 @@ export class FASTTabs extends FASTElement {
                 index -= 1;
             }
         }
-    };
+    }
 
-    private moveToTabByIndex = (group: HTMLElement[], index: number) => {
+    private moveToTabByIndex(group: HTMLElement[], index: number) {
         const tab: HTMLElement = group[index] as HTMLElement;
         this.activetab = tab;
         this.prevActiveTabIndex = this.activeTabIndex;
         this.activeTabIndex = index;
         tab.focus();
         this.setComponent();
-    };
+    }
 
     private focusTab(): void {
         this.tabs[this.activeTabIndex].focus();


### PR DESCRIPTION
## 📖 Description

The protected "setTabs" function in the `Tabs` component was written as an arrow function which made overriding it difficult as you can't simply call `super.setTabs()` to invoke the base class function when extending the `Tabs` class.  This change converts that function to a class member so it can be overridden more easily.  Additional minor cleanup of component code.

This is a breaking change in that anyone who currently has a workaround to override this function will need to make changes (ie. storing the base class arrow function and invoking it, for example).

### 🎫 Issues
Ad hoc.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
