### PR TITLE
Fix: add code owner permissions to change directory

### DIFF
--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 # All *code owners* who aren't on the "everything" list must be have ownership of
 # the change directory in order to approve PR's that include change files
-/change/ @bheston @scomea @radium-v @kingoftac
+/change/ @EisenbergEffect @chrisdholt @janechu @nicholasrice @bheston @scomea @radium-v @kingoftac
 
 # File type specific owners
 # Markdown specific files

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -9,7 +9,7 @@
 
 # All *code owners* who aren't on the "everything" list must be have ownership of
 # the change directory in order to approve PR's that include change files
-change/ @bheston @scomea @radium-v @kingoftac
+/change/ @bheston @scomea @radium-v @kingoftac
 
 # File type specific owners
 # Markdown specific files

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,6 +7,10 @@
 # These *code owners* will be the default owners for everything in the repository.
 * @chrisdholt @janechu @nicholasrice @EisenbergEffect
 
+# All *code owners* who aren't on the "everything" list must be have ownership of
+# the change directory in order to approve PR's that include change files
+change/ @bheston @scomea @radium-v @kingoftac
+
 # File type specific owners
 # Markdown specific files
 *.md @awentzel @chrisdholt @falkicon @EisenbergEffect

--- a/.github/CODEOWNERS
+++ b/.github/CODEOWNERS
@@ -7,10 +7,6 @@
 # These *code owners* will be the default owners for everything in the repository.
 * @chrisdholt @janechu @nicholasrice @EisenbergEffect
 
-# All *code owners* who aren't on the "everything" list must be have ownership of
-# the change directory in order to approve PR's that include change files
-/change/ @EisenbergEffect @chrisdholt @janechu @nicholasrice @bheston @scomea @radium-v @kingoftac
-
 # File type specific owners
 # Markdown specific files
 *.md @awentzel @chrisdholt @falkicon @EisenbergEffect
@@ -44,3 +40,6 @@ build/ @janechu @nicholasrice @chrisdholt @awentzel @EisenbergEffect
 # Web components
 /packages/web-components/fast-element/ @EisenbergEffect @chrisdholt @janechu @nicholasrice
 /packages/web-components/fast-foundation/ @EisenbergEffect @chrisdholt @bheston @scomea @radium-v @kingoftac
+
+# the change directory has no owners
+/change/


### PR DESCRIPTION
## 📖 Description
Code owners that own individual packages can't approve PR's that include change files at the project root.  This change gives Owners of the "fast-foundation" package need permissions to the root 'change' folder as well in order to approve pr's with change files.

### 🎫 Issues
ad-hoc

## ✅ Checklist

### General
- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)