### PR TITLE
fix: port data grid nav fix to fast-element-1

### DIFF
--- a/change/@microsoft-fast-foundation-8903565c-9500-4158-b15c-cd107cd258f7.json
+++ b/change/@microsoft-fast-foundation-8903565c-9500-4158-b15c-cd107cd258f7.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "backport data grid cell internal focus fix #6754",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -422,12 +422,12 @@ export const checkboxTemplate: FoundationElementTemplate<ViewTemplate<Checkbox>,
 
 // @public
 export interface ColumnDefinition {
-    cellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement;
+    cellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement | null;
     cellInternalFocusQueue?: boolean;
     cellTemplate?: ViewTemplate;
     columnDataKey: string;
     gridColumn?: string;
-    headerCellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement;
+    headerCellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement | null;
     headerCellInternalFocusQueue?: boolean;
     headerCellTemplate?: ViewTemplate;
     isRowHeader?: boolean;
@@ -771,6 +771,9 @@ export class DateFormatter {
 
 // @public
 export type DayFormat = "2-digit" | "numeric";
+
+// @public (undocumented)
+export const defaultCellFocusTargetCallback: (cell: DataGridCell) => HTMLElement | null;
 
 // @public
 export class DefaultComponentPresentation implements ComponentPresentation {

--- a/packages/web-components/fast-foundation/src/data-grid/README.md
+++ b/packages/web-components/fast-foundation/src/data-grid/README.md
@@ -147,6 +147,14 @@ export const myDataGrid = DataGrid.compose({
 
 <hr/>
 
+### Functions
+
+| Name                             | Description | Parameters           | Return                |
+| -------------------------------- | ----------- | -------------------- | --------------------- |
+| `defaultCellFocusTargetCallback` |             | `cell: DataGridCell` | `HTMLElement or null` |
+
+<hr/>
+
 
 
 ### class: `DataGridRow`

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
@@ -3,10 +3,19 @@ import {
     eventFocusIn,
     eventFocusOut,
     eventKeyDown,
+    keyArrowDown,
+    keyArrowLeft,
+    keyArrowRight,
+    keyArrowUp,
+    keyEnd,
     keyEnter,
     keyEscape,
     keyFunction2,
+    keyHome,
+    keyPageDown,
+    keyPageUp,
 } from "@microsoft/fast-web-utilities";
+import { isFocusable } from "tabbable";
 import { FoundationElement } from "../foundation-element/foundation-element.js";
 import type { ColumnDefinition } from "./data-grid.js";
 import { DataGridCellTypes } from "./data-grid.options.js";
@@ -34,6 +43,18 @@ const defaultHeaderCellContentsTemplate: ViewTemplate<DataGridCell> = html`
                 : x.columnDefinition.title}
     </template>
 `;
+
+// basic focusTargetCallback that returns the first child of the cell
+export const defaultCellFocusTargetCallback = (
+    cell: DataGridCell
+): HTMLElement | null => {
+    for (let i = 0; i < cell.children.length; i++) {
+        if (isFocusable(cell.children[i])) {
+            return cell.children[i] as HTMLElement;
+        }
+    }
+    return null;
+};
 
 /**
  * A Data Grid Cell Custom HTML Element.
@@ -151,9 +172,8 @@ export class DataGridCell extends FoundationElement {
                         "function"
                 ) {
                     // move focus to the focus target
-                    const focusTarget: HTMLElement = this.columnDefinition.headerCellFocusTargetCallback(
-                        this
-                    );
+                    const focusTarget: HTMLElement | null =
+                        this.columnDefinition.headerCellFocusTargetCallback(this);
                     if (focusTarget !== null) {
                         focusTarget.focus();
                     }
@@ -167,9 +187,8 @@ export class DataGridCell extends FoundationElement {
                     typeof this.columnDefinition.cellFocusTargetCallback === "function"
                 ) {
                     // move focus to the focus target
-                    const focusTarget: HTMLElement = this.columnDefinition.cellFocusTargetCallback(
-                        this
-                    );
+                    const focusTarget: HTMLElement | null =
+                        this.columnDefinition.cellFocusTargetCallback(this);
                     if (focusTarget !== null) {
                         focusTarget.focus();
                     }
@@ -186,25 +205,37 @@ export class DataGridCell extends FoundationElement {
         }
     }
 
+    private hasInternalFocusQueue(): boolean {
+        if (this.columnDefinition === null) {
+            return false;
+        }
+        if (
+            (this.cellType === DataGridCellTypes.default &&
+                this.columnDefinition.cellInternalFocusQueue) ||
+            (this.cellType === DataGridCellTypes.columnHeader &&
+                this.columnDefinition.headerCellInternalFocusQueue)
+        ) {
+            return true;
+        }
+        return false;
+    }
+
     public handleKeydown(e: KeyboardEvent): void {
+        // if the cell does not have an internal focus queue we can ignore keystrokes
         if (
             e.defaultPrevented ||
             this.columnDefinition === null ||
-            (this.cellType === DataGridCellTypes.default &&
-                this.columnDefinition.cellInternalFocusQueue !== true) ||
-            (this.cellType === DataGridCellTypes.columnHeader &&
-                this.columnDefinition.headerCellInternalFocusQueue !== true)
+            !this.hasInternalFocusQueue()
         ) {
             return;
         }
 
+        const rootActiveElement: Element | null = this.getRootActiveElement();
+
         switch (e.key) {
             case keyEnter:
             case keyFunction2:
-                if (
-                    this.contains(document.activeElement) &&
-                    document.activeElement !== this
-                ) {
+                if (this.contains(rootActiveElement) && rootActiveElement !== this) {
                     return;
                 }
 
@@ -214,9 +245,8 @@ export class DataGridCell extends FoundationElement {
                             this.columnDefinition.headerCellFocusTargetCallback !==
                             undefined
                         ) {
-                            const focusTarget: HTMLElement = this.columnDefinition.headerCellFocusTargetCallback(
-                                this
-                            );
+                            const focusTarget: HTMLElement | null =
+                                this.columnDefinition.headerCellFocusTargetCallback(this);
                             if (focusTarget !== null) {
                                 focusTarget.focus();
                             }
@@ -226,9 +256,8 @@ export class DataGridCell extends FoundationElement {
 
                     default:
                         if (this.columnDefinition.cellFocusTargetCallback !== undefined) {
-                            const focusTarget: HTMLElement = this.columnDefinition.cellFocusTargetCallback(
-                                this
-                            );
+                            const focusTarget: HTMLElement | null =
+                                this.columnDefinition.cellFocusTargetCallback(this);
                             if (focusTarget !== null) {
                                 focusTarget.focus();
                             }
@@ -239,15 +268,38 @@ export class DataGridCell extends FoundationElement {
                 break;
 
             case keyEscape:
-                if (
-                    this.contains(document.activeElement) &&
-                    document.activeElement !== this
-                ) {
+                if (this.contains(rootActiveElement) && rootActiveElement !== this) {
                     this.focus();
                     e.preventDefault();
                 }
                 break;
+
+            // stop any unhandled grid nav events that may bubble from the cell
+            // when internal navigation is active.
+            // note: preventDefault would also block arrow keys in input elements
+            case keyArrowDown:
+            case keyArrowLeft:
+            case keyArrowRight:
+            case keyArrowUp:
+            case keyEnd:
+            case keyHome:
+            case keyPageDown:
+            case keyPageUp:
+                if (this.contains(rootActiveElement) && rootActiveElement !== this) {
+                    e.stopPropagation();
+                }
+                break;
         }
+    }
+
+    private getRootActiveElement(): Element | null {
+        const rootNode = this.getRootNode();
+
+        if (rootNode instanceof ShadowRoot) {
+            return rootNode.activeElement;
+        }
+
+        return document.activeElement;
     }
 
     private updateCellView(): void {

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.ts
@@ -172,8 +172,9 @@ export class DataGridCell extends FoundationElement {
                         "function"
                 ) {
                     // move focus to the focus target
-                    const focusTarget: HTMLElement | null =
-                        this.columnDefinition.headerCellFocusTargetCallback(this);
+                    const focusTarget: HTMLElement | null = this.columnDefinition.headerCellFocusTargetCallback(
+                        this
+                    );
                     if (focusTarget !== null) {
                         focusTarget.focus();
                     }
@@ -187,8 +188,9 @@ export class DataGridCell extends FoundationElement {
                     typeof this.columnDefinition.cellFocusTargetCallback === "function"
                 ) {
                     // move focus to the focus target
-                    const focusTarget: HTMLElement | null =
-                        this.columnDefinition.cellFocusTargetCallback(this);
+                    const focusTarget: HTMLElement | null = this.columnDefinition.cellFocusTargetCallback(
+                        this
+                    );
                     if (focusTarget !== null) {
                         focusTarget.focus();
                     }
@@ -245,8 +247,9 @@ export class DataGridCell extends FoundationElement {
                             this.columnDefinition.headerCellFocusTargetCallback !==
                             undefined
                         ) {
-                            const focusTarget: HTMLElement | null =
-                                this.columnDefinition.headerCellFocusTargetCallback(this);
+                            const focusTarget: HTMLElement | null = this.columnDefinition.headerCellFocusTargetCallback(
+                                this
+                            );
                             if (focusTarget !== null) {
                                 focusTarget.focus();
                             }
@@ -256,8 +259,9 @@ export class DataGridCell extends FoundationElement {
 
                     default:
                         if (this.columnDefinition.cellFocusTargetCallback !== undefined) {
-                            const focusTarget: HTMLElement | null =
-                                this.columnDefinition.cellFocusTargetCallback(this);
+                            const focusTarget: HTMLElement | null = this.columnDefinition.cellFocusTargetCallback(
+                                this
+                            );
                             if (focusTarget !== null) {
                                 focusTarget.focus();
                             }

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -592,7 +592,7 @@ export class DataGrid extends FoundationElement {
             const generatedHeaderElement: HTMLElement = document.createElement(
                 this.rowElementTag
             );
-            this.generatedHeader = generatedHeaderElement as unknown as DataGridRow;
+            this.generatedHeader = (generatedHeaderElement as unknown) as DataGridRow;
             this.generatedHeader.columnDefinitions = this.columnDefinitions;
             this.generatedHeader.gridTemplateColumns = this.gridTemplateColumns;
             this.generatedHeader.rowType =
@@ -621,8 +621,7 @@ export class DataGrid extends FoundationElement {
                         newNode.nodeType === 1 &&
                         (newNode as Element).getAttribute("role") === "row"
                     ) {
-                        (newNode as DataGridRow).columnDefinitions =
-                            this.columnDefinitions;
+                        (newNode as DataGridRow).columnDefinitions = this.columnDefinitions;
                     }
                 });
             });

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.ts
@@ -65,7 +65,7 @@ export interface ColumnDefinition {
      * focus directly to the checkbox.
      * When headerCellInternalFocusQueue is true this function is called when the user hits Enter or F2
      */
-    headerCellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement;
+    headerCellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement | null;
 
     /**
      * cell template
@@ -85,7 +85,7 @@ export interface ColumnDefinition {
      * When cellInternalFocusQueue is true this function is called when the user hits Enter or F2
      */
 
-    cellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement;
+    cellFocusTargetCallback?: (cell: DataGridCell) => HTMLElement | null;
 
     /**
      * Whether this column is the row header
@@ -592,7 +592,7 @@ export class DataGrid extends FoundationElement {
             const generatedHeaderElement: HTMLElement = document.createElement(
                 this.rowElementTag
             );
-            this.generatedHeader = (generatedHeaderElement as unknown) as DataGridRow;
+            this.generatedHeader = generatedHeaderElement as unknown as DataGridRow;
             this.generatedHeader.columnDefinitions = this.columnDefinitions;
             this.generatedHeader.gridTemplateColumns = this.gridTemplateColumns;
             this.generatedHeader.rowType =
@@ -621,7 +621,8 @@ export class DataGrid extends FoundationElement {
                         newNode.nodeType === 1 &&
                         (newNode as Element).getAttribute("role") === "row"
                     ) {
-                        (newNode as DataGridRow).columnDefinitions = this.columnDefinitions;
+                        (newNode as DataGridRow).columnDefinitions =
+                            this.columnDefinitions;
                     }
                 });
             });


### PR DESCRIPTION
## 📖 Description

Keyboard events emitted from a data grid cell when a cell's internal navigation is active can incorrectly move focus in the parent grid. Rather than rely on authors to intercept these events the cell component can prevent their propagation.

Additionally, this change adds

a simple 'defaultCellFocusTargetCallback` function that authors can use to move focus to the first element of a cell.
an example of a grid with cells with internal focus targets and internal nav queue
fixes code that detects the current active element to work within shadow doms

This is a port of this pr:
https://github.com/microsoft/fast/pull/6754/files

### 🎫 Issues
Requested back port of a bug fix.

## 👩‍💻 Reviewer Notes


## 📑 Test Plan

## ✅ Checklist

### General
- [ x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps
