### PR TITLE
Fix CSS custom property precedence issue and work around Chromium bug

### DIFF
--- a/change/@microsoft-fast-element-348a13f7-d30c-461e-b725-d9d8c0a10110.json
+++ b/change/@microsoft-fast-element-348a13f7-d30c-461e-b725-d9d8c0a10110.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Export Symbol to allow prepending specific stylesheets to adoptedStyleSheets",
+  "packageName": "@microsoft/fast-element",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-6e548333-f93d-4f4d-b33e-988e42ca8135.json
+++ b/change/@microsoft-fast-foundation-6e548333-f93d-4f4d-b33e-988e42ca8135.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix CSS custom property precedence issue and work around Chromium bug",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -464,6 +464,9 @@ export interface PartialFASTElementDefinition {
 }
 
 // @public
+export const prependToAdoptedStyleSheetsSymbol: unique symbol;
+
+// @public
 export class PropertyChangeNotifier implements Notifier {
     constructor(source: any);
     notify(propertyName: string): void;

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -14,6 +14,7 @@ export {
     ElementStyleFactory,
     ComposableStyles,
     StyleTarget,
+    prependToAdoptedStyleSheetsSymbol,
 } from "./styles/element-styles.js";
 export { css, cssPartial } from "./styles/css.js";
 export { CSSDirective } from "./styles/css-directive.js";

--- a/packages/web-components/fast-element/src/styles/element-styles.ts
+++ b/packages/web-components/fast-element/src/styles/element-styles.ts
@@ -133,11 +133,33 @@ function reduceBehaviors(
             return prev.concat(curr);
         }, null as Behavior[] | null);
 }
+
+/**
+ * A Symbol that can be added to a CSSStyleSheet to cause it to be prepended (rather than appended) to adoptedStyleSheets.
+ * @public
+ */
+export const prependToAdoptedStyleSheetsSymbol = Symbol("prependToAdoptedStyleSheets");
+
+function separateSheetsToPrepend(
+    sheets: CSSStyleSheet[]
+): {
+    prepend: CSSStyleSheet[];
+    append: CSSStyleSheet[];
+} {
+    const prepend: CSSStyleSheet[] = [];
+    const append: CSSStyleSheet[] = [];
+    sheets.forEach(x =>
+        (x[prependToAdoptedStyleSheetsSymbol] ? prepend : append).push(x)
+    );
+    return { prepend, append };
+}
+
 let addAdoptedStyleSheets = (
     target: Required<StyleTarget>,
     sheets: CSSStyleSheet[]
 ): void => {
-    target.adoptedStyleSheets = [...target.adoptedStyleSheets!, ...sheets];
+    const { prepend, append } = separateSheetsToPrepend(sheets);
+    target.adoptedStyleSheets = [...prepend, ...target.adoptedStyleSheets!, ...append];
 };
 let removeAdoptedStyleSheets = (
     target: Required<StyleTarget>,
@@ -157,10 +179,7 @@ if (DOM.supportsAdoptedStyleSheets) {
         (document as any).adoptedStyleSheets.push();
         (document as any).adoptedStyleSheets.splice();
         addAdoptedStyleSheets = (target, sheets) => {
-            // Workaround for Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1522263
-            const prepend: CSSStyleSheet[] = [];
-            const append: CSSStyleSheet[] = [];
-            sheets.forEach(x => (x["prepend"] ? prepend : append).push(x));
+            const { prepend, append } = separateSheetsToPrepend(sheets);
             target.adoptedStyleSheets.splice(0, 0, ...prepend);
             target.adoptedStyleSheets.push(...append);
         };

--- a/packages/web-components/fast-element/src/styles/element-styles.ts
+++ b/packages/web-components/fast-element/src/styles/element-styles.ts
@@ -157,7 +157,12 @@ if (DOM.supportsAdoptedStyleSheets) {
         (document as any).adoptedStyleSheets.push();
         (document as any).adoptedStyleSheets.splice();
         addAdoptedStyleSheets = (target, sheets) => {
-            target.adoptedStyleSheets.push(...sheets);
+            // Workaround for Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1522263
+            const prepend: CSSStyleSheet[] = [];
+            const append: CSSStyleSheet[] = [];
+            sheets.forEach(x => (x["prepend"] ? prepend : append).push(x));
+            target.adoptedStyleSheets.splice(0, 0, ...prepend);
+            target.adoptedStyleSheets.push(...append);
         };
         removeAdoptedStyleSheets = (target, sheets) => {
             for (const sheet of sheets) {

--- a/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
+++ b/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
@@ -6,6 +6,7 @@ import {
     FASTElement,
     observable,
     Observable,
+    prependToAdoptedStyleSheetsSymbol,
 } from "@microsoft/fast-element";
 
 export const defaultElement = document.createElement("div");
@@ -38,8 +39,7 @@ class ConstructableStyleSheetTarget extends QueuedStyleSheetTarget {
         super();
 
         const sheet = new CSSStyleSheet();
-        // Workaround for Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1522263
-        sheet["prepend"] = true;
+        sheet[prependToAdoptedStyleSheetsSymbol] = true;
         this.target = (sheet.cssRules[sheet.insertRule(":host{}")] as CSSStyleRule).style;
         source.$fastController.addStyles(ElementStyles.create([sheet]));
     }

--- a/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
+++ b/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
@@ -38,6 +38,8 @@ class ConstructableStyleSheetTarget extends QueuedStyleSheetTarget {
         super();
 
         const sheet = new CSSStyleSheet();
+        // Workaround for Chromium bug: https://bugs.chromium.org/p/chromium/issues/detail?id=1522263
+        sheet["prepend"] = true;
         this.target = (sheet.cssRules[sheet.insertRule(":host{}")] as CSSStyleRule).style;
         source.$fastController.addStyles(ElementStyles.create([sheet]));
     }

--- a/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/design-token.spec.ts
@@ -787,7 +787,18 @@ describe("A DesignToken", () => {
             await DOM.nextUpdate();
             expect(window.getComputedStyle(target).getPropertyValue("width")).to.equal("12px");
             removeElement(parent)
-        })
+        });
+        it("should allow stylesheet to override token's CSS custom property", async () => {
+            const target = addElement();
+            const token = DesignToken.create<number>("test");
+            const styles = css`:host{${token.cssCustomProperty}: 34; width: calc(${token} * 1px);}`
+            target.$fastController.addStyles(styles);
+            token.setValueFor(target, 12);
+
+            await DOM.nextUpdate();
+            expect(window.getComputedStyle(target).getPropertyValue("width")).to.equal("34px");
+            removeElement(target)
+        });
     });
 
     describe("with a default value set", () => {


### PR DESCRIPTION
# Pull Request

## 📖 Description

This addresses two issues:
1. The last release of the `fast-element-1` branch included a change that exposed a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1522263). 
2. Overriding a design token's value in a stylesheet does not always work. A stylesheet containing custom properties for design tokens is added to `adoptedStyleSheets` alongside other client-defined stylesheets. If a client attempts to override a design token value for an element in CSS, in most cases the order of stylesheets in `adoptedStyleSheets` won't matter because of specificity-based precedence. But if the client stylesheet overrides the token property using the selector `:host`, then whichever stylesheet appears later in `adoptedStyleSheets` will be the one that wins. It seems that the client CSS's override should always take precedence.

This change causes the special stylesheet for design token CSS properties to always be prepended to `adoptedStyleSheets` so that client stylesheets take precedence when order matters.

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

This change was conceived as a workaround to issue 1, but during implementation, it was noted that it solved what seems like an actual bug (issue 2).

## 📑 Test Plan

New design token test case written that failed before and passes now.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

