### PR TITLE
feat: BREAKING - rename accordion's single mode to eager and add new single mode with differing behavior

### DIFF
--- a/change/@microsoft-fast-foundation-75e9690a-b1cb-4467-b8d1-0cd66ca0148d.json
+++ b/change/@microsoft-fast-foundation-75e9690a-b1cb-4467-b8d1-0cd66ca0148d.json
@@ -3,5 +3,5 @@
   "comment": "Rename Accordion's \"single\" expand mode to \"eager\" and add new \"single\" mode that does not expand the first item by default and allows the active item to be collapsed.",
   "packageName": "@microsoft/fast-foundation",
   "email": "32497422+KingOfTac@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-75e9690a-b1cb-4467-b8d1-0cd66ca0148d.json
+++ b/change/@microsoft-fast-foundation-75e9690a-b1cb-4467-b8d1-0cd66ca0148d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Rename Accordion's \"single\" expand mode to \"eager\" and add new \"single\" mode that does not expand the first item by default and allows the active item to be collapsed.",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "32497422+KingOfTac@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/accordion/accordion.options.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.options.ts
@@ -6,6 +6,11 @@ import type { ValuesOf } from "../utilities/index.js";
  */
 export const AccordionExpandMode = {
     /**
+     * The same as single, but the first {@link @microsoft/fast-foundation#(FASTAccordionItem:class) } is expanded by default.
+     */
+    eager: "eager",
+
+    /**
      * Designates only a single {@link @microsoft/fast-foundation#(FASTAccordionItem:class) } can be open a time.
      */
     single: "single",

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -61,6 +61,25 @@ test.describe("Accordion", () => {
         await expect(element).toHaveAttribute("expand-mode", AccordionExpandMode.single);
     });
 
+    test("should set an expand mode of `eager` when passed to the `expand-mode` attribute", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="eager">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
+
+        await expect(element).toHaveAttribute("expand-mode", AccordionExpandMode.eager);
+    });
+
     test("should set a default expand mode of `multi` when `expand-mode` attribute is not passed", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
@@ -150,10 +169,10 @@ test.describe("Accordion", () => {
         await expect(secondItem).toHaveBooleanAttribute("expanded");
     });
 
-    test("should set the expanded items' button to aria-disabled when in single expand mode", async () => {
+    test("should set the expanded items' button to aria-disabled when in eager expand mode", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
-                <fast-accordion expand-mode="single">
+                <fast-accordion expand-mode="eager">
                     <fast-accordion-item>
                         <span slot="heading">Heading 1</span>
                         <div>Content 1</div>
@@ -202,10 +221,10 @@ test.describe("Accordion", () => {
         );
     });
 
-    test("should remove an expanded items' expandbutton aria-disabled attribute when expand mode changes from single to multi", async () => {
+    test("should remove an expanded items' expandbutton aria-disabled attribute when expand mode changes from eager to multi", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
-                <fast-accordion expand-mode="single">
+                <fast-accordion expand-mode="eager">
                     <fast-accordion-item>
                         <span slot="heading">Heading 1</span>
                         <div>Content 1</div>
@@ -238,10 +257,10 @@ test.describe("Accordion", () => {
         await expect(firstItem.locator("button")).not.hasAttribute("aria-disabled");
     });
 
-    test("should set the first item as expanded if no child is expanded by default in single mode", async () => {
+    test("should set the first item as expanded if no child is expanded by default in eager mode", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
-                <fast-accordion expand-mode="single">
+                <fast-accordion expand-mode="eager">
                     <fast-accordion-item>
                         <span slot="heading">Heading 1</span>
                         <div>Content 1</div>
@@ -311,6 +330,52 @@ test.describe("Accordion", () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
+                    <fast-accordion-item>
+                        <span slot="heading">Heading 1</span>
+                        <div>Content 1</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item expanded disabled>
+                        <span slot="heading">Heading 2</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                    <fast-accordion-item expanded>
+                        <span slot="heading">Heading 3</span>
+                        <div>Content 2</div>
+                    </fast-accordion-item>
+                </fast-accordion>
+            `;
+        });
+
+        const items = element.locator("fast-accordion-item");
+
+        const firstItem = items.nth(0);
+
+        const secondItem = items.nth(1);
+
+        const thirdItem = items.nth(2);
+
+        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+
+        await expect(secondItem).toHaveBooleanAttribute("expanded");
+
+        await expect(thirdItem).toHaveBooleanAttribute("expanded");
+
+        await secondItem.evaluate(node => {
+            node.removeAttribute("disabled");
+        });
+
+        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+
+        await expect(secondItem).toHaveBooleanAttribute("expanded");
+
+        await expect(thirdItem).not.toHaveBooleanAttribute("expanded");
+    });
+
+    test("should allow disabled items to be expanded when in eager mode", async () => {
+        test.slow();
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-accordion expand-mode="eager">
                     <fast-accordion-item>
                         <span slot="heading">Heading 1</span>
                         <div>Content 1</div>

--- a/packages/web-components/fast-foundation/src/accordion/accordion.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.ts
@@ -81,7 +81,7 @@ export class FASTAccordion extends FASTElement {
         } else if (propertyName === "expanded") {
             // we only need to manage single expanded instances
             // such as scenarios where a child is programatically expanded
-            if (source.expanded && this.isSingleExpandMode()) {
+            if (source.expanded && this.isSingleExpandMode) {
                 this.setSingleExpandMode(source);
             }
         }
@@ -100,12 +100,12 @@ export class FASTAccordion extends FASTElement {
             return null;
         }
 
-        return (
-            this.accordionItems.find(
-                (item: Element | FASTAccordionItem) =>
-                    item instanceof FASTAccordionItem && item.expanded
-            ) ?? this.accordionItems[0]
-        );
+        return this.accordionItems.find(
+            (item: Element | FASTAccordionItem) =>
+                item instanceof FASTAccordionItem && item.expanded
+        ) ?? this.isEagerExpandMode
+            ? this.accordionItems[0]
+            : null;
     }
 
     private setItems = (): void => {
@@ -141,7 +141,7 @@ export class FASTAccordion extends FASTElement {
             item.addEventListener("focus", this.handleItemFocus);
         });
 
-        if (this.isSingleExpandMode()) {
+        if (this.isEagerExpandMode || this.isSingleExpandMode) {
             const expandedItem = this.findExpandedItem() as FASTAccordionItem;
             this.setSingleExpandMode(expandedItem);
         }
@@ -192,7 +192,7 @@ export class FASTAccordion extends FASTElement {
         if (item instanceof FASTAccordionItem) {
             this.activeid = item.getAttribute("id");
 
-            if (!this.isSingleExpandMode()) {
+            if (!this.isEagerExpandMode) {
                 item.expanded = !item.expanded;
                 // setSingleExpandMode sets activeItemIndex on its own
                 this.activeItemIndex = this.accordionItems.indexOf(item);
@@ -210,7 +210,11 @@ export class FASTAccordion extends FASTElement {
         });
     }
 
-    private isSingleExpandMode(): boolean {
+    private get isEagerExpandMode(): boolean {
+        return this.expandmode === AccordionExpandMode.eager;
+    }
+
+    private get isSingleExpandMode(): boolean {
         return this.expandmode === AccordionExpandMode.single;
     }
 

--- a/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
+++ b/packages/web-components/fast-foundation/src/accordion/stories/accordion.stories.ts
@@ -96,7 +96,32 @@ AccordionWithSingleExpandMode.args = {
             <div slot="heading">Accordion Item 1 Heading</div>
             Accordion Item 1 Content
         </fast-accordion-item>
-        <fast-accordion-item expanded>
+        <fast-accordion-item>
+            <div slot="heading">Accordion Item 2 Heading</div>
+            <fast-checkbox>A checkbox as content</fast-checkbox>
+        </fast-accordion-item>
+        <fast-accordion-item>
+            <div slot="heading">Accordion Item 3 Heading</div>
+            Accordion Item 3 Content
+        </fast-accordion-item>
+        <fast-accordion-item>
+            <div slot="heading">Accordion Item 4 Heading</div>
+            Accordion Item 4 Content
+        </fast-accordion-item>
+    `,
+};
+
+export const AccordionWithEagerExpandMode: Story<FASTAccordion> = renderComponent(
+    storyTemplate
+).bind({});
+AccordionWithEagerExpandMode.args = {
+    expandmode: "eager",
+    storyContent: html`
+        <fast-accordion-item expanded disabled>
+            <div slot="heading">Accordion Item 1 Heading</div>
+            Accordion Item 1 Content
+        </fast-accordion-item>
+        <fast-accordion-item>
             <div slot="heading">Accordion Item 2 Heading</div>
             <fast-checkbox>A checkbox as content</fast-checkbox>
         </fast-accordion-item>


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request
> This is a draft to gather thoughts/feadback while I work on tests for the new single expand mode.

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->
After working with Accordion in a couple different projects and researching other examples of Accordions in different UI libraries, I believe FAST's implementation is in need of an additional expand mode in order to cover more use cases.

This PR renames the existing `single` expand mode to `eager` as it eagerly expands the first non-disabled item by default. This PR also adds a new `single` mode that does not expand any items by default unless they already have the expanded attribute applied to them. The new `single` mode also allows the currently active, expanded item to be collapsed again thus reverting the Accordion back to its default state for this mode which is no items expanded.

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->
I updated the `isSingleExpandMode` method to be a private getter as that seemed more appropriate for the usage of the function. Please let me know if there is something I missed here in case there are deeper reasons why this needs to be a function instead of a getter.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->
Existing tests continue to pass. I did change the existing tests for single mode to be for eager mode and added some additional tests for eager mode in the few cases where I did not change the existing tests. I also added an additional story to showcase the differences between the eager and single modes.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->