### PR TITLE
Fix: Tabs switch on mousedown and checks for defaultPrevented

### DIFF
--- a/change/@microsoft-fast-foundation-1ef7e908-bd54-4364-9bd5-db865dc1f55b.json
+++ b/change/@microsoft-fast-foundation-1ef7e908-bd54-4364-9bd5-db865dc1f55b.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "tab events",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -169,7 +169,7 @@ export class FASTTabs extends FASTElement {
                 tab.setAttribute("id", tabId);
                 tab.setAttribute("aria-selected", isActiveTab ? "true" : "false");
                 tab.setAttribute("aria-controls", tabpanelId);
-                tab.addEventListener("click", this.handleTabClick);
+                tab.addEventListener("mousedown", this.handleTabMouseDown);
                 tab.addEventListener("keydown", this.handleTabKeyDown);
                 tab.setAttribute("tabindex", isActiveTab ? "0" : "-1");
                 if (isActiveTab) {
@@ -222,7 +222,10 @@ export class FASTTabs extends FASTElement {
         }
     }
 
-    private handleTabClick = (event: MouseEvent): void => {
+    private handleTabMouseDown = (event: MouseEvent): void => {
+        if (event.defaultPrevented) {
+            return;
+        }
         const selectedTab = event.currentTarget as HTMLElement;
         if (selectedTab.nodeType === 1 && this.isFocusableElement(selectedTab)) {
             this.prevActiveTabIndex = this.activeTabIndex;
@@ -236,6 +239,9 @@ export class FASTTabs extends FASTElement {
     }
 
     private handleTabKeyDown = (event: KeyboardEvent): void => {
+        if (event.defaultPrevented) {
+            return;
+        }
         if (this.isHorizontal()) {
             switch (event.key) {
                 case keyArrowLeft:


### PR DESCRIPTION
Tabs should select on `mousedown` rather than `click`, this seems typical and makes implementing draggable tabs easier in that the tab being dragged should be the selected one so selection should happen before `mouseup`.

Addtionally, added checks for `defaultPrevented` in the event handlers.  Tabs can have things like clickable close buttons that may want to block default handling.

### 🎫 Issues
Ad-hoc.  Stuff I'm noticing while implementing.

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
