### PR TITLE
FEAT: Tabs `tabOrder` enhancement

### DIFF
--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -1955,17 +1955,33 @@ export class FASTTabPanel extends FASTElement {
 //
 // @public
 export class FASTTabs extends FASTElement {
-    activeid: string;
+    activeid: string | undefined;
     // @internal (undocumented)
-    activeidChanged(oldValue: string, newValue: string): void;
-    activetab: HTMLElement;
+    activeidChanged(): void;
+    get activetab(): HTMLElement | undefined;
+    set activetab(tabElement: HTMLElement | undefined);
+    get activeTabIndex(): number;
+    set activeTabIndex(index: number);
     adjust(adjustment: number): void;
     // @internal (undocumented)
     connectedCallback(): void;
+    customTabOrder: string[] | undefined;
+    // (undocumented)
+    customTabOrderChanged(): void;
+    // @internal (undocumented)
+    disconnectedCallback(): void;
+    // @internal
+    handleTabKeyDown: (event: KeyboardEvent) => void;
+    // @internal
+    handleTabMouseDown: (event: MouseEvent) => void;
     orientation: TabsOrientation;
     // @internal (undocumented)
     orientationChanged(): void;
     protected setTabs(): void;
+    // @internal
+    tabList: HTMLElement;
+    // @internal
+    tabOrder: string[];
     // @internal (undocumented)
     tabpanels: HTMLElement[];
     // @internal (undocumented)
@@ -1974,6 +1990,7 @@ export class FASTTabs extends FASTElement {
     tabs: HTMLElement[];
     // @internal (undocumented)
     tabsChanged(): void;
+    protected updateActiveid(): void;
 }
 
 // @internal

--- a/packages/web-components/fast-foundation/src/tabs/README.md
+++ b/packages/web-components/fast-foundation/src/tabs/README.md
@@ -126,18 +126,22 @@ export const myTabs = Tabs.compose({
 
 #### Fields
 
-| Name          | Privacy | Type              | Default | Description                   | Inherited From |
-| ------------- | ------- | ----------------- | ------- | ----------------------------- | -------------- |
-| `orientation` | public  | `TabsOrientation` |         | The orientation               |                |
-| `activeid`    | public  | `string`          |         | The id of the active tab      |                |
-| `activetab`   | public  | `HTMLElement`     |         | A reference to the active tab |                |
+| Name             | Privacy | Type                       | Default | Description                                                                                                        | Inherited From |
+| ---------------- | ------- | -------------------------- | ------- | ------------------------------------------------------------------------------------------------------------------ | -------------- |
+| `orientation`    | public  | `TabsOrientation`          |         | The orientation                                                                                                    |                |
+| `activeid`       | public  | `string or undefined`      |         | The id of the active tab                                                                                           |                |
+| `customTabOrder` | public  | `string[] or undefined`    |         | An array of id's that specifies the order of tabs. This overrides the component's default DOM order based tabOrder |                |
+| `activetab`      | public  | `HTMLElement or undefined` |         | Sets the active tab Element                                                                                        |                |
+| `activeTabIndex` | public  | `number`                   |         | Sets the active tab index based on tabOrder. If the target tab is not focusable setting this will have no effect.  |                |
 
 #### Methods
 
-| Name      | Privacy | Description                                                                       | Parameters           | Return | Inherited From |
-| --------- | ------- | --------------------------------------------------------------------------------- | -------------------- | ------ | -------------- |
-| `setTabs` | public  | Function that is invoked whenever the selected tab or the tab collection changes. |                      | `void` |                |
-| `adjust`  | public  | The adjust method for FASTTabs                                                    | `adjustment: number` | `void` |                |
+| Name                    | Privacy   | Description                                                   | Parameters           | Return | Inherited From |
+| ----------------------- | --------- | ------------------------------------------------------------- | -------------------- | ------ | -------------- |
+| `customTabOrderChanged` | public    |                                                               |                      | `void` |                |
+| `setTabs`               | public    | Function that is invoked whenever the tab collection changes. |                      | `void` |                |
+| `updateActiveid`        | protected | Function that is invoked whenever the active tab changes.     |                      | `void` |                |
+| `adjust`                | public    | The adjust method for FASTTabs                                | `adjustment: number` | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/tabs/stories/tabs.stories.ts
+++ b/packages/web-components/fast-foundation/src/tabs/stories/tabs.stories.ts
@@ -101,12 +101,26 @@ const tabOrderStoryTemplate = html<StoryArgs<FASTTabs>>`
         <fast-tab id="t1" aria-controls="tp1">Tab 1</fast-tab>
         <fast-tab id="t2" aria-controls="tp2">Tab 2</fast-tab>
         <fast-tab id="t3" aria-controls="tp3">Tab 3</fast-tab>
-        <fast-tab-panel id="tp1" aria-labelledby="t1">Tab 1</fast-tab-panel>
-        <fast-tab-panel id="tp2" aria-labelledby="t2">Tab 2</fast-tab-panel>
-        <fast-tab-panel id="tp3" aria-labelledby="t3">Tab 3</fast-tab-panel>
+        <fast-tab-panel id="tp1">Tab 1</fast-tab-panel>
+        <fast-tab-panel id="tp2">Tab 2</fast-tab-panel>
+        <fast-tab-panel id="tp3">Tab 3</fast-tab-panel>
     </fast-tabs>
 `;
 
-export const WithTabOrder: Story<FASTTabs> = renderComponent(tabOrderStoryTemplate).bind(
-    {}
-);
+export const TabsWithTabOrder: Story<FASTTabs> = renderComponent(
+    tabOrderStoryTemplate
+).bind({});
+
+const tabOrderSharedPanelStoryTemplate = html<StoryArgs<FASTTabs>>`
+    <fast-tabs :customTabOrder=${["t2", "t3", "t1"]}>
+        <fast-tab id="t1" aria-controls="tp1">Tab 1</fast-tab>
+        <fast-tab id="t2" aria-controls="tp2">Tab 2</fast-tab>
+        <fast-tab id="t3" aria-controls="tp2">Tab 3</fast-tab>
+        <fast-tab-panel id="tp1">Tab 1</fast-tab-panel>
+        <fast-tab-panel id="tp2">Tab 2 and 3 share this</fast-tab-panel>
+    </fast-tabs>
+`;
+
+export const TabsWithSharedPanel: Story<FASTTabs> = renderComponent(
+    tabOrderSharedPanelStoryTemplate
+).bind({});

--- a/packages/web-components/fast-foundation/src/tabs/stories/tabs.stories.ts
+++ b/packages/web-components/fast-foundation/src/tabs/stories/tabs.stories.ts
@@ -95,3 +95,18 @@ DisabledTabs.args = {
         ],
     },
 };
+
+const tabOrderStoryTemplate = html<StoryArgs<FASTTabs>>`
+    <fast-tabs :customTabOrder=${["t2", "t3", "t1"]}>
+        <fast-tab id="t1" aria-controls="tp1">Tab 1</fast-tab>
+        <fast-tab id="t2" aria-controls="tp2">Tab 2</fast-tab>
+        <fast-tab id="t3" aria-controls="tp3">Tab 3</fast-tab>
+        <fast-tab-panel id="tp1" aria-labelledby="t1">Tab 1</fast-tab-panel>
+        <fast-tab-panel id="tp2" aria-labelledby="t2">Tab 2</fast-tab-panel>
+        <fast-tab-panel id="tp3" aria-labelledby="t3">Tab 3</fast-tab-panel>
+    </fast-tabs>
+`;
+
+export const WithTabOrder: Story<FASTTabs> = renderComponent(tabOrderStoryTemplate).bind(
+    {}
+);

--- a/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.template.ts
@@ -1,4 +1,4 @@
-import { ElementViewTemplate, html, slotted } from "@microsoft/fast-element";
+import { ElementViewTemplate, html, ref, slotted } from "@microsoft/fast-element";
 import { endSlotTemplate, startSlotTemplate } from "../patterns/index.js";
 import type { FASTTabs } from "./tabs.js";
 import type { TabsOptions } from "./tabs.options.js";
@@ -12,7 +12,7 @@ export function tabsTemplate<T extends FASTTabs>(
 ): ElementViewTemplate<T> {
     return html<T>`
         ${startSlotTemplate(options)}
-        <div class="tablist" part="tablist" role="tablist">
+        <div class="tablist" part="tablist" role="tablist" ${ref("tabList")}>
             <slot name="tab" ${slotted("tabs")}></slot>
         </div>
         ${endSlotTemplate(options)}

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -295,24 +295,18 @@ export class FASTTabs extends FASTElement {
             newTabIds.push(tab.id);
         });
 
-        // Do a second pass to set other default id based attributes if they have not been set.
+        // Do a second pass to set other default id based attributes.
         // This enables a default behavior where tabs and tabpanels are associated based on
         // their index in the DOM (ie. first tab associated with first tab panel, etc...)
         if (
             this.tabpanels.length === this.tabs.length &&
             this.customTabOrder === undefined
         ) {
-            this.tabpanels.forEach((tabPanel: HTMLElement, index: number) => {
-                // if a tab-panel does not already have a labbelledby defined
-                // assign the id of the tab of the same index.
-                // When using a custom tab order the labelledby attribute is only
-                // applied when a tab-panel is selected.
-                tabPanel.setAttribute("aria-labelledby", newTabIds[index]);
-            });
             this.tabs.forEach((tab: HTMLElement, index: number) => {
-                // if a tab does not already have a controlled panel defined
-                // assign the id of the panel of the same index.
                 tab.setAttribute("aria-controls", newTabPanelIds[index]);
+            });
+            this.tabpanels.forEach((tabPanel: HTMLElement, index: number) => {
+                tabPanel.setAttribute("aria-labelledby", newTabIds[index]);
             });
         }
 

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -303,8 +303,8 @@ export class FASTTabs extends FASTElement {
             this.customTabOrder === undefined
         ) {
             this.tabpanels.forEach((tabPanel: HTMLElement, index: number) => {
-                // if a tab does not already have a controlled panel defined
-                // assign the id of the panel of the same index
+                // if a tab-panel does not already have a labbelledby defined
+                // assign the id of the tab of the same index
                 tabPanel.setAttribute("aria-labelledby", newTabIds[index]);
             });
             this.tabs.forEach((tab: HTMLElement, index: number) => {

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -304,12 +304,14 @@ export class FASTTabs extends FASTElement {
         ) {
             this.tabpanels.forEach((tabPanel: HTMLElement, index: number) => {
                 // if a tab-panel does not already have a labbelledby defined
-                // assign the id of the tab of the same index
+                // assign the id of the tab of the same index.
+                // When using a custom tab order the labelledby attribute is only
+                // applied when a tab-panel is selected.
                 tabPanel.setAttribute("aria-labelledby", newTabIds[index]);
             });
             this.tabs.forEach((tab: HTMLElement, index: number) => {
                 // if a tab does not already have a controlled panel defined
-                // assign the id of the panel of the same index
+                // assign the id of the panel of the same index.
                 tab.setAttribute("aria-controls", newTabPanelIds[index]);
             });
         }
@@ -391,9 +393,18 @@ export class FASTTabs extends FASTElement {
         });
 
         this.tabpanels.forEach((tabpanel: HTMLElement, index: number) => {
-            tabpanel.id !== activeTab?.getAttribute("aria-controls")
-                ? tabpanel.setAttribute("hidden", "")
-                : tabpanel.removeAttribute("hidden");
+            if (
+                this.activeid &&
+                this.activeid !== "" &&
+                tabpanel.id === activeTab?.getAttribute("aria-controls")
+            ) {
+                tabpanel.removeAttribute("hidden");
+                // update labelled-by as a single panel can be associated with multiple tab elements
+                // this ensures the currently active panel is labelled by the currently active tab.
+                tabpanel.setAttribute("aria-labelledby", this.activeid);
+            } else {
+                tabpanel.setAttribute("hidden", "");
+            }
         });
 
         this.updatingActiveid = false;

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -298,20 +298,21 @@ export class FASTTabs extends FASTElement {
         // Do a second pass to set other default id based attributes if they have not been set.
         // This enables a default behavior where tabs and tabpanels are associated based on
         // their index in the DOM (ie. first tab associated with first tab panel, etc...)
-        this.tabpanels.forEach((tabPanel: HTMLElement, index: number) => {
-            if (!tabPanel.hasAttribute("aria-labelledby") && newTabIds.length > index) {
+        if (
+            this.tabpanels.length === this.tabs.length &&
+            this.customTabOrder === undefined
+        ) {
+            this.tabpanels.forEach((tabPanel: HTMLElement, index: number) => {
                 // if a tab does not already have a controlled panel defined
-                // assign the id of the panel of the same index if it exists
+                // assign the id of the panel of the same index
                 tabPanel.setAttribute("aria-labelledby", newTabIds[index]);
-            }
-        });
-        this.tabs.forEach((tab: HTMLElement, index: number) => {
-            if (!tab.hasAttribute("aria-controls") && newTabPanelIds.length > index) {
+            });
+            this.tabs.forEach((tab: HTMLElement, index: number) => {
                 // if a tab does not already have a controlled panel defined
-                // assign the id of the panel of the same index if it exists
+                // assign the id of the panel of the same index
                 tab.setAttribute("aria-controls", newTabPanelIds[index]);
-            }
-        });
+            });
+        }
 
         if (!this.customTabOrder) {
             this.tabOrder.splice(0, this.tabOrder.length, ...newTabIds);

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -157,9 +157,12 @@ export class FASTTabs extends FASTElement {
         ) {
             return;
         }
-        const targetTab = this.tabs.find(tab => tab.id === this.activeid);
-        if (targetTab) {
-            this.activeid = targetTab.id;
+        const targetTabId: string = this.tabOrder[index];
+        const tabElement: HTMLElement | undefined = this.tabs.find(
+            (tab: HTMLElement) => tab.id === targetTabId
+        );
+        if (tabElement && this.isFocusableElement(tabElement)) {
+            this.activeid = tabElement.id;
         }
     }
 

--- a/packages/web-components/fast-foundation/src/tabs/tabs.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.ts
@@ -369,6 +369,13 @@ export class FASTTabs extends FASTElement {
             if (tabElement) {
                 if (tabId === this.activeid) {
                     activeTab = tabElement;
+                    tabElement.setAttribute("role", "tab");
+                    tabElement.setAttribute("aria-posinset", `${index + 1}`);
+                    tabElement.setAttribute("aria-setsize", `${this.tabOrder.length}`);
+                } else {
+                    tabElement.removeAttribute("role");
+                    tabElement.removeAttribute("aria-posinset");
+                    tabElement.removeAttribute("aria-setsize");
                 }
                 // If the original property isn't emptied out,
                 // the next set will morph into a grid-area style setting that is not what we want


### PR DESCRIPTION
## 📖 Description

This is a draft version of a proposed rework of the `tabs` component with a primary goal of making it easier to extend.

The current api currently works based on the order of child elements in the DOM ie. the first child `tab` component is associated with the first `tab-panel` child, the second with the second, etc...  The component assigns children id's if they don't already have them and then populates aria "controls" and "labelledby" attributes accordingly.  So, tab/tab-panel linkage and keyboarding is via arrow keys is based on DOM order.  Not very flexible.

This change proposes:

- The component gets a new `customTabOrder` public property which is a `string[]` of tab id's which defines the order of active tabs.
- Authors can choose to provide a custom `tabOrder` property so the order of tabs can be easily managed without re-ordering the DOM (ie. should play well with frameworks).  
- component assigns id's to all tab and tab-panel elements if they don't already have one as the current behavior.
- The component assigns "aria-controls" attributes to child tab elements when none is provided by the author and there is no customTabOrder. When authors provide a customTabOrder they must specify the "aria-controls" attribute on each tab to set the associated tab panel 
- Authors could choose to have custom configurations like multiple tabs pointing at the same panel (addressing https://github.com/microsoft/fast/issues/6445). 
- Tab-panels have their "aria-labelledby" attribute set when they are activated
- `activeid` is the "source of truth" for active tab

A simple example of a custom tab order looks like this in markup:

<img width="443" alt="image" src="https://github.com/microsoft/fast/assets/7649425/ec895d31-a50b-479a-9419-0864d6f0fd03">

And renders the tabs in the specified order rather than dom order:

![image](https://github.com/microsoft/fast/assets/7649425/0d4db53a-3c6f-4d05-a7f4-6c36b5d432af)


This is a major rewrite, but it should (hopefully) not break folks that haven't extended/overridden the component.  There is a minor template change to add a `ref`.
 
### 🎫 Issues
https://github.com/microsoft/fast/issues/6445
-

## 👩‍💻 Reviewer Notes
Work in progress

## 📑 Test Plan
Need to add

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->