### PR TITLE
Fix CSS custom property precedence issue

### DIFF
--- a/change/@microsoft-fast-element-af94cffe-06a2-45f2-a5d6-ea40b67867ec.json
+++ b/change/@microsoft-fast-element-af94cffe-06a2-45f2-a5d6-ea40b67867ec.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix CSS custom property precedence issue",
+  "packageName": "@microsoft/fast-element",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-element-af94cffe-06a2-45f2-a5d6-ea40b67867ec.json
+++ b/change/@microsoft-fast-element-af94cffe-06a2-45f2-a5d6-ea40b67867ec.json
@@ -3,5 +3,5 @@
   "comment": "Fix CSS custom property precedence issue",
   "packageName": "@microsoft/fast-element",
   "email": "7282195+m-akinc@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-5af478ef-11f0-4516-8bd1-36a6844f5e29.json
+++ b/change/@microsoft-fast-foundation-5af478ef-11f0-4516-8bd1-36a6844f5e29.json
@@ -3,5 +3,5 @@
   "comment": "Fix CSS custom property precedence issue",
   "packageName": "@microsoft/fast-foundation",
   "email": "7282195+m-akinc@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/change/@microsoft-fast-foundation-5af478ef-11f0-4516-8bd1-36a6844f5e29.json
+++ b/change/@microsoft-fast-foundation-5af478ef-11f0-4516-8bd1-36a6844f5e29.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix CSS custom property precedence issue",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "7282195+m-akinc@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-element/docs/api-report.md
+++ b/packages/web-components/fast-element/docs/api-report.md
@@ -679,6 +679,9 @@ export interface PartialHTMLDirectiveDefinition {
 }
 
 // @public
+export const prependToAdoptedStyleSheetsSymbol: unique symbol;
+
+// @public
 export class PropertyChangeNotifier implements Notifier {
     constructor(subject: any);
     notify(propertyName: string): void;

--- a/packages/web-components/fast-element/src/components/element-controller.ts
+++ b/packages/web-components/fast-element/src/components/element-controller.ts
@@ -645,8 +645,27 @@ export class StyleElementStrategy implements StyleStrategy {
     }
 }
 
+/**
+ * A Symbol that can be added to a CSSStyleSheet to cause it to be prepended (rather than appended) to adoptedStyleSheets.
+ * @public
+ */
+export const prependToAdoptedStyleSheetsSymbol = Symbol("prependToAdoptedStyleSheets");
+
+function separateSheetsToPrepend(sheets: CSSStyleSheet[]): {
+    prepend: CSSStyleSheet[];
+    append: CSSStyleSheet[];
+} {
+    const prepend: CSSStyleSheet[] = [];
+    const append: CSSStyleSheet[] = [];
+    sheets.forEach(x =>
+        (x[prependToAdoptedStyleSheetsSymbol] ? prepend : append).push(x)
+    );
+    return { prepend, append };
+}
+
 let addAdoptedStyleSheets = (target: Required<StyleTarget>, sheets: CSSStyleSheet[]) => {
-    target.adoptedStyleSheets = [...target.adoptedStyleSheets!, ...sheets];
+    const { prepend, append } = separateSheetsToPrepend(sheets);
+    target.adoptedStyleSheets = [...prepend, ...target.adoptedStyleSheets!, ...append];
 };
 let removeAdoptedStyleSheets = (
     target: Required<StyleTarget>,
@@ -666,7 +685,9 @@ if (ElementStyles.supportsAdoptedStyleSheets) {
         (document as any).adoptedStyleSheets.push();
         (document as any).adoptedStyleSheets.splice();
         addAdoptedStyleSheets = (target, sheets) => {
-            target.adoptedStyleSheets.push(...sheets);
+            const { prepend, append } = separateSheetsToPrepend(sheets);
+            target.adoptedStyleSheets.splice(0, 0, ...prepend);
+            target.adoptedStyleSheets.push(...append);
         };
         removeAdoptedStyleSheets = (target, sheets) => {
             for (const sheet of sheets) {

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -148,4 +148,5 @@ export {
 export {
     ElementController,
     ElementControllerStrategy,
+    prependToAdoptedStyleSheetsSymbol,
 } from "./components/element-controller.js";

--- a/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
+++ b/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
@@ -1,10 +1,15 @@
-import {
-    type Constructable,
-    type ElementController,
-    type FASTElement,
-    prependToAdoptedStyleSheetsSymbol,
+import type {
+    Constructable,
+    ElementController,
+    FASTElement,
 } from "@microsoft/fast-element";
-import { ElementStyles, observable, Observable, Updates } from "@microsoft/fast-element";
+import {
+    ElementStyles,
+    observable,
+    Observable,
+    prependToAdoptedStyleSheetsSymbol,
+    Updates,
+} from "@microsoft/fast-element";
 
 /**
  * A target that can have key/value pairs set and removed.

--- a/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
+++ b/packages/web-components/fast-foundation/src/design-token/custom-property-manager.ts
@@ -1,7 +1,8 @@
-import type {
-    Constructable,
-    ElementController,
-    FASTElement,
+import {
+    type Constructable,
+    type ElementController,
+    type FASTElement,
+    prependToAdoptedStyleSheetsSymbol,
 } from "@microsoft/fast-element";
 import { ElementStyles, observable, Observable, Updates } from "@microsoft/fast-element";
 
@@ -33,6 +34,7 @@ class ConstructableStyleSheetTarget extends QueuedStyleSheetTarget {
         super();
 
         const sheet = new CSSStyleSheet();
+        sheet[prependToAdoptedStyleSheetsSymbol] = true;
         this.target = (sheet.cssRules[sheet.insertRule(":host{}")] as CSSStyleRule).style;
         source.$fastController.addStyles(new ElementStyles([sheet]));
     }

--- a/packages/web-components/fast-foundation/src/design-token/fast-design-token.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/fast-design-token.pw.spec.ts
@@ -1061,6 +1061,25 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe("12px");
         });
+        test("should allow stylesheet to override token's CSS custom property", async () => {
+            expect(
+                await page.evaluate(async () => {
+                    const target = addElement();
+                    const token = DesignToken.create<number>(uniqueTokenName());
+                    const styles = css`
+                        :host {
+                            ${token.cssCustomProperty}: 34;
+                            width: calc(${token} * 1px);
+                        }
+                    `;
+                    target.$fastController.addStyles(styles);
+                    token.setValueFor(target, 12);
+
+                    await Updates.next();
+                    return window.getComputedStyle(target).getPropertyValue("width");
+                })
+            ).toBe("34px");
+        });
     });
 
     test.describe("with a default value set", () => {


### PR DESCRIPTION
# Pull Request

## 📖 Description

Overriding a design token's value in a stylesheet does not always work. A stylesheet containing custom properties for design tokens is added to `adoptedStyleSheets` alongside other client-defined stylesheets. If a client attempts to override a design token value for an element in CSS, in most cases the order of stylesheets in `adoptedStyleSheets` won't matter because of specificity-based precedence. But if the client stylesheet overrides the token property using the selector `:host`, then whichever stylesheet appears later in `adoptedStyleSheets` will be the one that wins. It seems that the client CSS's override should always take precedence.

This change causes the special stylesheet for design token CSS properties to always be prepended to `adoptedStyleSheets` so that client stylesheets take precedence when order matters.

### 🎫 Issues

N/A

## 👩‍💻 Reviewer Notes

This change was conceived as a workaround to a [Chromium bug](https://bugs.chromium.org/p/chromium/issues/detail?id=1522263) that affected `archives/fast-element-1`. See PR #6906 into that branch.

## 📑 Test Plan

One test case added.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
