### PR TITLE
Align text-area component template to text-field component for feature consistency

### DIFF
--- a/change/@microsoft-fast-foundation-5f372622-ca21-45e1-8c69-fc6a59d04e9b.json
+++ b/change/@microsoft-fast-foundation-5f372622-ca21-45e1-8c69-fc6a59d04e9b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "align text-area component template to text-field component for feature consistency",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "github@david.vollmers.org",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-5f372622-ca21-45e1-8c69-fc6a59d04e9b.json
+++ b/change/@microsoft-fast-foundation-5f372622-ca21-45e1-8c69-fc6a59d04e9b.json
@@ -1,7 +1,7 @@
 {
-  "type": "minor",
+  "type": "prerelease",
   "comment": "align text-area component template to text-field component for feature consistency",
   "packageName": "@microsoft/fast-foundation",
   "email": "github@david.vollmers.org",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.template.ts
@@ -1,11 +1,15 @@
 import { ElementViewTemplate, html, ref, slotted } from "@microsoft/fast-element";
-import type { FASTTextArea } from "./text-area.js";
+import { whitespaceFilter } from "../utilities/whitespace-filter.js";
+import { endSlotTemplate, startSlotTemplate } from "../patterns/index.js";
+import type { FASTTextArea, TextAreaOptions } from "./text-area.js";
 
 /**
  * The template for the {@link @microsoft/fast-foundation#(FASTTextArea:class)} component.
  * @public
  */
-export function textAreaTemplate<T extends FASTTextArea>(): ElementViewTemplate<T> {
+export function textAreaTemplate<T extends FASTTextArea>(
+    options: TextAreaOptions = {}
+): ElementViewTemplate<T> {
     return html<T>`
         <label
             part="label"
@@ -15,48 +19,57 @@ export function textAreaTemplate<T extends FASTTextArea>(): ElementViewTemplate<
                     ? "label"
                     : "label label__hidden"}"
         >
-            <slot ${slotted("defaultSlottedNodes")}></slot>
+            <slot
+                ${slotted({
+                    property: "defaultSlottedNodes",
+                    filter: whitespaceFilter,
+                })}
+            ></slot>
         </label>
-        <textarea
-            part="control"
-            class="control"
-            id="control"
-            ?autofocus="${x => x.autofocus}"
-            cols="${x => x.cols}"
-            ?disabled="${x => x.disabled}"
-            form="${x => x.form}"
-            list="${x => x.list}"
-            maxlength="${x => x.maxlength}"
-            minlength="${x => x.minlength}"
-            name="${x => x.name}"
-            placeholder="${x => x.placeholder}"
-            ?readonly="${x => x.readOnly}"
-            ?required="${x => x.required}"
-            rows="${x => x.rows}"
-            ?spellcheck="${x => x.spellcheck}"
-            :value="${x => x.value}"
-            aria-atomic="${x => x.ariaAtomic}"
-            aria-busy="${x => x.ariaBusy}"
-            aria-controls="${x => x.ariaControls}"
-            aria-current="${x => x.ariaCurrent}"
-            aria-describedby="${x => x.ariaDescribedby}"
-            aria-details="${x => x.ariaDetails}"
-            aria-disabled="${x => x.ariaDisabled}"
-            aria-errormessage="${x => x.ariaErrormessage}"
-            aria-flowto="${x => x.ariaFlowto}"
-            aria-haspopup="${x => x.ariaHaspopup}"
-            aria-hidden="${x => x.ariaHidden}"
-            aria-invalid="${x => x.ariaInvalid}"
-            aria-keyshortcuts="${x => x.ariaKeyshortcuts}"
-            aria-label="${x => x.ariaLabel}"
-            aria-labelledby="${x => x.ariaLabelledby}"
-            aria-live="${x => x.ariaLive}"
-            aria-owns="${x => x.ariaOwns}"
-            aria-relevant="${x => x.ariaRelevant}"
-            aria-roledescription="${x => x.ariaRoledescription}"
-            @input="${(x, c) => x.handleTextInput()}"
-            @change="${x => x.handleChange()}"
-            ${ref("control")}
-        ></textarea>
+        <div class="root" part="root">
+            ${startSlotTemplate(options)}
+            <textarea
+                part="control"
+                class="control"
+                id="control"
+                ?autofocus="${x => x.autofocus}"
+                cols="${x => x.cols}"
+                ?disabled="${x => x.disabled}"
+                form="${x => x.form}"
+                list="${x => x.list}"
+                maxlength="${x => x.maxlength}"
+                minlength="${x => x.minlength}"
+                name="${x => x.name}"
+                placeholder="${x => x.placeholder}"
+                ?readonly="${x => x.readOnly}"
+                ?required="${x => x.required}"
+                rows="${x => x.rows}"
+                ?spellcheck="${x => x.spellcheck}"
+                :value="${x => x.value}"
+                aria-atomic="${x => x.ariaAtomic}"
+                aria-busy="${x => x.ariaBusy}"
+                aria-controls="${x => x.ariaControls}"
+                aria-current="${x => x.ariaCurrent}"
+                aria-describedby="${x => x.ariaDescribedby}"
+                aria-details="${x => x.ariaDetails}"
+                aria-disabled="${x => x.ariaDisabled}"
+                aria-errormessage="${x => x.ariaErrormessage}"
+                aria-flowto="${x => x.ariaFlowto}"
+                aria-haspopup="${x => x.ariaHaspopup}"
+                aria-hidden="${x => x.ariaHidden}"
+                aria-invalid="${x => x.ariaInvalid}"
+                aria-keyshortcuts="${x => x.ariaKeyshortcuts}"
+                aria-label="${x => x.ariaLabel}"
+                aria-labelledby="${x => x.ariaLabelledby}"
+                aria-live="${x => x.ariaLive}"
+                aria-owns="${x => x.ariaOwns}"
+                aria-relevant="${x => x.ariaRelevant}"
+                aria-roledescription="${x => x.ariaRoledescription}"
+                @input="${(x, c) => x.handleTextInput()}"
+                @change="${x => x.handleChange()}"
+                ${ref("control")}
+            ></textarea>
+            ${endSlotTemplate(options)}
+        </div>
     `;
 }

--- a/packages/web-components/fast-foundation/src/text-area/text-area.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.ts
@@ -1,15 +1,24 @@
 import { attr, nullableNumberConverter, observable } from "@microsoft/fast-element";
 import { DelegatesARIATextbox } from "../text-field/text-field.js";
 import { applyMixins } from "../utilities/apply-mixins.js";
+import { StartEnd, type StartEndOptions } from "../patterns/index.js";
 import { FormAssociatedTextArea } from "./text-area.form-associated.js";
 import { TextAreaResize } from "./text-area.options.js";
 
 export { TextAreaResize };
 
 /**
+ * Text area configuration options
+ * @public
+ */
+export type TextAreaOptions = StartEndOptions<FASTTextArea>;
+
+/**
  * A Text Area Custom HTML Element.
  * Based largely on the {@link https://developer.mozilla.org/en-US/docs/Web/HTML/Element/textarea | <textarea> element }.
  *
+ * @slot start - Content which can be provided before the text area
+ * @slot end - Content which can be provided after the text area
  * @slot - The default slot for the label
  * @csspart label - The label
  * @csspart root - The element wrapping the control
@@ -220,5 +229,5 @@ export class FASTTextArea extends FormAssociatedTextArea {
  * TODO: https://github.com/microsoft/fast/issues/3317
  * @internal
  */
-export interface FASTTextArea extends DelegatesARIATextbox {}
-applyMixins(FASTTextArea, DelegatesARIATextbox);
+export interface FASTTextArea extends StartEnd, DelegatesARIATextbox {}
+applyMixins(FASTTextArea, StartEnd, DelegatesARIATextbox);


### PR DESCRIPTION
# Pull Request

## 📖 Description

The `text-field` and `text-area` component are very similar but unfortunately not feature congruent. This PR adds the following missing features to the `text-area` component:

- Add a `start` and `end` slot before and after the `textarea` element
- Wrap the `textarea` element and the `start` and `end` slots in a `div.root` element
- Add a whitespace filter to the `default` (label) slot

## 👩‍💻 Reviewer Notes

As the contributing guidelines and the PR template seem outdated (fast-components no longer exist) I am not sure what else is necessary to include in this PR.
