### PR TITLE
Make Playwright tests async

### DIFF
--- a/change/@microsoft-fast-foundation-c5aeb6b7-9a2e-425e-b885-f0ac39d4feef.json
+++ b/change/@microsoft-fast-foundation-c5aeb6b7-9a2e-425e-b885-f0ac39d4feef.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "upgrade playwright to 1.41",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-ssr-f4dcbe20-67a7-4554-bfea-5ba0f3784567.json
+++ b/change/@microsoft-fast-ssr-f4dcbe20-67a7-4554-bfea-5ba0f3784567.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "upgrade playwright to 1.41",
+  "packageName": "@microsoft/fast-ssr",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-foundation/package.json
+++ b/packages/web-components/fast-foundation/package.json
@@ -253,7 +253,7 @@
     "@custom-elements-manifest/to-markdown": "^0.1.0",
     "@microsoft/api-extractor": "7.24.2",
     "@microsoft/tsdoc-config": "^0.13.4",
-    "@playwright/test": "^1.25.2",
+    "@playwright/test": "^1.41.2",
     "@rollup/plugin-node-resolve": "^13.3.0",
     "@storybook/addon-docs": "6.5.10",
     "@storybook/addon-essentials": "6.5.10",

--- a/packages/web-components/fast-foundation/playwright.config.ts
+++ b/packages/web-components/fast-foundation/playwright.config.ts
@@ -61,20 +61,4 @@ expect.extend({
 expected ${recieved} to have boolean attribute \`${name}\``,
         };
     },
-
-    async hasAttribute(recieved: Locator, attribute: string) {
-        if (await recieved.isVisible()) {
-            await (await recieved.elementHandle())?.waitForElementState("stable");
-        }
-
-        const pass = await recieved.evaluate(
-            (node, attribute) => node.hasAttribute(attribute),
-            attribute
-        );
-
-        return {
-            message: () => `expected ${recieved} to have attribute \`${attribute}\``,
-            pass,
-        };
-    },
 });

--- a/packages/web-components/fast-foundation/playwright.config.ts
+++ b/packages/web-components/fast-foundation/playwright.config.ts
@@ -1,5 +1,4 @@
-import type { Locator, PlaywrightTestConfig } from "@playwright/test";
-import { expect } from "@playwright/test";
+import type { PlaywrightTestConfig } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
     reporter: "list",
@@ -25,40 +24,3 @@ const config: PlaywrightTestConfig = {
 };
 
 export default config;
-
-expect.extend({
-    async toHaveBooleanAttribute(recieved: Locator, name: string) {
-        const options = {
-            comment: "Object.is equality",
-            isNot: this.isNot,
-            promise: this.promise,
-        };
-
-        name = name.trim();
-
-        await (await recieved.elementHandle())?.waitForElementState("stable");
-
-        const [hasAttribute, attributeValue] = await recieved.evaluate((node, name) => {
-            return [node.hasAttribute(name), node.getAttribute(name)];
-        }, name);
-
-        if (this.isNot) {
-            return {
-                pass: hasAttribute,
-                message: () => `expected ${name} to not be present`,
-            };
-        }
-
-        return {
-            pass: hasAttribute && (attributeValue === "" || attributeValue === name),
-            message: () => `${this.utils.matcherHint(
-                "toHaveBooleanAttribute",
-                undefined,
-                undefined,
-                options
-            )}
-
-expected ${recieved} to have boolean attribute \`${name}\``,
-        };
-    },
-});

--- a/packages/web-components/fast-foundation/playwright.config.ts
+++ b/packages/web-components/fast-foundation/playwright.config.ts
@@ -2,7 +2,6 @@ import type { Locator, PlaywrightTestConfig } from "@playwright/test";
 import { expect } from "@playwright/test";
 
 const config: PlaywrightTestConfig = {
-    projects: [{ name: "chromium" }, { name: "firefox" }, { name: "webkit" }],
     reporter: "list",
     testMatch: /.*\.pw\.spec\.ts$/,
     retries: 3,
@@ -10,6 +9,8 @@ const config: PlaywrightTestConfig = {
     timeout: process.env.CI ? 10000 : 30000,
     use: {
         baseURL: "http://localhost:6006/iframe.html",
+        deviceScaleFactor: 1,
+        launchOptions: { args: ["--force-device-scale-factor=1"] },
         viewport: {
             height: 1280,
             width: 720,

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
@@ -38,7 +38,7 @@ test.describe("Accordion item", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("headinglevel");
+        await expect(element).not.toHaveAttribute("headinglevel");
 
         await expect(element).toHaveJSProperty("headinglevel", 2);
     });

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
@@ -83,13 +83,13 @@ test.describe("Accordion item", () => {
             `;
         });
 
-        await expect(button).toHaveBooleanAttribute("disabled");
+        await expect(button).toHaveAttribute("disabled");
 
         await element.evaluate<void, FASTAccordionItem>(node => {
             node.disabled = false;
         });
 
-        await expect(button).not.toHaveBooleanAttribute("disabled");
+        await expect(button).not.toHaveAttribute("disabled");
     });
 
     test("should set internal properties to match the id when provided", async () => {

--- a/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion-item/accordion-item.pw.spec.ts
@@ -1,34 +1,16 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTAccordionItem } from "./accordion-item.js";
 
 test.describe("Accordion item", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let heading: Locator;
-    let button: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-accordion-item");
-
-        root = page.locator("#root");
-
-        heading = page.locator(`[role="heading"]`);
-
-        button = element.locator("button");
+    test("should set a default heading level of 2 when `headinglevel` is not provided", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+        const element = page.locator("fast-accordion-item");
 
         await page.goto(fixtureURL("accordion-item--accordion-item"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should set a default heading level of 2 when `headinglevel` is not provided", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion-item>
@@ -43,7 +25,15 @@ test.describe("Accordion item", () => {
         await expect(element).toHaveJSProperty("headinglevel", 2);
     });
 
-    test("should set the `aria-level` attribute on the internal heading element equal to the heading level", async () => {
+    test("should set the `aria-level` attribute on the internal heading element equal to the heading level", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+        const element = page.locator("fast-accordion-item");
+        const heading = page.locator(`[role="heading"]`);
+
+        await page.goto(fixtureURL("accordion-item--accordion-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion-item>
@@ -60,7 +50,15 @@ test.describe("Accordion item", () => {
         await expect(heading).toHaveAttribute("aria-level", "3");
     });
 
-    test("should set `aria-expanded` property on the internal control equal to the `expanded` property", async () => {
+    test("should set `aria-expanded` property on the internal control equal to the `expanded` property", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+        const element = page.locator("fast-accordion-item");
+        const button = element.locator("button");
+
+        await page.goto(fixtureURL("accordion-item--accordion-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion-item expanded></fast-accordion-item>
@@ -76,7 +74,15 @@ test.describe("Accordion item", () => {
         await expect(button).toHaveAttribute("aria-expanded", "false");
     });
 
-    test("should set `disabled` attribute on the internal control equal to the `disabled` property", async () => {
+    test("should set `disabled` attribute on the internal control equal to the `disabled` property", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+        const element = page.locator("fast-accordion-item");
+        const button = element.locator("button");
+
+        await page.goto(fixtureURL("accordion-item--accordion-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion-item disabled></fast-accordion-item>
@@ -92,7 +98,15 @@ test.describe("Accordion item", () => {
         await expect(button).not.toHaveAttribute("disabled");
     });
 
-    test("should set internal properties to match the id when provided", async () => {
+    test("should set internal properties to match the id when provided", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+        const element = page.locator("fast-accordion-item");
+        const button = element.locator("button");
+
+        await page.goto(fixtureURL("accordion-item--accordion-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion-item id="foo"></fast-accordion-item>

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -1,29 +1,17 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
-import { fixtureURL } from "../__test__/helpers.js";
+import { fixtureURL } from "src/__test__/helpers.js";
 import { AccordionExpandMode } from "./accordion.options.js";
-import type { FASTAccordion } from "./accordion.js";
 
 test.describe("Accordion", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-accordion");
-
-        root = page.locator("#root");
-
+    test("should set an expand mode of `multi` when passed to the `expand-mode` attribute", async ({
+        page,
+    }) => {
         await page.goto(fixtureURL("accordion--accordion"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
+        const root = page.locator("#root");
 
-    test("should set an expand mode of `multi` when passed to the `expand-mode` attribute", async () => {
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="multi">
@@ -42,7 +30,15 @@ test.describe("Accordion", () => {
         await expect(element).toHaveAttribute("expand-mode", AccordionExpandMode.multi);
     });
 
-    test("should set an expand mode of `single` when passed to the `expand-mode` attribute", async () => {
+    test("should set an expand mode of `single` when passed to the `expand-mode` attribute", async ({
+        page,
+    }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
@@ -61,7 +57,15 @@ test.describe("Accordion", () => {
         await expect(element).toHaveAttribute("expand-mode", AccordionExpandMode.single);
     });
 
-    test("should set a default expand mode of `multi` when `expand-mode` attribute is not passed", async () => {
+    test("should set a default expand mode of `multi` when `expand-mode` attribute is not passed", async ({
+        page,
+    }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion>
@@ -82,7 +86,13 @@ test.describe("Accordion", () => {
         await expect(element).toHaveAttribute("expand-mode", AccordionExpandMode.multi);
     });
 
-    test("should expand/collapse items when clicked in multi mode", async () => {
+    test("should expand/collapse items when clicked in multi mode", async ({ page }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="multi">
@@ -109,7 +119,13 @@ test.describe("Accordion", () => {
         await expect(items.nth(1)).toHaveAttribute("expanded", "");
     });
 
-    test("should only have one expanded item in single mode", async () => {
+    test("should only have one expanded item in single mode", async ({ page }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
@@ -150,7 +166,15 @@ test.describe("Accordion", () => {
         await expect(secondItem).toHaveAttribute("expanded");
     });
 
-    test("should set the expanded items' button to aria-disabled when in single expand mode", async () => {
+    test("should set the expanded items' button to aria-disabled when in single expand mode", async ({
+        page,
+    }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
@@ -202,7 +226,15 @@ test.describe("Accordion", () => {
         );
     });
 
-    test("should remove an expanded items' expandbutton aria-disabled attribute when expand mode changes from single to multi", async () => {
+    test("should remove an expanded items' expandbutton aria-disabled attribute when expand mode changes from single to multi", async ({
+        page,
+    }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
@@ -238,7 +270,15 @@ test.describe("Accordion", () => {
         await expect(firstItem.locator("button")).not.toHaveAttribute("aria-disabled");
     });
 
-    test("should set the first item as expanded if no child is expanded by default in single mode", async () => {
+    test("should set the first item as expanded if no child is expanded by default in single mode", async ({
+        page,
+    }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
@@ -271,7 +311,15 @@ test.describe("Accordion", () => {
         await expect(secondItem).toHaveAttribute("expanded");
     });
 
-    test("should set the first item with an expanded attribute to expanded in single mode", async () => {
+    test("should set the first item with an expanded attribute to expanded in single mode", async ({
+        page,
+    }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">
@@ -306,7 +354,15 @@ test.describe("Accordion", () => {
         await expect(thirdItem).not.toHaveAttribute("expanded");
     });
 
-    test("should allow disabled items to be expanded when in single mode", async () => {
+    test("should allow disabled items to be expanded when in single mode", async ({
+        page,
+    }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         test.slow();
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
@@ -352,7 +408,15 @@ test.describe("Accordion", () => {
         await expect(thirdItem).not.toHaveAttribute("expanded");
     });
 
-    test("should ignore `change` events from components other than accordion items", async () => {
+    test("should ignore `change` events from components other than accordion items", async ({
+        page,
+    }) => {
+        await page.goto(fixtureURL("accordion--accordion"));
+
+        const root = page.locator("#root");
+
+        const element = page.locator("fast-accordion");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-accordion expand-mode="single">

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -133,9 +133,9 @@ test.describe("Accordion", () => {
 
         await firstItem.click();
 
-        await expect(firstItem).toHaveBooleanAttribute("expanded");
+        await expect(firstItem).toHaveAttribute("expanded");
 
-        await expect(secondItem).not.toHaveBooleanAttribute("expanded");
+        await expect(secondItem).not.toHaveAttribute("expanded");
 
         const secondItemButton = secondItem.locator(`[part="button"]`);
 
@@ -145,9 +145,9 @@ test.describe("Accordion", () => {
             node.dispatchEvent(new MouseEvent("click", { bubbles: true }));
         });
 
-        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+        await expect(firstItem).not.toHaveAttribute("expanded");
 
-        await expect(secondItem).toHaveBooleanAttribute("expanded");
+        await expect(secondItem).toHaveAttribute("expanded");
     });
 
     test("should set the expanded items' button to aria-disabled when in single expand mode", async () => {
@@ -174,7 +174,7 @@ test.describe("Accordion", () => {
 
         await firstItem.click();
 
-        await expect(firstItem).toHaveBooleanAttribute("expanded");
+        await expect(firstItem).toHaveAttribute("expanded");
 
         await expect(firstItem.locator("button")).toHaveAttribute(
             "aria-disabled",
@@ -183,7 +183,7 @@ test.describe("Accordion", () => {
 
         await secondItem.click();
 
-        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+        await expect(firstItem).not.toHaveAttribute("expanded");
 
         await expect(firstItem.locator("button")).not.toHaveAttribute(
             "aria-disabled",
@@ -194,7 +194,7 @@ test.describe("Accordion", () => {
             "false"
         );
 
-        await expect(secondItem).toHaveBooleanAttribute("expanded");
+        await expect(secondItem).toHaveAttribute("expanded");
 
         await expect(secondItem.locator("button")).toHaveAttribute(
             "aria-disabled",
@@ -224,7 +224,7 @@ test.describe("Accordion", () => {
 
         await firstItem.click();
 
-        await expect(firstItem).toHaveBooleanAttribute("expanded");
+        await expect(firstItem).toHaveAttribute("expanded");
 
         await expect(firstItem.locator("button")).toHaveAttribute(
             "aria-disabled",
@@ -260,15 +260,15 @@ test.describe("Accordion", () => {
 
         const secondItem = items.nth(1);
 
-        await expect(firstItem).toHaveBooleanAttribute("expanded");
+        await expect(firstItem).toHaveAttribute("expanded");
 
-        await expect(secondItem).not.toHaveBooleanAttribute("expanded");
+        await expect(secondItem).not.toHaveAttribute("expanded");
 
         await secondItem.evaluate<void>(node => node.setAttribute("expanded", ""));
 
-        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+        await expect(firstItem).not.toHaveAttribute("expanded");
 
-        await expect(secondItem).toHaveBooleanAttribute("expanded");
+        await expect(secondItem).toHaveAttribute("expanded");
     });
 
     test("should set the first item with an expanded attribute to expanded in single mode", async () => {
@@ -299,11 +299,11 @@ test.describe("Accordion", () => {
 
         const thirdItem = items.nth(2);
 
-        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+        await expect(firstItem).not.toHaveAttribute("expanded");
 
-        await expect(secondItem).toHaveBooleanAttribute("expanded");
+        await expect(secondItem).toHaveAttribute("expanded");
 
-        await expect(thirdItem).not.toHaveBooleanAttribute("expanded");
+        await expect(thirdItem).not.toHaveAttribute("expanded");
     });
 
     test("should allow disabled items to be expanded when in single mode", async () => {
@@ -335,21 +335,21 @@ test.describe("Accordion", () => {
 
         const thirdItem = items.nth(2);
 
-        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+        await expect(firstItem).not.toHaveAttribute("expanded");
 
-        await expect(secondItem).toHaveBooleanAttribute("expanded");
+        await expect(secondItem).toHaveAttribute("expanded");
 
-        await expect(thirdItem).toHaveBooleanAttribute("expanded");
+        await expect(thirdItem).toHaveAttribute("expanded");
 
         await secondItem.evaluate(node => {
             node.removeAttribute("disabled");
         });
 
-        await expect(firstItem).not.toHaveBooleanAttribute("expanded");
+        await expect(firstItem).not.toHaveAttribute("expanded");
 
-        await expect(secondItem).toHaveBooleanAttribute("expanded");
+        await expect(secondItem).toHaveAttribute("expanded");
 
-        await expect(thirdItem).not.toHaveBooleanAttribute("expanded");
+        await expect(thirdItem).not.toHaveAttribute("expanded");
     });
 
     test("should ignore `change` events from components other than accordion items", async () => {

--- a/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/accordion/accordion.pw.spec.ts
@@ -235,7 +235,7 @@ test.describe("Accordion", () => {
             node.setAttribute("expand-mode", "multi");
         });
 
-        await expect(firstItem.locator("button")).not.hasAttribute("aria-disabled");
+        await expect(firstItem.locator("button")).not.toHaveAttribute("aria-disabled");
     });
 
     test("should set the first item as expanded if no child is expanded by default in single mode", async () => {

--- a/packages/web-components/fast-foundation/src/anchor/anchor.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/anchor/anchor.pw.spec.ts
@@ -1,24 +1,8 @@
 import { spinalCase } from "@microsoft/fast-web-utilities";
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 
 test.describe("Anchor", () => {
-    let page: Page;
-    let element: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-anchor");
-
-        await page.goto(fixtureURL("anchor", attributes));
-    });
-
-    test.afterAll(async () => {
-        await page.close();
-    });
-
     const attributes = {
         href: "href",
         ping: "ping",
@@ -52,7 +36,13 @@ test.describe("Anchor", () => {
     for (const [attribute, value] of Object.entries(attributes)) {
         const attributeSpinalCase = spinalCase(attribute);
 
-        test(`should set the \`${attributeSpinalCase}\` attribute to \`${value}\` on the internal control`, async () => {
+        test(`should set the \`${attributeSpinalCase}\` attribute to \`${value}\` on the internal control`, async ({
+            page,
+        }) => {
+            const element = page.locator("fast-anchor");
+
+            await page.goto(fixtureURL("anchor", attributes));
+
             await expect(element).toHaveAttribute(attributeSpinalCase, `${value}`);
         });
     }

--- a/packages/web-components/fast-foundation/src/anchored-region/anchored-region.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/anchored-region/anchored-region.pw.spec.ts
@@ -1,28 +1,17 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTAnchoredRegion } from "./anchored-region.js";
 
 test.describe("Anchored Region", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-anchored-region");
-
-        root = page.locator("#root");
-
+    test("should set positioning modes to 'uncontrolled' by default", async ({
+        page,
+    }) => {
         await page.goto(fixtureURL("anchored-region--anchored-region"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
+        const element = page.locator("fast-anchored-region");
 
-    test("should set positioning modes to 'uncontrolled' by default", async () => {
+        const root = page.locator("#root");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-anchored-region></fast-anchored-region>
@@ -37,7 +26,13 @@ test.describe("Anchored Region", () => {
         );
     });
 
-    test("should assign anchor and viewport elements by id", async () => {
+    test("should assign anchor and viewport elements by id", async ({ page }) => {
+        await page.goto(fixtureURL("anchored-region--anchored-region"));
+
+        const element = page.locator("fast-anchored-region");
+
+        const root = page.locator("#root");
+
         const anchorId = "anchor";
 
         await root.evaluate(
@@ -61,7 +56,13 @@ test.describe("Anchored Region", () => {
         expect(anchorElementId).toBe(anchorId);
     });
 
-    test("should be sized to match content by default", async () => {
+    test("should be sized to match content by default", async ({ page }) => {
+        await page.goto(fixtureURL("anchored-region--anchored-region"));
+
+        const element = page.locator("fast-anchored-region");
+
+        const root = page.locator("#root");
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-anchored-region>

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.pw.spec.ts
@@ -1,32 +1,16 @@
 import { spinalCase } from "@microsoft/fast-web-utilities";
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTBreadcrumbItem } from "./breadcrumb-item.js";
 
 test.describe("Breadcrumb item", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let control: Locator;
+    test("should include a `role` of `listitem`", async ({ page }) => {
+        const element = page.locator("fast-breadcrumb-item");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-breadcrumb-item");
-
-        root = page.locator("#root");
-
-        control = element.locator(".control");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("breadcrumb-item--breadcrumb-item"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should include a `role` of `listitem`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-breadcrumb-item></fast-breadcrumb-item>
@@ -36,7 +20,15 @@ test.describe("Breadcrumb item", () => {
         await expect(element).toHaveAttribute("role", "listitem");
     });
 
-    test("should render an internal anchor when the `href` attribute is not provided", async () => {
+    test("should render an internal anchor when the `href` attribute is not provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-breadcrumb-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("breadcrumb-item--breadcrumb-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-breadcrumb-item></fast-breadcrumb-item>
@@ -54,7 +46,15 @@ test.describe("Breadcrumb item", () => {
         await expect(element.locator("a")).toHaveCount(1);
     });
 
-    test("should render an internal anchor when the `href` attribute is provided", async () => {
+    test("should render an internal anchor when the `href` attribute is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-breadcrumb-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("breadcrumb-item--breadcrumb-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-breadcrumb-item href="https://fast.design"></fast-breadcrumb-item>
@@ -72,7 +72,15 @@ test.describe("Breadcrumb item", () => {
         });
     });
 
-    test("should add an element with a class of `separator` when the `separator` property is true", async () => {
+    test("should add an element with a class of `separator` when the `separator` property is true", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-breadcrumb-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("breadcrumb-item--breadcrumb-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-breadcrumb-item></fast-breadcrumb-item>
@@ -119,7 +127,17 @@ test.describe("Breadcrumb item", () => {
     for (const [attribute, value] of Object.entries(attributes)) {
         const attrToken = spinalCase(attribute);
 
-        test(`should set the \`${attrToken}\` attribute to \`${value}\` on the internal anchor`, async () => {
+        test(`should set the \`${attrToken}\` attribute to \`${value}\` on the internal anchor`, async ({
+            page,
+        }) => {
+            const element = page.locator("fast-breadcrumb-item");
+
+            const root = page.locator("#root");
+
+            const control = element.locator(".control");
+
+            await page.goto(fixtureURL("breadcrumb-item--breadcrumb-item"));
+
             await root.evaluate(
                 (node, { attrToken, value }) => {
                     node.innerHTML = /* html */ `

--- a/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb-item/breadcrumb-item.pw.spec.ts
@@ -45,7 +45,7 @@ test.describe("Breadcrumb item", () => {
 
         const anchor = element.locator("a");
 
-        await expect(element).not.hasAttribute("href");
+        await expect(element).not.toHaveAttribute("href");
 
         await expect(element).toHaveJSProperty("href", undefined);
 

--- a/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.pw.spec.ts
@@ -1,28 +1,15 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTBreadcrumb } from "./breadcrumb.js";
 
 test.describe("Breadcrumb", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should have a role of 'navigation'", async ({ page }) => {
+        const element = page.locator("fast-breadcrumb");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-breadcrumb");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("breadcrumb--breadcrumb"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of 'navigation'", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-breadcrumb></fast-breadcrumb>
@@ -32,7 +19,15 @@ test.describe("Breadcrumb", () => {
         await expect(element).toHaveAttribute("role", "navigation");
     });
 
-    test("should include an internal element with a `role` of `list`", async () => {
+    test("should include an internal element with a `role` of `list`", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-breadcrumb");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("breadcrumb--breadcrumb"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-breadcrumb></fast-breadcrumb>
@@ -42,7 +37,13 @@ test.describe("Breadcrumb", () => {
         await expect(element.locator(".list")).toHaveAttribute("role", "list");
     });
 
-    test("should not render a separator on last item", async () => {
+    test("should not render a separator on last item", async ({ page }) => {
+        const element = page.locator("fast-breadcrumb");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("breadcrumb--breadcrumb"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-breadcrumb>
@@ -60,7 +61,15 @@ test.describe("Breadcrumb", () => {
         await expect(items.last()).toHaveJSProperty("separator", false);
     });
 
-    test("should set `aria-current` on the internal anchor of the last node when `href` is present", async () => {
+    test("should set `aria-current` on the internal anchor of the last node when `href` is present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-breadcrumb");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("breadcrumb--breadcrumb"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-breadcrumb>
@@ -76,7 +85,15 @@ test.describe("Breadcrumb", () => {
         ).toHaveAttribute("aria-current", "page");
     });
 
-    test("should remove `aria-current` from any prior breadcrumb item children with child anchors when a new node is appended", async () => {
+    test("should remove `aria-current` from any prior breadcrumb item children with child anchors when a new node is appended", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-breadcrumb");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("breadcrumb--breadcrumb"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-breadcrumb>

--- a/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/breadcrumb/breadcrumb.pw.spec.ts
@@ -97,6 +97,6 @@ test.describe("Breadcrumb", () => {
 
         await expect(
             element.locator("fast-breadcrumb-item:nth-of-type(2) a")
-        ).not.hasAttribute("aria-current");
+        ).not.toHaveAttribute("aria-current");
     });
 });

--- a/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
@@ -33,13 +33,13 @@ test.describe("Button", () => {
             `;
         });
 
-        await expect(control).toHaveBooleanAttribute("disabled");
+        await expect(control).toHaveAttribute("disabled");
 
         await element.evaluate(node => {
             node.toggleAttribute("disabled");
         });
 
-        await expect(control).not.toHaveBooleanAttribute("disabled");
+        await expect(control).not.toHaveAttribute("disabled");
     });
 
     test("should set the `formnovalidate` attribute on the internal control", async () => {
@@ -49,13 +49,13 @@ test.describe("Button", () => {
             `;
         });
 
-        await expect(control).toHaveBooleanAttribute("formnovalidate");
+        await expect(control).toHaveAttribute("formnovalidate");
 
         await element.evaluate(node => {
             node.toggleAttribute("formnovalidate");
         });
 
-        await expect(control).not.toHaveBooleanAttribute("formnovalidate");
+        await expect(control).not.toHaveAttribute("formnovalidate");
     });
 
     test.describe("should set the attribute on the internal control", () => {
@@ -130,13 +130,13 @@ test.describe("Button", () => {
             `;
         });
 
-        await expect(control).toHaveBooleanAttribute("autofocus");
+        await expect(control).toHaveAttribute("autofocus");
 
         await element.evaluate(node => {
             node.toggleAttribute("autofocus");
         });
 
-        await expect(control).not.toHaveBooleanAttribute("autofocus");
+        await expect(control).not.toHaveAttribute("autofocus");
     });
 
     test("of type `submit` should submit the parent form when clicked", async () => {

--- a/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
@@ -1,32 +1,20 @@
 import { spinalCase } from "@microsoft/fast-web-utilities";
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTButton } from "./button.js";
 
 test.describe("Button", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let control: Locator;
+    test("should set the `disabled` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-button");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
+        const root = page.locator("#root");
 
-        element = page.locator("fast-button");
-
-        root = page.locator("#root");
-
-        control = element.locator(".control");
+        const control = element.locator(".control");
 
         await page.goto(fixtureURL("button--button"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should set the `disabled` attribute on the internal control", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-button disabled></fast-button>
@@ -42,7 +30,17 @@ test.describe("Button", () => {
         await expect(control).not.toHaveAttribute("disabled");
     });
 
-    test("should set the `formnovalidate` attribute on the internal control", async () => {
+    test("should set the `formnovalidate` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-button");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("button--button"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-button formnovalidate></fast-button>
@@ -94,7 +92,17 @@ test.describe("Button", () => {
         for (const [attribute, value] of Object.entries(attributes)) {
             const attrToken = spinalCase(attribute);
 
-            test(`should set the \`${attrToken}\` attribute to \`${value}\``, async () => {
+            test(`should set the \`${attrToken}\` attribute to \`${value}\``, async ({
+                page,
+            }) => {
+                const element = page.locator("fast-button");
+
+                const root = page.locator("#root");
+
+                const control = element.locator(".control");
+
+                await page.goto(fixtureURL("button--button"));
+
                 await root.evaluate(
                     (node, { attrToken, value }) => {
                         node.innerHTML = /* html */ `
@@ -109,7 +117,17 @@ test.describe("Button", () => {
         }
     });
 
-    test("should set the `form` attribute on the internal button when `formId` is provided", async () => {
+    test("should set the `form` attribute on the internal button when `formId` is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-button");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("button--button"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-button></fast-button>
@@ -123,7 +141,17 @@ test.describe("Button", () => {
         await expect(control).toHaveAttribute("form", "foo");
     });
 
-    test("should set the `autofocus` attribute on the internal control", async () => {
+    test("should set the `autofocus` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-button");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("button--button"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-button autofocus></fast-button>
@@ -139,7 +167,15 @@ test.describe("Button", () => {
         await expect(control).not.toHaveAttribute("autofocus");
     });
 
-    test("of type `submit` should submit the parent form when clicked", async () => {
+    test("of type `submit` should submit the parent form when clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-button");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("button--button"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -167,7 +203,15 @@ test.describe("Button", () => {
         expect(wasSubmitted).toBeTruthy();
     });
 
-    test("of type `reset` should reset the parent form when clicked", async () => {
+    test("of type `reset` should reset the parent form when clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-button");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("button--button"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -194,7 +238,13 @@ test.describe("Button", () => {
         expect(wasReset).toBeTruthy();
     });
 
-    test("should not propagate when clicked and `disabled` is true", async () => {
+    test("should not propagate when clicked and `disabled` is true", async ({ page }) => {
+        const element = page.locator("fast-button");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("button--button"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-button disabled>Disabled Button</fast-button>

--- a/packages/web-components/fast-foundation/src/calendar/calendar.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/calendar/calendar.pw.spec.ts
@@ -1,30 +1,13 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTCalendar } from "./calendar.js";
 import { DateFormatter } from "./date-formatter.js";
 
 test.describe("Calendar", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-calendar");
-
-        root = page.locator("#root");
-
-        await page.goto(fixtureURL("calendar--calendar"));
-    });
-
-    test.afterAll(async () => {
-        await page.close();
-    });
-
     test.describe("DateFormatter", () => {
-        test("should be able to set properties on construction", async () => {
+        test("should be able to set properties on construction", async ({ page }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const locale = "en-US";
             const dayFormat = "2-digit";
             const monthFormat = "narrow";
@@ -50,14 +33,20 @@ test.describe("Calendar", () => {
             expect(formatter.date.getFullYear()).toBe(2021);
         });
 
-        test("should return a date string for today by default", async () => {
+        test("should return a date string for today by default", async ({ page }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter();
             const today = new Date();
 
             expect(formatter.getDate()).toBe(formatter.getDate(today));
         });
 
-        test("should be able to get a date string for a specific date", async () => {
+        test("should be able to get a date string for a specific date", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter();
             const day = 2;
             const month = 1;
@@ -74,13 +63,19 @@ test.describe("Calendar", () => {
             ).toBe(dateString);
         });
 
-        test("should default formatting to [weekday='long'], [month='long'] [day='numeric'], [year='numeric'] string", async () => {
+        test("should default formatting to [weekday='long'], [month='long'] [day='numeric'], [year='numeric'] string", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter({ date: "1-1-2020" });
 
             expect(formatter.getDate()).toBe("Wednesday, January 1, 2020");
         });
 
-        test("should be able to change formats", async () => {
+        test("should be able to change formats", async ({ page }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter({
                 weekdayFormat: undefined,
                 monthFormat: "short",
@@ -101,21 +96,27 @@ test.describe("Calendar", () => {
             ).toBe("J 01, 20");
         });
 
-        test("should return todays day by default for getDay()", async () => {
+        test("should return todays day by default for getDay()", async ({ page }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter();
             const today = new Date();
 
             expect(formatter.getDay()).toBe(today.getDate().toString());
         });
 
-        test("should return formatted days with getDay()", async () => {
+        test("should return formatted days with getDay()", async ({ page }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter();
 
             expect(formatter.getDay(14)).toBe("14");
             expect(formatter.getDay(8, "2-digit")).toBe("08");
         });
 
-        test("should return this month by default for getMonth()", async () => {
+        test("should return this month by default for getMonth()", async ({ page }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter();
             const today = new Date();
             const months = [
@@ -136,7 +137,9 @@ test.describe("Calendar", () => {
             expect(formatter.getMonth()).toBe(months[today.getMonth()]);
         });
 
-        test("should return formatted month with getMonth()", async () => {
+        test("should return formatted month with getMonth()", async ({ page }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter();
 
             expect(formatter.getMonth(1)).toBe("January");
@@ -146,21 +149,29 @@ test.describe("Calendar", () => {
             expect(formatter.getMonth(5, "2-digit")).toBe("05");
         });
 
-        test("should return this year by default for getYear()", async () => {
+        test("should return this year by default for getYear()", async ({ page }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter();
             const today = new Date();
 
             expect(formatter.getYear()).toBe(today.getFullYear().toString());
         });
 
-        test("should return formatted year with getYear()", async () => {
+        test("should return formatted year with getYear()", async ({ page }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter({ yearFormat: "2-digit" });
 
             expect(formatter.getYear(2012)).toBe("12");
             expect(formatter.getYear(2015, "numeric")).toBe("2015");
         });
 
-        test("should return formatted weekday string with getWeekday()", async () => {
+        test("should return formatted weekday string with getWeekday()", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter();
 
             //defaults to sunday
@@ -170,7 +181,11 @@ test.describe("Calendar", () => {
             expect(formatter.getWeekday(4, "narrow")).toBe("T");
         });
 
-        test("should return a list of formatted weekday labels with getWeekdays()", async () => {
+        test("should return a list of formatted weekday labels with getWeekdays()", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter();
             const weekdays = [
                 "Sunday",
@@ -193,7 +208,11 @@ test.describe("Calendar", () => {
             );
         });
 
-        test("should return a localized string when setting the locale", async () => {
+        test("should return a localized string when setting the locale", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("calendar--calendar"));
+
             const formatter = new DateFormatter({ locale: "fr-FR", date: "3-1-2015" });
 
             expect(formatter.getDate()).toBe("dimanche 1 mars 2015");
@@ -207,7 +226,13 @@ test.describe("Calendar", () => {
     });
 
     test.describe("Defaults", () => {
-        test("should default to the current month and year", async () => {
+        test("should default to the current month and year", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar></fast-calendar>
@@ -220,7 +245,13 @@ test.describe("Calendar", () => {
             await expect(element).toHaveJSProperty("year", today.getFullYear());
         });
 
-        test("should return 5 weeks of days for August 2021", async () => {
+        test("should return 5 weeks of days for August 2021", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="8" year="2021"></fast-calendar>
@@ -240,7 +271,15 @@ test.describe("Calendar", () => {
             await expect(day).toHaveCount(35);
         });
 
-        test("should return 6 weeks of days for August 2021 when min-weeks is set to 6", async () => {
+        test("should return 6 weeks of days for August 2021 when min-weeks is set to 6", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="8" year="2021" min-weeks="6"></fast-calendar>
@@ -260,7 +299,13 @@ test.describe("Calendar", () => {
             await expect(day).toHaveCount(42);
         });
 
-        test("should highlight the current date", async () => {
+        test("should highlight the current date", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar></fast-calendar>
@@ -276,7 +321,15 @@ test.describe("Calendar", () => {
     });
 
     test.describe("Month info", () => {
-        test("should display 31 days for the month of January in the year 2022", async () => {
+        test("should display 31 days for the month of January in the year 2022", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="1" year="2022" readonly></fast-calendar>
@@ -292,7 +345,15 @@ test.describe("Calendar", () => {
             await expect(days).toHaveCount(31);
         });
 
-        test("should display 28 days for the month of February in the year 2022", async () => {
+        test("should display 28 days for the month of February in the year 2022", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="2" year="2022" readonly></fast-calendar>
@@ -308,7 +369,15 @@ test.describe("Calendar", () => {
             await expect(days).toHaveCount(28);
         });
 
-        test("should display 29 days for the month of February in the year 2020", async () => {
+        test("should display 29 days for the month of February in the year 2020", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="2" year="2020" readonly></fast-calendar>
@@ -324,7 +393,13 @@ test.describe("Calendar", () => {
             await expect(days).toHaveCount(29);
         });
 
-        test("should start on Friday for January 2021", async () => {
+        test("should start on Friday for January 2021", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="1" year="2021" readonly></fast-calendar>
@@ -340,7 +415,13 @@ test.describe("Calendar", () => {
             await expect(days.nth(5)).toHaveText("1");
         });
 
-        test("should start on Monday for February 2021", async () => {
+        test("should start on Monday for February 2021", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="2" year="2021" readonly></fast-calendar>
@@ -357,8 +438,14 @@ test.describe("Calendar", () => {
         });
     });
 
-    test.describe("Labels", async () => {
-        test("should return January for month 1", async () => {
+    test.describe("Labels", () => {
+        test("should return January for month 1", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="1" year="2021" readonly></fast-calendar>
@@ -372,7 +459,13 @@ test.describe("Calendar", () => {
             ).toBe("January");
         });
 
-        test("should return Jan for month 1 and short format", async () => {
+        test("should return Jan for month 1 and short format", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="1" year="2021" month-format="short" readonly></fast-calendar>
@@ -386,7 +479,13 @@ test.describe("Calendar", () => {
             ).toBe("Jan");
         });
 
-        test("should return Mon for Monday by default", async () => {
+        test("should return Mon for Monday by default", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="1" year="2021" readonly></fast-calendar>
@@ -400,7 +499,13 @@ test.describe("Calendar", () => {
             ).toBe("Mon");
         });
 
-        test("should return Monday weekday for long format", async () => {
+        test("should return Monday weekday for long format", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="1" year="2021" weekday-format="long" readonly></fast-calendar>
@@ -414,7 +519,13 @@ test.describe("Calendar", () => {
             ).toBe("Monday");
         });
 
-        test("should return M for Monday for narrow format", async () => {
+        test("should return M for Monday for narrow format", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="1" year="2021" weekday-format="narrow" readonly></fast-calendar>
@@ -429,8 +540,14 @@ test.describe("Calendar", () => {
         });
     });
 
-    test.describe("Localization", async () => {
-        test(`should be "mai" for the month May in French`, async () => {
+    test.describe("Localization", () => {
+        test(`should be "mai" for the month May in French`, async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="5" year="2021" locale="fr" readonly></fast-calendar>
@@ -444,7 +561,15 @@ test.describe("Calendar", () => {
             ).toBe("mai");
         });
 
-        test("should have French weekday labels for the fr-FR market", async () => {
+        test("should have French weekday labels for the fr-FR market", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="1" year="2021" locale="fr-FR" readonly></fast-calendar>
@@ -466,7 +591,15 @@ test.describe("Calendar", () => {
             await expect(weekdayLabels).toHaveText(frenchWeekdays);
         });
 
-        test('should set the formatted `year` property to "1942" when the `year` attribute is "2021" for the Hindu calendar', async () => {
+        test('should set the formatted `year` property to "1942" when the `year` attribute is "2021" for the Hindu calendar', async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="6" year="2021" locale="hi-IN-u-ca-indian"></fast-calendar>
@@ -480,7 +613,15 @@ test.describe("Calendar", () => {
             ).toBe("1942 शक");
         });
 
-        test('should set the formatted `year` property to "2564" when the `year` attribute is "2021" for the Buddhist calendar', async () => {
+        test('should set the formatted `year` property to "2564" when the `year` attribute is "2021" for the Buddhist calendar', async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="6" year="2021" locale="th-TH-u-ca-buddhist"></fast-calendar>
@@ -494,7 +635,15 @@ test.describe("Calendar", () => {
             ).toBe("พ.ศ. 2564");
         });
 
-        test("should not be RTL for languages that are not Arabic or Hebrew", async () => {
+        test("should not be RTL for languages that are not Arabic or Hebrew", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="1" year="2021" locale="fr-FR" readonly></fast-calendar>
@@ -514,8 +663,13 @@ test.describe("Calendar", () => {
             }
         });
 
-        /* FIXME this test is an incorrect assertion */
-        test.skip("Should be RTL for Arabic language", async () => {
+        test("Should be RTL for Arabic language", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="8" year="2021" locale="ar-XE-u-ca-islamic-nu-arab" readonly></fast-calendar>
@@ -532,8 +686,14 @@ test.describe("Calendar", () => {
         });
     });
 
-    test.describe("Day states", async () => {
-        test("should not show date as disabled by default", async () => {
+    test.describe("Day states", () => {
+        test("should not show date as disabled by default", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="5" year="2021" readonly></fast-calendar>
@@ -559,7 +719,15 @@ test.describe("Calendar", () => {
             await expect(disabled).toHaveCount(0);
         });
 
-        test("should show date as disabled when added to disabled-dates attribute", async () => {
+        test("should show date as disabled when added to disabled-dates attribute", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="5" year="2021" disabled-dates="5-6-2021,5-7-2021,5-8-2021" readonly></fast-calendar>
@@ -588,7 +756,13 @@ test.describe("Calendar", () => {
             await expect(disabled).toHaveCount(3);
         });
 
-        test("should not show date as selected by default", async () => {
+        test("should not show date as selected by default", async ({ page }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="5" year="2021" readonly></fast-calendar>
@@ -597,25 +771,32 @@ test.describe("Calendar", () => {
 
             expect(
                 await element.evaluate((node: FASTCalendar) =>
-                    node.dateInString(`5-7-2021`, node.selectedDates)
+                    node.dateInString("5-7-2021", node.selectedDates)
                 )
             ).toBe(false);
 
             expect(
-                element.evaluate(
-                    (node: FASTCalendar) =>
-                        node
-                            .getDayClassNames({ month: 5, day: 7, year: 2021 })
-                            .indexOf("selected") === -1
+                await element.evaluate((node: FASTCalendar) =>
+                    node
+                        .getDayClassNames({ month: 5, day: 7, year: 2021 })
+                        .indexOf("selected")
                 )
-            ).toBeTruthy();
+            ).toBe(-1);
 
             const selected = element.locator(".selected");
 
             await expect(selected).toHaveCount(0);
         });
 
-        test("should show date as selected when added to selected-dates attribute", async () => {
+        test("should show date as selected when added to selected-dates attribute", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-calendar");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("calendar--calendar"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-calendar month="5" year="2021" selected-dates="5-6-2021,5-7-2021,5-8-2021" readonly></fast-calendar>

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.pw.spec.ts
@@ -1,31 +1,15 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTCheckbox } from "./checkbox.js";
 
 test.describe("Checkbox", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let form: Locator;
+    test("should have a role of `checkbox`", async ({ page }) => {
+        const element = page.locator("fast-checkbox");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-checkbox");
-
-        root = page.locator("#root");
-
-        form = page.locator("form");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("checkbox--checkbox"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of `checkbox`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -34,7 +18,13 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("role", "checkbox");
     });
 
-    test("should set a tabindex of 0 on the element", async () => {
+    test("should set a tabindex of 0 on the element", async ({ page }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -46,7 +36,15 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should set a default `aria-checked` value when `checked` is not defined", async () => {
+    test("should set a default `aria-checked` value when `checked` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -58,7 +56,15 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
-    test("should set the `aria-checked` attribute equal to the `checked` property", async () => {
+    test("should set the `aria-checked` attribute equal to the `checked` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox checked></fast-checkbox>
@@ -74,7 +80,15 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
-    test("should NOT set a default `aria-required` value when `required` is not defined", async () => {
+    test("should NOT set a default `aria-required` value when `required` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -86,7 +100,15 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("aria-required", "false");
     });
 
-    test("should set the `aria-required` attribute equal to the `required` property", async () => {
+    test("should set the `aria-required` attribute equal to the `required` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -106,7 +128,15 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("aria-required", "false");
     });
 
-    test("should set a default `aria-disabled` value when `disabled` is not defined", async () => {
+    test("should set a default `aria-disabled` value when `disabled` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -118,7 +148,15 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should set the `aria-disabled` attribute equal to the `disabled` property", async () => {
+    test("should set the `aria-disabled` attribute equal to the `disabled` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -138,7 +176,13 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should NOT set a tabindex when `disabled` is true", async () => {
+    test("should NOT set a tabindex when `disabled` is true", async ({ page }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox disabled></fast-checkbox>
@@ -150,7 +194,15 @@ test.describe("Checkbox", () => {
         await expect(element).not.toHaveAttribute("tabindex", "0");
     });
 
-    test("should set the aria-checked value to 'mixed' when indeterminate property is true", async () => {
+    test("should set the aria-checked value to 'mixed' when indeterminate property is true", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -170,7 +222,15 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
-    test("should set off `indeterminate` on `checked` change by user click", async () => {
+    test("should set off `indeterminate` on `checked` change by user click", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox>checkbox</fast-checkbox>
@@ -188,7 +248,15 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveJSProperty("indeterminate", false);
     });
 
-    test("should set off `indeterminate` on `checked` change by user keypress", async () => {
+    test("should set off `indeterminate` on `checked` change by user keypress", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -206,7 +274,15 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveJSProperty("indeterminate", false);
     });
 
-    test("should add a class of `label` to the internal label when default slotted content exists", async () => {
+    test("should add a class of `label` to the internal label when default slotted content exists", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox>
@@ -220,7 +296,15 @@ test.describe("Checkbox", () => {
         await expect(label).toHaveClass(/label/);
     });
 
-    test("should add classes of `label` and `label__hidden` to the internal label when default slotted content exists", async () => {
+    test("should add classes of `label` and `label__hidden` to the internal label when default slotted content exists", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox>
@@ -240,7 +324,15 @@ test.describe("Checkbox", () => {
         await expect(label).toHaveClass(/label label__hidden/);
     });
 
-    test("should initialize to the initial value if no value property is set", async () => {
+    test("should initialize to the initial value if no value property is set", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -255,28 +347,40 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveJSProperty("value", initialValue);
     });
 
-    test("should initialize to the provided `value` attribute when set pre-connection", async () => {
+    test("should initialize to the provided `value` attribute when set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox value="foo"></fast-checkbox>
             `;
         });
 
-        const element = page.locator("fast-checkbox");
-
         const value = await element.evaluate((node: FASTCheckbox) => node.value);
 
         expect(value).toBe("foo");
     });
 
-    test("should initialize to the provided `value` attribute when set post-connection", async () => {
+    test("should initialize to the provided `value` attribute when set post-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
             `;
         });
-
-        const element = page.locator("fast-checkbox");
 
         const expectedValue = "foobar";
 
@@ -287,7 +391,13 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveJSProperty("value", expectedValue);
     });
 
-    test("should initialize to the provided `value` property when set pre-connection", async () => {
+    test("should initialize to the provided `value` property when set pre-connection", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-checkbox></fast-checkbox>
@@ -307,7 +417,13 @@ test.describe("Checkbox", () => {
         expect(value).toBe(expectedValue);
     });
 
-    test("should be invalid when unchecked", async () => {
+    test("should be invalid when unchecked", async ({ page }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -321,7 +437,13 @@ test.describe("Checkbox", () => {
         ).toBe(true);
     });
 
-    test("should be valid when checked", async () => {
+    test("should be valid when checked", async ({ page }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -339,7 +461,17 @@ test.describe("Checkbox", () => {
         ).toBe(false);
     });
 
-    test("should set the `checked` property to false if the `checked` attribute is unset", async () => {
+    test("should set the `checked` property to false if the `checked` attribute is unset", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        const form = page.locator("form");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -363,7 +495,17 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveJSProperty("checked", false);
     });
 
-    test("should set its checked property to true if the checked attribute is set", async () => {
+    test("should set its checked property to true if the checked attribute is set", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        const form = page.locator("form");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -387,7 +529,17 @@ test.describe("Checkbox", () => {
         await expect(element).toHaveJSProperty("checked", true);
     });
 
-    test("should put the control into a clean state, where checked attribute modifications change the checked property prior to user or programmatic interaction", async () => {
+    test("should put the control into a clean state, where checked attribute modifications change the checked property prior to user or programmatic interaction", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-checkbox");
+
+        const root = page.locator("#root");
+
+        const form = page.locator("form");
+
+        await page.goto(fixtureURL("checkbox--checkbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>

--- a/packages/web-components/fast-foundation/src/checkbox/checkbox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/checkbox/checkbox.pw.spec.ts
@@ -53,7 +53,7 @@ test.describe("Checkbox", () => {
             `;
         });
 
-        await expect(element).not.toHaveBooleanAttribute("checked");
+        await expect(element).not.toHaveAttribute("checked");
 
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
@@ -81,7 +81,7 @@ test.describe("Checkbox", () => {
             `;
         });
 
-        await expect(element).not.toHaveBooleanAttribute("required");
+        await expect(element).not.toHaveAttribute("required");
 
         await expect(element).toHaveAttribute("aria-required", "false");
     });
@@ -113,7 +113,7 @@ test.describe("Checkbox", () => {
             `;
         });
 
-        await expect(element).not.toHaveBooleanAttribute("disabled");
+        await expect(element).not.toHaveAttribute("disabled");
 
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });

--- a/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
@@ -262,7 +262,7 @@ test.describe("Combobox", () => {
             node.open = true;
         });
 
-        await expect(element).toHaveBooleanAttribute("open");
+        await expect(element).toHaveAttribute("open");
 
         await expect(listbox).toBeVisible();
     });
@@ -283,7 +283,7 @@ test.describe("Combobox", () => {
 
             await element.locator(".listbox").waitFor({ state: "visible" });
 
-            await expect(element).toHaveBooleanAttribute("open");
+            await expect(element).toHaveAttribute("open");
 
             const [wasChanged] = await Promise.all([
                 element.evaluate(node =>

--- a/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
@@ -1,31 +1,19 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTCombobox } from "./combobox.js";
 
 test.describe("Combobox", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let control: Locator;
+    test('should include a control with a `role` attribute equal to "combobox"', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
+        const root = page.locator("#root");
 
-        element = page.locator("fast-combobox");
-
-        root = page.locator("#root");
-
-        control = element.locator(`input[role="combobox"]`);
+        const control = element.locator(`input[role="combobox"]`);
 
         await page.goto(fixtureURL("combobox--combobox"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test('should include a control with a `role` attribute equal to "combobox"', async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-combobox>
@@ -39,7 +27,15 @@ test.describe("Combobox", () => {
         await expect(control).toHaveCount(1);
     });
 
-    test("should set the `aria-disabled` attribute equal to the `disabled` property", async () => {
+    test("should set the `aria-disabled` attribute equal to the `disabled` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-combobox>
@@ -65,7 +61,15 @@ test.describe("Combobox", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should set and remove the `tabindex` attribute based on the value of the `disabled` property", async () => {
+    test("should set and remove the `tabindex` attribute based on the value of the `disabled` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-combobox disabled>
@@ -85,7 +89,17 @@ test.describe("Combobox", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should NOT set the `value` property to the first available option", async () => {
+    test("should NOT set the `value` property to the first available option", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(`input[role="combobox"]`);
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-combobox>
@@ -101,7 +115,17 @@ test.describe("Combobox", () => {
         await expect(control).toHaveValue("");
     });
 
-    test("should set the `placeholder` attribute on the internal control equal to the `placeholder` attribute", async () => {
+    test("should set the `placeholder` attribute on the internal control equal to the `placeholder` attribute", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(`input[role="combobox"]`);
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-combobox placeholder="placeholder text">
@@ -117,7 +141,17 @@ test.describe("Combobox", () => {
         await expect(control).toHaveAttribute("placeholder", "placeholder text");
     });
 
-    test("should set the control's `aria-controls` attribute to the ID of the internal listbox element while open", async () => {
+    test("should set the control's `aria-controls` attribute to the ID of the internal listbox element while open", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(`input[role="combobox"]`);
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-combobox>
@@ -147,7 +181,17 @@ test.describe("Combobox", () => {
         await expect(control).toHaveAttribute("aria-controls", "");
     });
 
-    test("should set the control's `aria-activedescendant` property to the ID of the currently selected option while open", async () => {
+    test("should set the control's `aria-activedescendant` property to the ID of the currently selected option while open", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(`input[role="combobox"]`);
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-combobox>
@@ -191,7 +235,15 @@ test.describe("Combobox", () => {
         await expect(element).not.toHaveAttribute("aria-activedescendant");
     });
 
-    test("should set its value to the first option with the `selected` attribute present", async () => {
+    test("should set its value to the first option with the `selected` attribute present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -216,7 +268,15 @@ test.describe("Combobox", () => {
         await expect(element).toHaveJSProperty("value", "two");
     });
 
-    test("should return the same value when the `value` property is set before connecting", async () => {
+    test("should return the same value when the `value` property is set before connecting", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -228,7 +288,15 @@ test.describe("Combobox", () => {
         expect(await element.evaluate((node: FASTCombobox) => node.value)).toBe("test");
     });
 
-    test("should return the same value when the `value` property is set after connecting", async () => {
+    test("should return the same value when the `value` property is set after connecting", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -243,7 +311,15 @@ test.describe("Combobox", () => {
         await expect(element).toHaveJSProperty("value", "test");
     });
 
-    test("should display the listbox when the `open` property is true before connecting", async () => {
+    test("should display the listbox when the `open` property is true before connecting", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-combobox>
@@ -268,7 +344,13 @@ test.describe("Combobox", () => {
     });
 
     test.describe("should NOT emit a 'change' event when the value changes by user input while open", () => {
-        test("via arrow down key", async () => {
+        test("via arrow down key", async ({ page }) => {
+            const element = page.locator("fast-combobox");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("combobox--combobox"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                         <fast-combobox>
@@ -300,7 +382,13 @@ test.describe("Combobox", () => {
             expect(wasChanged).toBeFalsy();
         });
 
-        test("via arrow up key", async () => {
+        test("via arrow up key", async ({ page }) => {
+            const element = page.locator("fast-combobox");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("combobox--combobox"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                         <fast-combobox>
@@ -338,7 +426,13 @@ test.describe("Combobox", () => {
     });
 
     test.describe("should NOT emit a 'change' event when the value changes by programmatic interaction", () => {
-        test("via end key", async () => {
+        test("via end key", async ({ page }) => {
+            const element = page.locator("fast-combobox");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("combobox--combobox"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                         <fast-combobox>
@@ -372,7 +466,13 @@ test.describe("Combobox", () => {
     });
 
     test.describe("when the owning form's reset() function is invoked", () => {
-        test("should reset the value property to its initial value", async () => {
+        test("should reset the value property to its initial value", async ({ page }) => {
+            const element = page.locator("fast-combobox");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("combobox--combobox"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -400,7 +500,15 @@ test.describe("Combobox", () => {
             await expect(element).toHaveJSProperty("value", "one");
         });
 
-        test("should reset its value property to the first option with the `selected` attribute present", async () => {
+        test("should reset its value property to the first option with the `selected` attribute present", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-combobox");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("combobox--combobox"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -431,7 +539,15 @@ test.describe("Combobox", () => {
         });
     });
 
-    test("should focus the control when an associated label is clicked", async () => {
+    test("should focus the control when an associated label is clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-combobox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("combobox--combobox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-combobox>

--- a/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
@@ -76,7 +76,7 @@ test.describe("Combobox", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("tabindex");
+        await expect(element).not.toHaveAttribute("tabindex");
 
         await element.evaluate((node: FASTCombobox) => {
             node.disabled = false;
@@ -160,13 +160,13 @@ test.describe("Combobox", () => {
 
         const options = element.locator("fast-option");
 
-        await expect(control).not.hasAttribute("aria-activedescendant");
+        await expect(control).not.toHaveAttribute("aria-activedescendant");
 
         await element.evaluate((node: FASTCombobox) => {
             node.open = true;
         });
 
-        await expect(element).toHaveAttribute("aria-activedescendant", "");
+        await expect(element).not.toHaveAttribute("aria-activedescendant");
 
         const optionsCount = await options.count();
 
@@ -186,9 +186,9 @@ test.describe("Combobox", () => {
             node.value = "other";
         });
 
-        await expect(control).hasAttribute("aria-activedescendant");
+        await expect(control).toHaveAttribute("aria-activedescendant");
 
-        await expect(element).toHaveAttribute("aria-activedescendant", "");
+        await expect(element).not.toHaveAttribute("aria-activedescendant");
     });
 
     test("should set its value to the first option with the `selected` attribute present", async () => {
@@ -267,117 +267,109 @@ test.describe("Combobox", () => {
         await expect(listbox).toBeVisible();
     });
 
-    test.describe(
-        "should NOT emit a 'change' event when the value changes by user input while open",
-        () => {
-            test("via arrow down key", async () => {
-                await root.evaluate(node => {
-                    node.innerHTML = /* html */ `
+    test.describe("should NOT emit a 'change' event when the value changes by user input while open", () => {
+        test("via arrow down key", async () => {
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
                         <fast-combobox>
                             <fast-option>Option 1</fast-option>
                             <fast-option>Option 2</fast-option>
                             <fast-option>Option 3</fast-option>
                         </fast-combobox>
                     `;
-                });
-
-                await element.click();
-
-                await element.locator(".listbox").waitFor({ state: "visible" });
-
-                await expect(element).toHaveBooleanAttribute("open");
-
-                const [wasChanged] = await Promise.all([
-                    element.evaluate(node =>
-                        Promise.race<boolean>([
-                            new Promise(resolve => {
-                                node.addEventListener("change", () => resolve(true));
-                            }),
-                            new Promise(resolve => setTimeout(() => resolve(false), 100)),
-                        ])
-                    ),
-                    element.press("ArrowDown"),
-                ]);
-
-                expect(wasChanged).toBeFalsy();
             });
 
-            test("via arrow up key", async () => {
-                await root.evaluate(node => {
-                    node.innerHTML = /* html */ `
+            await element.click();
+
+            await element.locator(".listbox").waitFor({ state: "visible" });
+
+            await expect(element).toHaveBooleanAttribute("open");
+
+            const [wasChanged] = await Promise.all([
+                element.evaluate(node =>
+                    Promise.race<boolean>([
+                        new Promise(resolve => {
+                            node.addEventListener("change", () => resolve(true));
+                        }),
+                        new Promise(resolve => setTimeout(() => resolve(false), 100)),
+                    ])
+                ),
+                element.press("ArrowDown"),
+            ]);
+
+            expect(wasChanged).toBeFalsy();
+        });
+
+        test("via arrow up key", async () => {
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
                         <fast-combobox>
                             <fast-option>Option 1</fast-option>
                             <fast-option>Option 2</fast-option>
                             <fast-option>Option 3</fast-option>
                         </fast-combobox>
                     `;
-                });
-
-                await element.evaluate((node: FASTCombobox) => {
-                    node.value = "two";
-                });
-
-                await element.click();
-
-                await element.locator(".listbox").waitFor({ state: "visible" });
-
-                expect(
-                    await element.evaluate(node => node.hasAttribute("open"))
-                ).toBeTruthy();
-
-                const [wasChanged] = await Promise.all([
-                    element.evaluate(node =>
-                        Promise.race<boolean>([
-                            new Promise(resolve => {
-                                node.addEventListener("change", () => resolve(true));
-                            }),
-                            new Promise(resolve => setTimeout(() => resolve(false), 100)),
-                        ])
-                    ),
-                    element.press("ArrowUp"),
-                ]);
-
-                expect(wasChanged).toBeFalsy();
             });
-        }
-    );
 
-    test.describe(
-        "should NOT emit a 'change' event when the value changes by programmatic interaction",
-        () => {
-            test("via end key", async () => {
-                await root.evaluate(node => {
-                    node.innerHTML = /* html */ `
+            await element.evaluate((node: FASTCombobox) => {
+                node.value = "two";
+            });
+
+            await element.click();
+
+            await element.locator(".listbox").waitFor({ state: "visible" });
+
+            await expect(element).toHaveAttribute("open");
+
+            const [wasChanged] = await Promise.all([
+                element.evaluate(node =>
+                    Promise.race<boolean>([
+                        new Promise(resolve => {
+                            node.addEventListener("change", () => resolve(true));
+                        }),
+                        new Promise(resolve => setTimeout(() => resolve(false), 100)),
+                    ])
+                ),
+                element.press("ArrowUp"),
+            ]);
+
+            expect(wasChanged).toBeFalsy();
+        });
+    });
+
+    test.describe("should NOT emit a 'change' event when the value changes by programmatic interaction", () => {
+        test("via end key", async () => {
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
                         <fast-combobox>
                             <fast-option>Option 1</fast-option>
                             <fast-option>Option 2</fast-option>
                             <fast-option>Option 3</fast-option>
                         </fast-combobox>
                     `;
-                });
-
-                await element.evaluate((node: FASTCombobox) => {
-                    node.value = "two";
-                });
-
-                const [wasChanged] = await Promise.all([
-                    element.evaluate(node =>
-                        Promise.race<boolean>([
-                            new Promise(resolve => {
-                                node.addEventListener("change", () => resolve(true));
-                            }),
-                            new Promise(resolve => setTimeout(() => resolve(false), 50)),
-                        ])
-                    ),
-                    element.press("End"),
-                ]);
-
-                expect(wasChanged).toBeFalsy();
-
-                await expect(element).toHaveJSProperty("value", "two");
             });
-        }
-    );
+
+            await element.evaluate((node: FASTCombobox) => {
+                node.value = "two";
+            });
+
+            const [wasChanged] = await Promise.all([
+                element.evaluate(node =>
+                    Promise.race<boolean>([
+                        new Promise(resolve => {
+                            node.addEventListener("change", () => resolve(true));
+                        }),
+                        new Promise(resolve => setTimeout(() => resolve(false), 50)),
+                    ])
+                ),
+                element.press("End"),
+            ]);
+
+            expect(wasChanged).toBeFalsy();
+
+            await expect(element).toHaveJSProperty("value", "two");
+        });
+    });
 
     test.describe("when the owning form's reset() function is invoked", () => {
         test("should reset the value property to its initial value", async () => {

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-cell.pw.spec.ts
@@ -1,4 +1,3 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTDataGridCell } from "./data-grid-cell.js";
@@ -7,25 +6,13 @@ import { DataGridCellTypes } from "./data-grid.options.js";
 declare const FAST: any;
 
 test.describe("Data grid cell", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test('should set the `role` attribute to "gridcell" by default', async ({ page }) => {
+        const element = page.locator("fast-data-grid-cell");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-data-grid-cell");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test('should set the `role` attribute to "gridcell" by default', async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell></fast-data-grid-cell>
@@ -35,7 +22,13 @@ test.describe("Data grid cell", () => {
         await expect(element).toHaveAttribute("role", "gridcell");
     });
 
-    test("should have a tabIndex of -1 by default", async () => {
+    test("should have a tabIndex of -1 by default", async ({ page }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell></fast-data-grid-cell>
@@ -45,7 +38,15 @@ test.describe("Data grid cell", () => {
         await expect(element).toHaveAttribute("tabindex", "-1");
     });
 
-    test('should set the `role` attribute to "columnheader" when the `cell-type` attribute is "columnheader"', async () => {
+    test('should set the `role` attribute to "columnheader" when the `cell-type` attribute is "columnheader"', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
@@ -55,7 +56,15 @@ test.describe("Data grid cell", () => {
         await expect(element).toHaveAttribute("role", "columnheader");
     });
 
-    test('should set the `role` attribute to "rowheader" when the `cell-type` attribute is "rowheader"', async () => {
+    test('should set the `role` attribute to "rowheader" when the `cell-type` attribute is "rowheader"', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell cell-type="rowheader"></fast-data-grid-cell>
@@ -65,7 +74,15 @@ test.describe("Data grid cell", () => {
         await expect(element).toHaveAttribute("role", "rowheader");
     });
 
-    test("should set the `grid-column` CSS property to match the `grid-column` attribute", async () => {
+    test("should set the `grid-column` CSS property to match the `grid-column` attribute", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell grid-column="2"></fast-data-grid-cell>
@@ -77,7 +94,13 @@ test.describe("Data grid cell", () => {
         await expect(element).toHaveCSS("grid-column-end", "auto");
     });
 
-    test("should not render data if no columndefinition provided", async () => {
+    test("should not render data if no columndefinition provided", async ({ page }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell></fast-data-grid-cell>
@@ -96,7 +119,13 @@ test.describe("Data grid cell", () => {
         await expect(element).toBeEmpty();
     });
 
-    test("should render data when a column definition is provided", async () => {
+    test("should render data when a column definition is provided", async ({ page }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell></fast-data-grid-cell>
@@ -116,7 +145,13 @@ test.describe("Data grid cell", () => {
         await expect(element).toHaveText("data grid cell value 1");
     });
 
-    test("should render a custom cell template when provided", async () => {
+    test("should render a custom cell template when provided", async ({ page }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell></fast-data-grid-cell>
@@ -133,7 +168,13 @@ test.describe("Data grid cell", () => {
         await expect(element).toHaveText("custom cell template");
     });
 
-    test("should render a custom header cell template if provided", async () => {
+    test("should render a custom header cell template if provided", async ({ page }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>
@@ -150,7 +191,13 @@ test.describe("Data grid cell", () => {
         await expect(element).toHaveText("custom header cell template");
     });
 
-    test(`should fire a "cell-focused" event when focused`, async () => {
+    test(`should fire a "cell-focused" event when focused`, async ({ page }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell></fast-data-grid-cell>
@@ -169,7 +216,15 @@ test.describe("Data grid cell", () => {
         ).toBeTruthy();
     });
 
-    test("should focus on custom cell template when a focus target callback is provided", async () => {
+    test("should focus on custom cell template when a focus target callback is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell></fast-data-grid-cell>
@@ -192,7 +247,15 @@ test.describe("Data grid cell", () => {
         );
     });
 
-    test("should focus on custom header cell template when a focus target callback is provided", async () => {
+    test("should focus on custom header cell template when a focus target callback is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid-cell");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-cell--data-grid-cell"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-cell cell-type="columnheader"></fast-data-grid-cell>

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid-row.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid-row.pw.spec.ts
@@ -1,4 +1,3 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTDataGridRow } from "./data-grid-row.js";
@@ -6,25 +5,13 @@ import type { FASTDataGridRow } from "./data-grid-row.js";
 test.describe("DataGridRow", () => {
     const cellQueryString = "fast-data-grid-cell";
 
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test('should set the `role` attribute to "row" by default', async ({ page }) => {
+        const element = page.locator("fast-data-grid-row");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-data-grid-row");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("data-grid-data-grid-row--data-grid-row"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test('should set the `role` attribute to "row" by default', async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-row></fast-data-grid-row>
@@ -34,7 +21,15 @@ test.describe("DataGridRow", () => {
         await expect(element).toHaveAttribute("role", "row");
     });
 
-    test("should set `grid-template-columns` style to match attribute", async () => {
+    test("should set `grid-template-columns` style to match attribute", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid-row");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-row--data-grid-row"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-row grid-template-columns="1fr 2fr 3fr"></fast-data-grid-row>
@@ -47,7 +42,13 @@ test.describe("DataGridRow", () => {
         );
     });
 
-    test("should fire an event when a child cell is focused", async () => {
+    test("should fire an event when a child cell is focused", async ({ page }) => {
+        const element = page.locator("fast-data-grid-row");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-row--data-grid-row"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-row>
@@ -74,7 +75,13 @@ test.describe("DataGridRow", () => {
         expect(wasFocused).toBeTruthy();
     });
 
-    test("should move focus with left/right arrow key strokes", async () => {
+    test("should move focus with left/right arrow key strokes", async ({ page }) => {
+        const element = page.locator("fast-data-grid-row");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-row--data-grid-row"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-row>
@@ -98,7 +105,15 @@ test.describe("DataGridRow", () => {
         await expect(element).toHaveJSProperty("focusColumnIndex", 0);
     });
 
-    test("should move focus to the start/end of the row with home/end keystrokes", async () => {
+    test("should move focus to the start/end of the row with home/end keystrokes", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid-row");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-row--data-grid-row"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid-row>
@@ -122,7 +137,13 @@ test.describe("DataGridRow", () => {
         await expect(element).toHaveJSProperty("focusColumnIndex", 0);
     });
 
-    test("should render no cells if provided no column definitions", async () => {
+    test("should render no cells if provided no column definitions", async ({ page }) => {
+        const element = page.locator("fast-data-grid-row");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-row--data-grid-row"));
+
         const cells = element.locator("fast-data-grid-cell");
 
         await root.evaluate(node => {
@@ -141,7 +162,15 @@ test.describe("DataGridRow", () => {
         await expect(cells).toHaveCount(0);
     });
 
-    test("should render as many column header cells as specified in column definitions", async () => {
+    test("should render as many column header cells as specified in column definitions", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid-row");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid-data-grid-row--data-grid-row"));
+
         const cells = element.locator(cellQueryString);
 
         await root.evaluate(node => {
@@ -174,66 +203,5 @@ test.describe("DataGridRow", () => {
         });
 
         await expect(cells).toHaveCount(3);
-    });
-
-    test("should emit a 'rowselectionchange' event when clicked with disableClickSelect disabled", async () => {
-        await root.evaluate((node: FASTDataGridRow) => {
-            node.innerHTML = /* html */ `
-                <fast-data-grid-row>
-                    <fast-data-grid-cell ></fast-data-grid-cell>
-                </fast-data-grid-row>
-            `;
-            node.disableClickSelect = false;
-        });
-
-        const wasInvoked = await Promise.all([
-            element.evaluate(node =>
-                node.addEventListener("rowselectionchange", () => true)
-            ),
-            element.click(),
-        ]);
-
-        expect(wasInvoked).toBeTruthy;
-    });
-
-    test("should not emit a 'rowselectionchange' event when clicked with disableClickSelect disabled", async () => {
-        await root.evaluate((node: FASTDataGridRow) => {
-            node.innerHTML = /* html */ `
-                <fast-data-grid-row>
-                    <fast-data-grid-cell ></fast-data-grid-cell>
-                </fast-data-grid-row>
-            `;
-            node.disableClickSelect = true;
-        });
-
-        const wasInvoked = await Promise.all([
-            element.evaluate(node =>
-                node.addEventListener("rowselectionchange", () => true)
-            ),
-            element.click(),
-        ]);
-
-        expect(wasInvoked).toBeFalsy;
-    });
-
-    test("should emit a 'rowselectionchange' event when space key is pressed with disableClickSelect disabled", async () => {
-        await root.evaluate((node: FASTDataGridRow) => {
-            node.innerHTML = /* html */ `
-                <fast-data-grid-row>
-                    <fast-data-grid-cell ></fast-data-grid-cell>
-                </fast-data-grid-row>
-            `;
-            node.disableClickSelect = false;
-        });
-
-        const wasInvoked = await Promise.all([
-            element.evaluate(node => {
-                node.addEventListener("rowselectionchange", () => true);
-                // FIXME: Playwright's keyboard API is not working as expected.
-                node.dispatchEvent(new KeyboardEvent("keydown", { key: "Space" }));
-            }),
-        ]);
-
-        expect(wasInvoked).toBeTruthy;
     });
 });

--- a/packages/web-components/fast-foundation/src/data-grid/data-grid.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/data-grid/data-grid.pw.spec.ts
@@ -1,33 +1,20 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTDataGridRow } from "./data-grid-row.js";
 import type { FASTDataGrid } from "./data-grid.js";
 import { DataGridRowTypes } from "./data-grid.options.js";
 
 test.describe("Data grid", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-
     const selectedRowQueryString = '[aria-selected="true"]';
     const rowQueryString = "fast-data-grid-row";
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
+    test("should set role to 'grid'", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
 
-        element = page.locator("fast-data-grid");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("data-grid--data-grid"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should set role to 'grid'", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid></fast-data-grid>
@@ -37,7 +24,13 @@ test.describe("Data grid", () => {
         await expect(element).toHaveAttribute("role", "grid");
     });
 
-    test("should have a tabIndex of 0 by default", async () => {
+    test("should have a tabIndex of 0 by default", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid></fast-data-grid>
@@ -47,7 +40,13 @@ test.describe("Data grid", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should have a tabIndex of -1 when no-tabbing is true", async () => {
+    test("should have a tabIndex of -1 when no-tabbing is true", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
             <fast-data-grid no-tabbing></fast-data-grid>
@@ -57,7 +56,13 @@ test.describe("Data grid", () => {
         await expect(element).toHaveAttribute("tabindex", "-1");
     });
 
-    test("should have a tabIndex of -1 when a cell is focused", async () => {
+    test("should have a tabIndex of -1 when a cell is focused", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid>
@@ -74,7 +79,15 @@ test.describe("Data grid", () => {
         await expect(element).toHaveAttribute("tabindex", "-1");
     });
 
-    test("should generate a basic grid with a row header based on rowsData only", async () => {
+    test("should generate a basic grid with a row header based on rowsData only", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid></fast-data-grid>
@@ -129,7 +142,15 @@ test.describe("Data grid", () => {
         await expect(row3Cells.nth(1)).toHaveText("Person 2");
     });
 
-    test("should not generate a header when `generateHeader` is `none`", async () => {
+    test("should not generate a header when `generateHeader` is `none`", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid generate-header="none"></fast-data-grid>
@@ -172,7 +193,13 @@ test.describe("Data grid", () => {
         await expect(row2Cells.nth(1)).toHaveText("Person 2");
     });
 
-    test("should not generate a header when rowsData is empty", async () => {
+    test("should not generate a header when rowsData is empty", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -188,7 +215,15 @@ test.describe("Data grid", () => {
         await expect(rows).toHaveCount(0);
     });
 
-    test("should generate a sticky header when generateHeader is set to 'sticky'", async () => {
+    test("should generate a sticky header when generateHeader is set to 'sticky'", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid generate-header="sticky"></fast-data-grid>
@@ -243,7 +278,13 @@ test.describe("Data grid", () => {
         await expect(row3Cells.nth(1)).toHaveText("Person 2");
     });
 
-    test("should set the row index attribute of child rows'", async () => {
+    test("should set the row index attribute of child rows'", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid generate-header="sticky"></fast-data-grid>
@@ -269,7 +310,13 @@ test.describe("Data grid", () => {
         }
     });
 
-    test("should move focus with up/down arrow key strokes", async () => {
+    test("should move focus with up/down arrow key strokes", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid generate-header="none"></fast-data-grid>
@@ -317,7 +364,15 @@ test.describe("Data grid", () => {
         await expect(row2Cells.nth(0)).toBeFocused();
     });
 
-    test("should move focus to first/last cells with ctrl + home/end key strokes", async () => {
+    test("should move focus to first/last cells with ctrl + home/end key strokes", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid generate-header="none"></fast-data-grid>
@@ -351,7 +406,15 @@ test.describe("Data grid", () => {
         await expect(firstCell).toBeFocused();
     });
 
-    test("should move focus by setting the `focusRowIndex` property", async () => {
+    test("should move focus by setting the `focusRowIndex` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid generate-header="none"></fast-data-grid>
@@ -393,7 +456,13 @@ test.describe("Data grid", () => {
         await expect(cells.nth(0)).toBeFocused();
     });
 
-    test("should move focus by setting `focusColumnIndex`", async () => {
+    test("should move focus by setting `focusColumnIndex`", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid generate-header="none"></fast-data-grid>
@@ -435,7 +504,13 @@ test.describe("Data grid", () => {
         await expect(cells.nth(0)).toBeFocused();
     });
 
-    test("should scroll into view on focus", async () => {
+    test("should scroll into view on focus", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid generate-header="none" style="height:100px; overflow-y: scroll;">
@@ -466,7 +541,15 @@ test.describe("Data grid", () => {
         await expect(element).toHaveJSProperty("scrollTop", 200);
     });
 
-    test("should not apply initial selection in default 'none' selection mode", async () => {
+    test("should not apply initial selection in default 'none' selection mode", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-data-grid generate-header="none" initial-row-selection="0" selection-mode="none">
@@ -486,7 +569,15 @@ test.describe("Data grid", () => {
         await expect(element).toHaveJSProperty("selectedRowIndexes", []);
     });
 
-    test("should apply initial selection in 'single-row' selection mode", async () => {
+    test("should apply initial selection in 'single-row' selection mode", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
             <fast-data-grid generate-header="none" initial-row-selection="0" selection-mode="single-row">
@@ -506,7 +597,15 @@ test.describe("Data grid", () => {
         await expect(element).toHaveJSProperty("selectedRowIndexes", [0]);
     });
 
-    test("should apply initial selection in 'multi-row' selection mode", async () => {
+    test("should apply initial selection in 'multi-row' selection mode", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
             <fast-data-grid generate-header="none" initial-row-selection="0,1" selection-mode="multi-row">
@@ -526,7 +625,15 @@ test.describe("Data grid", () => {
         await expect(element).toHaveJSProperty("selectedRowIndexes", [0, 1]);
     });
 
-    test("should apply user set selection in 'single-row' selection mode", async () => {
+    test("should apply user set selection in 'single-row' selection mode", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         const selectedRows = element.locator(selectedRowQueryString);
 
         await root.evaluate(node => {
@@ -561,7 +668,15 @@ test.describe("Data grid", () => {
         await expect(selectedRows).toHaveCount(1);
     });
 
-    test("should apply user set selection in 'multi-row' selection mode", async () => {
+    test("should apply user set selection in 'multi-row' selection mode", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         const selectedRows = element.locator(selectedRowQueryString);
 
         await root.evaluate(node => {
@@ -596,7 +711,13 @@ test.describe("Data grid", () => {
         await expect(selectedRows).toHaveCount(3);
     });
 
-    test("should not allow selection of header row by default", async () => {
+    test("should not allow selection of header row by default", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         const selectedRows = element.locator(selectedRowQueryString);
 
         await root.evaluate(node => {
@@ -619,7 +740,15 @@ test.describe("Data grid", () => {
         await expect(selectedRows).toHaveCount(0);
     });
 
-    test("should select and deselect rows with space bar + shift keys", async () => {
+    test("should select and deselect rows with space bar + shift keys", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         const rows = element.locator(rowQueryString);
         const selectedRows = element.locator(selectedRowQueryString);
         const firstCell = rows.nth(0).locator("fast-data-grid-cell").nth(0);
@@ -653,7 +782,13 @@ test.describe("Data grid", () => {
         await expect(element).toHaveJSProperty("selectedRowIndexes", [2]);
     });
 
-    test("should select and deselect rows with a click", async () => {
+    test("should select and deselect rows with a click", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         const rows = element.locator(rowQueryString);
         const selectedRows = element.locator(selectedRowQueryString);
         const firstCell = rows.nth(0).locator("fast-data-grid-cell").nth(0);
@@ -685,7 +820,15 @@ test.describe("Data grid", () => {
         await expect(element).toHaveJSProperty("selectedRowIndexes", [2]);
     });
 
-    test("should select/deselect all in row multi-select with a ctrl + a", async () => {
+    test("should select/deselect all in row multi-select with a ctrl + a", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         const selectedRows = element.locator(selectedRowQueryString);
         const rows = element.locator(rowQueryString);
         const firstCell = rows.nth(0).locator("fast-data-grid-cell").nth(0);
@@ -713,7 +856,15 @@ test.describe("Data grid", () => {
         await expect(selectedRows).toHaveCount(0);
     });
 
-    test("should select/deselect multiple rows with shift key in multi-select mode", async () => {
+    test("should select/deselect multiple rows with shift key in multi-select mode", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         const selectedRows = element.locator(selectedRowQueryString);
         const rows = element.locator(rowQueryString);
         const firstCell = rows.nth(0).locator("fast-data-grid-cell").nth(0);
@@ -742,7 +893,13 @@ test.describe("Data grid", () => {
         await expect(selectedRows).toHaveCount(2);
     });
 
-    test("should emit an event when row selection changes", async () => {
+    test("should emit an event when row selection changes", async ({ page }) => {
+        const element = page.locator("fast-data-grid");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("data-grid--data-grid"));
+
         const rows = element.locator(rowQueryString);
         const firstCell = rows.nth(0).locator("fast-data-grid-cell").nth(0);
         await firstCell.focus();

--- a/packages/web-components/fast-foundation/src/design-token/core/design-token-node.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/core/design-token-node.pw.spec.ts
@@ -36,7 +36,7 @@ class DesignToken<T> implements IDesignToken<T> {
 
 test.describe("DesignTokenNode", () => {
     test.describe("appending a child", () => {
-        test("should assign the `parent` property of the child to the caller", () => {
+        test("should assign the `parent` property of the child to the caller", async () => {
             const parent = new DesignTokenNode();
             const child = new DesignTokenNode();
 
@@ -45,7 +45,7 @@ test.describe("DesignTokenNode", () => {
             expect(child.parent).toEqual(parent);
         });
 
-        test("should add the child to the `children` property of the caller", () => {
+        test("should add the child to the `children` property of the caller", async () => {
             const parent = new DesignTokenNode();
             const child = new DesignTokenNode();
 
@@ -54,7 +54,7 @@ test.describe("DesignTokenNode", () => {
             expect(parent.children.includes(child)).toBe(true);
         });
 
-        test("should re-parent the child if the child is already a child of another node", () => {
+        test("should re-parent the child if the child is already a child of another node", async () => {
             const parent = new DesignTokenNode();
             const child = new DesignTokenNode();
             const newParent = new DesignTokenNode();
@@ -68,7 +68,7 @@ test.describe("DesignTokenNode", () => {
         });
     });
     test.describe("removing a child", () => {
-        test("should assign the `parent` property of the child to null if the child is a child of the parent", () => {
+        test("should assign the `parent` property of the child to null if the child is a child of the parent", async () => {
             const parent = new DesignTokenNode();
             const child = new DesignTokenNode();
 
@@ -77,7 +77,7 @@ test.describe("DesignTokenNode", () => {
             parent.removeChild(child);
             expect(child.parent).toBe(null);
         });
-        test("should remove the child from the `children` set if the item is a child of the parent", () => {
+        test("should remove the child from the `children` set if the item is a child of the parent", async () => {
             const parent = new DesignTokenNode();
             const child = new DesignTokenNode();
 
@@ -86,7 +86,7 @@ test.describe("DesignTokenNode", () => {
             parent.removeChild(child);
             expect(child.parent).toBe(null);
         });
-        test("should no-op when called with an item that is not a child of the parent", () => {
+        test("should no-op when called with an item that is not a child of the parent", async () => {
             const parent = new DesignTokenNode();
             const child = new DesignTokenNode();
             const tangent = new DesignTokenNode();
@@ -101,7 +101,7 @@ test.describe("DesignTokenNode", () => {
         });
     });
     test.describe("setting a token to a static value", () => {
-        test("should support getting and setting falsey values", () => {
+        test("should support getting and setting falsey values", async () => {
             const target = new DesignTokenNode();
             [false, null, 0, "", NaN].forEach(value => {
                 const token = new DesignToken<typeof value>();
@@ -115,7 +115,7 @@ test.describe("DesignTokenNode", () => {
             });
         });
 
-        test("should return the value set for an ancestor if a value has not been set for the target", () => {
+        test("should return the value set for an ancestor if a value has not been set for the target", async () => {
             const ancestor = new DesignTokenNode();
             const target = new DesignTokenNode();
             ancestor.appendChild(target);
@@ -125,7 +125,7 @@ test.describe("DesignTokenNode", () => {
             expect(target.getTokenValue(token)).toEqual(12);
         });
 
-        test("sound return the nearest ancestor's value after an intermediary value is set where no value was set prior", () => {
+        test("sound return the nearest ancestor's value after an intermediary value is set where no value was set prior", async () => {
             const grandparent = new DesignTokenNode();
             const parent = new DesignTokenNode();
             const target = new DesignTokenNode();
@@ -144,7 +144,7 @@ test.describe("DesignTokenNode", () => {
             expect(target.getTokenValue(token)).toEqual(14);
         });
 
-        test("should return the new ancestor's value after being re-parented", () => {
+        test("should return the new ancestor's value after being re-parented", async () => {
             const parentA = new DesignTokenNode();
             const parentB = new DesignTokenNode();
             const target = new DesignTokenNode();
@@ -161,7 +161,7 @@ test.describe("DesignTokenNode", () => {
             expect(target.getTokenValue(token)).toEqual(14);
         });
 
-        test("should not throw when setting a token value from within a change handler", () => {
+        test("should not throw when setting a token value from within a change handler", async () => {
             const node = new DesignTokenNode();
             const tokenA = { $value: undefined };
             const tokenB = { $value: undefined };
@@ -179,7 +179,7 @@ test.describe("DesignTokenNode", () => {
         });
     });
     test.describe("setting a token to a derived value", () => {
-        test("should support getting and setting falsey values", () => {
+        test("should support getting and setting falsey values", async () => {
             const target = new DesignTokenNode();
             [false, null, 0, "", NaN].forEach(value => {
                 const token = new DesignToken<typeof value>();
@@ -193,14 +193,14 @@ test.describe("DesignTokenNode", () => {
             });
         });
 
-        test("should get the return value of a derived value", () => {
+        test("should get the return value of a derived value", async () => {
             const target = new DesignTokenNode();
             const token = new DesignToken<number>();
             target.setTokenValue(token, () => 12);
 
             expect(target.getTokenValue(token)).toEqual(12);
         });
-        test("should get an updated value when other design tokens used in a derived property are changed", () => {
+        test("should get an updated value when other design tokens used in a derived property are changed", async () => {
             const target = new DesignTokenNode();
             const tokenA = new DesignToken<number>();
             const tokenB = new DesignToken<number>();
@@ -214,7 +214,7 @@ test.describe("DesignTokenNode", () => {
 
             expect(target.getTokenValue(tokenB)).toEqual(14);
         });
-        test("should use the closest value of a dependent token when getting a token for a target", () => {
+        test("should use the closest value of a dependent token when getting a token for a target", async () => {
             const ancestor = new DesignTokenNode();
             const parent = new DesignTokenNode();
             const target = new DesignTokenNode();
@@ -231,7 +231,7 @@ test.describe("DesignTokenNode", () => {
             expect(target.getTokenValue(tokenB)).toEqual(12);
         });
 
-        test("should update value of a dependent token when getting a token for a target", () => {
+        test("should update value of a dependent token when getting a token for a target", async () => {
             const ancestor = new DesignTokenNode();
             const parent = new DesignTokenNode();
             const target = new DesignTokenNode();
@@ -251,7 +251,7 @@ test.describe("DesignTokenNode", () => {
             expect(target.getTokenValue(tokenB)).toEqual(14);
         });
 
-        test("should get an updated value when a used design token is set for a node closer to the target", () => {
+        test("should get an updated value when a used design token is set for a node closer to the target", async () => {
             const ancestor = new DesignTokenNode();
             const parent = new DesignTokenNode();
             const target = new DesignTokenNode();
@@ -270,7 +270,7 @@ test.describe("DesignTokenNode", () => {
 
             expect(target.getTokenValue(tokenB)).toEqual(14);
         });
-        test("should resolve a value for the token being assigned from the parent node", () => {
+        test("should resolve a value for the token being assigned from the parent node", async () => {
             const token = new DesignToken<number>();
             const parent = createNode();
             const child = createNode(parent);
@@ -282,7 +282,7 @@ test.describe("DesignTokenNode", () => {
 
             expect(child.getTokenValue(token)).toEqual(24);
         });
-        test("should error if attempting to resolve the token being assigned and there is no parent node", () => {
+        test("should error if attempting to resolve the token being assigned and there is no parent node", async () => {
             const token = new DesignToken<number>();
             const target = new DesignTokenNode();
 
@@ -292,7 +292,7 @@ test.describe("DesignTokenNode", () => {
                 });
             }).toThrow();
         });
-        test("should error if attempting to resolve the token being assigned and the token is not assigned for any ancestor", () => {
+        test("should error if attempting to resolve the token being assigned and the token is not assigned for any ancestor", async () => {
             const token = new DesignToken<number>();
             const ancestor = createNode();
             const parent = createNode(ancestor);
@@ -305,7 +305,7 @@ test.describe("DesignTokenNode", () => {
             }).toThrow();
         });
 
-        test("should not throw when setting a token derived value from within a change handler", () => {
+        test("should not throw when setting a token derived value from within a change handler", async () => {
             const node = new DesignTokenNode();
             const tokenA = { $value: undefined };
             const tokenB = { $value: undefined };
@@ -324,27 +324,27 @@ test.describe("DesignTokenNode", () => {
     });
 
     test.describe("getting a token value", () => {
-        test("should throw if no token value has been set for the token in a node tree", () => {
+        test("should throw if no token value has been set for the token in a node tree", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
 
             expect(() => node.getTokenValue(token)).toThrow;
         });
-        test("should return the assigned value when a node is assigned a static value", () => {
+        test("should return the assigned value when a node is assigned a static value", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             node.setTokenValue(token, 12);
 
             expect(node.getTokenValue(token)).toEqual(12);
         });
-        test("should return the resolved value when a node is assigned a derived value", () => {
+        test("should return the resolved value when a node is assigned a derived value", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             node.setTokenValue(token, () => 12);
 
             expect(node.getTokenValue(token)).toEqual(12);
         });
-        test("should resolve a static value from an ancestor node assigned a static value when the descendent node does not have the token assigned a value", () => {
+        test("should resolve a static value from an ancestor node assigned a static value when the descendent node does not have the token assigned a value", async () => {
             const token = new DesignToken<number>();
             const ancestor = createNode();
             const parent = createNode(ancestor);
@@ -354,7 +354,7 @@ test.describe("DesignTokenNode", () => {
 
             expect(descendent.getTokenValue(token)).toEqual(12);
         });
-        test("should resolve a static value from an ancestor node assigned a derived value when the descendent node does not have the token assigned a value", () => {
+        test("should resolve a static value from an ancestor node assigned a derived value when the descendent node does not have the token assigned a value", async () => {
             const token = new DesignToken<number>();
             const ancestor = createNode();
             const parent = createNode(ancestor);
@@ -367,12 +367,12 @@ test.describe("DesignTokenNode", () => {
     });
 
     test.describe("getAssignedTokensForNode", () => {
-        test("should return an empty set if no tokens are set for a node", () => {
+        test("should return an empty set if no tokens are set for a node", async () => {
             const node = new DesignTokenNode();
 
             expect(DesignTokenNode.getAssignedTokensForNode(node).length).toEqual(0);
         });
-        test("should return an array that contains the tokens set for the node", () => {
+        test("should return an array that contains the tokens set for the node", async () => {
             const node = new DesignTokenNode();
             const token = new DesignToken<number>();
             node.setTokenValue(token, 12);
@@ -381,7 +381,7 @@ test.describe("DesignTokenNode", () => {
             expect(assigned.includes(token)).toBe(true);
             expect(assigned.length).toEqual(1);
         });
-        test("should return an array that does not contain tokens set for ancestor nodes", () => {
+        test("should return an array that does not contain tokens set for ancestor nodes", async () => {
             const parent = new DesignTokenNode();
             const node = new DesignTokenNode();
             parent.appendChild(node);
@@ -394,14 +394,14 @@ test.describe("DesignTokenNode", () => {
         });
     });
     test.describe("getAssignedTokensForNodeTree", () => {
-        test("should return an empty set if no tokens are set for a node or it's ancestors", () => {
+        test("should return an empty set if no tokens are set for a node or it's ancestors", async () => {
             const node = new DesignTokenNode();
             const parent = new DesignTokenNode();
             parent.appendChild(node);
 
             expect(DesignTokenNode.composeAssignedTokensForNode(node).length).toEqual(0);
         });
-        test("should return an array that contains the tokens set for the node", () => {
+        test("should return an array that contains the tokens set for the node", async () => {
             const node = new DesignTokenNode();
             const parent = new DesignTokenNode();
             parent.appendChild(node);
@@ -412,7 +412,7 @@ test.describe("DesignTokenNode", () => {
             expect(assigned.includes(token)).toBe(true);
             expect(assigned.length).toEqual(1);
         });
-        test("should return an array that does contains tokens set for ancestor nodes", () => {
+        test("should return an array that does contains tokens set for ancestor nodes", async () => {
             const parent = new DesignTokenNode();
             const node = new DesignTokenNode();
             parent.appendChild(node);
@@ -426,7 +426,7 @@ test.describe("DesignTokenNode", () => {
     });
 
     test.describe("should notify", () => {
-        test("the token with the node that has the token assigned a static value", () => {
+        test("the token with the node that has the token assigned a static value", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { subscriber, handleChange } = createChangeHandler();
@@ -441,7 +441,7 @@ test.describe("DesignTokenNode", () => {
             );
             expect(node.getTokenValue(token)).toEqual(12);
         });
-        test("the token for the node assigned a static value when the value assigned is the same as the inherited static value", () => {
+        test("the token for the node assigned a static value when the value assigned is the same as the inherited static value", async () => {
             const token = new DesignToken<number>();
             const parent = createNode();
             const child = createNode(parent);
@@ -458,7 +458,7 @@ test.describe("DesignTokenNode", () => {
                 new DesignTokenChangeRecord(child, DesignTokenMutationType.add, token, 12)
             );
         });
-        test("the token with the node that has the token assigned a derived value", () => {
+        test("the token with the node that has the token assigned a derived value", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { subscriber, handleChange } = createChangeHandler();
@@ -479,7 +479,7 @@ test.describe("DesignTokenNode", () => {
             );
             expect(node.getTokenValue(token)).toEqual(12);
         });
-        test("the token with the node that has the token reassigned a static value from a derived value", () => {
+        test("the token with the node that has the token reassigned a static value from a derived value", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { subscriber, handleChange } = createChangeHandler();
@@ -512,7 +512,7 @@ test.describe("DesignTokenNode", () => {
             );
             expect(node.getTokenValue(token)).toEqual(14);
         });
-        test("the token with the node that has the token reassigned a derived value from a static value", () => {
+        test("the token with the node that has the token reassigned a derived value from a static value", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { subscriber, handleChange } = createChangeHandler();
@@ -539,7 +539,7 @@ test.describe("DesignTokenNode", () => {
             );
             expect(node.getTokenValue(token)).toEqual(14);
         });
-        test("the token with the node that has the token assigned a static value which is then deleted", () => {
+        test("the token with the node that has the token assigned a static value which is then deleted", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { subscriber, handleChange } = createChangeHandler();
@@ -561,7 +561,7 @@ test.describe("DesignTokenNode", () => {
             );
             expect(() => node.getTokenValue(token)).toThrow();
         });
-        test("the token with the node that has the token assigned a derived value which is then deleted", () => {
+        test("the token with the node that has the token assigned a derived value which is then deleted", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { subscriber, handleChange } = createChangeHandler();
@@ -589,7 +589,7 @@ test.describe("DesignTokenNode", () => {
             );
             expect(() => node.getTokenValue(token)).toThrow();
         });
-        test("the token with the node that has a token assigned a derived value and a dependency of the derived value changes for the node", () => {
+        test("the token with the node that has a token assigned a derived value and a dependency of the derived value changes for the node", async () => {
             const token = new DesignToken<number>();
             const dependency = new DesignToken<number>();
             const node = new DesignTokenNode();
@@ -618,7 +618,7 @@ test.describe("DesignTokenNode", () => {
             );
             expect(node.getTokenValue(token)).toEqual(14);
         });
-        test("the token with the descendent node that has a token assigned a static value that is a dependency of a value assigned for an ancestor", () => {
+        test("the token with the descendent node that has a token assigned a static value that is a dependency of a value assigned for an ancestor", async () => {
             const token = new DesignToken<number>();
             const dependency = new DesignToken<number>();
             const ancestor = createNode();
@@ -651,7 +651,7 @@ test.describe("DesignTokenNode", () => {
             expect(parent.getTokenValue(token)).toEqual(12);
             expect(descendent.getTokenValue(token)).toEqual(14);
         });
-        test("the token with the descendent node that has a token assigned a derived value that is a dependency of a value assigned for an ancestor", () => {
+        test("the token with the descendent node that has a token assigned a derived value that is a dependency of a value assigned for an ancestor", async () => {
             const token = new DesignToken<number>();
             const dependency = new DesignToken<number>();
             const ancestor = createNode();
@@ -684,7 +684,7 @@ test.describe("DesignTokenNode", () => {
             expect(parent.getTokenValue(token)).toEqual(12);
             expect(descendent.getTokenValue(token)).toEqual(14);
         });
-        test("the token with the descendent node that has a token reassigned a static value that is a dependency of a value assigned for an ancestor", () => {
+        test("the token with the descendent node that has a token reassigned a static value that is a dependency of a value assigned for an ancestor", async () => {
             const token = new DesignToken<number>();
             const dependency = new DesignToken<number>();
             const ancestor = createNode();
@@ -718,7 +718,7 @@ test.describe("DesignTokenNode", () => {
             expect(parent.getTokenValue(token)).toEqual(12);
             expect(descendent.getTokenValue(token)).toEqual(16);
         });
-        test("the token with the descendent node that has a token reassigned a derived value that is a dependency of a value assigned for an ancestor", () => {
+        test("the token with the descendent node that has a token reassigned a derived value that is a dependency of a value assigned for an ancestor", async () => {
             const token = new DesignToken<number>();
             const dependency = new DesignToken<number>();
             const ancestor = createNode();
@@ -752,7 +752,7 @@ test.describe("DesignTokenNode", () => {
             expect(parent.getTokenValue(token)).toEqual(12);
             expect(descendent.getTokenValue(token)).toEqual(16);
         });
-        test("the token with a descendent node when a ancestor and descendent both have a dependency assigned and the ancestor is reassigned a token to a derived value that resolves the dependency and results in a value change", () => {
+        test("the token with a descendent node when a ancestor and descendent both have a dependency assigned and the ancestor is reassigned a token to a derived value that resolves the dependency and results in a value change", async () => {
             const token = new DesignToken<number>();
             const dependency = new DesignToken<number>();
             const ancestor = createNode();
@@ -795,7 +795,7 @@ test.describe("DesignTokenNode", () => {
             expect(parent.getTokenValue(token)).toEqual(10);
             expect(descendent.getTokenValue(token)).toEqual(14);
         });
-        test("the token with the descendent node that has a token assigned a static value deleted that is a dependency of a value assigned for an ancestor", () => {
+        test("the token with the descendent node that has a token assigned a static value deleted that is a dependency of a value assigned for an ancestor", async () => {
             const token = new DesignToken<number>();
             const dependency = new DesignToken<number>();
             const ancestor = createNode();
@@ -827,7 +827,7 @@ test.describe("DesignTokenNode", () => {
             expect(parent.getTokenValue(token)).toEqual(12);
             expect(descendent.getTokenValue(token)).toEqual(12);
         });
-        test("the token with the descendent node that has a token assigned a derived value deleted that is a dependency of a value assigned for an ancestor", () => {
+        test("the token with the descendent node that has a token assigned a derived value deleted that is a dependency of a value assigned for an ancestor", async () => {
             const token = new DesignToken<number>();
             const dependency = new DesignToken<number>();
             const ancestor = createNode();
@@ -859,7 +859,7 @@ test.describe("DesignTokenNode", () => {
             expect(parent.getTokenValue(token)).toEqual(12);
             expect(descendent.getTokenValue(token)).toEqual(12);
         });
-        test("should the token for ancestor, parent, and descendent nodes when parent and descendent are assigned a value that depends on the token and the ancestor's value is changed", () => {
+        test("should the token for ancestor, parent, and descendent nodes when parent and descendent are assigned a value that depends on the token and the ancestor's value is changed", async () => {
             const token = new DesignToken<number>();
             const ancestor = createNode();
             const parent = createNode(ancestor);
@@ -914,7 +914,7 @@ test.describe("DesignTokenNode", () => {
         /**
          * Appending nodes
          */
-        test("the token with the descendent node that has a dependency assigned when the node is appended to an ancestor with a derived value assigned that depends on the dependency", () => {
+        test("the token with the descendent node that has a dependency assigned when the node is appended to an ancestor with a derived value assigned that depends on the dependency", async () => {
             const ancestor = createNode();
             const parent = createNode(ancestor);
             const descendent = createNode();
@@ -947,7 +947,7 @@ test.describe("DesignTokenNode", () => {
         /**
          * Removing nodes
          */
-        test("the token with the descendent node that has a dependency assigned when the node is appended to an ancestor with a derived value assigned that depends on the dependency and is then removed", () => {
+        test("the token with the descendent node that has a dependency assigned when the node is appended to an ancestor with a derived value assigned that depends on the dependency and is then removed", async () => {
             const ancestor = createNode();
             const parent = createNode(ancestor);
             const descendent = createNode();
@@ -980,7 +980,7 @@ test.describe("DesignTokenNode", () => {
         /**
          * Moving node
          */
-        test("the token with the descendent node that has a dependency assigned when the node is re-parented to an ancestor with a different derived value assigned that depends on the dependency", () => {
+        test("the token with the descendent node that has a dependency assigned when the node is re-parented to an ancestor with a different derived value assigned that depends on the dependency", async () => {
             const ancestorA = createNode();
             const ancestorB = createNode();
             const parentA = createNode(ancestorA);
@@ -1013,7 +1013,7 @@ test.describe("DesignTokenNode", () => {
             );
             expect(descendent.getTokenValue(token)).toEqual(21);
         });
-        test("should support reparenting a node with a derived token assigned to a tree where the immediate parent doesn't not have the dependency assigned", () => {
+        test("should support reparenting a node with a derived token assigned to a tree where the immediate parent doesn't not have the dependency assigned", async () => {
             const ancestor = new DesignTokenNode();
             const parent = new DesignTokenNode();
             const child = new DesignTokenNode();
@@ -1035,7 +1035,7 @@ test.describe("DesignTokenNode", () => {
         /**
          * Observable values
          */
-        test("the token with the node assigned a derived value when an observable value used by the value is changed", () => {
+        test("the token with the node assigned a derived value when an observable value used by the value is changed", async () => {
             const node = createNode();
             const token = new DesignToken<number>();
             const dependencies: { value: number } = reactive({ value: 6 });
@@ -1062,7 +1062,7 @@ test.describe("DesignTokenNode", () => {
                 )
             );
         });
-        test("the token with the ancestor and descendent node when the ancestor is assigned a derived value using an observable and a token, where both nodes contain a value set for the dependency", () => {
+        test("the token with the ancestor and descendent node when the ancestor is assigned a derived value using an observable and a token, where both nodes contain a value set for the dependency", async () => {
             const ancestor = createNode();
             const parent = createNode(ancestor);
             const descendent = createNode(parent);
@@ -1110,7 +1110,7 @@ test.describe("DesignTokenNode", () => {
     });
 
     test.describe("should not notify", () => {
-        test("the token when the static value assigned to a node is the same value as was previously assigned", () => {
+        test("the token when the static value assigned to a node is the same value as was previously assigned", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { handleChange, subscriber } = createChangeHandler();
@@ -1121,7 +1121,7 @@ test.describe("DesignTokenNode", () => {
 
             expect(handleChange).not.toHaveBeenCalled();
         });
-        test("the token when the derived value assigned to a node results in the same value as the previously assigned static value", () => {
+        test("the token when the derived value assigned to a node results in the same value as the previously assigned static value", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { handleChange, subscriber } = createChangeHandler();
@@ -1132,7 +1132,7 @@ test.describe("DesignTokenNode", () => {
 
             expect(handleChange).not.toHaveBeenCalled();
         });
-        test("the token when the derived value assigned to a node results in the same value as the previously assigned derived value", () => {
+        test("the token when the derived value assigned to a node results in the same value as the previously assigned derived value", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { handleChange, subscriber } = createChangeHandler();
@@ -1153,7 +1153,7 @@ test.describe("DesignTokenNode", () => {
             expect(handleChange).not.toHaveBeenCalled();
         });
 
-        test("the token when a dependency of a derived token value is set for a descendent but there is an intermediary value set that is a static value", () => {
+        test("the token when a dependency of a derived token value is set for a descendent but there is an intermediary value set that is a static value", async () => {
             const token = new DesignToken<number>();
             const dependency = new DesignToken<number>();
             const ancestor = createNode();
@@ -1187,7 +1187,7 @@ test.describe("DesignTokenNode", () => {
             expect(handleChange).not.toHaveBeenCalled();
             expect(child.getTokenValue(token)).toEqual(25);
         });
-        test("the token when a derived value using an observable value is deleted and then the observable value is changed", () => {
+        test("the token when a derived value using an observable value is deleted and then the observable value is changed", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { subscriber, handleChange } = createChangeHandler();
@@ -1202,7 +1202,7 @@ test.describe("DesignTokenNode", () => {
 
             expect(handleChange).not.toHaveBeenCalled();
         });
-        test("the token when a derived value using an observable value is re-assigned and then the observable value is changed", () => {
+        test("the token when a derived value using an observable value is re-assigned and then the observable value is changed", async () => {
             const token = new DesignToken<number>();
             const node = new DesignTokenNode();
             const { subscriber, handleChange } = createChangeHandler();

--- a/packages/web-components/fast-foundation/src/design-token/fast-design-token.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/design-token/fast-design-token.pw.spec.ts
@@ -5,7 +5,6 @@ import type {
     Observable as FASTObservable,
     Updates as FASTUpdates,
 } from "@microsoft/fast-element";
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { DesignTokenResolver } from "./core/design-token-node.js";
@@ -48,40 +47,22 @@ function uniqueTokenName(): string {
 // Test utilities
 
 test.describe("A DesignToken", () => {
-    let page: Page;
-    let root: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-        root = page.locator("#root");
-
+    test("should support declared types", async ({ page }) => {
         await page.goto(fixtureURL("debug-designtoken--design-token"));
         await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
-    });
-    test.afterAll(async () => {
-        await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
-        await page.close();
-    });
 
-    test.afterEach(async () => {
-        await page.evaluate(() => cleanup());
-    });
-
-    test("should support declared types", async () => {
         await page.evaluate((name: string) => {
-            const number = DesignToken.create<number>(name);
-            const nil = DesignToken.create<null>(name);
-            const bool = DesignToken.create<boolean>(name);
-            const arr = DesignToken.create<number[]>(name);
-            const obj = DesignToken.create<{}>(name);
             class Foo {}
-            const _class = DesignToken.create<Foo>(name);
-            const sym = DesignToken.create<symbol>(name);
         }, uniqueTokenName());
     });
 
     test.describe("should have a create method", () => {
-        test("that creates a CSSDesignToken when invoked with a string value", async () => {
+        test("that creates a CSSDesignToken when invoked with a string value", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const result = await page.evaluate(
                 (name: string) => DesignToken.create(name) instanceof CSSDesignToken,
                 uniqueTokenName()
@@ -89,7 +70,12 @@ test.describe("A DesignToken", () => {
 
             expect(result).toBe(true);
         });
-        test("that creates a CSSDesignToken when invoked with a CSSDesignTokenConfiguration", async () => {
+        test("that creates a CSSDesignToken when invoked with a CSSDesignTokenConfiguration", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const result = await page.evaluate(
                 (name: string) =>
                     DesignToken.create({
@@ -100,7 +86,12 @@ test.describe("A DesignToken", () => {
             );
             expect(result).toBe(true);
         });
-        test("that creates a DesignToken when invoked with a DesignTokenConfiguration", async () => {
+        test("that creates a DesignToken when invoked with a DesignTokenConfiguration", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const result = await page.evaluate(
                 (name: string) => DesignToken.create({ name }) instanceof CSSDesignToken,
                 uniqueTokenName()
@@ -111,14 +102,20 @@ test.describe("A DesignToken", () => {
     });
 
     test.describe("that is not a CSSDesignToken", () => {
-        test("should not have a cssCustomProperty property", async () => {
+        test("should not have a cssCustomProperty property", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const result = await page.evaluate((name: string) => {
                 return "cssCustomProperty" in DesignToken.create<number>({ name });
             }, uniqueTokenName());
 
             expect(result).toEqual(false);
         });
-        test("should not have a cssVar property", async () => {
+        test("should not have a cssVar property", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const result = await page.evaluate((name: string) => {
                 return "cssVar" in DesignToken.create<number>({ name });
             }, uniqueTokenName());
@@ -126,7 +123,12 @@ test.describe("A DesignToken", () => {
         });
     });
     test.describe("getting and setting a simple value", () => {
-        test("should throw if the token value has never been set on the element or its ancestors", async () => {
+        test("should throw if the token value has never been set on the element or its ancestors", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const result = await page.evaluate((name: string) => {
                 const target = addElement();
                 const token = DesignToken.create<number>(name);
@@ -136,7 +138,12 @@ test.describe("A DesignToken", () => {
             expect(result).toBe(true);
         });
 
-        test("should return the value set for the element if one has been set", async () => {
+        test("should return the value set for the element if one has been set", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const result = await page.evaluate((name: string) => {
                 const target = addElement();
                 const token = DesignToken.create<number>(name);
@@ -147,7 +154,12 @@ test.describe("A DesignToken", () => {
             expect(result).toEqual(12);
         });
 
-        test("should return the value set for an ancestor if a value has not been set for the target", async () => {
+        test("should return the value set for an ancestor if a value has not been set for the target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const result = await page.evaluate((name: string) => {
                 const ancestor = addElement();
                 const target = addElement(ancestor);
@@ -159,7 +171,12 @@ test.describe("A DesignToken", () => {
             expect(result).toEqual(12);
         });
 
-        test("sound return the nearest ancestor's value after an intermediary value is set where no value was set prior", async () => {
+        test("sound return the nearest ancestor's value after an intermediary value is set where no value was set prior", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -179,7 +196,12 @@ test.describe("A DesignToken", () => {
             ).toEqual([12, 14]);
         });
 
-        test("should return the new ancestor's value after being re-parented", async () => {
+        test("should return the new ancestor's value after being re-parented", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -202,7 +224,12 @@ test.describe("A DesignToken", () => {
             ).toEqual([12, 14]);
         });
 
-        test("should persist explicitly set value even if it matches the inherited value", async () => {
+        test("should persist explicitly set value even if it matches the inherited value", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -224,7 +251,10 @@ test.describe("A DesignToken", () => {
             ).toEqual([12, 12]);
         });
 
-        test("should support getting and setting falsey values", async () => {
+        test("should support getting and setting falsey values", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const target = addElement();
@@ -250,7 +280,12 @@ test.describe("A DesignToken", () => {
         });
 
         test.describe("that is a CSSDesignToken", () => {
-            test("should set the CSS custom property for the element", async () => {
+            test("should set the CSS custom property for the element", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const target = addElement();
@@ -263,7 +298,10 @@ test.describe("A DesignToken", () => {
                     })
                 ).toBe("12");
             });
-            test("should be a CSSDirective", async () => {
+            test("should be a CSSDirective", async ({ page }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const token = DesignToken.create<number>(
@@ -286,7 +324,10 @@ test.describe("A DesignToken", () => {
                 ).toBe("12");
             });
 
-            test("should inherit CSS custom property from ancestor", async () => {
+            test("should inherit CSS custom property from ancestor", async ({ page }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
@@ -312,7 +353,12 @@ test.describe("A DesignToken", () => {
                 ).toEqual(["12", "14"]);
             });
 
-            test("should set CSS custom property for element if value stops matching inherited value", async () => {
+            test("should set CSS custom property for element if value stops matching inherited value", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
@@ -340,7 +386,12 @@ test.describe("A DesignToken", () => {
             });
         });
         test.describe("that is not a CSSDesignToken", () => {
-            test("should not set a CSS custom property for the element", async () => {
+            test("should not set a CSS custom property for the element", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(() => {
                         const name = uniqueTokenName();
@@ -357,7 +408,10 @@ test.describe("A DesignToken", () => {
     });
 
     test.describe("getting and setting derived values", () => {
-        test("should get the return value of a derived value", async () => {
+        test("should get the return value of a derived value", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const name = uniqueTokenName();
             expect(
                 await page.evaluate((name: string) => {
@@ -369,7 +423,12 @@ test.describe("A DesignToken", () => {
                 }, name)
             ).toBe(12);
         });
-        test("should get an updated value when observable properties used in a derived property are changed", async () => {
+        test("should get an updated value when observable properties used in a derived property are changed", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const name = uniqueTokenName();
             expect(
                 await page.evaluate(async (name: string) => {
@@ -392,7 +451,12 @@ test.describe("A DesignToken", () => {
             ).toEqual([12, 14]);
         });
 
-        test("should get an updated value when other design tokens used in a derived property are changed", async () => {
+        test("should get an updated value when other design tokens used in a derived property are changed", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const target = addElement();
@@ -412,7 +476,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toEqual([12, 14]);
         });
-        test("should use the closest value of a dependent token when getting a token for a target", async () => {
+        test("should use the closest value of a dependent token when getting a token for a target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const ancestor = addElement();
@@ -430,7 +499,12 @@ test.describe("A DesignToken", () => {
             ).toBe(12);
         });
 
-        test("should update value of a dependent token when getting a token for a target", async () => {
+        test("should update value of a dependent token when getting a token for a target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -455,7 +529,12 @@ test.describe("A DesignToken", () => {
             ).toEqual([12, 14]);
         });
 
-        test("should get an updated value when a used design token is set for a node closer to the target", async () => {
+        test("should get an updated value when a used design token is set for a node closer to the target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -479,13 +558,18 @@ test.describe("A DesignToken", () => {
         });
 
         test.describe("that is a CSSDesignToken", () => {
-            test("should set a CSS custom property equal to the resolved value of a derived token value", async () => {
+            test("should set a CSS custom property equal to the resolved value of a derived token value", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const target = addElement();
                         const token = DesignToken.create<number>(uniqueTokenName());
 
-                        token.setValueFor(target, target => 12);
+                        token.setValueFor(target, () => 12);
 
                         await Updates.next();
                         return window
@@ -494,7 +578,12 @@ test.describe("A DesignToken", () => {
                     })
                 ).toBe("12");
             });
-            test("should set a CSS custom property equal to the resolved value of a derived token value with a dependent token", async () => {
+            test("should set a CSS custom property equal to the resolved value of a derived token value with a dependent token", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const target = addElement();
@@ -513,7 +602,12 @@ test.describe("A DesignToken", () => {
                 ).toBe("12");
             });
 
-            test("should update a CSS custom property to the resolved value of a derived token value with a dependent token when the dependent token changes", async () => {
+            test("should update a CSS custom property to the resolved value of a derived token value with a dependent token when the dependent token changes", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
@@ -544,7 +638,12 @@ test.describe("A DesignToken", () => {
                 ).toEqual(["12", "14"]);
             });
 
-            test("should set a CSS custom property equal to the resolved value for an element of a derived token value with a dependent token", async () => {
+            test("should set a CSS custom property equal to the resolved value for an element of a derived token value with a dependent token", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
@@ -574,14 +673,19 @@ test.describe("A DesignToken", () => {
                 ).toEqual(["12", "14"]);
             });
 
-            test("should set a CSS custom property equal to the resolved value for an element in a shadow DOM of a derived token value with a dependent token", async () => {
+            test("should set a CSS custom property equal to the resolved value for an element in a shadow DOM of a derived token value with a dependent token", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
                         const parent = addElement();
                         const child = addElement(parent);
                         const target = createElement();
-                        child.shadowRoot!.appendChild(target);
+                        child.shadowRoot?.appendChild(target);
                         const tokenA = DesignToken.create<number>(uniqueTokenName());
                         const tokenB = DesignToken.create<number>(uniqueTokenName());
 
@@ -606,7 +710,12 @@ test.describe("A DesignToken", () => {
                 ).toEqual(["12", "14"]);
             });
 
-            test("should set a CSS custom property equal to the resolved value for both elements for which a dependent token is set when setting a derived token value", async () => {
+            test("should set a CSS custom property equal to the resolved value for both elements for which a dependent token is set when setting a derived token value", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
@@ -636,7 +745,12 @@ test.describe("A DesignToken", () => {
                 ).toEqual(["12", "14"]);
             });
 
-            test("should revert a CSS custom property back to a previous value when the Design Token value is reverted", async () => {
+            test("should revert a CSS custom property back to a previous value when the Design Token value is reverted", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
@@ -674,7 +788,10 @@ test.describe("A DesignToken", () => {
         });
 
         test.describe("that is not a CSSDesignToken", () => {
-            test("should not emit a CSS custom property", async () => {
+            test("should not emit a CSS custom property", async ({ page }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(() => {
                         const target = addElement();
@@ -692,7 +809,10 @@ test.describe("A DesignToken", () => {
             });
         });
 
-        test("should support getting and setting falsey values", async () => {
+        test("should support getting and setting falsey values", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const target = addElement();
@@ -718,7 +838,10 @@ test.describe("A DesignToken", () => {
     });
 
     test.describe("getting and setting a token value", () => {
-        test("should retrieve the value of the token it was set to", async () => {
+        test("should retrieve the value of the token it was set to", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const tokenA = DesignToken.create<number>(uniqueTokenName());
@@ -733,7 +856,12 @@ test.describe("A DesignToken", () => {
             ).toBe(12);
         });
 
-        test("should update the value of the token it was set to when the token's value changes", async () => {
+        test("should update the value of the token it was set to when the token's value changes", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -753,7 +881,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toEqual([12, 14]);
         });
-        test("should update the derived value of the token when a dependency of the derived value changes", async () => {
+        test("should update the derived value of the token when a dependency of the derived value changes", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -778,7 +911,10 @@ test.describe("A DesignToken", () => {
         });
 
         test.describe("that is a CSSDesignToken", () => {
-            test("should emit a CSS custom property", async () => {
+            test("should emit a CSS custom property", async ({ page }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const tokenA = DesignToken.create<number>("token-a");
@@ -795,7 +931,12 @@ test.describe("A DesignToken", () => {
                     })
                 );
             });
-            test("should update the emitted CSS custom property when the token's value changes", async () => {
+            test("should update the emitted CSS custom property when the token's value changes", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
@@ -827,7 +968,12 @@ test.describe("A DesignToken", () => {
                     })
                 ).toEqual(["12", "14"]);
             });
-            test("should update the emitted CSS custom property of a token assigned a derived value when the token dependency changes", async () => {
+            test("should update the emitted CSS custom property of a token assigned a derived value when the token dependency changes", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
@@ -861,7 +1007,12 @@ test.describe("A DesignToken", () => {
                 ).toEqual(["12", "14"]);
             });
 
-            test("should support accessing the token being assigned from the derived value, resolving to a parent value", async () => {
+            test("should support accessing the token being assigned from the derived value, resolving to a parent value", async ({
+                page,
+            }) => {
+                await page.goto(fixtureURL("debug-designtoken--design-token"));
+                await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
                 expect(
                     await page.evaluate(async () => {
                         const results = [];
@@ -881,7 +1032,12 @@ test.describe("A DesignToken", () => {
                 ).toEqual([12, 24]);
             });
         });
-        test("should update the CSS custom property of a derived token with a dependency that is a derived token that depends on a third token", async () => {
+        test("should update the CSS custom property of a derived token with a dependency that is a derived token that depends on a third token", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -921,7 +1077,12 @@ test.describe("A DesignToken", () => {
         });
     });
     test.describe("deleting simple values", () => {
-        test("should throw when deleted and no parent token value is set", async () => {
+        test("should throw when deleted and no parent token value is set", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const results = [];
@@ -939,7 +1100,10 @@ test.describe("A DesignToken", () => {
                 })
             ).toEqual([12, true]);
         });
-        test("should allow getting a value that was set upstream", async () => {
+        test("should allow getting a value that was set upstream", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const results = [];
@@ -961,7 +1125,12 @@ test.describe("A DesignToken", () => {
         });
     });
     test.describe("deleting derived values", () => {
-        test("should throw when deleted and no parent token value is set", async () => {
+        test("should throw when deleted and no parent token value is set", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const results = [];
@@ -979,7 +1148,10 @@ test.describe("A DesignToken", () => {
                 })
             ).toEqual([12, true]);
         });
-        test("should allow getting a value that was set upstream", async () => {
+        test("should allow getting a value that was set upstream", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const results = [];
@@ -1000,7 +1172,10 @@ test.describe("A DesignToken", () => {
             ).toEqual([14, 12]);
         });
 
-        test("should cause dependent tokens to re-evaluate", async () => {
+        test("should cause dependent tokens to re-evaluate", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const results = [];
@@ -1024,7 +1199,12 @@ test.describe("A DesignToken", () => {
         });
     });
     test.describe("when used as a CSSDirective", () => {
-        test("should set a CSS custom property for the element when the token is set for the element", async () => {
+        test("should set a CSS custom property for the element when the token is set for the element", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const target = addElement();
@@ -1042,7 +1222,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe("12px");
         });
-        test("should set a CSS custom property for the element when the token is set for an ancestor element", async () => {
+        test("should set a CSS custom property for the element when the token is set for an ancestor element", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const parent = addElement();
@@ -1064,7 +1249,12 @@ test.describe("A DesignToken", () => {
     });
 
     test.describe("with a default value set", () => {
-        test("should return the default value if no value is set for a target", async () => {
+        test("should return the default value if no value is set for a target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const target = addElement();
@@ -1074,7 +1264,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe(2);
         });
-        test("should return the default value for a descendent if no value is set for a target", async () => {
+        test("should return the default value for a descendent if no value is set for a target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const parent = addElement();
@@ -1086,7 +1281,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe(2);
         });
-        test("should return the value set and not the default if value is set", async () => {
+        test("should return the value set and not the default if value is set", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const target = addElement();
@@ -1098,7 +1298,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe(2);
         });
-        test("should get a new default value if a new default is provided", async () => {
+        test("should get a new default value if a new default is provided", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const target = addElement();
@@ -1110,7 +1315,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe(4);
         });
-        test("should return the default value if retrieved for an element that has not been connected", async () => {
+        test("should return the default value if retrieved for an element that has not been connected", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const token = DesignToken.create<number>(
@@ -1122,7 +1332,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe(12);
         });
-        test("should set a derived value that uses a token's default value prior to connection", async () => {
+        test("should set a derived value that uses a token's default value prior to connection", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const dependency = DesignToken.create<number>(
@@ -1137,7 +1352,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe(false);
         });
-        test("should delete a derived value that uses a token's default value prior to connection", async () => {
+        test("should delete a derived value that uses a token's default value prior to connection", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const dependency = DesignToken.create<number>(
@@ -1154,7 +1374,12 @@ test.describe("A DesignToken", () => {
     });
 
     test.describe("with subscribers", () => {
-        test("should notify an un-targeted subscriber when the value changes for any element", async () => {
+        test("should notify an un-targeted subscriber when the value changes for any element", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const results: any = [];
@@ -1200,7 +1425,12 @@ test.describe("A DesignToken", () => {
                 [true, true, true],
             ]);
         });
-        test("should notify a target-subscriber if the value is changed for the provided target", async () => {
+        test("should notify a target-subscriber if the value is changed for the provided target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const results = [];
@@ -1225,7 +1455,10 @@ test.describe("A DesignToken", () => {
             ).toEqual([1, 2]);
         });
 
-        test("should not notify a subscriber after unsubscribing", async () => {
+        test("should not notify a subscriber after unsubscribing", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     const target = addElement();
@@ -1245,29 +1478,34 @@ test.describe("A DesignToken", () => {
             ).toBe(0);
         });
 
-        test("should infer DesignToken and CSSDesignToken token types on subscription record", async () => {
+        test("should infer DesignToken and CSSDesignToken token types on subscription record", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             await page.evaluate(() => {
                 type AssertCSSDesignToken<T> = T extends CSSDesignTokenImpl<any>
                     ? T
                     : never;
                 DesignToken.create<number>("css").subscribe({
-                    handleChange(token, record) {
-                        const test: AssertCSSDesignToken<typeof record.token> =
-                            record.token;
-                    },
+                    handleChange(token, record) {},
                 });
 
                 type AssertDesignToken<T> = T extends CSSDesignTokenImpl<any> ? never : T;
 
                 DesignToken.create<number>({ name: "no-css" }).subscribe({
-                    handleChange(token, record) {
-                        const test: AssertDesignToken<typeof record.token> = record.token;
-                    },
+                    handleChange(token, record) {},
                 });
             });
         });
 
-        test("should notify a subscriber when a dependency of a subscribed token changes", async () => {
+        test("should notify a subscriber when a dependency of a subscribed token changes", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const tokenA = DesignToken.create<number>(uniqueTokenName());
@@ -1290,7 +1528,12 @@ test.describe("A DesignToken", () => {
             ).toBe(1);
         });
 
-        test("should notify a subscriber when a dependency of a dependency of a subscribed token changes", async () => {
+        test("should notify a subscriber when a dependency of a dependency of a subscribed token changes", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const tokenA = DesignToken.create<number>(uniqueTokenName());
@@ -1315,7 +1558,12 @@ test.describe("A DesignToken", () => {
             ).toBe(1);
         });
 
-        test("should notify a subscriber when a dependency changes for an element down the DOM tree", async () => {
+        test("should notify a subscriber when a dependency changes for an element down the DOM tree", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const tokenA = DesignToken.create<number>(uniqueTokenName());
@@ -1339,7 +1587,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe(1);
         });
-        test("should notify a subscriber when a static-value dependency of subscribed token changes for a parent of the subscription target", async () => {
+        test("should notify a subscriber when a static-value dependency of subscribed token changes for a parent of the subscription target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -1368,7 +1621,12 @@ test.describe("A DesignToken", () => {
                 })
             ).toEqual([1, 14]);
         });
-        test("should notify a subscriber when a derived-value dependency of subscribed token changes for a parent of the subscription target", async () => {
+        test("should notify a subscriber when a derived-value dependency of subscribed token changes for a parent of the subscription target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -1396,15 +1654,19 @@ test.describe("A DesignToken", () => {
                 })
             ).toEqual([1, 14]);
         });
-        test("should notify a subscriber when a dependency of subscribed token changes for a parent of the subscription target", async () => {
+        test("should notify a subscriber when a dependency of subscribed token changes for a parent of the subscription target", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const tokenA = DesignToken.create<number>(uniqueTokenName());
                     const tokenB = DesignToken.create<number>(uniqueTokenName());
 
                     const grandparent = addElement();
-                    const parent = addElement(grandparent);
-                    const child = addElement(parent);
+                    addElement(grandparent);
 
                     tokenA.withDefault(() => 6);
                     tokenB.withDefault(resolve => resolve(tokenA) * 2);
@@ -1425,7 +1687,12 @@ test.describe("A DesignToken", () => {
     });
 
     test.describe("with root registration", () => {
-        test("should not emit CSS custom properties for the default value if a root is not registered", async () => {
+        test("should not emit CSS custom properties for the default value if a root is not registered", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(() => {
                     DesignToken.unregisterDefaultStyleTarget();
@@ -1439,7 +1706,12 @@ test.describe("A DesignToken", () => {
             );
         });
 
-        test("should emit CSS custom properties for the default value when a design token root is registered", async () => {
+        test("should emit CSS custom properties for the default value when a design token root is registered", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const token = DesignToken.create<number>(
@@ -1456,7 +1728,12 @@ test.describe("A DesignToken", () => {
             ).toBe("12");
         });
 
-        test("should remove emitted CSS custom properties for a root when the root is deregistered", async () => {
+        test("should remove emitted CSS custom properties for a root when the root is deregistered", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [];
@@ -1480,7 +1757,12 @@ test.describe("A DesignToken", () => {
             ).toEqual(["12", ""]);
         });
 
-        test("should emit CSS custom properties to an element when the element is provided as a root", async () => {
+        test("should emit CSS custom properties to an element when the element is provided as a root", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const token = DesignToken.create<number>(
@@ -1497,7 +1779,10 @@ test.describe("A DesignToken", () => {
                 })
             ).toBe("12");
         });
-        test("should emit CSS custom properties to multiple roots", async () => {
+        test("should emit CSS custom properties to multiple roots", async ({ page }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             expect(
                 await page.evaluate(async () => {
                     const results = [] as any;
@@ -1545,7 +1830,12 @@ test.describe("A DesignToken", () => {
         });
 
         // Flakey and seems to be corrupted by other tests.
-        test.skip("should set properties for a PropertyTarget registered as the root", async () => {
+        test("should set properties for a PropertyTarget registered as the root", async ({
+            page,
+        }) => {
+            await page.goto(fixtureURL("debug-designtoken--design-token"));
+            await page.evaluate(() => DesignToken.registerDefaultStyleTarget());
+
             const results = await page.evaluate(async () => {
                 const results = [];
                 const token = DesignToken.create<number>(uniqueTokenName()).withDefault(

--- a/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
@@ -97,7 +97,7 @@ test.describe("Dialog", () => {
             node.modal = false;
         });
 
-        await expect(control).not.hasAttribute("aria-modal");
+        await expect(control).not.toHaveAttribute("aria-modal");
     });
 
     test('should add an overlay element with a `role` attribute of "presentation" when the `modal` property is true', async () => {
@@ -143,7 +143,7 @@ test.describe("Dialog", () => {
 
         await expect(element).toHaveJSProperty("hidden", false);
 
-        await expect(element).not.hasAttribute("hidden");
+        await expect(element).not.toHaveAttribute("hidden");
 
         await element.evaluate((node: FASTDialog) => {
             node.hide();

--- a/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
@@ -1,42 +1,37 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTDialog } from "./index.js";
 
 test.describe("Dialog", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let control: Locator;
-    let overlay: Locator;
+    test("should include a role of `dialog` on the control", async ({ page }) => {
+        const element = page.locator("fast-dialog");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-dialog");
-
-        root = page.locator("#root");
-
-        control = element.locator(`[role="dialog"]`);
-
-        overlay = element.locator(".overlay");
+        const control = element.locator(`[role="dialog"]`);
 
         await page.goto(fixtureURL("dialog--dialog"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should include a role of `dialog` on the control", async () => {
         await expect(control).toHaveClass(/control/);
     });
 
-    test('should set the `tabindex` attribute on the control to "-1" by default', async () => {
+    test('should set the `tabindex` attribute on the control to "-1" by default', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        const control = element.locator(`[role="dialog"]`);
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await expect(control).toHaveAttribute("tabindex", "-1");
     });
 
-    test("should set the `hidden` attribute to equal the value of the `hidden` property", async () => {
+    test("should set the `hidden` attribute to equal the value of the `hidden` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await element.evaluate((node: FASTDialog) => {
             node.hidden = true;
         });
@@ -50,7 +45,17 @@ test.describe("Dialog", () => {
         await expect(element).not.toHaveAttribute("hidden");
     });
 
-    test("should set the `aria-describedby` attribute on the control when provided", async () => {
+    test("should set the `aria-describedby` attribute on the control when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(`[role="dialog"]`);
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-dialog aria-describedby="description">
@@ -62,7 +67,17 @@ test.describe("Dialog", () => {
         await expect(control).toHaveAttribute("aria-describedby", "description");
     });
 
-    test("should set the `aria-labelledby` attribute on the dialog control when provided", async () => {
+    test("should set the `aria-labelledby` attribute on the dialog control when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(`[role="dialog"]`);
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-dialog aria-labelledby="label">
@@ -74,7 +89,17 @@ test.describe("Dialog", () => {
         await expect(control).toHaveAttribute("aria-labelledby", "label");
     });
 
-    test("should set the `aria-label` attribute on the dialog control when provided", async () => {
+    test("should set the `aria-label` attribute on the dialog control when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(`[role="dialog"]`);
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-dialog aria-label="Label"></fast-dialog>
@@ -84,7 +109,17 @@ test.describe("Dialog", () => {
         await expect(control).toHaveAttribute("aria-label", "Label");
     });
 
-    test("should add an attribute of `aria-modal` with a value equal to the `modal` attribute", async () => {
+    test("should add an attribute of `aria-modal` with a value equal to the `modal` attribute", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(`[role="dialog"]`);
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-dialog modal></fast-dialog>
@@ -100,7 +135,17 @@ test.describe("Dialog", () => {
         await expect(control).not.toHaveAttribute("aria-modal");
     });
 
-    test('should add an overlay element with a `role` attribute of "presentation" when the `modal` property is true', async () => {
+    test('should add an overlay element with a `role` attribute of "presentation" when the `modal` property is true', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        const root = page.locator("#root");
+
+        const overlay = element.locator(".overlay");
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-dialog modal></fast-dialog>
@@ -116,7 +161,15 @@ test.describe("Dialog", () => {
         await expect(overlay).toHaveCount(0);
     });
 
-    test("should add an attribute of `no-focus-trap` when `noFocusTrap` is true", async () => {
+    test("should add an attribute of `no-focus-trap` when `noFocusTrap` is true", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-dialog no-focus-trap></fast-dialog>
@@ -136,7 +189,13 @@ test.describe("Dialog", () => {
         await expect(element).not.toHaveAttribute("no-focus-trap");
     });
 
-    test("should add the `hidden` attribute when the `hide()` method is invoked", async () => {
+    test("should add the `hidden` attribute when the `hide()` method is invoked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await element.evaluate((node: FASTDialog) => {
             node.hidden = false;
         });
@@ -152,7 +211,13 @@ test.describe("Dialog", () => {
         await expect(element).toHaveJSProperty("hidden", true);
     });
 
-    test("should remove the `hidden` attribute when the `show()` method is invoked", async () => {
+    test("should remove the `hidden` attribute when the `show()` method is invoked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await element.evaluate((node: FASTDialog) => {
             node.hidden = true;
         });
@@ -170,7 +235,17 @@ test.describe("Dialog", () => {
         await expect(element).not.toHaveAttribute("hidden");
     });
 
-    test("should fire a 'dismiss' event when its overlay is clicked", async () => {
+    test("should fire a 'dismiss' event when its overlay is clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        const root = page.locator("#root");
+
+        const overlay = element.locator(".overlay");
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-dialog modal></fast-dialog>
@@ -193,7 +268,15 @@ test.describe("Dialog", () => {
         expect(wasDismissed).toBeTruthy();
     });
 
-    test("should fire a `cancel` event when its overlay is clicked", async () => {
+    test("should fire a `cancel` event when its overlay is clicked", async ({ page }) => {
+        const element = page.locator("fast-dialog");
+
+        const root = page.locator("#root");
+
+        const overlay = element.locator(".overlay");
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-dialog modal></fast-dialog>
@@ -216,7 +299,17 @@ test.describe("Dialog", () => {
         expect(wasDismissed).toBeTruthy();
     });
 
-    test("should fire a 'dismiss' event when keydown is invoked on the document", async () => {
+    test("should fire a 'dismiss' event when keydown is invoked on the document", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-dialog");
+
+        const root = page.locator("#root");
+
+        const overlay = element.locator(".overlay");
+
+        await page.goto(fixtureURL("dialog--dialog"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-dialog modal></fast-dialog>

--- a/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/dialog/dialog.pw.spec.ts
@@ -41,13 +41,13 @@ test.describe("Dialog", () => {
             node.hidden = true;
         });
 
-        await expect(element).toHaveBooleanAttribute("hidden");
+        await expect(element).toHaveAttribute("hidden");
 
         await element.evaluate((node: FASTDialog) => {
             node.hidden = false;
         });
 
-        await expect(element).not.toHaveBooleanAttribute("hidden");
+        await expect(element).not.toHaveAttribute("hidden");
     });
 
     test("should set the `aria-describedby` attribute on the control when provided", async () => {
@@ -127,13 +127,13 @@ test.describe("Dialog", () => {
             node.noFocusTrap = true;
         });
 
-        await expect(element).toHaveBooleanAttribute("no-focus-trap");
+        await expect(element).toHaveAttribute("no-focus-trap");
 
         await element.evaluate((node: FASTDialog) => {
             node.noFocusTrap = false;
         });
 
-        await expect(element).not.toHaveBooleanAttribute("no-focus-trap");
+        await expect(element).not.toHaveAttribute("no-focus-trap");
     });
 
     test("should add the `hidden` attribute when the `hide()` method is invoked", async () => {
@@ -159,7 +159,7 @@ test.describe("Dialog", () => {
 
         await expect(element).toHaveJSProperty("hidden", true);
 
-        await expect(element).toHaveBooleanAttribute("hidden");
+        await expect(element).toHaveAttribute("hidden");
 
         await element.evaluate((node: FASTDialog) => {
             node.show();
@@ -167,7 +167,7 @@ test.describe("Dialog", () => {
 
         await expect(element).toHaveJSProperty("hidden", false);
 
-        await expect(element).not.toHaveBooleanAttribute("hidden");
+        await expect(element).not.toHaveAttribute("hidden");
     });
 
     test("should fire a 'dismiss' event when its overlay is clicked", async () => {

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.pw.spec.ts
@@ -1,33 +1,28 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTDisclosure } from "./disclosure.js";
 
 test.describe("Disclosure", () => {
     test.describe("States, Attributes, and Properties", () => {
-        let page: Page;
-        let element: Locator;
-        let summary: Locator;
+        test("should set the `aria-controls` attribute on the internal summary element", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-disclosure");
 
-        test.beforeAll(async ({ browser }) => {
-            page = await browser.newPage();
-
-            element = page.locator("fast-disclosure");
-
-            summary = element.locator("summary");
+            const summary = element.locator("summary");
 
             await page.goto(fixtureURL("disclosure--disclosure"));
-        });
 
-        test.afterAll(async () => {
-            await page.close();
-        });
-
-        test("should set the `aria-controls` attribute on the internal summary element", async () => {
             await expect(summary).toHaveAttribute("aria-controls", "disclosure-content");
         });
 
-        test("should toggle the `expanded` attribute based on the value of the `expanded` property", async () => {
+        test("should toggle the `expanded` attribute based on the value of the `expanded` property", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-disclosure");
+
+            await page.goto(fixtureURL("disclosure--disclosure"));
+
             await expect(element).not.toHaveAttribute("expanded");
 
             await element.evaluate((node: FASTDisclosure) => {
@@ -43,7 +38,15 @@ test.describe("Disclosure", () => {
             await expect(element).not.toHaveAttribute("expanded");
         });
 
-        test("should set summary slot content to the value of the summary attribute", async () => {
+        test("should set summary slot content to the value of the summary attribute", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-disclosure");
+
+            const summary = element.locator("summary");
+
+            await page.goto(fixtureURL("disclosure--disclosure"));
+
             const summaryContent =
                 "Should set the summary slot content to the value of the summary attribute";
 
@@ -54,7 +57,13 @@ test.describe("Disclosure", () => {
             await expect(summary).toHaveText(summaryContent);
         });
 
-        test("should toggle the content when the `toggle()` method is invoked", async () => {
+        test("should toggle the content when the `toggle()` method is invoked", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-disclosure");
+
+            await page.goto(fixtureURL("disclosure--disclosure"));
+
             await element.evaluate((node: FASTDisclosure) => {
                 node.toggle();
             });
@@ -68,7 +77,13 @@ test.describe("Disclosure", () => {
             await expect(element).toHaveJSProperty("expanded", false);
         });
 
-        test("should expand and collapse the content when the `show()` and `hide()` methods are invoked", async () => {
+        test("should expand and collapse the content when the `show()` and `hide()` methods are invoked", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-disclosure");
+
+            await page.goto(fixtureURL("disclosure--disclosure"));
+
             await expect(element).toHaveJSProperty("expanded", false);
 
             await element.evaluate((node: FASTDisclosure) => {
@@ -84,7 +99,15 @@ test.describe("Disclosure", () => {
             await expect(element).toHaveJSProperty("expanded", false);
         });
 
-        test("should set the `aria-expanded` attribute on the internal summary element equal to the `expanded` property", async () => {
+        test("should set the `aria-expanded` attribute on the internal summary element equal to the `expanded` property", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-disclosure");
+
+            const summary = element.locator("summary");
+
+            await page.goto(fixtureURL("disclosure--disclosure"));
+
             await expect(summary).toHaveAttribute("aria-expanded", "false");
 
             await element.evaluate((node: FASTDisclosure) => {

--- a/packages/web-components/fast-foundation/src/disclosure/disclosure.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/disclosure/disclosure.pw.spec.ts
@@ -28,19 +28,19 @@ test.describe("Disclosure", () => {
         });
 
         test("should toggle the `expanded` attribute based on the value of the `expanded` property", async () => {
-            await expect(element).not.toHaveBooleanAttribute("expanded");
+            await expect(element).not.toHaveAttribute("expanded");
 
             await element.evaluate((node: FASTDisclosure) => {
                 node.expanded = true;
             });
 
-            await expect(element).toHaveBooleanAttribute("expanded");
+            await expect(element).toHaveAttribute("expanded");
 
             await element.evaluate((node: FASTDisclosure) => {
                 node.expanded = false;
             });
 
-            await expect(element).not.toHaveBooleanAttribute("expanded");
+            await expect(element).not.toHaveAttribute("expanded");
         });
 
         test("should set summary slot content to the value of the summary attribute", async () => {

--- a/packages/web-components/fast-foundation/src/divider/divider.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/divider/divider.pw.spec.ts
@@ -1,29 +1,16 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import { DividerOrientation, DividerRole } from "./divider.options.js";
 import type { FASTDivider } from "./index.js";
 
 test.describe("Divider", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test('should set a default `role` attribute of "separator"', async ({ page }) => {
+        const element = page.locator("fast-divider");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-divider");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("divider--divider"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test('should set a default `role` attribute of "separator"', async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-divider></fast-divider>
@@ -33,7 +20,15 @@ test.describe("Divider", () => {
         await expect(element).toHaveAttribute("role", DividerRole.separator);
     });
 
-    test("should set the `role` attribute equal to the role provided", async () => {
+    test("should set the `role` attribute equal to the role provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-divider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("divider--divider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-divider role="presentation"></fast-divider>
@@ -49,7 +44,15 @@ test.describe("Divider", () => {
         await expect(element).toHaveAttribute("role", DividerRole.separator);
     });
 
-    test("should set the `aria-orientation` attribute equal to the `orientation` value", async () => {
+    test("should set the `aria-orientation` attribute equal to the `orientation` value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-divider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("divider--divider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-divider orientation="vertical"></fast-divider>
@@ -71,7 +74,15 @@ test.describe("Divider", () => {
         );
     });
 
-    test("should NOT set the `aria-orientation` attribute equal to the `orientation` value if the `role` is presentational", async () => {
+    test("should NOT set the `aria-orientation` attribute equal to the `orientation` value if the `role` is presentational", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-divider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("divider--divider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-divider orientation="vertical"></fast-divider>

--- a/packages/web-components/fast-foundation/src/flipper/flipper.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.pw.spec.ts
@@ -77,7 +77,7 @@ test.describe("Flipper", () => {
 
         await (await element.elementHandle())?.waitForElementState("stable");
 
-        await expect(element).not.hasAttribute("aria-disabled");
+        await expect(element).not.toHaveAttribute("aria-disabled");
     });
 
     test('should set the `tabindex` attribute to "-1" when `hiddenFromAT` is true', async () => {

--- a/packages/web-components/fast-foundation/src/flipper/flipper.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/flipper/flipper.pw.spec.ts
@@ -1,28 +1,15 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTFlipper } from "./flipper.js";
 
 test.describe("Flipper", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should include a role of button", async ({ page }) => {
+        const element = page.locator("fast-flipper");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-flipper");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("flipper--flipper"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should include a role of button", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-flipper></fast-flipper>
@@ -32,7 +19,13 @@ test.describe("Flipper", () => {
         await expect(element).toHaveAttribute("role", "button");
     });
 
-    test('should set `aria-hidden` to "true" by default', async () => {
+    test('should set `aria-hidden` to "true" by default', async ({ page }) => {
+        const element = page.locator("fast-flipper");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("flipper--flipper"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-flipper></fast-flipper>
@@ -42,7 +35,15 @@ test.describe("Flipper", () => {
         await expect(element).toHaveAttribute("aria-hidden", "true");
     });
 
-    test("should set the `hiddenFromAT` property to true by default", async () => {
+    test("should set the `hiddenFromAT` property to true by default", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-flipper");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("flipper--flipper"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-flipper></fast-flipper>
@@ -52,7 +53,13 @@ test.describe("Flipper", () => {
         await expect(element).toHaveJSProperty("hiddenFromAT", true);
     });
 
-    test('should set the `direction` property to "next" by default', async () => {
+    test('should set the `direction` property to "next" by default', async ({ page }) => {
+        const element = page.locator("fast-flipper");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("flipper--flipper"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-flipper></fast-flipper>
@@ -62,7 +69,15 @@ test.describe("Flipper", () => {
         await expect(element.locator("span")).toHaveClass(/next/);
     });
 
-    test("should toggle the `aria-disabled` attribute based on the value of the `disabled` property", async () => {
+    test("should toggle the `aria-disabled` attribute based on the value of the `disabled` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-flipper");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("flipper--flipper"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-flipper disabled></fast-flipper>
@@ -80,7 +95,15 @@ test.describe("Flipper", () => {
         await expect(element).not.toHaveAttribute("aria-disabled");
     });
 
-    test('should set the `tabindex` attribute to "-1" when `hiddenFromAT` is true', async () => {
+    test('should set the `tabindex` attribute to "-1" when `hiddenFromAT` is true', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-flipper");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("flipper--flipper"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-flipper></fast-flipper>
@@ -104,7 +127,13 @@ test.describe("Flipper", () => {
         await expect(element).toHaveAttribute("tabindex", "-1");
     });
 
-    test("should set a `tabindex` of 0 when `aria-hidden` is false", async () => {
+    test("should set a `tabindex` of 0 when `aria-hidden` is false", async ({ page }) => {
+        const element = page.locator("fast-flipper");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("flipper--flipper"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-flipper aria-hidden="false"></fast-flipper>
@@ -120,7 +149,15 @@ test.describe("Flipper", () => {
         await expect(element).toHaveAttribute("tabindex", "-1");
     });
 
-    test('should render a span with a class of "next" when the `direction` attribute is "next"', async () => {
+    test('should render a span with a class of "next" when the `direction` attribute is "next"', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-flipper");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("flipper--flipper"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-flipper direction="next"></fast-flipper>
@@ -134,7 +171,15 @@ test.describe("Flipper", () => {
         await expect(spans).toHaveClass(/next/);
     });
 
-    test('should render a span with a class of "previous" when the `direction` attribute is "previous"', async () => {
+    test('should render a span with a class of "previous" when the `direction` attribute is "previous"', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-flipper");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("flipper--flipper"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-flipper direction="previous"></fast-flipper>

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.pw.spec.ts
@@ -359,7 +359,7 @@ test.describe("FormAssociated", () => {
 
             await expect(element).toHaveJSProperty("currentValue", "foo");
 
-            await expect(element).not.hasAttribute("value");
+            await expect(element).not.toHaveAttribute("value");
 
             await form.evaluate((node: HTMLFormElement) => {
                 node.reset();
@@ -369,7 +369,7 @@ test.describe("FormAssociated", () => {
 
             await expect(element).toHaveJSProperty("currentValue", "");
 
-            await expect(element).not.hasAttribute("value");
+            await expect(element).not.toHaveAttribute("value");
         });
 
         test("should reset it's value property to the value of the value attribute if it is set", async () => {

--- a/packages/web-components/fast-foundation/src/form-associated/form-associated.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/form-associated/form-associated.pw.spec.ts
@@ -1,4 +1,3 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 
@@ -9,21 +8,13 @@ import type {
 } from "./stories/form-associated.register.js";
 
 test.describe("FormAssociated", () => {
-    let page: Page;
-    let root: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-        root = page.locator("#root");
+    test("should have an empty string value prior to connectedCallback", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("debug--blank"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have an empty string value prior to connectedCallback", async () => {
         const [value, currentValue] = await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -37,7 +28,13 @@ test.describe("FormAssociated", () => {
         expect(currentValue).toBe("");
     });
 
-    test("should initialize to the initial value if no value property is set", async () => {
+    test("should initialize to the initial value if no value property is set", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -57,7 +54,13 @@ test.describe("FormAssociated", () => {
         await expect(element).toHaveJSProperty("initialValue", "foobar");
     });
 
-    test("should initialize to the provided value ATTRIBUTE if set pre-connection", async () => {
+    test("should initialize to the provided value ATTRIBUTE if set pre-connection", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -75,7 +78,13 @@ test.describe("FormAssociated", () => {
         await expect(element).toHaveJSProperty("currentValue", "foobar");
     });
 
-    test("should initialize to the provided value ATTRIBUTE if set post-connection", async () => {
+    test("should initialize to the provided value ATTRIBUTE if set post-connection", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <test-element></test-element>
@@ -93,7 +102,13 @@ test.describe("FormAssociated", () => {
         await expect(element).toHaveJSProperty("currentValue", "foobar");
     });
 
-    test("should initialize to the provided value PROPERTY if set pre-connection", async () => {
+    test("should initialize to the provided value PROPERTY if set pre-connection", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -111,7 +126,13 @@ test.describe("FormAssociated", () => {
         await expect(element).toHaveJSProperty("currentValue", "foobar");
     });
 
-    test("should initialize to the provided value PROPERTY if set post-connection", async () => {
+    test("should initialize to the provided value PROPERTY if set post-connection", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <test-element></test-element>
@@ -129,7 +150,13 @@ test.describe("FormAssociated", () => {
         await expect(element).toHaveJSProperty("currentValue", "foobar");
     });
 
-    test("should initialize to the initial value when initial value is assigned by extending class", async () => {
+    test("should initialize to the initial value when initial value is assigned by extending class", async ({
+        page,
+    }) => {
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <custom-initial-value></custom-initial-value>
@@ -143,7 +170,11 @@ test.describe("FormAssociated", () => {
         await expect(element).toHaveJSProperty("currentValue", "foobar");
     });
 
-    test("should communicate initial value to the parent form", async () => {
+    test("should communicate initial value to the parent form", async ({ page }) => {
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -164,7 +195,13 @@ test.describe("FormAssociated", () => {
     });
 
     test.describe("changes:", () => {
-        test("setting value ATTRIBUTE should set value if value PROPERTY has not been explicitly set", async () => {
+        test("setting value ATTRIBUTE should set value if value PROPERTY has not been explicitly set", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <test-element></test-element>
@@ -190,7 +227,13 @@ test.describe("FormAssociated", () => {
             await expect(element).toHaveJSProperty("currentValue", "bar");
         });
 
-        test("setting value ATTRIBUTE should not set value if value PROPERTY has been explicitly set", async () => {
+        test("setting value ATTRIBUTE should not set value if value PROPERTY has been explicitly set", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <test-element></test-element>
@@ -216,7 +259,13 @@ test.describe("FormAssociated", () => {
             await expect(element).toHaveJSProperty("currentValue", "foo");
         });
 
-        test("setting value ATTRIBUTE should set parent form value if value PROPERTY has not been explicitly set", async () => {
+        test("setting value ATTRIBUTE should set parent form value if value PROPERTY has not been explicitly set", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -254,7 +303,11 @@ test.describe("FormAssociated", () => {
             ).toBe("bar");
         });
 
-        test("setting value PROPERTY should set parent form value", async () => {
+        test("setting value PROPERTY should set parent form value", async ({ page }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -292,7 +345,13 @@ test.describe("FormAssociated", () => {
             ).toBe("bar");
         });
 
-        test("assigning the currentValue property should set the controls value property to the same value", async () => {
+        test("assigning the currentValue property should set the controls value property to the same value", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <test-element></test-element>
@@ -314,7 +373,13 @@ test.describe("FormAssociated", () => {
             await expect(element).toHaveJSProperty("currentValue", "foo");
         });
 
-        test("setting the current-value property should set the controls value property to the same value", async () => {
+        test("setting the current-value property should set the controls value property to the same value", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <test-element></test-element>
@@ -338,7 +403,13 @@ test.describe("FormAssociated", () => {
     });
 
     test.describe("when the owning form's reset() method is invoked", () => {
-        test("should reset it's value property to an empty string if no value attribute is set", async () => {
+        test("should reset it's value property to an empty string if no value attribute is set", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -372,7 +443,13 @@ test.describe("FormAssociated", () => {
             await expect(element).not.toHaveAttribute("value");
         });
 
-        test("should reset it's value property to the value of the value attribute if it is set", async () => {
+        test("should reset it's value property to the value of the value attribute if it is set", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -412,7 +489,13 @@ test.describe("FormAssociated", () => {
             await expect(element).toHaveAttribute("value", "attr-value");
         });
 
-        test("should put the control into a clean state, where modifcations to the `value` attribute update the `value` property prior to user or programmatic interaction", async () => {
+        test("should put the control into a clean state, where modifcations to the `value` attribute update the `value` property prior to user or programmatic interaction", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -464,7 +547,13 @@ test.describe("FormAssociated", () => {
     });
 
     test.describe("CheckableFormAssociated", () => {
-        test("should have a 'checked' property that is initialized to false", async () => {
+        test("should have a 'checked' property that is initialized to false", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <checkable-form-associated></checkable-form-associated>
@@ -480,7 +569,13 @@ test.describe("FormAssociated", () => {
             await expect(element).toHaveAttribute("current-checked", "false");
         });
 
-        test("should align the `currentChecked` property and `current-checked` attribute with `checked` property changes", async () => {
+        test("should align the `currentChecked` property and `current-checked` attribute with `checked` property changes", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <checkable-form-associated></checkable-form-associated>
@@ -516,7 +611,13 @@ test.describe("FormAssociated", () => {
             await expect(element).toHaveAttribute("current-checked", "false");
         });
 
-        test("should align the `checked` property and `current-checked` attribute with `currentChecked` property changes", async () => {
+        test("should align the `checked` property and `current-checked` attribute with `currentChecked` property changes", async ({
+            page,
+        }) => {
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <checkable-form-associated></checkable-form-associated>

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
@@ -1,60 +1,46 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTHorizontalScroll } from "./horizontal-scroll.js";
 
 test.describe("HorizontalScroll", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-
-    let cards: Locator;
-    let scrollNext: Locator;
-    let scrollPrevious: Locator;
-    let scrollView: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-horizontal-scroll");
-
-        root = page.locator("#root");
-
-        cards = element.locator("fast-card");
-
-        scrollNext = element.locator(".scroll-next");
-
-        scrollPrevious = element.locator(".scroll-prev");
-
-        scrollView = element.locator(".scroll-view");
-
-        await page.goto(fixtureURL("horizontal-scroll--horizontal-scroll"));
-
-        await element.evaluate((node: FASTHorizontalScroll) => {
-            node.speed = 0;
-        });
-    });
-
-    test.afterAll(async () => {
-        await page.close();
-    });
-
     test.describe("Flippers", () => {
-        test.beforeEach(async () => {
-            await element.evaluate((node: FASTHorizontalScroll) => {
-                node.scrollToPosition(0);
-            });
-        });
+        test("should enable the next flipper element when content exceeds horizontal-scroll width", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-horizontal-scroll");
 
-        test("should enable the next flipper element when content exceeds horizontal-scroll width", async () => {
+            const scrollNext = element.locator(".scroll-next");
+
+            await page.goto(
+                fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 })
+            );
+
             await expect(scrollNext).not.toHaveClass(/disabled/);
         });
 
-        test("should start in the 0 position", async () => {
+        test("should start in the 0 position", async ({ page }) => {
+            const element = page.locator("fast-horizontal-scroll");
+
+            const scrollView = element.locator(".scroll-view");
+
+            await page.goto(
+                fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 })
+            );
+
             await expect(scrollView).toHaveJSProperty("scrollLeft", 0);
         });
 
-        test("should scroll to the beginning of the last element in full view", async () => {
+        test("should scroll to the beginning of the last element in full view", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-horizontal-scroll");
+
+            const scrollView = element.locator(".scroll-view");
+
+            await page.goto(
+                fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 })
+            );
+
             await element.evaluate((node: FASTHorizontalScroll) => {
                 node.scrollToNext();
             });
@@ -62,7 +48,15 @@ test.describe("HorizontalScroll", () => {
             await expect(scrollView).toHaveJSProperty("scrollLeft", 375);
         });
 
-        test("should not scroll past the beginning", async () => {
+        test("should not scroll past the beginning", async ({ page }) => {
+            const element = page.locator("fast-horizontal-scroll");
+
+            const scrollView = element.locator(".scroll-view");
+
+            await page.goto(
+                fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 })
+            );
+
             await expect(scrollView).toHaveJSProperty("scrollLeft", 0);
 
             await element.evaluate((node: FASTHorizontalScroll) => {
@@ -72,7 +66,17 @@ test.describe("HorizontalScroll", () => {
             await expect(scrollView).toHaveJSProperty("scrollLeft", 0);
         });
 
-        test("should not scroll past the last in view element", async () => {
+        test("should not scroll past the last in view element", async ({ page }) => {
+            const element = page.locator("fast-horizontal-scroll");
+
+            const cards = element.locator("fast-card");
+
+            const scrollView = element.locator(".scroll-view");
+
+            await page.goto(
+                fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 })
+            );
+
             await element.evaluate((node: FASTHorizontalScroll) => {
                 const scrollView = node.shadowRoot?.querySelector(".scroll-view");
 
@@ -98,7 +102,17 @@ test.describe("HorizontalScroll", () => {
             );
         });
 
-        test('should set the "disabled" class on the previous flipper when the scroll position is at the beginning of the content', async () => {
+        test('should set the "disabled" class on the previous flipper when the scroll position is at the beginning of the content', async ({
+            page,
+        }) => {
+            const element = page.locator("fast-horizontal-scroll");
+
+            const scrollPrevious = element.locator(".scroll-prev");
+
+            await page.goto(
+                fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 })
+            );
+
             await expect(scrollPrevious).toHaveClass(/disabled/);
 
             await element.evaluate((node: FASTHorizontalScroll) => {
@@ -114,7 +128,17 @@ test.describe("HorizontalScroll", () => {
             await expect(scrollPrevious).toHaveClass(/disabled/);
         });
 
-        test('should set the "disabled" class on the next flipper when the scroll position is at the end of the content', async () => {
+        test('should set the "disabled" class on the next flipper when the scroll position is at the end of the content', async ({
+            page,
+        }) => {
+            const element = page.locator("fast-horizontal-scroll");
+
+            const scrollNext = element.locator(".scroll-next");
+
+            await page.goto(
+                fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 })
+            );
+
             await expect(scrollNext).not.toHaveClass(/disabled/);
 
             await element.evaluate((node: FASTHorizontalScroll) => {
@@ -131,7 +155,17 @@ test.describe("HorizontalScroll", () => {
         });
     });
 
-    test("should hide the next flipper if content is less than horizontal-scroll width", async () => {
+    test("should hide the next flipper if content is less than horizontal-scroll width", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-horizontal-scroll");
+
+        const root = page.locator("#root");
+
+        const scrollNext = element.locator(".scroll-next");
+
+        await page.goto(fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 }));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-horizontal-scroll style="width: 1000px;">
@@ -140,28 +174,24 @@ test.describe("HorizontalScroll", () => {
             `;
         });
 
-        const element = page.locator("fast-horizontal-scroll");
-
-        const scrollNext = element.locator(".scroll-next");
-
         await expect(scrollNext).toBeHidden();
     });
 
     test.describe("Scrolling", () => {
-        test.fixme("should change scroll stop on resize", async () => {
+        test.fixme("should change scroll stop on resize", async ({ page }) => {
+            const element = page.locator("fast-horizontal-scroll");
+
+            const scrollView = element.locator(".scroll-view");
+
             await page.goto(
                 fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 })
             );
-
-            const element = page.locator("fast-horizontal-scroll");
 
             const flippers = element.locator("fast-flipper");
 
             const previousFlipper = flippers.nth(0);
 
             const nextFlipper = flippers.nth(1);
-
-            const scrollView = element.locator(".scroll-view");
 
             await nextFlipper.click();
 
@@ -213,7 +243,7 @@ test.describe("HorizontalScroll", () => {
 
             const scrollView = element.locator(".scroll-view");
 
-            cards = element.locator("fast-card");
+            const cards = element.locator("fast-card");
 
             const lastCard = cards.last();
 

--- a/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/horizontal-scroll/horizontal-scroll.pw.spec.ts
@@ -148,7 +148,7 @@ test.describe("HorizontalScroll", () => {
     });
 
     test.describe("Scrolling", () => {
-        test("should change scroll stop on resize", async () => {
+        test.fixme("should change scroll stop on resize", async () => {
             await page.goto(
                 fixtureURL("horizontal-scroll--horizontal-scroll", { speed: 0 })
             );

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.pw.spec.ts
@@ -71,7 +71,7 @@ test.describe("ListboxOption", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-checked");
+        await expect(element).not.toHaveAttribute("aria-checked");
 
         await element.evaluate((node: FASTListboxOption) => {
             node.checked = true;

--- a/packages/web-components/fast-foundation/src/listbox-option/listbox-option.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox-option/listbox-option.pw.spec.ts
@@ -1,28 +1,15 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTListboxOption } from "./listbox-option.js";
 
 test.describe("ListboxOption", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should have a role of `option`", async ({ page }) => {
+        const element = page.locator("fast-option");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-option");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("listbox-option--listbox-option"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of `option`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-option></fast-option>
@@ -32,7 +19,13 @@ test.describe("ListboxOption", () => {
         await expect(element).toHaveAttribute("role", "option");
     });
 
-    test("should set the `aria-disabled` attribute when disabled", async () => {
+    test("should set the `aria-disabled` attribute when disabled", async ({ page }) => {
+        const element = page.locator("fast-option");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox-option--listbox-option"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-option disabled></fast-option>
@@ -48,7 +41,13 @@ test.describe("ListboxOption", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should set the `aria-selected` attribute when selected", async () => {
+    test("should set the `aria-selected` attribute when selected", async ({ page }) => {
+        const element = page.locator("fast-option");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox-option--listbox-option"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-option selected></fast-option>
@@ -64,7 +63,13 @@ test.describe("ListboxOption", () => {
         await expect(element).toHaveAttribute("aria-selected", "false");
     });
 
-    test("should set the `aria-checked` attribute when checked", async () => {
+    test("should set the `aria-checked` attribute when checked", async ({ page }) => {
+        const element = page.locator("fast-option");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox-option--listbox-option"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-option></fast-option>
@@ -86,7 +91,15 @@ test.describe("ListboxOption", () => {
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
-    test("should have an empty string `value` when the `value` attribute exists and is empty", async () => {
+    test("should have an empty string `value` when the `value` attribute exists and is empty", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-option");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox-option--listbox-option"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-option value=""></fast-option>
@@ -102,7 +115,15 @@ test.describe("ListboxOption", () => {
         await expect(element).toHaveAttribute("value", "");
     });
 
-    test("should return the text content when the `value` attribute does not exist", async () => {
+    test("should return the text content when the `value` attribute does not exist", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-option");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox-option--listbox-option"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-option>hello</fast-option>
@@ -114,7 +135,15 @@ test.describe("ListboxOption", () => {
         await expect(element).toHaveJSProperty("value", "hello");
     });
 
-    test("should return the trimmed text content with the `text` property", async () => {
+    test("should return the trimmed text content with the `text` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-option");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox-option--listbox-option"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-option>
@@ -129,7 +158,13 @@ test.describe("ListboxOption", () => {
         await expect(element).toHaveText("hello world");
     });
 
-    test("should always return the `value` as a string", async () => {
+    test("should always return the `value` as a string", async ({ page }) => {
+        const element = page.locator("fast-option");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox-option--listbox-option"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-option value="1"></fast-option>

--- a/packages/web-components/fast-foundation/src/listbox/listbox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.pw.spec.ts
@@ -46,7 +46,7 @@ test.describe("Listbox", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("tabindex");
+        await expect(element).not.toHaveAttribute("tabindex");
     });
 
     test("should select nothing when no options have the `selected` attribute", async () => {
@@ -66,7 +66,7 @@ test.describe("Listbox", () => {
             )
         ).toBe(false);
 
-        await expect(element).not.hasAttribute("value");
+        await expect(element).not.toHaveAttribute("value");
 
         await expect(element).toHaveJSProperty("selectedIndex", -1);
     });
@@ -117,62 +117,59 @@ test.describe("Listbox", () => {
         await expect(element).toHaveAttribute("size", "5");
     });
 
-    test.describe(
-        "should set the `size` property to 0 when a negative value is set",
-        () => {
-            test("via the `size` property", async () => {
-                await root.evaluate(node => {
-                    node.innerHTML = /* html */ `
+    test.describe("should set the `size` property to 0 when a negative value is set", () => {
+        test("via the `size` property", async () => {
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
                         <fast-listbox>
                             <fast-option>Option 1</fast-option>
                             <fast-option>Option 2</fast-option>
                             <fast-option>Option 3</fast-option>
                         </fast-listbox>
                     `;
-                });
-
-                await element.evaluate((node: FASTListboxElement) => {
-                    node.size = 1;
-                });
-
-                await expect(element).toHaveJSProperty("size", 1);
-                await expect(element).toHaveAttribute("size", "1");
-
-                await element.evaluate((node: FASTListboxElement) => {
-                    node.size = -1;
-                });
-
-                await expect(element).toHaveJSProperty("size", 0);
-                await expect(element).toHaveAttribute("size", "0");
             });
 
-            test("via the `size` attribute", async () => {
-                await root.evaluate(node => {
-                    node.innerHTML = /* html */ `
+            await element.evaluate((node: FASTListboxElement) => {
+                node.size = 1;
+            });
+
+            await expect(element).toHaveJSProperty("size", 1);
+            await expect(element).toHaveAttribute("size", "1");
+
+            await element.evaluate((node: FASTListboxElement) => {
+                node.size = -1;
+            });
+
+            await expect(element).toHaveJSProperty("size", 0);
+            await expect(element).toHaveAttribute("size", "0");
+        });
+
+        test("via the `size` attribute", async () => {
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
                         <fast-listbox>
                             <fast-option>Option 1</fast-option>
                             <fast-option>Option 2</fast-option>
                             <fast-option>Option 3</fast-option>
                         </fast-listbox>
                     `;
-                });
-
-                await element.evaluate((node: FASTListboxElement) =>
-                    node.setAttribute("size", "1")
-                );
-
-                await expect(element).toHaveJSProperty("size", 1);
-                await expect(element).toHaveAttribute("size", "1");
-
-                await element.evaluate((node: FASTListboxElement) =>
-                    node.setAttribute("size", "-1")
-                );
-
-                await expect(element).toHaveJSProperty("size", 0);
-                await expect(element).toHaveAttribute("size", "0");
             });
-        }
-    );
+
+            await element.evaluate((node: FASTListboxElement) =>
+                node.setAttribute("size", "1")
+            );
+
+            await expect(element).toHaveJSProperty("size", 1);
+            await expect(element).toHaveAttribute("size", "1");
+
+            await element.evaluate((node: FASTListboxElement) =>
+                node.setAttribute("size", "-1")
+            );
+
+            await expect(element).toHaveJSProperty("size", 0);
+            await expect(element).toHaveAttribute("size", "0");
+        });
+    });
 
     test("should set the `aria-setsize` and `aria-posinset` properties on slotted options", async () => {
         await root.evaluate(node => {
@@ -260,6 +257,6 @@ test.describe("Listbox", () => {
             node.multiple = false;
         });
 
-        await expect(element).not.hasAttribute("aria-multiselectable");
+        await expect(element).not.toHaveAttribute("aria-multiselectable");
     });
 });

--- a/packages/web-components/fast-foundation/src/listbox/listbox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/listbox/listbox.pw.spec.ts
@@ -1,31 +1,17 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTListboxElement } from "./listbox.element.js";
 
 test.describe("Listbox", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let options: Locator;
+    test("should have a tabindex of 0 when `disabled` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-listbox");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-listbox");
-
-        root = page.locator("#root");
-
-        options = element.locator("fast-option");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("listbox--listbox"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a tabindex of 0 when `disabled` is not defined", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox>
@@ -39,7 +25,13 @@ test.describe("Listbox", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should NOT have a tabindex when `disabled` is true", async () => {
+    test("should NOT have a tabindex when `disabled` is true", async ({ page }) => {
+        const element = page.locator("fast-listbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox--listbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox disabled></fast-listbox>
@@ -49,7 +41,17 @@ test.describe("Listbox", () => {
         await expect(element).not.toHaveAttribute("tabindex");
     });
 
-    test("should select nothing when no options have the `selected` attribute", async () => {
+    test("should select nothing when no options have the `selected` attribute", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-listbox");
+
+        const root = page.locator("#root");
+
+        const options = element.locator("fast-option");
+
+        await page.goto(fixtureURL("listbox--listbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox>
@@ -71,7 +73,15 @@ test.describe("Listbox", () => {
         await expect(element).toHaveJSProperty("selectedIndex", -1);
     });
 
-    test("should select the option with a `selected` attribute", async () => {
+    test("should select the option with a `selected` attribute", async ({ page }) => {
+        const element = page.locator("fast-listbox");
+
+        const root = page.locator("#root");
+
+        const options = element.locator("fast-option");
+
+        await page.goto(fixtureURL("listbox--listbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox>
@@ -89,7 +99,15 @@ test.describe("Listbox", () => {
         ]);
     });
 
-    test("should set the `size` property to match the `size` attribute", async () => {
+    test("should set the `size` property to match the `size` attribute", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-listbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox--listbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox size="5"></fast-listbox>
@@ -99,7 +117,15 @@ test.describe("Listbox", () => {
         await expect(element).toHaveJSProperty("size", 5);
     });
 
-    test("should set the `size` attribute to match the `size` property", async () => {
+    test("should set the `size` attribute to match the `size` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-listbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox--listbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox>
@@ -118,7 +144,13 @@ test.describe("Listbox", () => {
     });
 
     test.describe("should set the `size` property to 0 when a negative value is set", () => {
-        test("via the `size` property", async () => {
+        test("via the `size` property", async ({ page }) => {
+            const element = page.locator("fast-listbox");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("listbox--listbox"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                         <fast-listbox>
@@ -144,7 +176,13 @@ test.describe("Listbox", () => {
             await expect(element).toHaveAttribute("size", "0");
         });
 
-        test("via the `size` attribute", async () => {
+        test("via the `size` attribute", async ({ page }) => {
+            const element = page.locator("fast-listbox");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("listbox--listbox"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                         <fast-listbox>
@@ -171,7 +209,17 @@ test.describe("Listbox", () => {
         });
     });
 
-    test("should set the `aria-setsize` and `aria-posinset` properties on slotted options", async () => {
+    test("should set the `aria-setsize` and `aria-posinset` properties on slotted options", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-listbox");
+
+        const root = page.locator("#root");
+
+        const options = element.locator("fast-option");
+
+        await page.goto(fixtureURL("listbox--listbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox>
@@ -194,7 +242,17 @@ test.describe("Listbox", () => {
         }
     });
 
-    test("should set a unique ID for each slotted option without an ID", async () => {
+    test("should set a unique ID for each slotted option without an ID", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-listbox");
+
+        const root = page.locator("#root");
+
+        const options = element.locator("fast-option");
+
+        await page.goto(fixtureURL("listbox--listbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox>
@@ -212,7 +270,17 @@ test.describe("Listbox", () => {
         await expect(options.nth(2)).toHaveAttribute("id", /option-\d+/);
     });
 
-    test("should set the `aria-activedescendant` property to the ID of the currently selected option", async () => {
+    test("should set the `aria-activedescendant` property to the ID of the currently selected option", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-listbox");
+
+        const root = page.locator("#root");
+
+        const options = element.locator("fast-option");
+
+        await page.goto(fixtureURL("listbox--listbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox>
@@ -236,7 +304,15 @@ test.describe("Listbox", () => {
         }
     });
 
-    test("should set the `aria-multiselectable` attribute to match the `multiple` attribute", async () => {
+    test("should set the `aria-multiselectable` attribute to match the `multiple` attribute", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-listbox");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("listbox--listbox"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-listbox>

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.pw.spec.ts
@@ -1,29 +1,18 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTMenuItem } from "./menu-item.js";
 import { MenuItemRole } from "./menu-item.options.js";
 
 test.describe("Menu item", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should include a role of `menuitem` by default when no role is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu-item");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-menu-item");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("menu-item--menu-item"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should include a role of `menuitem` by default when no role is provided", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu-item>Menu item</fast-menu-item>
@@ -36,7 +25,13 @@ test.describe("Menu item", () => {
     test.describe("should include a matching role when the `role` property is provided", () => {
         let role: MenuItemRole;
         for (role in MenuItemRole) {
-            test(role, async () => {
+            test(role, async ({ page }) => {
+                const element = page.locator("fast-menu-item");
+
+                const root = page.locator("#root");
+
+                await page.goto(fixtureURL("menu-item--menu-item"));
+
                 await root.evaluate(node => {
                     node.innerHTML = /* html */ `
                             <fast-menu-item>Menu item</fast-menu-item>
@@ -52,7 +47,15 @@ test.describe("Menu item", () => {
         }
     });
 
-    test("should set the `aria-disabled` attribute with the `disabled` value when provided", async () => {
+    test("should set the `aria-disabled` attribute with the `disabled` value when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("menu-item--menu-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu-item disabled>Menu item</fast-menu-item>
@@ -62,7 +65,15 @@ test.describe("Menu item", () => {
         await expect(element).toHaveAttribute("aria-disabled", "true");
     });
 
-    test("should set an `aria-expanded` attribute with the `expanded` value when provided", async () => {
+    test("should set an `aria-expanded` attribute with the `expanded` value when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("menu-item--menu-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu-item expanded>Menu item</fast-menu-item>
@@ -72,7 +83,15 @@ test.describe("Menu item", () => {
         await expect(element).toHaveAttribute("aria-expanded", "true");
     });
 
-    test("should set an `aria-checked` attribute with the `checked` value when provided to a menuitemcheckbox", async () => {
+    test("should set an `aria-checked` attribute with the `checked` value when provided to a menuitemcheckbox", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("menu-item--menu-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu-item role="menuitemcheckbox" checked>Menu item</fast-menu-item>
@@ -82,7 +101,15 @@ test.describe("Menu item", () => {
         await expect(element).toHaveAttribute("aria-checked", "true");
     });
 
-    test("should NOT set an `aria-checked` attribute when checked is provided to a menuitem", async () => {
+    test("should NOT set an `aria-checked` attribute when checked is provided to a menuitem", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("menu-item--menu-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu-item role="menuitem" checked>Menu item</fast-menu-item>
@@ -92,7 +119,15 @@ test.describe("Menu item", () => {
         await expect(element).not.toHaveAttribute("aria-checked", "true");
     });
 
-    test("should toggle the `aria-checked` attribute of checkbox item when clicked", async () => {
+    test("should toggle the `aria-checked` attribute of checkbox item when clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("menu-item--menu-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu-item role="menuitemcheckbox">Menu item</fast-menu-item>
@@ -110,7 +145,15 @@ test.describe("Menu item", () => {
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
-    test("should set the `aria-checked` attribute of radio item to true when clicked", async () => {
+    test("should set the `aria-checked` attribute of radio item to true when clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("menu-item--menu-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu-item role="menuitemradio">Menu item</fast-menu-item>
@@ -129,7 +172,13 @@ test.describe("Menu item", () => {
     });
 
     test.describe("events", () => {
-        test("should emit a `change` an event when clicked", async () => {
+        test("should emit a `change` an event when clicked", async ({ page }) => {
+            const element = page.locator("fast-menu-item");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("menu-item--menu-item"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-menu-item>Menu item</fast-menu-item>
@@ -149,7 +198,15 @@ test.describe("Menu item", () => {
             expect(wasClicked).toBe(true);
         });
 
-        test("should emit a `keydown` event when space key is invoked", async () => {
+        test("should emit a `keydown` event when space key is invoked", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-menu-item");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("menu-item--menu-item"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-menu-item>Menu item</fast-menu-item>
@@ -174,7 +231,15 @@ test.describe("Menu item", () => {
             expect(wasChanged).toBe(true);
         });
 
-        test("should emit a `keydown` event when `Enter` key is invoked", async () => {
+        test("should emit a `keydown` event when `Enter` key is invoked", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-menu-item");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("menu-item--menu-item"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-menu-item>Menu item</fast-menu-item>

--- a/packages/web-components/fast-foundation/src/menu-item/menu-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu-item/menu-item.pw.spec.ts
@@ -33,27 +33,24 @@ test.describe("Menu item", () => {
         await expect(element).toHaveAttribute("role", MenuItemRole.menuitem);
     });
 
-    test.describe(
-        "should include a matching role when the `role` property is provided",
-        () => {
-            let role: MenuItemRole;
-            for (role in MenuItemRole) {
-                test(role, async () => {
-                    await root.evaluate(node => {
-                        node.innerHTML = /* html */ `
+    test.describe("should include a matching role when the `role` property is provided", () => {
+        let role: MenuItemRole;
+        for (role in MenuItemRole) {
+            test(role, async () => {
+                await root.evaluate(node => {
+                    node.innerHTML = /* html */ `
                             <fast-menu-item>Menu item</fast-menu-item>
                         `;
-                    });
-
-                    await element.evaluate(
-                        (node: FASTMenuItem, role) => (node.role = role),
-                        role
-                    );
-                    await expect(element).toHaveAttribute("role", role);
                 });
-            }
+
+                await element.evaluate(
+                    (node: FASTMenuItem, role) => (node.role = role),
+                    role
+                );
+                await expect(element).toHaveAttribute("role", role);
+            });
         }
-    );
+    });
 
     test("should set the `aria-disabled` attribute with the `disabled` value when provided", async () => {
         await root.evaluate(node => {
@@ -102,7 +99,7 @@ test.describe("Menu item", () => {
             `;
         });
 
-        await expect(element).hasAttribute("aria-checked", "false");
+        await expect(element).toHaveAttribute("aria-checked", "false");
 
         await element.click();
 
@@ -120,7 +117,7 @@ test.describe("Menu item", () => {
             `;
         });
 
-        await expect(element).hasAttribute("aria-checked", "false");
+        await expect(element).toHaveAttribute("aria-checked", "false");
 
         await element.click();
 

--- a/packages/web-components/fast-foundation/src/menu/menu.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.pw.spec.ts
@@ -1,5 +1,5 @@
-import { expect, test } from "@playwright/test";
 import type { Locator, Page } from "@playwright/test";
+import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTMenu } from "./menu.js";
 
@@ -324,7 +324,7 @@ test.describe("Menu", () => {
         await expect(menuItems.nth(3)).toHaveAttribute("aria-checked", "true");
     });
 
-    test("should navigate the menu on arrow up/down keys", async () => {
+    test.fixme("should navigate the menu on arrow up/down keys", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -359,8 +359,7 @@ test.describe("Menu", () => {
         await expect(menuItems.nth(3)).toBeFocused();
     });
 
-    test("should close the menu when pressing the escape key", async () => {
-        test.slow();
+    test.fixme("should close the menu when pressing the escape key", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>

--- a/packages/web-components/fast-foundation/src/menu/menu.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/menu/menu.pw.spec.ts
@@ -1,31 +1,15 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTMenu } from "./menu.js";
 
 test.describe("Menu", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let menuItems: Locator;
+    test("should have a role of `menu`", async ({ page }) => {
+        const element = page.locator("fast-menu");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-menu");
-
-        root = page.locator("#root");
-
-        menuItems = element.locator("fast-menu-item");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("menu--menu"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of `menu`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -37,7 +21,17 @@ test.describe("Menu", () => {
         await expect(element).toHaveAttribute("role", "menu");
     });
 
-    test("should set `tabindex` of the first focusable menu item to 0", async () => {
+    test("should set `tabindex` of the first focusable menu item to 0", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -50,7 +44,13 @@ test.describe("Menu", () => {
         await expect(menuItems.first()).toHaveAttribute("tabindex", "0");
     });
 
-    test("should NOT set any `tabindex` on non-menu-item elements", async () => {
+    test("should NOT set any `tabindex` on non-menu-item elements", async ({ page }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -65,7 +65,15 @@ test.describe("Menu", () => {
         expect(await divider.getAttribute("tabindex")).toBeNull();
     });
 
-    test("should focus on first menu item when focus is called", async () => {
+    test("should focus on first menu item when focus is called", async ({ page }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -79,7 +87,7 @@ test.describe("Menu", () => {
 
         await expect(menuItems.first()).toHaveAttribute("tabindex", "0");
 
-        await root.evaluate(node => {
+        await root.evaluate(() => {
             document.querySelector<FASTMenu>("fast-menu")?.focus();
         });
 
@@ -90,21 +98,35 @@ test.describe("Menu", () => {
         ).toBeTruthy();
     });
 
-    test("should not throw when focus is called with no items", async () => {
+    test("should not throw when focus is called with no items", async ({ page }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu></fast-menu>
             `;
         });
 
-        await root.evaluate(node => {
+        await root.evaluate(() => {
             document.querySelector<FASTMenu>("fast-menu")?.focus();
         });
 
         expect(await page.evaluate(() => document.activeElement?.id)).toBe("");
     });
 
-    test("should not throw when focus is called before initialization is complete", async () => {
+    test("should not throw when focus is called before initialization is complete", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -118,7 +140,15 @@ test.describe("Menu", () => {
         expect(await page.evaluate(() => document.activeElement?.id)).toBe("");
     });
 
-    test("should focus disabled items", async () => {
+    test("should focus disabled items", async ({ page }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -140,7 +170,15 @@ test.describe("Menu", () => {
     });
 
     ["menuitem", "menuitemcheckbox", "menuitemradio"].forEach(role => {
-        test(`should accept elements as focusable child with "${role}" role`, async () => {
+        test(`should accept elements as focusable child with "${role}" role`, async ({
+            page,
+        }) => {
+            const element = page.locator("fast-menu");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("menu--menu"));
+
             await root.evaluate(
                 (node, { role }) => {
                     node.innerHTML = /* html */ `
@@ -158,7 +196,17 @@ test.describe("Menu", () => {
         });
     });
 
-    test("should not navigate to hidden items when changed after connection", async () => {
+    test("should not navigate to hidden items when changed after connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -217,7 +265,17 @@ test.describe("Menu", () => {
         await expect(menuItems.nth(2)).toBeFocused();
     });
 
-    test("should treat all checkbox menu items as individually selectable items", async () => {
+    test("should treat all checkbox menu items as individually selectable items", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -246,7 +304,17 @@ test.describe("Menu", () => {
         }
     });
 
-    test(`should treat all radio menu items as a radiogroup and limit selection to one item within the group`, async () => {
+    test(`should treat all radio menu items as a radiogroup and limit selection to one item within the group`, async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -282,7 +350,17 @@ test.describe("Menu", () => {
         await expect(menuItems.nth(2)).toHaveAttribute("aria-checked", "true");
     });
 
-    test('should use elements with `[role="separator"]` to divide radio menu items into different radio groups', async () => {
+    test('should use elements with `[role="separator"]` to divide radio menu items into different radio groups', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -324,7 +402,15 @@ test.describe("Menu", () => {
         await expect(menuItems.nth(3)).toHaveAttribute("aria-checked", "true");
     });
 
-    test.fixme("should navigate the menu on arrow up/down keys", async () => {
+    test.fixme("should navigate the menu on arrow up/down keys", async ({ page }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -359,7 +445,15 @@ test.describe("Menu", () => {
         await expect(menuItems.nth(3)).toBeFocused();
     });
 
-    test.fixme("should close the menu when pressing the escape key", async () => {
+    test.fixme("should close the menu when pressing the escape key", async ({ page }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>
@@ -391,7 +485,17 @@ test.describe("Menu", () => {
         await expect(menuItems.first()).toBeFocused();
     });
 
-    test("should not navigate to hidden items when set before connection", async () => {
+    test("should not navigate to hidden items when set before connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-menu");
+
+        const root = page.locator("#root");
+
+        const menuItems = element.locator("fast-menu-item");
+
+        await page.goto(fixtureURL("menu--menu"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-menu>

--- a/packages/web-components/fast-foundation/src/number-field/number-field.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.pw.spec.ts
@@ -1,32 +1,18 @@
 import { spinalCase } from "@microsoft/fast-web-utilities";
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTNumberField } from "./number-field.js";
 
 test.describe("NumberField", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let control: Locator;
+    test("should initialize to the provided value attribute if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-number-field");
-
-        root = page.locator("#root");
-
-        control = element.locator(".control");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("number-field--number-field"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should initialize to the provided value attribute if set pre-connection", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field value="10"></fast-number-field>
@@ -36,7 +22,17 @@ test.describe("NumberField", () => {
         await expect(element).toHaveJSProperty("value", "10");
     });
 
-    test("should set the `autofocus` attribute on the internal control", async () => {
+    test("should set the `autofocus` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field autofocus></fast-number-field>
@@ -46,7 +42,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveAttribute("autofocus");
     });
 
-    test("should set the `disabled` attribute on the internal control", async () => {
+    test("should set the `disabled` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field disabled></fast-number-field>
@@ -55,7 +61,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveAttribute("disabled");
     });
 
-    test("should set the `readonly` attribute on the internal control", async () => {
+    test("should set the `readonly` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field readonly></fast-number-field>
@@ -64,7 +80,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveAttribute("readonly");
     });
 
-    test("should set the `required` attribute on the internal control", async () => {
+    test("should set the `required` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field required></fast-number-field>
@@ -103,7 +129,17 @@ test.describe("NumberField", () => {
     })) {
         const attrToken = spinalCase(attribute);
 
-        test(`should set the \`${attrToken}\` attribute to "${value}" on the internal control`, async () => {
+        test(`should set the \`${attrToken}\` attribute to "${value}" on the internal control`, async ({
+            page,
+        }) => {
+            const element = page.locator("fast-number-field");
+
+            const root = page.locator("#root");
+
+            const control = element.locator(".control");
+
+            await page.goto(fixtureURL("number-field--number-field"));
+
             await root.evaluate(
                 (node, { attrToken, value }) => {
                     node.innerHTML = /* html */ `
@@ -117,7 +153,17 @@ test.describe("NumberField", () => {
         });
     }
 
-    test("should set `value` property equal to the `max` property when value is greater than max", async () => {
+    test("should set `value` property equal to the `max` property when value is greater than max", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field max="10"></fast-number-field>
@@ -129,7 +175,15 @@ test.describe("NumberField", () => {
         await expect(element).toHaveJSProperty("value", "10");
     });
 
-    test("should set `value` property equal to the `max` property when max is less than the value", async () => {
+    test("should set `value` property equal to the `max` property when max is less than the value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field value="20"></fast-number-field>
@@ -145,7 +199,17 @@ test.describe("NumberField", () => {
         await expect(element).toHaveJSProperty("value", "10");
     });
 
-    test("should set the `value` property equal to the `min` property when value is less than min", async () => {
+    test("should set the `value` property equal to the `min` property when value is less than min", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field min="10"></fast-number-field>
@@ -159,7 +223,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("10");
     });
 
-    test("should update the `value` property when the `min` property is greater than the `value`", async () => {
+    test("should update the `value` property when the `min` property is greater than the `value`", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field value="10"></fast-number-field>
@@ -175,7 +249,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("20");
     });
 
-    test("should set the `max` property equal to the `min` property when min is greater than max", async () => {
+    test("should set the `max` property equal to the `min` property when min is greater than max", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field min="10" max="5"></fast-number-field>
@@ -187,7 +271,15 @@ test.describe("NumberField", () => {
         await expect(control).toHaveJSProperty("max", "10");
     });
 
-    test("should initialize to the provided `value` attribute if set post-connection", async () => {
+    test("should initialize to the provided `value` attribute if set post-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -201,7 +293,17 @@ test.describe("NumberField", () => {
         await expect(element).toHaveJSProperty("value", "10");
     });
 
-    test('should fire a "change" event when the internal control emits a "change" event', async () => {
+    test('should fire a "change" event when the internal control emits a "change" event', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -225,7 +327,15 @@ test.describe("NumberField", () => {
         expect(wasChanged).toBeTruthy();
     });
 
-    test('should fire an "input" event when incrementing or decrementing', async () => {
+    test('should fire an "input" event when incrementing or decrementing', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -261,7 +371,15 @@ test.describe("NumberField", () => {
         expect(wasDecreased).toBeTruthy();
     });
 
-    test("should allow positive float numbers", async () => {
+    test("should allow positive float numbers", async ({ page }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -275,7 +393,15 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("1.1");
     });
 
-    test("should allow negative float numbers", async () => {
+    test("should allow negative float numbers", async ({ page }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -289,7 +415,15 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("-1.1");
     });
 
-    test("should allow positive integer numbers", async () => {
+    test("should allow positive integer numbers", async ({ page }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -303,7 +437,15 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("1");
     });
 
-    test("should allow negative integer numbers", async () => {
+    test("should allow negative integer numbers", async ({ page }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -319,7 +461,15 @@ test.describe("NumberField", () => {
 
     // TODO: This test doesn't account for the `e` character.
     // See https://github.com/microsoft/fast/issues/6251
-    test("should disallow non-numeric characters", async () => {
+    test("should disallow non-numeric characters", async ({ page }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -333,7 +483,15 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("");
     });
 
-    test('should set the `step` property to "1" by default', async () => {
+    test('should set the `step` property to "1" by default', async ({ page }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -343,7 +501,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveAttribute("step", "1");
     });
 
-    test("should update the `step` attribute on the internal control when the `step` property is changed", async () => {
+    test("should update the `step` attribute on the internal control when the `step` property is changed", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -357,7 +525,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveAttribute("step", "2");
     });
 
-    test("should increment the `value` property by the step amount when the `stepUp()` method is invoked", async () => {
+    test("should increment the `value` property by the step amount when the `stepUp()` method is invoked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field step="2" value="5"></fast-number-field>
@@ -373,7 +551,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("7");
     });
 
-    test("should decrement the `value` property by the step amount when the `stepDown()` method is invoked", async () => {
+    test("should decrement the `value` property by the step amount when the `stepDown()` method is invoked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field step="2" value="5"></fast-number-field>
@@ -389,7 +577,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("3");
     });
 
-    test("should offset an undefined `value` from zero when stepped down", async () => {
+    test("should offset an undefined `value` from zero when stepped down", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field step="2"></fast-number-field>
@@ -405,7 +603,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("-2");
     });
 
-    test("should offset an undefined `value` from zero when stepped up", async () => {
+    test("should offset an undefined `value` from zero when stepped up", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field step="2"></fast-number-field>
@@ -421,7 +629,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("2");
     });
 
-    test("should offset the `value` from zero after stepping down when `min` is a negative value", async () => {
+    test("should offset the `value` from zero after stepping down when `min` is a negative value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field min="-10"></fast-number-field>
@@ -437,7 +655,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("0");
     });
 
-    test("should offset the `value` from zero after stepping up when `min` is a negative value", async () => {
+    test("should offset the `value` from zero after stepping up when `min` is a negative value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field min="-10"></fast-number-field>
@@ -453,7 +681,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("0");
     });
 
-    test("should set `value` to match `min` after stepping down when `min` is greater than 0", async () => {
+    test("should set `value` to match `min` after stepping down when `min` is greater than 0", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field min="10"></fast-number-field>
@@ -469,7 +707,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("10");
     });
 
-    test("should set `value` to match `min` after stepping up when `min` is greater than 0", async () => {
+    test("should set `value` to match `min` after stepping up when `min` is greater than 0", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field min="10"></fast-number-field>
@@ -485,7 +733,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("10");
     });
 
-    test("should set the `value` to match `max` after stepping down when `value` is undefined and `min` and `max` are less than zero", async () => {
+    test("should set the `value` to match `max` after stepping down when `value` is undefined and `min` and `max` are less than zero", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field min="-10" max="-5"></fast-number-field>
@@ -501,7 +759,17 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("-5");
     });
 
-    test("should set the `value` to match `max` after stepping up when `value` is undefined and `min` and `max` are less than zero", async () => {
+    test("should set the `value` to match `max` after stepping up when `value` is undefined and `min` and `max` are less than zero", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field min="-10" max="-5"></fast-number-field>
@@ -517,7 +785,15 @@ test.describe("NumberField", () => {
         await expect(control).toHaveValue("-5");
     });
 
-    test("should update the proxy value when stepping down", async () => {
+    test("should update the proxy value when stepping down", async ({ page }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field step="2" value="5"></fast-number-field>
@@ -537,7 +813,15 @@ test.describe("NumberField", () => {
         );
     });
 
-    test("should update the proxy value when stepping up", async () => {
+    test("should update the proxy value when stepping up", async ({ page }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field step="2" value="5"></fast-number-field>
@@ -557,7 +841,15 @@ test.describe("NumberField", () => {
         );
     });
 
-    test("should correct rounding errors when stepping down", async () => {
+    test("should correct rounding errors when stepping down", async ({ page }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         const step = 0.1;
         const value = 0.2;
 
@@ -581,7 +873,15 @@ test.describe("NumberField", () => {
         }
     });
 
-    test("should not render step controls when `hide-step` attribute is present", async () => {
+    test("should not render step controls when `hide-step` attribute is present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field hide-step></fast-number-field>
@@ -593,7 +893,15 @@ test.describe("NumberField", () => {
         await expect(controls).toBeHidden();
     });
 
-    test("should not render step controls when `readonly` attribute is present", async () => {
+    test("should not render step controls when `readonly` attribute is present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field readonly></fast-number-field>
@@ -605,7 +913,15 @@ test.describe("NumberField", () => {
         await expect(controls).toHaveCount(0);
     });
 
-    test("should allow setting `valueAsNumber` property with a number", async () => {
+    test("should allow setting `valueAsNumber` property with a number", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field></fast-number-field>
@@ -619,7 +935,15 @@ test.describe("NumberField", () => {
         await expect(element).toHaveJSProperty("value", "18");
     });
 
-    test("should allow reading the `valueAsNumber` property as number", async () => {
+    test("should allow reading the `valueAsNumber` property as number", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-number-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("number-field--number-field"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-number-field value="18"></fast-number-field>
@@ -630,7 +954,15 @@ test.describe("NumberField", () => {
     });
 
     test.describe("when the owning form's reset() method is invoked", () => {
-        test('should reset its `value` property to "" if no `value` attribute is set', async () => {
+        test('should reset its `value` property to "" if no `value` attribute is set', async ({
+            page,
+        }) => {
+            const element = page.locator("fast-number-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("number-field--number-field"));
+
             const form = page.locator("form");
 
             await root.evaluate(node => {
@@ -652,7 +984,15 @@ test.describe("NumberField", () => {
             await expect(element).toHaveJSProperty("value", "");
         });
 
-        test("should reset the `value` property to match the `value` attribute", async () => {
+        test("should reset the `value` property to match the `value` attribute", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-number-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("number-field--number-field"));
+
             const form = page.locator("form");
 
             await root.evaluate(node => {
@@ -676,7 +1016,15 @@ test.describe("NumberField", () => {
             await expect(element).toHaveJSProperty("value", "10");
         });
 
-        test("should put the control into a clean state, where `value` attribute modifications change the `value` property prior to user or programmatic interaction", async () => {
+        test("should put the control into a clean state, where `value` attribute modifications change the `value` property prior to user or programmatic interaction", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-number-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("number-field--number-field"));
+
             const form = page.locator("form");
 
             await root.evaluate(node => {

--- a/packages/web-components/fast-foundation/src/number-field/number-field.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/number-field/number-field.pw.spec.ts
@@ -43,7 +43,7 @@ test.describe("NumberField", () => {
             `;
         });
 
-        await expect(control).toHaveBooleanAttribute("autofocus");
+        await expect(control).toHaveAttribute("autofocus");
     });
 
     test("should set the `disabled` attribute on the internal control", async () => {
@@ -52,7 +52,7 @@ test.describe("NumberField", () => {
                 <fast-number-field disabled></fast-number-field>
             `;
         });
-        await expect(control).toHaveBooleanAttribute("disabled");
+        await expect(control).toHaveAttribute("disabled");
     });
 
     test("should set the `readonly` attribute on the internal control", async () => {
@@ -61,7 +61,7 @@ test.describe("NumberField", () => {
                 <fast-number-field readonly></fast-number-field>
             `;
         });
-        await expect(control).toHaveBooleanAttribute("readonly");
+        await expect(control).toHaveAttribute("readonly");
     });
 
     test("should set the `required` attribute on the internal control", async () => {
@@ -70,7 +70,7 @@ test.describe("NumberField", () => {
                 <fast-number-field required></fast-number-field>
             `;
         });
-        await expect(control).toHaveBooleanAttribute("required");
+        await expect(control).toHaveAttribute("required");
     });
 
     for (const [attribute, value] of Object.entries({

--- a/packages/web-components/fast-foundation/src/progress-ring/progress-ring.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/progress-ring/progress-ring.pw.spec.ts
@@ -1,27 +1,14 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 
 test.describe("Progress ring", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should include a role of progressbar", async ({ page }) => {
+        const element = page.locator("fast-progress-ring");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-progress-ring");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("progress-progress-ring--progress-ring"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should include a role of progressbar", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress-ring></fast-progress-ring>
@@ -31,7 +18,15 @@ test.describe("Progress ring", () => {
         await expect(element).toHaveAttribute("role", "progressbar");
     });
 
-    test("should set the `aria-valuenow` attribute with the `value` property when provided", async () => {
+    test("should set the `aria-valuenow` attribute with the `value` property when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress-ring");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress-progress-ring--progress-ring"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress-ring value="50"></fast-progress-ring>
@@ -41,7 +36,15 @@ test.describe("Progress ring", () => {
         await expect(element).toHaveAttribute("aria-valuenow", "50");
     });
 
-    test("should set the `aria-valuemin` attribute with the `min` property when provided", async () => {
+    test("should set the `aria-valuemin` attribute with the `min` property when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress-ring");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress-progress-ring--progress-ring"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress-ring min="10"></fast-progress-ring>
@@ -51,7 +54,15 @@ test.describe("Progress ring", () => {
         await expect(element).toHaveAttribute("aria-valuemin", "10");
     });
 
-    test("should set the `aria-valuemax` attribute with the `max` property when provided", async () => {
+    test("should set the `aria-valuemax` attribute with the `max` property when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress-ring");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress-progress-ring--progress-ring"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress-ring max="75"></fast-progress-ring>
@@ -61,7 +72,15 @@ test.describe("Progress ring", () => {
         await expect(element).toHaveAttribute("aria-valuemax", "75");
     });
 
-    test("should render an element with a `determinate` slot when a value is provided", async () => {
+    test("should render an element with a `determinate` slot when a value is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress-ring");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress-progress-ring--progress-ring"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress-ring value="50"></fast-progress-ring>

--- a/packages/web-components/fast-foundation/src/progress/progress.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/progress/progress.pw.spec.ts
@@ -1,32 +1,25 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTProgress } from "./progress.js";
 
 test.describe("Progress ring", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-progress");
-
-        root = page.locator("#root");
+    test("should include a role of progressbar", async ({ page }) => {
+        const element = page.locator("fast-progress");
 
         await page.goto(fixtureURL("progress--progress"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should include a role of progressbar", async () => {
         await expect(element).toHaveAttribute("role", "progressbar");
     });
 
-    test("should set the `aria-valuenow` attribute with the `value` property when provided", async () => {
+    test("should set the `aria-valuenow` attribute with the `value` property when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress--progress"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress value="50"></fast-progress>
@@ -36,7 +29,15 @@ test.describe("Progress ring", () => {
         await expect(element).toHaveAttribute("aria-valuenow", "50");
     });
 
-    test("should set the `aria-valuemin` attribute with the `min` property when provided", async () => {
+    test("should set the `aria-valuemin` attribute with the `min` property when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress--progress"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress min="50"></fast-progress>
@@ -46,7 +47,15 @@ test.describe("Progress ring", () => {
         await expect(element).toHaveAttribute("aria-valuemin", "50");
     });
 
-    test("should set the `aria-valuemax` attribute with the `max` property when provided", async () => {
+    test("should set the `aria-valuemax` attribute with the `max` property when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress--progress"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress max="50"></fast-progress>
@@ -56,7 +65,15 @@ test.describe("Progress ring", () => {
         await expect(element).toHaveAttribute("aria-valuemax", "50");
     });
 
-    test("should render an element with a `determinate` slot when a value is provided", async () => {
+    test("should render an element with a `determinate` slot when a value is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress--progress"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress value="50"></fast-progress>
@@ -68,7 +85,15 @@ test.describe("Progress ring", () => {
         await expect(progress).toHaveAttribute("slot", "determinate");
     });
 
-    test("should render an element with an `indeterminate` slot when no value is provided", async () => {
+    test("should render an element with an `indeterminate` slot when no value is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress--progress"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress></fast-progress>
@@ -80,7 +105,15 @@ test.describe("Progress ring", () => {
         await expect(progress).toHaveAttribute("slot", "indeterminate");
     });
 
-    test("should return the `percentComplete` property as a value between 0 and 100 when `min` and `max` are unset", async () => {
+    test("should return the `percentComplete` property as a value between 0 and 100 when `min` and `max` are unset", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress--progress"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress value="50"></fast-progress>
@@ -90,7 +123,15 @@ test.describe("Progress ring", () => {
         await expect(element).toHaveJSProperty("percentComplete", 50);
     });
 
-    test("should set the `percentComplete` property to match the current `value` in the range of `min` and `max`", async () => {
+    test("should set the `percentComplete` property to match the current `value` in the range of `min` and `max`", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-progress");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("progress--progress"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-progress value="0"></fast-progress>

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
@@ -118,7 +118,7 @@ test.describe("Radio Group", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-disabled");
+        await expect(element).not.toHaveAttribute("aria-disabled");
 
         await element.evaluate<void, FASTRadioGroup>(node => {
             node.disabled = true;
@@ -150,7 +150,7 @@ test.describe("Radio Group", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-readonly");
+        await expect(element).not.toHaveAttribute("aria-readonly");
 
         await element.evaluate<void, FASTRadioGroup>(node => {
             node.readOnly = true;
@@ -172,7 +172,7 @@ test.describe("Radio Group", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-disabled");
+        await expect(element).not.toHaveAttribute("aria-disabled");
     });
 
     test("should NOT modify child radio elements disabled state when the `disabled` attribute is present", async () => {
@@ -436,9 +436,7 @@ test.describe("Radio Group", () => {
 
         // radio-group explicitly sets non-matching radio's checked to false if
         // a value match was found, but the attribute should still persist.
-        expect(
-            await radios.nth(1).evaluate(node => node.hasAttribute("checked"))
-        ).toBeTruthy();
+        await expect(radios.nth(1)).toHaveAttribute("checked");
 
         await expect(radios.nth(2)).not.toBeChecked();
     });

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
@@ -186,7 +186,7 @@ test.describe("Radio Group", () => {
             `;
         });
 
-        await expect(element).not.toHaveBooleanAttribute("disabled");
+        await expect(element).not.toHaveAttribute("disabled");
 
         const firstRadio = radios.nth(0);
         const secondRadio = radios.nth(1);
@@ -222,7 +222,7 @@ test.describe("Radio Group", () => {
 
         element.evaluate<void, FASTRadioGroup>(node => node.setAttribute("disabled", ""));
 
-        await expect(element).toHaveBooleanAttribute("disabled");
+        await expect(element).toHaveAttribute("disabled");
 
         expect(
             await firstRadio.evaluate<boolean, FASTRadio>(radio =>
@@ -259,7 +259,7 @@ test.describe("Radio Group", () => {
             `;
         });
 
-        await expect(element).toHaveBooleanAttribute("disabled");
+        await expect(element).toHaveAttribute("disabled");
 
         await first.focus();
 
@@ -306,7 +306,7 @@ test.describe("Radio Group", () => {
 
         await element.evaluate<boolean, FASTRadioGroup>(node => (node.disabled = true));
 
-        await expect(element).toHaveBooleanAttribute("disabled");
+        await expect(element).toHaveAttribute("disabled");
 
         for (let i = 0; i < radioItemsCount; i++) {
             const item = radios.nth(i);

--- a/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio-group/radio-group.pw.spec.ts
@@ -1,33 +1,18 @@
+import type { Locator } from "@playwright/test";
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import type { FASTRadio } from "../radio/index.js";
 import { fixtureURL } from "../__test__/helpers.js";
-import { RadioGroupOrientation } from "./radio-group.options.js";
 import type { FASTRadioGroup } from "./radio-group.js";
+import { RadioGroupOrientation } from "./radio-group.options.js";
 
 test.describe("Radio Group", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let radios: Locator;
+    test("should have a role of `radiogroup`", async ({ page }) => {
+        const element = page.locator("fast-radio-group");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-radio-group");
-
-        root = page.locator("#root");
-
-        radios = element.locator("fast-radio");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("radio-group--radio-group"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of `radiogroup`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group></fast-radio-group>
@@ -37,7 +22,15 @@ test.describe("Radio Group", () => {
         await expect(element).toHaveAttribute("role", "radiogroup");
     });
 
-    test("should set a default `aria-orientation` value when `orientation` is not defined", async () => {
+    test("should set a default `aria-orientation` value when `orientation` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group></fast-radio-group>
@@ -50,7 +43,15 @@ test.describe("Radio Group", () => {
         );
     });
 
-    test("should set a matching class on the `positioning-region` when an orientation is provided", async () => {
+    test("should set a matching class on the `positioning-region` when an orientation is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group></fast-radio-group>
@@ -75,7 +76,15 @@ test.describe("Radio Group", () => {
         await expect(positioningRegion).toHaveClass(/horizontal/);
     });
 
-    test("should set the `aria-orientation` attribute equal to the `orientation` value", async () => {
+    test("should set the `aria-orientation` attribute equal to the `orientation` value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group></fast-radio-group>
@@ -101,7 +110,13 @@ test.describe("Radio Group", () => {
         );
     });
 
-    test("should set the `aria-disabled` attribute when disabled", async () => {
+    test("should set the `aria-disabled` attribute when disabled", async ({ page }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group disabled></fast-radio-group>
@@ -111,7 +126,15 @@ test.describe("Radio Group", () => {
         await expect(element).toHaveAttribute("aria-disabled", "true");
     });
 
-    test("should set the `aria-disabled` attribute equal to the `disabled` property", async () => {
+    test("should set the `aria-disabled` attribute equal to the `disabled` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group></fast-radio-group>
@@ -133,7 +156,15 @@ test.describe("Radio Group", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should set the `aria-readonly` attribute when the `readonly` attribute is present", async () => {
+    test("should set the `aria-readonly` attribute when the `readonly` attribute is present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group readonly></fast-radio-group>
@@ -143,7 +174,15 @@ test.describe("Radio Group", () => {
         await expect(element).toHaveAttribute("aria-readonly", "true");
     });
 
-    test("should set the `aria-readonly` attribute equal to the `readonly` property", async () => {
+    test("should set the `aria-readonly` attribute equal to the `readonly` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group></fast-radio-group>
@@ -165,7 +204,15 @@ test.describe("Radio Group", () => {
         await expect(element).toHaveAttribute("aria-readonly", "false");
     });
 
-    test("should NOT set a default `aria-disabled` value when `disabled` is not defined", async () => {
+    test("should NOT set a default `aria-disabled` value when `disabled` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group></fast-radio-group>
@@ -175,7 +222,17 @@ test.describe("Radio Group", () => {
         await expect(element).not.toHaveAttribute("aria-disabled");
     });
 
-    test("should NOT modify child radio elements disabled state when the `disabled` attribute is present", async () => {
+    test("should NOT modify child radio elements disabled state when the `disabled` attribute is present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        const radios = element.locator("fast-radio");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group>
@@ -243,7 +300,13 @@ test.describe("Radio Group", () => {
         ).toEqual(expectedThird);
     });
 
-    test("should NOT be focusable when disabled", async () => {
+    test("should NOT be focusable when disabled", async ({ page }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         const first: Locator = page.locator("button", { hasText: "First" });
         const second: Locator = page.locator("button", { hasText: "Second" });
 
@@ -276,7 +339,15 @@ test.describe("Radio Group", () => {
         ).toBeTruthy();
     });
 
-    test("should NOT be focusable via click when disabled", async () => {
+    test("should NOT be focusable via click when disabled", async ({ page }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        const radios = element.locator("fast-radio");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <button>Button</button>
@@ -317,7 +388,17 @@ test.describe("Radio Group", () => {
         }
     });
 
-    test("should set tabindex of 0 to a child radio with a matching `value`", async () => {
+    test("should set tabindex of 0 to a child radio with a matching `value`", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        const radios = element.locator("fast-radio");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group value="foo">
@@ -331,7 +412,17 @@ test.describe("Radio Group", () => {
         await expect(radios.nth(0)).toHaveAttribute("tabindex", "0");
     });
 
-    test("should NOT set `tabindex` of 0 to a child radio if its value does not match the radiogroup `value`", async () => {
+    test("should NOT set `tabindex` of 0 to a child radio if its value does not match the radiogroup `value`", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        const radios = element.locator("fast-radio");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group value="foo">
@@ -349,7 +440,17 @@ test.describe("Radio Group", () => {
         ).toBeTruthy();
     });
 
-    test("should set a child radio with a matching `value` to `checked`", async () => {
+    test("should set a child radio with a matching `value` to `checked`", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        const radios = element.locator("fast-radio");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group value="bar">
@@ -367,7 +468,17 @@ test.describe("Radio Group", () => {
         await expect(radios.nth(2)).not.toBeChecked();
     });
 
-    test("should set a child radio with a matching `value` to `checked` when value changes", async () => {
+    test("should set a child radio with a matching `value` to `checked` when value changes", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        const radios = element.locator("fast-radio");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group value="foo">
@@ -389,7 +500,17 @@ test.describe("Radio Group", () => {
         await expect(radios.nth(2)).not.toBeChecked();
     });
 
-    test("should mark only the last radio defaulted to checked as checked", async () => {
+    test("should mark only the last radio defaulted to checked as checked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        const radios = element.locator("fast-radio");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group>
@@ -413,7 +534,17 @@ test.describe("Radio Group", () => {
         await expect(radios.nth(2)).toBeChecked();
     });
 
-    test("should mark radio matching value on radio-group over any checked attributes", async () => {
+    test("should mark radio matching value on radio-group over any checked attributes", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        const radios = element.locator("fast-radio");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group value="foo">
@@ -441,7 +572,15 @@ test.describe("Radio Group", () => {
         await expect(radios.nth(2)).not.toBeChecked();
     });
 
-    test("should allow resetting of elements by the parent form", async () => {
+    test("should allow resetting of elements by the parent form", async ({ page }) => {
+        const element = page.locator("fast-radio-group");
+
+        const root = page.locator("#root");
+
+        const radios = element.locator("fast-radio");
+
+        await page.goto(fixtureURL("radio-group--radio-group"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>

--- a/packages/web-components/fast-foundation/src/radio/radio.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.pw.spec.ts
@@ -90,7 +90,7 @@ test.describe("Radio", () => {
             `;
         });
 
-        await expect(element).toHaveAttribute("tabindex", "");
+        await expect(element).not.toHaveAttribute("tabindex");
     });
 
     test("should initialize to the initial value if no value property is set", async () => {

--- a/packages/web-components/fast-foundation/src/radio/radio.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/radio/radio.pw.spec.ts
@@ -1,28 +1,15 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTRadio } from "./radio.js";
 
 test.describe("Radio", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should have a role of `radio`", async ({ page }) => {
+        const element = page.locator("fast-radio");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-radio");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("radio--radio"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of `radio`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>Radio</fast-radio>
@@ -32,7 +19,13 @@ test.describe("Radio", () => {
         await expect(element).toHaveAttribute("role", "radio");
     });
 
-    test("should set ARIA attributes to match the state", async () => {
+    test("should set ARIA attributes to match the state", async ({ page }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>Radio</fast-radio>
@@ -73,7 +66,13 @@ test.describe("Radio", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should set a tabindex of 0 on the element", async () => {
+    test("should set a tabindex of 0 on the element", async ({ page }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>Radio</fast-radio>
@@ -83,7 +82,13 @@ test.describe("Radio", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should NOT set a tabindex when disabled is `true`", async () => {
+    test("should NOT set a tabindex when disabled is `true`", async ({ page }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio disabled></fast-radio>
@@ -93,7 +98,15 @@ test.describe("Radio", () => {
         await expect(element).not.toHaveAttribute("tabindex");
     });
 
-    test("should initialize to the initial value if no value property is set", async () => {
+    test("should initialize to the initial value if no value property is set", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>Radio</fast-radio>
@@ -105,7 +118,15 @@ test.describe("Radio", () => {
         await expect(element).toHaveJSProperty("initialValue", "on");
     });
 
-    test("should initialize to the provided value attribute if set pre-connection", async () => {
+    test("should initialize to the provided value attribute if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>Radio</fast-radio>
@@ -117,7 +138,15 @@ test.describe("Radio", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided value attribute if set post-connection", async () => {
+    test("should initialize to the provided value attribute if set post-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>Radio</fast-radio>
@@ -129,7 +158,15 @@ test.describe("Radio", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided value property if set pre-connection", async () => {
+    test("should initialize to the provided value property if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio value="foo"></fast-radio>
@@ -139,7 +176,15 @@ test.describe("Radio", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should set the `label__hidden` class on the internal label when default slotted content does not exist", async () => {
+    test("should set the `label__hidden` class on the internal label when default slotted content does not exist", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>label</fast-radio>
@@ -157,7 +202,13 @@ test.describe("Radio", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should fire an event when spacebar is pressed", async () => {
+    test("should fire an event when spacebar is pressed", async ({ page }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>Radio</fast-radio>
@@ -182,7 +233,13 @@ test.describe("Radio", () => {
         expect(wasPressed).toBeTruthy();
     });
 
-    test("should NOT fire events when clicked", async () => {
+    test("should NOT fire events when clicked", async ({ page }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio>Radio</fast-radio>
@@ -206,7 +263,15 @@ test.describe("Radio", () => {
         expect(wasClicked).toBeFalsy();
     });
 
-    test("should handle validity when the `required` attribute is present", async () => {
+    test("should handle validity when the `required` attribute is present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-radio");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("radio--radio"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-radio-group>
@@ -227,7 +292,15 @@ test.describe("Radio", () => {
     });
 
     test.describe("whose parent form has its reset() method invoked", () => {
-        test("should set its checked property to false if the checked attribute is unset", async () => {
+        test("should set its checked property to false if the checked attribute is unset", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-radio");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("radio--radio"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -249,7 +322,15 @@ test.describe("Radio", () => {
             await expect(element).not.toBeChecked();
         });
 
-        test("should set its checked property to true if the checked attribute is set", async () => {
+        test("should set its checked property to true if the checked attribute is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-radio");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("radio--radio"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -277,7 +358,15 @@ test.describe("Radio", () => {
             await expect(element).toBeChecked();
         });
 
-        test("should put the control into a clean state, where `checked` attribute modifications modify the `checked` property prior to user or programmatic interaction", async () => {
+        test("should put the control into a clean state, where `checked` attribute modifications modify the `checked` property prior to user or programmatic interaction", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-radio");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("radio--radio"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>

--- a/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
@@ -1,31 +1,9 @@
 import { spinalCase } from "@microsoft/fast-web-utilities";
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTSearch } from "./search.js";
 
 test.describe("Search", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let control: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-search");
-
-        root = page.locator("#root");
-
-        control = element.locator(".control");
-
-        await page.goto(fixtureURL("search--search"));
-    });
-
-    test.afterAll(async () => {
-        await page.close();
-    });
-
     test.describe("should set the boolean attribute on the internal input", () => {
         const attributes = {
             autofocus: true,
@@ -36,7 +14,13 @@ test.describe("Search", () => {
         };
 
         for (const attribute of Object.keys(attributes)) {
-            test(`should set ${attribute}`, async () => {
+            test(`should set ${attribute}`, async ({ page }) => {
+                const element = page.locator("fast-search");
+
+                const root = page.locator("#root");
+
+                await page.goto(fixtureURL("search--search"));
+
                 await root.evaluate(
                     (node, { attribute }) => {
                         node.innerHTML = /* html */ `
@@ -81,7 +65,15 @@ test.describe("Search", () => {
 
         for (const [attribute, value] of Object.entries(attributes)) {
             const attrToken = spinalCase(attribute);
-            test(`should set ${attrToken} to ${value}`, async () => {
+            test(`should set ${attrToken} to ${value}`, async ({ page }) => {
+                const element = page.locator("fast-search");
+
+                const root = page.locator("#root");
+
+                const control = element.locator(".control");
+
+                await page.goto(fixtureURL("search--search"));
+
                 await root.evaluate(node => {
                     node.innerHTML = /* html */ `
                         <fast-search>Search</fast-search>
@@ -100,7 +92,15 @@ test.describe("Search", () => {
         }
     });
 
-    test("should initialize to the initial value if no value property is set", async () => {
+    test("should initialize to the initial value if no value property is set", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-search>Search</fast-search>
@@ -110,7 +110,15 @@ test.describe("Search", () => {
         await expect(element).toHaveJSProperty("value", "");
     });
 
-    test("should initialize to the provided value attribute if set pre-connection", async () => {
+    test("should initialize to the provided value attribute if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-search value="foo">Search</fast-search>
@@ -120,7 +128,15 @@ test.describe("Search", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided value attribute if set post-connection", async () => {
+    test("should initialize to the provided value attribute if set post-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-search>Search</fast-search>
@@ -134,7 +150,15 @@ test.describe("Search", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided value property if set pre-connection", async () => {
+    test("should initialize to the provided value property if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -146,7 +170,15 @@ test.describe("Search", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should hide the label when no default slotted content is provided", async () => {
+    test("should hide the label when no default slotted content is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-search></fast-search>
@@ -158,7 +190,13 @@ test.describe("Search", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should hide the label when start content is provided", async () => {
+    test("should hide the label when start content is provided", async ({ page }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-search><span slot="start">Start</span></fast-search>
@@ -170,7 +208,13 @@ test.describe("Search", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should hide the label when end content is provided", async () => {
+    test("should hide the label when end content is provided", async ({ page }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-search><span slot="end">End</span></fast-search>
@@ -182,7 +226,15 @@ test.describe("Search", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should hide the label when start and end content is provided", async () => {
+    test("should hide the label when start and end content is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-search>
@@ -197,7 +249,15 @@ test.describe("Search", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should hide the label when space-only text nodes are slotted", async () => {
+    test("should hide the label when space-only text nodes are slotted", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-search>label</fast-search>
@@ -215,14 +275,22 @@ test.describe("Search", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should fire a change event when the internal control emits a change event", async () => {
+    test("should fire a change event when the internal control emits a change event", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-search");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("search--search"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-search>Search</fast-search>
             `;
         });
-
-        const control = element.locator(".control");
 
         const [wasChanged] = await Promise.all([
             element.evaluate(
@@ -240,7 +308,15 @@ test.describe("Search", () => {
     });
 
     test.describe("when the owning form's reset() method is invoked", () => {
-        test("should reset its `value` property to an empty string when no value attribute is set", async () => {
+        test("should reset its `value` property to an empty string when no value attribute is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-search");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("search--search"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -268,7 +344,15 @@ test.describe("Search", () => {
             await expect(element).toHaveJSProperty("value", "");
         });
 
-        test("should reset its `value` property to the value of the value attribute if it is set", async () => {
+        test("should reset its `value` property to the value of the value attribute if it is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-search");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("search--search"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -292,7 +376,15 @@ test.describe("Search", () => {
             await expect(element).toHaveJSProperty("value", "test value");
         });
 
-        test("should put the control into a clean state, where `value` attribute modifications change the `value` property prior to user or programmatic interaction", async () => {
+        test("should put the control into a clean state, where `value` attribute modifications change the `value` property prior to user or programmatic interaction", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-search");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("search--search"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>

--- a/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
@@ -46,7 +46,7 @@ test.describe("Search", () => {
                     { attribute }
                 );
 
-                await expect(element).toHaveBooleanAttribute(attribute);
+                await expect(element).toHaveAttribute(attribute);
             });
         }
     });

--- a/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/search/search.pw.spec.ts
@@ -257,13 +257,13 @@ test.describe("Search", () => {
 
             await expect(element).toHaveJSProperty("value", "test value");
 
-            await expect(element).not.hasAttribute("value");
+            await expect(element).not.toHaveAttribute("value");
 
             await form.evaluate<void, HTMLFormElement>(node => {
                 node.reset();
             });
 
-            await expect(element).not.hasAttribute("value");
+            await expect(element).not.toHaveAttribute("value");
 
             await expect(element).toHaveJSProperty("value", "");
         });

--- a/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
@@ -1,31 +1,16 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import type { FASTListboxOption } from "../listbox-option/index.js";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTSelect } from "./select.js";
 
 test.describe("Select", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should have a role of `combobox`", async ({ page }) => {
+        const element = page.locator("fast-select");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
+        const root = page.locator("#root");
 
-        element = page.locator("fast-select");
+        await page.goto(fixtureURL("select--select"));
 
-        root = page.locator("#root");
-
-        await page.goto(fixtureURL("select--select"), {
-            waitUntil: "load",
-        });
-    });
-
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of `combobox`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select></fast-select>
@@ -35,7 +20,15 @@ test.describe("Select", () => {
         await expect(element).toHaveAttribute("role", "combobox");
     });
 
-    test("should have a tabindex of 0 when `disabled` is not defined", async () => {
+    test("should have a tabindex of 0 when `disabled` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -49,7 +42,15 @@ test.describe("Select", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should set the `aria-disabled` attribute equal to the `disabled` value", async () => {
+    test("should set the `aria-disabled` attribute equal to the `disabled` value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select disabled></fast-select>
@@ -65,7 +66,13 @@ test.describe("Select", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should have the attribute aria-expanded set to false", async () => {
+    test("should have the attribute aria-expanded set to false", async ({ page }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select></fast-select>
@@ -75,7 +82,13 @@ test.describe("Select", () => {
         await expect(element).toHaveAttribute("aria-expanded", "false");
     });
 
-    test("should set its value to the first enabled option", async () => {
+    test("should set its value to the first enabled option", async ({ page }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -91,7 +104,13 @@ test.describe("Select", () => {
         await expect(element).toHaveJSProperty("selectedIndex", 0);
     });
 
-    test("should NOT have a tabindex when `disabled` is true", async () => {
+    test("should NOT have a tabindex when `disabled` is true", async ({ page }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select disabled></fast-select>
@@ -101,7 +120,15 @@ test.describe("Select", () => {
         await expect(element).not.toHaveAttribute("tabindex");
     });
 
-    test("should set its value to the first enabled option when disabled", async () => {
+    test("should set its value to the first enabled option when disabled", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select disabled>
@@ -117,7 +144,15 @@ test.describe("Select", () => {
         await expect(element).toHaveJSProperty("selectedIndex", 0);
     });
 
-    test("should select the first option with a `selected` attribute", async () => {
+    test("should select the first option with a `selected` attribute", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -133,7 +168,15 @@ test.describe("Select", () => {
         await expect(element).toHaveJSProperty("selectedIndex", 1);
     });
 
-    test("should select the first option with a `selected` attribute when disabled", async () => {
+    test("should select the first option with a `selected` attribute when disabled", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select disabled>
@@ -149,7 +192,15 @@ test.describe("Select", () => {
         await expect(element).toHaveJSProperty("selectedIndex", 1);
     });
 
-    test("should return the same value when the `value` property is set before connect", async () => {
+    test("should return the same value when the `value` property is set before connect", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select value="Option 2">
@@ -163,7 +214,15 @@ test.describe("Select", () => {
         await expect(element).toHaveJSProperty("value", "Option 2");
     });
 
-    test("should return the same value when the value property is set after connect", async () => {
+    test("should return the same value when the value property is set after connect", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -181,7 +240,15 @@ test.describe("Select", () => {
         await expect(element).toHaveJSProperty("value", "Option 3");
     });
 
-    test("should select the next selectable option when the value is set to match a disabled option", async () => {
+    test("should select the next selectable option when the value is set to match a disabled option", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -205,7 +272,15 @@ test.describe("Select", () => {
         await expect(element).toHaveJSProperty("selectedIndex", 2);
     });
 
-    test("should update the `value` property when the selected option's `value` property changes", async () => {
+    test("should update the `value` property when the selected option's `value` property changes", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -227,7 +302,13 @@ test.describe("Select", () => {
         await expect(element).toHaveJSProperty("value", "new value");
     });
 
-    test("should return the `value` property as a string", async () => {
+    test("should return the `value` property as a string", async ({ page }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -245,7 +326,13 @@ test.describe("Select", () => {
         ).toBe("string");
     });
 
-    test("should update the aria-expanded attribute when opened", async () => {
+    test("should update the aria-expanded attribute when opened", async ({ page }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -265,7 +352,15 @@ test.describe("Select", () => {
         await expect(element).toHaveAttribute("aria-expanded", "true");
     });
 
-    test("should display the listbox when the `open` property is true before connecting", async () => {
+    test("should display the listbox when the `open` property is true before connecting", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select open>
@@ -290,7 +385,17 @@ test.describe("Select", () => {
             { expectedValue: "Option 3", key: "End" },
             { expectedValue: "Option 1", key: "Home" },
         ].forEach(({ expectedValue, key }) => {
-            test(`should NOT emit \`${eventName}\` event while open when the value changes by user input via ${key} key`, async () => {
+            test(`should NOT emit \`${eventName}\` event while open when the value changes by user input via ${key} key`, async ({
+                page,
+            }) => {
+                const element = page.locator("fast-select");
+
+                const root = page.locator("#root");
+
+                await page.goto(fixtureURL("select--select"), {
+                    waitUntil: "load",
+                });
+
                 await root.evaluate(node => {
                     node.innerHTML = /* html */ `
                         <fast-select open>
@@ -329,7 +434,17 @@ test.describe("Select", () => {
                 await expect(element).toHaveJSProperty("value", expectedValue);
             });
 
-            test(`should emit \`${eventName}\` event while closed when the value changes by user input via ${key} key`, async () => {
+            test(`should emit \`${eventName}\` event while closed when the value changes by user input via ${key} key`, async ({
+                page,
+            }) => {
+                const element = page.locator("fast-select");
+
+                const root = page.locator("#root");
+
+                await page.goto(fixtureURL("select--select"), {
+                    waitUntil: "load",
+                });
+
                 await root.evaluate(node => {
                     node.innerHTML = /* html */ `
                         <fast-select>
@@ -361,7 +476,15 @@ test.describe("Select", () => {
 
     test.describe("when the value changes by programmatic interaction", () => {
         ["input", "change"].forEach(eventName => {
-            test(`should NOT emit \`${eventName}\` event`, async () => {
+            test(`should NOT emit \`${eventName}\` event`, async ({ page }) => {
+                const element = page.locator("fast-select");
+
+                const root = page.locator("#root");
+
+                await page.goto(fixtureURL("select--select"), {
+                    waitUntil: "load",
+                });
+
                 await page.goto(fixtureURL("select--select"));
 
                 const [wasChanged] = await Promise.all([
@@ -393,7 +516,17 @@ test.describe("Select", () => {
     });
 
     test.describe("when the owning form's reset() function is invoked", () => {
-        test("should reset the value property to the first available option", async () => {
+        test("should reset the value property to the first available option", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-select");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("select--select"), {
+                waitUntil: "load",
+            });
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -424,7 +557,15 @@ test.describe("Select", () => {
         });
     });
 
-    test("should set the `aria-activedescendant` attribute to the ID of the currently selected option", async () => {
+    test("should set the `aria-activedescendant` attribute to the ID of the currently selected option", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -450,7 +591,15 @@ test.describe("Select", () => {
         await expect(element).toHaveAttribute("aria-activedescendant", "option-3");
     });
 
-    test("should set the `aria-controls` attribute to the ID of the internal listbox element while open", async () => {
+    test("should set the `aria-controls` attribute to the ID of the internal listbox element while open", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>
@@ -480,7 +629,15 @@ test.describe("Select", () => {
         await expect(element).toHaveAttribute("aria-controls", "");
     });
 
-    test("should update the `displayValue` when the selected option's content changes", async () => {
+    test("should update the `displayValue` when the selected option's content changes", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-select");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("select--select"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-select>

--- a/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
@@ -98,7 +98,7 @@ test.describe("Select", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("tabindex");
+        await expect(element).not.toHaveAttribute("tabindex");
     });
 
     test("should set its value to the first enabled option when disabled", async () => {

--- a/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/select/select.pw.spec.ts
@@ -278,7 +278,7 @@ test.describe("Select", () => {
 
         const listbox = element.locator(".listbox");
 
-        await expect(element).toHaveBooleanAttribute("open");
+        await expect(element).toHaveAttribute("open");
 
         await expect(listbox).toBeVisible();
     });

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.pw.spec.ts
@@ -30,7 +30,7 @@ test.describe("Slider label", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-disabled");
+        await expect(element).not.toHaveAttribute("aria-disabled");
     });
 
     test("should set the `aria-disabled` attribute when the `disabled` property is true", async () => {

--- a/packages/web-components/fast-foundation/src/slider-label/slider-label.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider-label/slider-label.pw.spec.ts
@@ -1,29 +1,18 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTSliderLabel } from "./slider-label.js";
 
 // TODO: Need to add tests for positioning and slider configuration
 test.describe("Slider label", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should NOT set the `aria-disabled` attribute when `disabled` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider-label");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-slider-label");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("slider-label--slider-label"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should NOT set the `aria-disabled` attribute when `disabled` is not defined", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider-label></fast-slider-label>
@@ -33,7 +22,15 @@ test.describe("Slider label", () => {
         await expect(element).not.toHaveAttribute("aria-disabled");
     });
 
-    test("should set the `aria-disabled` attribute when the `disabled` property is true", async () => {
+    test("should set the `aria-disabled` attribute when the `disabled` property is true", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider-label");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider-label--slider-label"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider-label disabled></fast-slider-label>

--- a/packages/web-components/fast-foundation/src/slider/slider.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.pw.spec.ts
@@ -1,32 +1,18 @@
 import { Direction } from "@microsoft/fast-web-utilities";
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTSlider } from "./slider.js";
 import { SliderOrientation } from "./slider.options.js";
 
 // TODO: Need to add tests for keyboard handling, position, and focus management
 test.describe("Slider", () => {
-    let page: Page;
-    let element: Locator;
+    test("should have a role of `slider`", async ({ page }) => {
+        const element = page.locator("fast-slider");
 
-    let root: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("slider--slider"));
 
-        element = page.locator("fast-slider");
-
-        root = page.locator("#root");
-    });
-
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of `slider`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -35,7 +21,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveAttribute("role", "slider");
     });
 
-    test("should set a default `min` property of 0 when `min` is not provided", async () => {
+    test("should set a default `min` property of 0 when `min` is not provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -45,7 +39,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveJSProperty("min", 0);
     });
 
-    test("should set a default `max` property of 0 when `max` is not provided", async () => {
+    test("should set a default `max` property of 0 when `max` is not provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -55,7 +57,13 @@ test.describe("Slider", () => {
         await expect(element).toHaveAttribute("max", "10");
     });
 
-    test("should set a `tabindex` of 0", async () => {
+    test("should set a `tabindex` of 0", async ({ page }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -65,7 +73,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should NOT set a default `aria-disabled` value when `disabled` is not defined", async () => {
+    test("should NOT set a default `aria-disabled` value when `disabled` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -75,7 +91,15 @@ test.describe("Slider", () => {
         await expect(element).not.toHaveAttribute("aria-disabled");
     });
 
-    test("should set a default `aria-orientation` value when `orientation` is not defined", async () => {
+    test("should set a default `aria-orientation` value when `orientation` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -88,7 +112,15 @@ test.describe("Slider", () => {
         );
     });
 
-    test("should NOT set a default `aria-readonly` value when `readonly` is not defined", async () => {
+    test("should NOT set a default `aria-readonly` value when `readonly` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -98,7 +130,15 @@ test.describe("Slider", () => {
         await expect(element).not.toHaveAttribute("aria-readonly");
     });
 
-    test("should initialize to the initial value if no value property is set", async () => {
+    test("should initialize to the initial value if no value property is set", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -112,7 +152,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveJSProperty("value", initialValue);
     });
 
-    test("should set the `aria-disabled` attribute when `disabled` value is true", async () => {
+    test("should set the `aria-disabled` attribute when `disabled` value is true", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -126,7 +174,13 @@ test.describe("Slider", () => {
         await expect(element).toHaveAttribute("aria-disabled", "true");
     });
 
-    test("should NOT set a tabindex when `disabled` value is true", async () => {
+    test("should NOT set a tabindex when `disabled` value is true", async ({ page }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -140,7 +194,15 @@ test.describe("Slider", () => {
         await expect(element).not.toHaveAttribute("tabindex", "0");
     });
 
-    test("should set the `aria-readonly` attribute when `readonly` value is true", async () => {
+    test("should set the `aria-readonly` attribute when `readonly` value is true", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -154,7 +216,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveAttribute("aria-readonly", "true");
     });
 
-    test("should set the `aria-orientation` attribute equal to the `orientation` value", async () => {
+    test("should set the `aria-orientation` attribute equal to the `orientation` value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -180,7 +250,13 @@ test.describe("Slider", () => {
         );
     });
 
-    test("should set direction equal to the `direction` value", async () => {
+    test("should set direction equal to the `direction` value", async ({ page }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -200,7 +276,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveJSProperty("direction", Direction.rtl);
     });
 
-    test("should set the `aria-valuenow` attribute with the `value` property when provided", async () => {
+    test("should set the `aria-valuenow` attribute with the `value` property when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -214,7 +298,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveAttribute("aria-valuenow", "8");
     });
 
-    test("should set the `aria-valuemin` attribute with the `min` property when provided", async () => {
+    test("should set the `aria-valuemin` attribute with the `min` property when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -228,7 +320,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveAttribute("aria-valuemin", "0");
     });
 
-    test("should set the `aria-valuemax` attribute with the `max` property when provided", async () => {
+    test("should set the `aria-valuemax` attribute with the `max` property when provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -243,7 +343,13 @@ test.describe("Slider", () => {
     });
 
     test.describe("valueAsNumber", () => {
-        test("should allow setting value with number", async () => {
+        test("should allow setting value with number", async ({ page }) => {
+            const element = page.locator("fast-slider");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("slider--slider"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-slider></fast-slider>
@@ -257,7 +363,13 @@ test.describe("Slider", () => {
             await expect(element).toHaveJSProperty("value", "8");
         });
 
-        test("should allow reading value as number", async () => {
+        test("should allow reading value as number", async ({ page }) => {
+            const element = page.locator("fast-slider");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("slider--slider"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-slider></fast-slider>
@@ -272,7 +384,15 @@ test.describe("Slider", () => {
         });
     });
 
-    test("should set an `aria-valuestring` attribute with the result of the valueTextFormatter() method", async () => {
+    test("should set an `aria-valuestring` attribute with the result of the valueTextFormatter() method", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -287,7 +407,15 @@ test.describe("Slider", () => {
     });
 
     test.describe("increment and decrement methods", () => {
-        test("should increment the value when the `increment()` method is invoked", async () => {
+        test("should increment the value when the `increment()` method is invoked", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-slider");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("slider--slider"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-slider min="0" max="100" value="50" step="5"></fast-slider>
@@ -305,7 +433,15 @@ test.describe("Slider", () => {
             await expect(element).toHaveAttribute("aria-valuenow", "55");
         });
 
-        test("should decrement the value when the `decrement()` method is invoked", async () => {
+        test("should decrement the value when the `decrement()` method is invoked", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-slider");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("slider--slider"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-slider min="0" max="100" value="50" step="5"></fast-slider>
@@ -321,7 +457,15 @@ test.describe("Slider", () => {
             await expect(element).toHaveAttribute("aria-valuenow", "45");
         });
 
-        test("should increment the value when the `increment()` method is invoked and step is not provided", async () => {
+        test("should increment the value when the `increment()` method is invoked and step is not provided", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-slider");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("slider--slider"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-slider min="0" max="100" value="50"></fast-slider>
@@ -339,7 +483,15 @@ test.describe("Slider", () => {
             await expect(element).toHaveAttribute("aria-valuenow", "51");
         });
 
-        test("should decrement the value when the `decrement()` method is invoked and step is not provided", async () => {
+        test("should decrement the value when the `decrement()` method is invoked and step is not provided", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-slider");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("slider--slider"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-slider min="0" max="100" value="50"></fast-slider>
@@ -356,7 +508,15 @@ test.describe("Slider", () => {
         });
     });
 
-    test("should increase or decrease the slider value on arrow left/right keys", async () => {
+    test("should increase or decrease the slider value on arrow left/right keys", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -386,7 +546,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveJSProperty("value", "7");
     });
 
-    test("should increase or decrease the slider value on arrow up/down keys", async () => {
+    test("should increase or decrease the slider value on arrow up/down keys", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -416,7 +584,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveJSProperty("value", "7");
     });
 
-    test("should constrain and normalize the value between `min` and `max` when the value is out of range", async () => {
+    test("should constrain and normalize the value between `min` and `max` when the value is out of range", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider min="0" max="100"></fast-slider>
@@ -438,7 +614,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveJSProperty("value", "0");
     });
 
-    test("should initialize to the provided value attribute if set pre-connection", async () => {
+    test("should initialize to the provided value attribute if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider value="4"></fast-slider>
@@ -450,7 +634,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveJSProperty("value", "4");
     });
 
-    test("should initialize to the provided value attribute if set post-connection", async () => {
+    test("should initialize to the provided value attribute if set post-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider></fast-slider>
@@ -464,7 +656,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveJSProperty("value", "3");
     });
 
-    test("should initialize to the provided value property if set pre-connection", async () => {
+    test("should initialize to the provided value property if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -476,7 +676,15 @@ test.describe("Slider", () => {
         await expect(element).toHaveJSProperty("value", "3");
     });
 
-    test("should update the `stepMultiplier` when the `step` attribute has been updated", async () => {
+    test("should update the `stepMultiplier` when the `step` attribute has been updated", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-slider");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("slider--slider"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-slider step="2" value="4"></fast-slider>
@@ -498,7 +706,15 @@ test.describe("Slider", () => {
     });
 
     test.describe("when the owning form's reset() method is invoked", () => {
-        test("should reset its `value` property to the midpoint if no `value` attribute is set", async () => {
+        test("should reset its `value` property to the midpoint if no `value` attribute is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-slider");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("slider--slider"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -524,7 +740,15 @@ test.describe("Slider", () => {
             await expect(element).toHaveJSProperty("value", "5");
         });
 
-        test("should reset its `value` property to match the `value` attribute when it is set", async () => {
+        test("should reset its `value` property to match the `value` attribute when it is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-slider");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("slider--slider"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -553,7 +777,15 @@ test.describe("Slider", () => {
             await expect(element).toHaveJSProperty("value", "7");
         });
 
-        test("should put the control into a clean state, where the value attribute changes the value property prior to user or programmatic interaction", async () => {
+        test("should put the control into a clean state, where the value attribute changes the value property prior to user or programmatic interaction", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-slider");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("slider--slider"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>

--- a/packages/web-components/fast-foundation/src/slider/slider.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/slider/slider.pw.spec.ts
@@ -72,7 +72,7 @@ test.describe("Slider", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-disabled");
+        await expect(element).not.toHaveAttribute("aria-disabled");
     });
 
     test("should set a default `aria-orientation` value when `orientation` is not defined", async () => {
@@ -95,7 +95,7 @@ test.describe("Slider", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-readonly");
+        await expect(element).not.toHaveAttribute("aria-readonly");
     });
 
     test("should initialize to the initial value if no value property is set", async () => {
@@ -513,7 +513,7 @@ test.describe("Slider", () => {
                 node.value = "3";
             });
 
-            await expect(element).toHaveAttribute("value", "");
+            await expect(element).not.toHaveAttribute("value");
 
             await expect(element).toHaveJSProperty("value", "3");
 

--- a/packages/web-components/fast-foundation/src/switch/switch.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.pw.spec.ts
@@ -69,7 +69,7 @@ test.describe("Switch", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-readonly");
+        await expect(element).not.toHaveAttribute("aria-readonly");
     });
 
     test("should set the `aria-checked` attribute equal to the `checked` property", async () => {
@@ -188,7 +188,7 @@ test.describe("Switch", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("tabindex");
+        await expect(element).not.toHaveAttribute("tabindex");
 
         await element.evaluate((node: FASTSwitch) => {
             node.disabled = false;

--- a/packages/web-components/fast-foundation/src/switch/switch.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.pw.spec.ts
@@ -343,7 +343,7 @@ test.describe("Switch", () => {
 
             const form = page.locator("form");
 
-            await expect(element).not.toHaveBooleanAttribute("checked");
+            await expect(element).not.toHaveAttribute("checked");
 
             await element.evaluate((node: FASTSwitch) => {
                 node.checked = true;
@@ -369,7 +369,7 @@ test.describe("Switch", () => {
 
             const form = page.locator("form");
 
-            await expect(element).toHaveBooleanAttribute("checked");
+            await expect(element).toHaveAttribute("checked");
 
             await element.evaluate((node: FASTSwitch) => {
                 node.checked = false;

--- a/packages/web-components/fast-foundation/src/switch/switch.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/switch/switch.pw.spec.ts
@@ -1,28 +1,15 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTSwitch } from "./switch.js";
 
 test.describe("Switch", () => {
-    let page: Page;
-    let root: Locator;
-    let element: Locator;
+    test("should have a role of `switch`", async ({ page }) => {
+        const element = page.locator("fast-switch");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-switch");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("switch--switch"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of `switch`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -32,7 +19,13 @@ test.describe("Switch", () => {
         await expect(element).toHaveAttribute("role", "switch");
     });
 
-    test("should set a tabindex of 0 on the element", async () => {
+    test("should set a tabindex of 0 on the element", async ({ page }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -42,7 +35,15 @@ test.describe("Switch", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should set a default `aria-checked` value when `checked` is not defined", async () => {
+    test("should set a default `aria-checked` value when `checked` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -52,7 +53,15 @@ test.describe("Switch", () => {
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
-    test("should set a default `aria-disabled` value when `disabled` is not defined", async () => {
+    test("should set a default `aria-disabled` value when `disabled` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -62,7 +71,15 @@ test.describe("Switch", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should NOT set a default `aria-readonly` value when `readonly` is not defined", async () => {
+    test("should NOT set a default `aria-readonly` value when `readonly` is not defined", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -72,7 +89,15 @@ test.describe("Switch", () => {
         await expect(element).not.toHaveAttribute("aria-readonly");
     });
 
-    test("should set the `aria-checked` attribute equal to the `checked` property", async () => {
+    test("should set the `aria-checked` attribute equal to the `checked` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -92,7 +117,15 @@ test.describe("Switch", () => {
         await expect(element).toHaveAttribute("aria-checked", "false");
     });
 
-    test("should set the `aria-readonly` attribute equal to the `readonly` value", async () => {
+    test("should set the `aria-readonly` attribute equal to the `readonly` value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -112,7 +145,15 @@ test.describe("Switch", () => {
         await expect(element).toHaveAttribute("aria-readonly", "false");
     });
 
-    test("should initialize to the initial value if no value property is set", async () => {
+    test("should initialize to the initial value if no value property is set", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -126,7 +167,15 @@ test.describe("Switch", () => {
         await expect(element).toHaveJSProperty("value", initialValue);
     });
 
-    test("should add a class of `label` to the internal label when default slotted content exists", async () => {
+    test("should add a class of `label` to the internal label when default slotted content exists", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -143,7 +192,15 @@ test.describe("Switch", () => {
         await expect(label).not.toHaveClass(/label__hidden/);
     });
 
-    test("should add classes of `label` and `label__hidden` to the internal label when default slotted content exists", async () => {
+    test("should add classes of `label` and `label__hidden` to the internal label when default slotted content exists", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch>Switch</fast-switch>
@@ -161,7 +218,15 @@ test.describe("Switch", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should set the `aria-disabled` attribute equal to the `disabled` value", async () => {
+    test("should set the `aria-disabled` attribute equal to the `disabled` value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -181,7 +246,13 @@ test.describe("Switch", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should NOT set a tabindex when disabled is `true`", async () => {
+    test("should NOT set a tabindex when disabled is `true`", async ({ page }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch disabled></fast-switch>
@@ -197,7 +268,15 @@ test.describe("Switch", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should initialize to the provided value attribute if set pre-connection", async () => {
+    test("should initialize to the provided value attribute if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch value="foo"></fast-switch>
@@ -207,7 +286,15 @@ test.describe("Switch", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided value attribute if set post-connection", async () => {
+    test("should initialize to the provided value attribute if set post-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -221,7 +308,15 @@ test.describe("Switch", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided value property if set pre-connection", async () => {
+    test("should initialize to the provided value property if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -233,7 +328,13 @@ test.describe("Switch", () => {
         await expect(element).toHaveJSProperty("value", "foobar");
     });
 
-    test("should emit an event when clicked", async () => {
+    test("should emit an event when clicked", async ({ page }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -255,7 +356,13 @@ test.describe("Switch", () => {
         expect(wasClicked).toBe(true);
     });
 
-    test("should fire an event when spacebar is invoked", async () => {
+    test("should fire an event when spacebar is invoked", async ({ page }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -277,7 +384,13 @@ test.describe("Switch", () => {
         expect(wasEmitted).toBe(true);
     });
 
-    test("should fire an event when enter is invoked", async () => {
+    test("should fire an event when enter is invoked", async ({ page }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-switch></fast-switch>
@@ -299,7 +412,13 @@ test.describe("Switch", () => {
         expect(wasEmitted).toBe(true);
     });
 
-    test("should be invalid when required and unchecked", async () => {
+    test("should be invalid when required and unchecked", async ({ page }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -315,7 +434,13 @@ test.describe("Switch", () => {
         ).toBe(true);
     });
 
-    test("should be valid when required and checked", async () => {
+    test("should be valid when required and checked", async ({ page }) => {
+        const element = page.locator("fast-switch");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("switch--switch"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <form>
@@ -332,7 +457,15 @@ test.describe("Switch", () => {
     });
 
     test.describe("who's parent form has it's reset() method invoked", () => {
-        test("should set its checked property to false if the checked attribute is unset", async () => {
+        test("should set its checked property to false if the checked attribute is unset", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-switch");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("switch--switch"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -358,7 +491,15 @@ test.describe("Switch", () => {
             await expect(element).toHaveJSProperty("checked", false);
         });
 
-        test("should set its checked property to true if the checked attribute is set", async () => {
+        test("should set its checked property to true if the checked attribute is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-switch");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("switch--switch"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -384,7 +525,15 @@ test.describe("Switch", () => {
             await expect(element).toHaveJSProperty("checked", true);
         });
 
-        test("should put the control into a clean state, where `checked` attribute modifications update the `checked` property prior to user or programmatic interaction", async () => {
+        test("should put the control into a clean state, where `checked` attribute modifications update the `checked` property prior to user or programmatic interaction", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-switch");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("switch--switch"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>

--- a/packages/web-components/fast-foundation/src/tab-panel/tab-panel.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tab-panel/tab-panel.pw.spec.ts
@@ -1,27 +1,14 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 
 test.describe("TabPanel", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should have a role of `tabpanel`", async ({ page }) => {
+        const element = page.locator("fast-tab-panel");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-tab-panel");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("tabs-tab-panel--tab-panel"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have a role of `tabpanel`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tab-panel></fast-tab-panel>
@@ -31,7 +18,13 @@ test.describe("TabPanel", () => {
         await expect(element).toHaveAttribute("role", "tabpanel");
     });
 
-    test("should have a slot attribute of `tabpanel`", async () => {
+    test("should have a slot attribute of `tabpanel`", async ({ page }) => {
+        const element = page.locator("fast-tab-panel");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tabs-tab-panel--tab-panel"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tab-panel></fast-tab-panel>

--- a/packages/web-components/fast-foundation/src/tab/tab.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tab/tab.pw.spec.ts
@@ -29,7 +29,7 @@ test.describe("Tab", () => {
         });
 
         test("should set the `aria-disabled` attribute when `disabled` is true", async () => {
-            await expect(element).not.hasAttribute("aria-disabled");
+            await expect(element).not.toHaveAttribute("aria-disabled");
 
             await element.evaluate<void, FASTTab>(node => {
                 node.disabled = true;

--- a/packages/web-components/fast-foundation/src/tab/tab.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tab/tab.pw.spec.ts
@@ -1,34 +1,32 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTTab } from "./tab.js";
 
 test.describe("Tab", () => {
     test.describe("States, attributes, and properties", () => {
-        let page: Page;
-        let element: Locator;
-
-        test.beforeAll(async ({ browser }) => {
-            page = await browser.newPage();
+        test("should have a role of `tab`", async ({ page }) => {
+            const element = page.locator("fast-tab");
 
             await page.goto(fixtureURL("tabs-tab--tab"));
 
-            element = page.locator("fast-tab");
-        });
-
-        test.afterAll(async () => {
-            await page.close();
-        });
-
-        test("should have a role of `tab`", async () => {
             await expect(element).toHaveAttribute("role", "tab");
         });
 
-        test("should have a slot attribute of `tab`", async () => {
+        test("should have a slot attribute of `tab`", async ({ page }) => {
+            const element = page.locator("fast-tab");
+
+            await page.goto(fixtureURL("tabs-tab--tab"));
+
             await expect(element).toHaveAttribute("slot", "tab");
         });
 
-        test("should set the `aria-disabled` attribute when `disabled` is true", async () => {
+        test("should set the `aria-disabled` attribute when `disabled` is true", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tab");
+
+            await page.goto(fixtureURL("tabs-tab--tab"));
+
             await expect(element).not.toHaveAttribute("aria-disabled");
 
             await element.evaluate<void, FASTTab>(node => {

--- a/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
@@ -291,11 +291,11 @@ test.describe("Tabs", () => {
 
             const tabPanels = element.locator("fast-tab-panel");
 
-            await expect(tabPanels.nth(0)).not.toHaveBooleanAttribute("hidden");
+            await expect(tabPanels.nth(0)).not.toHaveAttribute("hidden");
 
-            await expect(tabPanels.nth(1)).toHaveBooleanAttribute("hidden");
+            await expect(tabPanels.nth(1)).toHaveAttribute("hidden");
 
-            await expect(tabPanels.nth(2)).toHaveBooleanAttribute("hidden");
+            await expect(tabPanels.nth(2)).toHaveAttribute("hidden");
         });
     });
 

--- a/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tabs/tabs.pw.spec.ts
@@ -1,4 +1,3 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import type { FASTTab } from "../tab/tab.js";
 import { fixtureURL } from "../__test__/helpers.js";
@@ -6,12 +5,6 @@ import type { FASTTabs } from "./tabs.js";
 
 // TODO: Need to add tests for keyboard handling, activeIndicator position, and focus management
 test.describe("Tabs", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let tablist: Locator;
-    let tabs: Locator;
-
     const template = /* html */ `
         <fast-tabs>
             <fast-tab>Tab one</fast-tab>
@@ -23,25 +16,15 @@ test.describe("Tabs", () => {
         </fast-tabs>
     `;
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
+    test("should have an internal element with a role of `tablist`", async ({ page }) => {
+        const element = page.locator("fast-tabs");
 
-        element = page.locator("fast-tabs");
+        const root = page.locator("#root");
 
-        root = page.locator("#root");
-
-        tablist = element.locator(".tablist");
-
-        tabs = element.locator("fast-tab");
+        const tablist = element.locator(".tablist");
 
         await page.goto(fixtureURL("tabs--tabs"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should have an internal element with a role of `tablist`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tabs></fast-tabs>
@@ -51,7 +34,15 @@ test.describe("Tabs", () => {
         await expect(tablist).toHaveAttribute("role", "tablist");
     });
 
-    test("should set a default orientation value of `horizontal` when `orientation` is not provided", async () => {
+    test("should set a default orientation value of `horizontal` when `orientation` is not provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tabs");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tabs--tabs"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tabs></fast-tabs>
@@ -61,7 +52,17 @@ test.describe("Tabs", () => {
         await expect(element).toHaveJSProperty("orientation", "horizontal");
     });
 
-    test("should set an `id` attribute on the active tab when an `id` is provided", async () => {
+    test("should set an `id` attribute on the active tab when an `id` is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tabs");
+
+        const root = page.locator("#root");
+
+        const tabs = element.locator("fast-tab");
+
+        await page.goto(fixtureURL("tabs--tabs"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tabs></fast-tabs>
@@ -81,7 +82,17 @@ test.describe("Tabs", () => {
         }
     });
 
-    test("should set an `id` attribute on tab items with a unique ID when an `id` is NOT provided", async () => {
+    test("should set an `id` attribute on tab items with a unique ID when an `id` is NOT provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tabs");
+
+        const root = page.locator("#root");
+
+        const tabs = element.locator("fast-tab");
+
+        await page.goto(fixtureURL("tabs--tabs"));
+
         await root.evaluate(
             (node, { template }) => {
                 node.innerHTML = template;
@@ -105,7 +116,17 @@ test.describe("Tabs", () => {
         }
     });
 
-    test("should set `aria-labelledby` on the tab panel and `aria-controls` on the tab which corresponds to the matching ID when IDs are NOT provided", async () => {
+    test("should set `aria-labelledby` on the tab panel and `aria-controls` on the tab which corresponds to the matching ID when IDs are NOT provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tabs");
+
+        const root = page.locator("#root");
+
+        const tabs = element.locator("fast-tab");
+
+        await page.goto(fixtureURL("tabs--tabs"));
+
         await root.evaluate(
             (node, { template }) => {
                 node.innerHTML = template;
@@ -136,7 +157,17 @@ test.describe("Tabs", () => {
         }
     });
 
-    test("should set `aria-labelledby` on the tab panel and `aria-controls` on the tab which corresponds to the matching ID when IDs are NOT provided and additional tabs and panels are added", async () => {
+    test("should set `aria-labelledby` on the tab panel and `aria-controls` on the tab which corresponds to the matching ID when IDs are NOT provided and additional tabs and panels are added", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tabs");
+
+        const root = page.locator("#root");
+
+        const tabs = element.locator("fast-tab");
+
+        await page.goto(fixtureURL("tabs--tabs"));
+
         await root.evaluate(
             (node, { template }) => {
                 node.innerHTML = template;
@@ -202,7 +233,17 @@ test.describe("Tabs", () => {
     });
 
     test.describe("active tab", () => {
-        test("should set an `aria-selected` attribute on the active tab when `activeid` is provided", async () => {
+        test("should set an `aria-selected` attribute on the active tab when `activeid` is provided", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tabs");
+
+            const root = page.locator("#root");
+
+            const tabs = element.locator("fast-tab");
+
+            await page.goto(fixtureURL("tabs--tabs"));
+
             await root.evaluate(
                 (node, { template }) => {
                     node.innerHTML = template;
@@ -221,7 +262,17 @@ test.describe("Tabs", () => {
             await expect(secondTab).toHaveAttribute("aria-selected", "true");
         });
 
-        test("should default the first tab as the active index if `activeid` is NOT provided", async () => {
+        test("should default the first tab as the active index if `activeid` is NOT provided", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tabs");
+
+            const root = page.locator("#root");
+
+            const tabs = element.locator("fast-tab");
+
+            await page.goto(fixtureURL("tabs--tabs"));
+
             await root.evaluate(
                 (node, { template }) => {
                     node.innerHTML = template;
@@ -234,7 +285,17 @@ test.describe("Tabs", () => {
             await expect(element).toHaveJSProperty("activeTabIndex", 0);
         });
 
-        test("should update `aria-selected` attribute on the active tab when `activeId` is updated", async () => {
+        test("should update `aria-selected` attribute on the active tab when `activeId` is updated", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tabs");
+
+            const root = page.locator("#root");
+
+            const tabs = element.locator("fast-tab");
+
+            await page.goto(fixtureURL("tabs--tabs"));
+
             await root.evaluate(
                 (node, { template }) => {
                     node.innerHTML = template;
@@ -257,7 +318,17 @@ test.describe("Tabs", () => {
     });
 
     test.describe("active tabpanel", () => {
-        test("should set an `aria-labelledby` attribute on the tabpanel with a value of the tab id when `activeid` is provided", async () => {
+        test("should set an `aria-labelledby` attribute on the tabpanel with a value of the tab id when `activeid` is provided", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tabs");
+
+            const root = page.locator("#root");
+
+            const tabs = element.locator("fast-tab");
+
+            await page.goto(fixtureURL("tabs--tabs"));
+
             await root.evaluate(
                 (node, { template }) => {
                     node.innerHTML = template;
@@ -281,7 +352,15 @@ test.describe("Tabs", () => {
             );
         });
 
-        test("should set an attribute of hidden if the tabpanel is not active", async () => {
+        test("should set an attribute of hidden if the tabpanel is not active", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tabs");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("tabs--tabs"));
+
             await root.evaluate(
                 (node, { template }) => {
                     node.innerHTML = template;
@@ -299,7 +378,17 @@ test.describe("Tabs", () => {
         });
     });
 
-    test("should not allow selecting a tab that has been disabled after it has been connected", async () => {
+    test("should not allow selecting a tab that has been disabled after it has been connected", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tabs");
+
+        const root = page.locator("#root");
+
+        const tabs = element.locator("fast-tab");
+
+        await page.goto(fixtureURL("tabs--tabs"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tabs>
@@ -342,7 +431,17 @@ test.describe("Tabs", () => {
         await expect(element).toHaveJSProperty("activeid", firstTabId);
     });
 
-    test("should allow selecting tab that has been enabled after it has been connected", async () => {
+    test("should allow selecting tab that has been enabled after it has been connected", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tabs");
+
+        const root = page.locator("#root");
+
+        const tabs = element.locator("fast-tab");
+
+        await page.goto(fixtureURL("tabs--tabs"));
+
         test.slow();
 
         await root.evaluate(node => {
@@ -387,7 +486,15 @@ test.describe("Tabs", () => {
         await expect(element).toHaveJSProperty("activeid", secondTabId);
     });
 
-    test("should not allow selecting hidden tab using arrow keys", async () => {
+    test("should not allow selecting hidden tab using arrow keys", async ({ page }) => {
+        const element = page.locator("fast-tabs");
+
+        const root = page.locator("#root");
+
+        const tabs = element.locator("fast-tab");
+
+        await page.goto(fixtureURL("tabs--tabs"));
+
         test.slow();
 
         await root.evaluate(node => {
@@ -420,7 +527,15 @@ test.describe("Tabs", () => {
         await expect(element).toHaveJSProperty("activeid", thirdTabId);
     });
 
-    test("should not allow selecting hidden tab by pressing End", async () => {
+    test("should not allow selecting hidden tab by pressing End", async ({ page }) => {
+        const element = page.locator("fast-tabs");
+
+        const root = page.locator("#root");
+
+        const tabs = element.locator("fast-tab");
+
+        await page.goto(fixtureURL("tabs--tabs"));
+
         test.slow();
 
         await root.evaluate(node => {

--- a/packages/web-components/fast-foundation/src/text-area/text-area.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.pw.spec.ts
@@ -184,7 +184,7 @@ test.describe("TextArea", () => {
                 node.value = "foo";
             });
 
-            await expect(element).not.hasAttribute("value");
+            await expect(element).not.toHaveAttribute("value");
 
             await expect(element).toHaveJSProperty("value", "foo");
 
@@ -192,7 +192,7 @@ test.describe("TextArea", () => {
                 node.reset();
             });
 
-            await expect(element).not.hasAttribute("value");
+            await expect(element).not.toHaveAttribute("value");
 
             await expect(element).toHaveJSProperty("value", "");
         });

--- a/packages/web-components/fast-foundation/src/text-area/text-area.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.pw.spec.ts
@@ -1,31 +1,9 @@
 import { spinalCase } from "@microsoft/fast-web-utilities";
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTTextArea } from "./text-area.js";
 
 test.describe("TextArea", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let control: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-text-area");
-
-        root = page.locator("#root");
-
-        control = element.locator(".control");
-
-        await page.goto(fixtureURL("text-area--text-area"));
-    });
-
-    test.afterAll(async () => {
-        await page.close();
-    });
-
     test.describe("should set the boolean attribute on the internal input", () => {
         const attributes = {
             autofocus: true,
@@ -36,7 +14,15 @@ test.describe("TextArea", () => {
         };
 
         for (const attribute of Object.keys(attributes)) {
-            test(attribute, async () => {
+            test(attribute, async ({ page }) => {
+                const element = page.locator("fast-text-area");
+
+                const root = page.locator("#root");
+
+                const control = element.locator(".control");
+
+                await page.goto(fixtureURL("text-area--text-area"));
+
                 await root.evaluate((node, attribute: string) => {
                     node.innerHTML = /* html */ `
                         <fast-text-area ${attribute}></fast-text-area>
@@ -81,7 +67,15 @@ test.describe("TextArea", () => {
         for (const [attribute, value] of Object.entries(attributes)) {
             const attributeSpinalCase = spinalCase(attribute);
 
-            test(attribute, async () => {
+            test(attribute, async ({ page }) => {
+                const element = page.locator("fast-text-area");
+
+                const root = page.locator("#root");
+
+                const control = element.locator(".control");
+
+                await page.goto(fixtureURL("text-area--text-area"));
+
                 await root.evaluate(
                     (node, { attributeSpinalCase, value }) => {
                         node.innerHTML = /* html */ `
@@ -96,7 +90,15 @@ test.describe("TextArea", () => {
         }
     });
 
-    test("should initialize to the initial value if no value property is set", async () => {
+    test("should initialize to the initial value if no value property is set", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-area");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("text-area--text-area"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-area></fast-text-area>
@@ -106,7 +108,15 @@ test.describe("TextArea", () => {
         await expect(element).toHaveJSProperty("value", "");
     });
 
-    test("should initialize to the provided value attribute if set pre-connection", async () => {
+    test("should initialize to the provided value attribute if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-area");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("text-area--text-area"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-area value="foo"></fast-text-area>
@@ -116,7 +126,15 @@ test.describe("TextArea", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided value property if set pre-connection", async () => {
+    test("should initialize to the provided value property if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-area");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("text-area--text-area"));
+
         await root.evaluate(node => {
             node.innerHTML = "";
 
@@ -128,7 +146,15 @@ test.describe("TextArea", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided value attribute if set post-connection", async () => {
+    test("should initialize to the provided value attribute if set post-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-area");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("text-area--text-area"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-area></fast-text-area>
@@ -142,7 +168,17 @@ test.describe("TextArea", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should fire a `change` event when the internal control emits a `change` event", async () => {
+    test("should fire a `change` event when the internal control emits a `change` event", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-area");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("text-area--text-area"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-area></fast-text-area>
@@ -169,7 +205,15 @@ test.describe("TextArea", () => {
     });
 
     test.describe("when the owning form's reset() method is invoked", () => {
-        test("should reset the `value` property to an empty string when no `value` attribute is set", async () => {
+        test("should reset the `value` property to an empty string when no `value` attribute is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-area");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("text-area--text-area"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -197,7 +241,15 @@ test.describe("TextArea", () => {
             await expect(element).toHaveJSProperty("value", "");
         });
 
-        test("should reset the `value` property to match the `value` attribute", async () => {
+        test("should reset the `value` property to match the `value` attribute", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-area");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("text-area--text-area"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>
@@ -225,7 +277,15 @@ test.describe("TextArea", () => {
             await expect(element).toHaveJSProperty("value", "foo");
         });
 
-        test("should put the control into a clean state, where `value` attribute modifications change the `value` property prior to user or programmatic interaction", async () => {
+        test("should put the control into a clean state, where `value` attribute modifications change the `value` property prior to user or programmatic interaction", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-area");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("text-area--text-area"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <form>

--- a/packages/web-components/fast-foundation/src/text-area/text-area.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-area/text-area.pw.spec.ts
@@ -43,7 +43,7 @@ test.describe("TextArea", () => {
                     `;
                 }, attribute);
 
-                await expect(control).toHaveBooleanAttribute(attribute);
+                await expect(control).toHaveAttribute(attribute);
             });
         }
     });

--- a/packages/web-components/fast-foundation/src/text-field/text-field.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.pw.spec.ts
@@ -1,35 +1,20 @@
 import { spinalCase } from "@microsoft/fast-web-utilities";
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTTextField } from "./text-field.js";
 
 test.describe("TextField", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let control: Locator;
-    let label: Locator;
+    test("should set the `autofocus` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
+        const root = page.locator("#root");
 
-        element = page.locator("fast-text-field");
-
-        root = page.locator("#root");
-
-        control = element.locator(".control");
-
-        label = element.locator(".label");
+        const control = element.locator(".control");
 
         await page.goto(fixtureURL("debug--blank"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should set the `autofocus` attribute on the internal control", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field autofocus></fast-text-field>
@@ -39,7 +24,17 @@ test.describe("TextField", () => {
         await expect(control).toHaveAttribute("autofocus");
     });
 
-    test("should set the `disabled` attribute on the internal control", async () => {
+    test("should set the `disabled` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field disabled></fast-text-field>
@@ -49,7 +44,17 @@ test.describe("TextField", () => {
         await expect(control).toHaveAttribute("disabled");
     });
 
-    test("should set the `readonly` attribute on the internal control", async () => {
+    test("should set the `readonly` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field readonly></fast-text-field>
@@ -59,7 +64,17 @@ test.describe("TextField", () => {
         await expect(control).toHaveAttribute("readonly");
     });
 
-    test("should set the `required` attribute on the internal control", async () => {
+    test("should set the `required` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field required></fast-text-field>
@@ -69,7 +84,17 @@ test.describe("TextField", () => {
         await expect(control).toHaveAttribute("required");
     });
 
-    test("should set the `spellcheck` attribute on the internal control", async () => {
+    test("should set the `spellcheck` attribute on the internal control", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field spellcheck></fast-text-field>
@@ -111,7 +136,17 @@ test.describe("TextField", () => {
         for (const [attribute, value] of Object.entries(attributes)) {
             const attrToken = spinalCase(attribute);
 
-            test(`should set the \`${attrToken}\` attribute on the internal control`, async () => {
+            test(`should set the \`${attrToken}\` attribute on the internal control`, async ({
+                page,
+            }) => {
+                const element = page.locator("fast-text-field");
+
+                const root = page.locator("#root");
+
+                const control = element.locator(".control");
+
+                await page.goto(fixtureURL("debug--blank"));
+
                 await root.evaluate(
                     (node, { attrToken, value }) => {
                         node.innerHTML = /* html */ `
@@ -126,7 +161,15 @@ test.describe("TextField", () => {
         }
     });
 
-    test("should initialize to the `initialValue` property if no value property is set", async () => {
+    test("should initialize to the `initialValue` property if no value property is set", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field></fast-text-field>
@@ -140,19 +183,33 @@ test.describe("TextField", () => {
         await expect(element).toHaveJSProperty("value", initialValue);
     });
 
-    test("should initialize to the provided `value` attribute if set pre-connection", async () => {
+    test("should initialize to the provided `value` attribute if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field value="foo"></fast-text-field>
             `;
         });
 
-        const element = page.locator("fast-text-field");
-
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided `value` property if set pre-connection", async () => {
+    test("should initialize to the provided `value` property if set pre-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ ``;
 
@@ -166,7 +223,15 @@ test.describe("TextField", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should initialize to the provided `value` attribute if set post-connection", async () => {
+    test("should initialize to the provided `value` attribute if set post-connection", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field></fast-text-field>
@@ -180,7 +245,17 @@ test.describe("TextField", () => {
         await expect(element).toHaveJSProperty("value", "foo");
     });
 
-    test("should hide the label when no default slotted content is provided", async () => {
+    test("should hide the label when no default slotted content is provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const label = element.locator(".label");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = "<fast-text-field></fast-text-field>";
         });
@@ -188,7 +263,15 @@ test.describe("TextField", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should hide the label when start content is provided", async () => {
+    test("should hide the label when start content is provided", async ({ page }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const label = element.locator(".label");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field>
@@ -200,7 +283,15 @@ test.describe("TextField", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should hide the label when end content is provided", async () => {
+    test("should hide the label when end content is provided", async ({ page }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const label = element.locator(".label");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field>
@@ -212,7 +303,17 @@ test.describe("TextField", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should hide the label when start and end content are provided", async () => {
+    test("should hide the label when start and end content are provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const label = element.locator(".label");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field>
@@ -225,7 +326,17 @@ test.describe("TextField", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should hide the label when space-only text nodes are slotted", async () => {
+    test("should hide the label when space-only text nodes are slotted", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const label = element.locator(".label");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = `<fast-text-field>\n \n</fast-text-field>`;
         });
@@ -235,7 +346,17 @@ test.describe("TextField", () => {
         await expect(label).toHaveClass(/label__hidden/);
     });
 
-    test("should fire a `change` event when the internal control emits a `change` event", async () => {
+    test("should fire a `change` event when the internal control emits a `change` event", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-text-field");
+
+        const root = page.locator("#root");
+
+        const control = element.locator(".control");
+
+        await page.goto(fixtureURL("debug--blank"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-text-field></fast-text-field>
@@ -262,7 +383,15 @@ test.describe("TextField", () => {
     });
 
     test.describe("with a type of `password`", () => {
-        test("should report invalid validity when the `value` property is an empty string and `required` is true", async () => {
+        test("should report invalid validity when the `value` property is an empty string and `required` is true", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="password" required></fast-text-field>
@@ -276,7 +405,15 @@ test.describe("TextField", () => {
             ).toBeTruthy();
         });
 
-        test("should report valid validity when the `value` property is a string that is non-empty and `required` is true", async () => {
+        test("should report valid validity when the `value` property is a string that is non-empty and `required` is true", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="password" required value="some-value"></fast-text-field>
@@ -290,7 +427,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` is empty and `minlength` is set", async () => {
+        test("should report valid validity when `value` is empty and `minlength` is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="password" minlength="1"></fast-text-field>
@@ -304,7 +449,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` has a length less than `minlength`", async () => {
+        test("should report valid validity when `value` has a length less than `minlength`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="password" minlength="10" value="123456789"></fast-text-field>
@@ -318,7 +471,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` is empty and `maxlength` is set", async () => {
+        test("should report valid validity when `value` is empty and `maxlength` is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="password" maxlength="10"></fast-text-field>
@@ -332,7 +493,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` has a length which exceeds the `maxlength`", async () => {
+        test("should report valid validity when `value` has a length which exceeds the `maxlength`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="password" maxlength="10" value="12345678901"></fast-text-field>
@@ -346,7 +515,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when the `value` is shorter than `maxlength` and the element is `required`", async () => {
+        test("should report valid validity when the `value` is shorter than `maxlength` and the element is `required`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="password" maxlength="10" required value="123456789"></fast-text-field>
@@ -360,7 +537,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when the `value` property matches the `pattern` property", async () => {
+        test("should report valid validity when the `value` property matches the `pattern` property", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="password" pattern="\\d+" value="123456789"></fast-text-field>
@@ -374,14 +559,20 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report invalid validity when `value` does not match `pattern`", async () => {
+        test("should report invalid validity when `value` does not match `pattern`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="password" pattern="value" value="other value"></fast-text-field>
                 `;
             });
-
-            const element = page.locator("fast-text-field");
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -392,7 +583,15 @@ test.describe("TextField", () => {
     });
 
     test.describe("with a type of `tel`", () => {
-        test("should report invalid validity when the `value` property is an empty string and `required` is true", async () => {
+        test("should report invalid validity when the `value` property is an empty string and `required` is true", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="tel" required></fast-text-field>
@@ -406,7 +605,15 @@ test.describe("TextField", () => {
             ).toBeTruthy();
         });
 
-        test("should report valid validity when the `value` property is not empty and `required` is true", async () => {
+        test("should report valid validity when the `value` property is not empty and `required` is true", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="tel" required value="some-value"></fast-text-field>
@@ -420,7 +627,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `minlength` is set and `value` is an empty string", async () => {
+        test("should report valid validity when `minlength` is set and `value` is an empty string", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="tel" minlength="1"></fast-text-field>
@@ -434,7 +649,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when the length of `value` is less than `minlength`", async () => {
+        test("should report valid validity when the length of `value` is less than `minlength`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="tel" minlength="10" value="123456789"></fast-text-field>
@@ -448,7 +671,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` is an empty string", async () => {
+        test("should report valid validity when `value` is an empty string", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="tel" maxlength="10"></fast-text-field>
@@ -462,7 +693,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` has a length which exceeds `maxlength`", async () => {
+        test("should report valid validity when `value` has a length which exceeds `maxlength`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="tel" maxlength="10" value="12345678901"></fast-text-field>
@@ -476,7 +715,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when the `value` is shorter than `maxlength` and the element is `required`", async () => {
+        test("should report valid validity when the `value` is shorter than `maxlength` and the element is `required`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="tel" maxlength="10" required value="123456789"></fast-text-field>
@@ -490,14 +737,20 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when the `value` matches `pattern`", async () => {
+        test("should report valid validity when the `value` matches `pattern`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="tel" pattern="\\d+" value="123456789"></fast-text-field>
                 `;
             });
-
-            const element = page.locator("fast-text-field");
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -506,14 +759,20 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report invalid validity when `value` does not match `pattern`", async () => {
+        test("should report invalid validity when `value` does not match `pattern`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="tel" pattern="value" required value="other value"></fast-text-field>
                 `;
             });
-
-            const element = page.locator("fast-text-field");
 
             expect(
                 await element.evaluate<boolean, FASTTextField>(
@@ -524,7 +783,15 @@ test.describe("TextField", () => {
     });
 
     test.describe("with a type of `text`", () => {
-        test("should report invalid validity when the `value` property is an empty string and `required` is true", async () => {
+        test("should report invalid validity when the `value` property is an empty string and `required` is true", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="text" required></fast-text-field>
@@ -538,7 +805,15 @@ test.describe("TextField", () => {
             ).toBeTruthy();
         });
 
-        test("should report valid validity when the `value` property is not empty and `required` is true", async () => {
+        test("should report valid validity when the `value` property is not empty and `required` is true", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="text" required value="some value"></fast-text-field>
@@ -552,7 +827,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` is an empty string and `minlength` is set", async () => {
+        test("should report valid validity when `value` is an empty string and `minlength` is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="text" minlength="1"></fast-text-field>
@@ -566,7 +849,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` has a length less than `minlength`", async () => {
+        test("should report valid validity when `value` has a length less than `minlength`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="text" minlength="6" value="value"></fast-text-field>
@@ -580,7 +871,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` is empty and `maxlength` is set", async () => {
+        test("should report valid validity when `value` is empty and `maxlength` is set", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="text" maxlength="0"></fast-text-field>
@@ -594,7 +893,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when `value` has a length which exceeds `maxlength`", async () => {
+        test("should report valid validity when `value` has a length which exceeds `maxlength`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="text" maxlength="4" value="value"></fast-text-field>
@@ -608,7 +915,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when the `value` is shorter than `maxlength` and the element is `required`", async () => {
+        test("should report valid validity when the `value` is shorter than `maxlength` and the element is `required`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="text" maxlength="6" required value="value"></fast-text-field>
@@ -622,7 +937,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report valid validity when the `value` matches `pattern`", async () => {
+        test("should report valid validity when the `value` matches `pattern`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="text" pattern="value" required value="value"></fast-text-field>
@@ -636,7 +959,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should report invalid validity when `value` does not match `pattern`", async () => {
+        test("should report invalid validity when `value` does not match `pattern`", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="text" pattern="value" required value="other value"></fast-text-field>
@@ -652,7 +983,15 @@ test.describe("TextField", () => {
     });
 
     test.describe("with a type of `email`", () => {
-        test("should report valid validity when `value` is an empty string", async () => {
+        test("should report valid validity when `value` is an empty string", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="email"></fast-text-field>
@@ -666,7 +1005,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should have invalid invalidity with a `typeMismatch` when `value` is not a valid email", async () => {
+        test("should have invalid invalidity with a `typeMismatch` when `value` is not a valid email", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="email" value="not an email"></fast-text-field>
@@ -682,7 +1029,15 @@ test.describe("TextField", () => {
     });
 
     test.describe("with a type of `url`", () => {
-        test("should report valid validity when `value` is an empty string", async () => {
+        test("should report valid validity when `value` is an empty string", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="url"></fast-text-field>
@@ -696,7 +1051,15 @@ test.describe("TextField", () => {
             ).toBeFalsy();
         });
 
-        test("should have invalid invalidity with a `typeMismatch` when `value` is not a valid URL", async () => {
+        test("should have invalid invalidity with a `typeMismatch` when `value` is not a valid URL", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-text-field");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("debug--blank"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-text-field type="url" value="not a url"></fast-text-field>

--- a/packages/web-components/fast-foundation/src/text-field/text-field.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/text-field/text-field.pw.spec.ts
@@ -36,7 +36,7 @@ test.describe("TextField", () => {
             `;
         });
 
-        await expect(control).toHaveBooleanAttribute("autofocus");
+        await expect(control).toHaveAttribute("autofocus");
     });
 
     test("should set the `disabled` attribute on the internal control", async () => {
@@ -46,7 +46,7 @@ test.describe("TextField", () => {
             `;
         });
 
-        await expect(control).toHaveBooleanAttribute("disabled");
+        await expect(control).toHaveAttribute("disabled");
     });
 
     test("should set the `readonly` attribute on the internal control", async () => {
@@ -56,7 +56,7 @@ test.describe("TextField", () => {
             `;
         });
 
-        await expect(control).toHaveBooleanAttribute("readonly");
+        await expect(control).toHaveAttribute("readonly");
     });
 
     test("should set the `required` attribute on the internal control", async () => {
@@ -66,7 +66,7 @@ test.describe("TextField", () => {
             `;
         });
 
-        await expect(control).toHaveBooleanAttribute("required");
+        await expect(control).toHaveAttribute("required");
     });
 
     test("should set the `spellcheck` attribute on the internal control", async () => {
@@ -76,7 +76,7 @@ test.describe("TextField", () => {
             `;
         });
 
-        await expect(control).toHaveBooleanAttribute("spellcheck");
+        await expect(control).toHaveAttribute("spellcheck");
     });
 
     test.describe("should set the attribute on the internal control", () => {

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.pw.spec.ts
@@ -1,35 +1,36 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import { ToolbarOrientation } from "./toolbar.options.js";
 
 test.describe("Toolbar", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-toolbar");
-
-        root = page.locator("#root");
+    test("should have a role of `toolbar`", async ({ page }) => {
+        const element = page.locator("fast-toolbar");
 
         await page.goto(fixtureURL("toolbar--toolbar"));
-    });
 
-    test("should have a role of `toolbar`", async () => {
         await expect(element).toHaveAttribute("role", "toolbar");
     });
 
-    test("should have a default orientation of `horizontal`", async () => {
+    test("should have a default orientation of `horizontal`", async ({ page }) => {
+        const element = page.locator("fast-toolbar");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await expect(element).toHaveAttribute(
             "orientation",
             ToolbarOrientation.horizontal
         );
     });
 
-    test("should move focus to its first focusable element when it receives focus", async () => {
+    test("should move focus to its first focusable element when it receives focus", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -44,8 +45,6 @@ test.describe("Toolbar", () => {
             `;
         });
 
-        const element = page.locator("fast-toolbar");
-
         const buttons = element.locator("button");
 
         const firstButton = buttons.filter({ hasText: "Start Slot Button" });
@@ -55,7 +54,15 @@ test.describe("Toolbar", () => {
         await expect(firstButton).toBeFocused();
     });
 
-    test("should move focus to next element when keyboard incrementer is pressed", async () => {
+    test("should move focus to next element when keyboard incrementer is pressed", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -101,7 +108,15 @@ test.describe("Toolbar", () => {
         await expect(buttons.filter({ hasText: "End Slot Button" })).toBeFocused();
     });
 
-    test("should skip disabled elements when keyboard incrementer is pressed", async () => {
+    test("should skip disabled elements when keyboard incrementer is pressed", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -147,7 +162,15 @@ test.describe("Toolbar", () => {
         await expect(endSlotButton).toBeFocused();
     });
 
-    test("should skip hidden elements when keyboard incrementer is pressed", async () => {
+    test("should skip hidden elements when keyboard incrementer is pressed", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -193,7 +216,15 @@ test.describe("Toolbar", () => {
         await expect(endSlotButton).toBeFocused();
     });
 
-    test("should move focus to next element when keyboard incrementer is pressed and start slot content is added after connect", async () => {
+    test("should move focus to next element when keyboard incrementer is pressed and start slot content is added after connect", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `<fast-toolbar></fast-toolbar>`;
         });
@@ -225,7 +256,15 @@ test.describe("Toolbar", () => {
         await expect(button2).toBeFocused();
     });
 
-    test("should move focus to next element when keyboard incrementer is pressed and end slot content is added after connect", async () => {
+    test("should move focus to next element when keyboard incrementer is pressed and end slot content is added after connect", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar></fast-toolbar>
@@ -260,7 +299,15 @@ test.describe("Toolbar", () => {
         await expect(endSlotButton).toBeFocused();
     });
 
-    test("should maintain correct activeIndex when the set of focusable children changes", async () => {
+    test("should maintain correct activeIndex when the set of focusable children changes", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -304,7 +351,15 @@ test.describe("Toolbar", () => {
         await expect(element).toHaveJSProperty("activeIndex", 1);
     });
 
-    test("should reset activeIndex to 0 when the focused item is no longer focusable", async () => {
+    test("should reset activeIndex to 0 when the focused item is no longer focusable", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -350,7 +405,15 @@ test.describe("Toolbar", () => {
         await expect(element).toHaveJSProperty("activeIndex", 0);
     });
 
-    test("should update activeIndex when an element within the toolbar is clicked", async () => {
+    test("should update activeIndex when an element within the toolbar is clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -382,7 +445,15 @@ test.describe("Toolbar", () => {
         await expect(element).toHaveJSProperty("activeIndex", 2);
     });
 
-    test("should update activeIndex when a nested element within the toolbar is clicked", async () => {
+    test("should update activeIndex when a nested element within the toolbar is clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -419,7 +490,15 @@ test.describe("Toolbar", () => {
         await expect(element).toHaveJSProperty("activeIndex", 2);
     });
 
-    test("should focus most recently focused item when toolbar receives focus", async () => {
+    test("should focus most recently focused item when toolbar receives focus", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -436,7 +515,9 @@ test.describe("Toolbar", () => {
         });
         const button2 = element.locator("button", { hasText: "Button 2" });
 
-        const buttonOutsideToolbar = page.locator("button", { hasText: "Button Outside Toolbar"});
+        const buttonOutsideToolbar = page.locator("button", {
+            hasText: "Button Outside Toolbar",
+        });
 
         await button2.click();
         await expect(button2).toBeFocused();
@@ -449,7 +530,15 @@ test.describe("Toolbar", () => {
         await expect(button2).toBeFocused();
     });
 
-    test("should focus clicked item when focus enters toolbar by clicking an item that is not the most recently focused item", async () => {
+    test("should focus clicked item when focus enters toolbar by clicking an item that is not the most recently focused item", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-toolbar");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("toolbar--toolbar"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-toolbar>
@@ -468,7 +557,9 @@ test.describe("Toolbar", () => {
 
         const button3 = element.locator("button", { hasText: "Button 3" });
 
-        const buttonOutsideToolbar = page.locator("button", { hasText: "Button Outside Toolbar"});
+        const buttonOutsideToolbar = page.locator("button", {
+            hasText: "Button Outside Toolbar",
+        });
 
         await button2.click();
         await expect(button2).toBeFocused();

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
@@ -1,37 +1,27 @@
-import type { Locator, Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTTooltip } from "./tooltip.js";
 
 test.describe("Tooltip", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
-    let anchoredRegion: Locator;
+    test("should not render the tooltip by default", async ({ page }) => {
+        const element = page.locator("fast-tooltip");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-tooltip");
-
-        root = page.locator("#root");
-
-        anchoredRegion = element.locator("fast-anchored-region");
+        const anchoredRegion = element.locator("fast-anchored-region");
 
         await page.goto(fixtureURL("tooltip--tooltip", { delay: 0 }));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should not render the tooltip by default", async () => {
         await expect(element).toHaveJSProperty("visible", false);
 
         await expect(anchoredRegion).toBeHidden();
     });
 
-    test("should render the tooltip when the anchor is hovered", async () => {
+    test("should render the tooltip when the anchor is hovered", async ({ page }) => {
+        const element = page.locator("fast-tooltip");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tooltip--tooltip", { delay: 0 }));
+
         await root.evaluate((node: HTMLElement) => {
             node.innerHTML = /* html */ `
             <fast-tooltip anchor="anchor-default">
@@ -52,7 +42,13 @@ test.describe("Tooltip", () => {
         await expect(element).toBeVisible();
     });
 
-    test("should render the tooltip when the anchor is focused", async () => {
+    test("should render the tooltip when the anchor is focused", async ({ page }) => {
+        const element = page.locator("fast-tooltip");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tooltip--tooltip", { delay: 0 }));
+
         await root.evaluate((node: HTMLElement) => {
             node.innerHTML = /* html */ `
                 <fast-tooltip anchor="anchor-default">
@@ -77,7 +73,15 @@ test.describe("Tooltip", () => {
         await expect(element).toBeVisible();
     });
 
-    test('should render the tooltip when the `show` attribute is "true"', async () => {
+    test('should render the tooltip when the `show` attribute is "true"', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tooltip");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tooltip--tooltip", { delay: 0 }));
+
         await root.evaluate((node: HTMLElement) => {
             node.innerHTML = /* html */ `
                 <fast-tooltip anchor="anchor-default" show="true">
@@ -94,7 +98,15 @@ test.describe("Tooltip", () => {
         await expect(element).toBeVisible();
     });
 
-    test('should not render the tooltip when the `show` attribute is "false"', async () => {
+    test('should not render the tooltip when the `show` attribute is "false"', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tooltip");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tooltip--tooltip", { delay: 0 }));
+
         await root.evaluate((node: HTMLElement) => {
             node.innerHTML = /* html */ `
                 <fast-tooltip anchor="anchor-default" show="false">
@@ -115,7 +127,15 @@ test.describe("Tooltip", () => {
         await expect(element).toBeHidden();
     });
 
-    test('should not render the tooltip when the anchor is hovered and `show` is "false"', async () => {
+    test('should not render the tooltip when the anchor is hovered and `show` is "false"', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tooltip");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tooltip--tooltip", { delay: 0 }));
+
         await root.evaluate((node: HTMLElement) => {
             node.innerHTML = /* html */ `
                 <fast-tooltip anchor="anchor-default">
@@ -144,7 +164,15 @@ test.describe("Tooltip", () => {
         await expect(element).toBeHidden();
     });
 
-    test("should change anchor element when the `anchor` attribute changes", async () => {
+    test("should change anchor element when the `anchor` attribute changes", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tooltip");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tooltip--tooltip", { delay: 0 }));
+
         await page.goto(fixtureURL("tooltip--tooltip"));
 
         await root.evaluate(node => {

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
@@ -73,7 +73,7 @@ test.describe("TreeItem", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-expanded");
+        await expect(element).not.toHaveAttribute("aria-expanded");
     });
 
     test("should NOT set the `aria-expanded` attribute when the `expanded` state is true and the tree item has no children", async () => {
@@ -83,13 +83,13 @@ test.describe("TreeItem", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-expanded");
+        await expect(element).not.toHaveAttribute("aria-expanded");
 
         await element.evaluate<void, FASTTreeItem>(node => {
             node.expanded = true;
         });
 
-        await expect(element).not.hasAttribute("aria-expanded");
+        await expect(element).not.toHaveAttribute("aria-expanded");
     });
 
     test("should NOT set the `aria-selected` attribute if `selected` value is not provided", async () => {
@@ -99,7 +99,7 @@ test.describe("TreeItem", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-selected");
+        await expect(element).not.toHaveAttribute("aria-selected");
     });
 
     test("should set the `aria-selected` attribute equal to the `selected` value", async () => {
@@ -145,7 +145,7 @@ test.describe("TreeItem", () => {
             `;
         });
 
-        await expect(element).not.hasAttribute("aria-disabled");
+        await expect(element).not.toHaveAttribute("aria-disabled");
 
         await element.evaluate<void, FASTTreeItem>(node => {
             node.disabled = true;
@@ -314,7 +314,7 @@ test.describe("TreeItem", () => {
 
             await expect(element).not.toHaveBooleanAttribute("selected");
 
-            await expect(element).not.hasAttribute("aria-selected");
+            await expect(element).not.toHaveAttribute("aria-selected");
         });
 
         test("should fire an event when expanded state changes via the `expanded` attribute", async () => {

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
@@ -312,7 +312,7 @@ test.describe("TreeItem", () => {
 
             await element.click({ force: true });
 
-            await expect(element).not.toHaveBooleanAttribute("selected");
+            await expect(element).not.toHaveAttribute("selected");
 
             await expect(element).not.toHaveAttribute("aria-selected");
         });

--- a/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-item/tree-item.pw.spec.ts
@@ -1,28 +1,15 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 import type { FASTTreeItem } from "./tree-item.js";
 
 test.describe("TreeItem", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should include a role of `treeitem`", async ({ page }) => {
+        const element = page.locator("fast-tree-item");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-tree-item");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should include a role of `treeitem`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>tree item</fast-tree-item>
@@ -32,7 +19,15 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("role", "treeitem");
     });
 
-    test("should set the `aria-expanded` attribute equal to the `expanded` value when the tree item has children", async () => {
+    test("should set the `aria-expanded` attribute equal to the `expanded` value when the tree item has children", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>
@@ -54,7 +49,15 @@ test.describe("TreeItem", () => {
         await expect(element.first()).toHaveAttribute("aria-expanded", "false");
     });
 
-    test("should set the `aria-expanded` attribute equal to TRUE when the `expanded` attribute is present", async () => {
+    test("should set the `aria-expanded` attribute equal to TRUE when the `expanded` attribute is present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item expanded>
@@ -66,7 +69,15 @@ test.describe("TreeItem", () => {
         await expect(element.first()).toHaveAttribute("aria-expanded", "true");
     });
 
-    test("should NOT set the `aria-expanded` attribute when the tree item has no children", async () => {
+    test("should NOT set the `aria-expanded` attribute when the tree item has no children", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>tree item</fast-tree-item>
@@ -76,7 +87,15 @@ test.describe("TreeItem", () => {
         await expect(element).not.toHaveAttribute("aria-expanded");
     });
 
-    test("should NOT set the `aria-expanded` attribute when the `expanded` state is true and the tree item has no children", async () => {
+    test("should NOT set the `aria-expanded` attribute when the `expanded` state is true and the tree item has no children", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item expanded></fast-tree-item>
@@ -92,7 +111,15 @@ test.describe("TreeItem", () => {
         await expect(element).not.toHaveAttribute("aria-expanded");
     });
 
-    test("should NOT set the `aria-selected` attribute if `selected` value is not provided", async () => {
+    test("should NOT set the `aria-selected` attribute if `selected` value is not provided", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>tree item</fast-tree-item>
@@ -102,7 +129,15 @@ test.describe("TreeItem", () => {
         await expect(element).not.toHaveAttribute("aria-selected");
     });
 
-    test("should set the `aria-selected` attribute equal to the `selected` value", async () => {
+    test("should set the `aria-selected` attribute equal to the `selected` value", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>tree item</fast-tree-item>
@@ -122,7 +157,15 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("aria-selected", "false");
     });
 
-    test("should set the `aria-selected` attribute equal to TRUE when the selected attribute is present", async () => {
+    test("should set the `aria-selected` attribute equal to TRUE when the selected attribute is present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item selected>tree item</fast-tree-item>
@@ -138,7 +181,15 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should set the `aria-disabled` attribute equal to the `disabled` property", async () => {
+    test("should set the `aria-disabled` attribute equal to the `disabled` property", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>tree item</fast-tree-item>
@@ -160,7 +211,15 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("aria-disabled", "false");
     });
 
-    test("should set the `aria-disabled` attribute equal to TRUE when the disabled attribute is present", async () => {
+    test("should set the `aria-disabled` attribute equal to TRUE when the disabled attribute is present", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item disabled>tree item</fast-tree-item>
@@ -170,7 +229,15 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("aria-disabled", "true");
     });
 
-    test('should add a slot attribute of "item" to nested tree items', async () => {
+    test('should add a slot attribute of "item" to nested tree items', async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>
@@ -185,7 +252,13 @@ test.describe("TreeItem", () => {
         );
     });
 
-    test("should have a default `tabindex` attribute of -1", async () => {
+    test("should have a default `tabindex` attribute of -1", async ({ page }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>tree item</fast-tree-item>
@@ -195,7 +268,13 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("tabindex", "-1");
     });
 
-    test("should have a tabindex of 0 when focused", async () => {
+    test("should have a tabindex of 0 when focused", async ({ page }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>tree item</fast-tree-item>
@@ -207,7 +286,15 @@ test.describe("TreeItem", () => {
         await expect(element).toHaveAttribute("tabindex", "0");
     });
 
-    test("should render an element with a class of `expand-collapse-button` when nested tree items exist", async () => {
+    test("should render an element with a class of `expand-collapse-button` when nested tree items exist", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>
@@ -223,7 +310,15 @@ test.describe("TreeItem", () => {
         await expect(expandCollapseButton).toHaveAttribute("aria-hidden", "true");
     });
 
-    test("should render an element with a role of `group` when nested tree items exist and `expanded` is true", async () => {
+    test("should render an element with a role of `group` when nested tree items exist and `expanded` is true", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item expanded>
@@ -235,7 +330,15 @@ test.describe("TreeItem", () => {
         await expect(element.first().locator(".items")).toHaveAttribute("role", "group");
     });
 
-    test("should NOT render an element with a role of `group` when nested tree items exist and `expanded` is false", async () => {
+    test("should NOT render an element with a role of `group` when nested tree items exist and `expanded` is false", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-item");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-item>
@@ -248,7 +351,15 @@ test.describe("TreeItem", () => {
     });
 
     test.describe("events", () => {
-        test('should emit a "change" event when the `expanded` property changes', async () => {
+        test('should emit a "change" event when the `expanded` property changes', async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tree-item");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-tree-item>
@@ -280,7 +391,15 @@ test.describe("TreeItem", () => {
             expect(wasClicked).toBe(true);
         });
 
-        test("should fire a selected change event when the `selected` property changes", async () => {
+        test("should fire a selected change event when the `selected` property changes", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tree-item");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-tree-item>tree item</fast-tree-item>
@@ -303,7 +422,15 @@ test.describe("TreeItem", () => {
             expect(wasChanged).toBeTruthy();
         });
 
-        test("should NOT set `selected` state when a disabled element is clicked", async () => {
+        test("should NOT set `selected` state when a disabled element is clicked", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tree-item");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-tree-item disabled>tree item</fast-tree-item>
@@ -317,7 +444,15 @@ test.describe("TreeItem", () => {
             await expect(element).not.toHaveAttribute("aria-selected");
         });
 
-        test("should fire an event when expanded state changes via the `expanded` attribute", async () => {
+        test("should fire an event when expanded state changes via the `expanded` attribute", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tree-item");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-tree-item>tree item</fast-tree-item>
@@ -340,7 +475,15 @@ test.describe("TreeItem", () => {
             expect(wasChanged).toBeTruthy();
         });
 
-        test("should fire an event when selected state changes via the `selected` attribute", async () => {
+        test("should fire an event when selected state changes via the `selected` attribute", async ({
+            page,
+        }) => {
+            const element = page.locator("fast-tree-item");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("tree-view-tree-item--tree-item"));
+
             await root.evaluate(node => {
                 node.innerHTML = /* html */ `
                     <fast-tree-item>tree item</fast-tree-item>

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
@@ -167,7 +167,7 @@ test.describe("TreeView", () => {
 
         await expandCollapseButton.click();
 
-        await expect(firstTreeItem).toHaveBooleanAttribute("expanded");
+        await expect(firstTreeItem).toHaveAttribute("expanded");
 
         await expect(firstTreeItem).toHaveAttribute("aria-expanded", "true");
 

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
@@ -1,28 +1,15 @@
 import { expect, test } from "@playwright/test";
-import type { Locator, Page } from "@playwright/test";
 import { fixtureURL } from "../__test__/helpers.js";
 
 // TODO: Need to add tests for keyboard handling & focus management
 test.describe("TreeView", () => {
-    let page: Page;
-    let element: Locator;
-    let root: Locator;
+    test("should include a role of `tree`", async ({ page }) => {
+        const element = page.locator("fast-tree-view");
 
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-
-        element = page.locator("fast-tree-view");
-
-        root = page.locator("#root");
+        const root = page.locator("#root");
 
         await page.goto(fixtureURL("tree-view--tree-view"));
-    });
 
-    test.afterAll(async () => {
-        await page.close();
-    });
-
-    test("should include a role of `tree`", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-view></fast-tree-view>
@@ -32,7 +19,15 @@ test.describe("TreeView", () => {
         await expect(element).toHaveAttribute("role", "tree");
     });
 
-    test("should set tree item `nested` properties to true if *any* tree item has nested items", async () => {
+    test("should set tree item `nested` properties to true if *any* tree item has nested items", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-view");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view--tree-view"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-view>
@@ -66,7 +61,15 @@ test.describe("TreeView", () => {
         ).toBe(true);
     });
 
-    test("should set the selected state on tree items when a tree item is clicked", async () => {
+    test("should set the selected state on tree items when a tree item is clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-view");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view--tree-view"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-view>
@@ -98,9 +101,17 @@ test.describe("TreeView", () => {
         await expect(firstTreeItem).toHaveAttribute("aria-selected", "true");
     });
 
-    test.fixme("should only allow one tree item to be selected at a time", async () => {
-        await root.evaluate(node => {
-            node.innerHTML = /* html */ `
+    test.fixme(
+        "should only allow one tree item to be selected at a time",
+        async ({ page }) => {
+            const element = page.locator("fast-tree-view");
+
+            const root = page.locator("#root");
+
+            await page.goto(fixtureURL("tree-view--tree-view"));
+
+            await root.evaluate(node => {
+                node.innerHTML = /* html */ `
                 <fast-tree-view>
                     <fast-tree-item>
                         Root item 1
@@ -119,26 +130,37 @@ test.describe("TreeView", () => {
                     </fast-tree-item>
                 </fast-tree-view>
             `;
-        });
+            });
 
-        const treeItems = element.locator("> fast-tree-item");
+            const treeItems = element.locator("> fast-tree-item");
 
-        const selectedTreeItems = element.locator(`fast-tree-item[aria-selected="true"]`);
+            const selectedTreeItems = element.locator(
+                `fast-tree-item[aria-selected="true"]`
+            );
 
-        const treeItemsCount = await treeItems.count();
+            const treeItemsCount = await treeItems.count();
 
-        for (let i = 0; i < treeItemsCount; i++) {
-            const treeItem = treeItems.nth(i);
+            for (let i = 0; i < treeItemsCount; i++) {
+                const treeItem = treeItems.nth(i);
 
-            await treeItem.dispatchEvent("click");
+                await treeItem.dispatchEvent("click");
 
-            await expect(treeItem).toHaveAttribute("aria-selected", "true");
+                await expect(treeItem).toHaveAttribute("aria-selected", "true");
 
-            await expect(selectedTreeItems).toHaveCount(1);
+                await expect(selectedTreeItems).toHaveCount(1);
+            }
         }
-    });
+    );
 
-    test("should toggle the expanded state when `expand-collapse-button` is clicked", async () => {
+    test("should toggle the expanded state when `expand-collapse-button` is clicked", async ({
+        page,
+    }) => {
+        const element = page.locator("fast-tree-view");
+
+        const root = page.locator("#root");
+
+        await page.goto(fixtureURL("tree-view--tree-view"));
+
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-view>

--- a/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tree-view/tree-view.pw.spec.ts
@@ -98,7 +98,7 @@ test.describe("TreeView", () => {
         await expect(firstTreeItem).toHaveAttribute("aria-selected", "true");
     });
 
-    test("should only allow one tree item to be selected at a time", async () => {
+    test.fixme("should only allow one tree item to be selected at a time", async () => {
         await root.evaluate(node => {
             node.innerHTML = /* html */ `
                 <fast-tree-view>

--- a/packages/web-components/fast-foundation/src/utilities/utilities.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/utilities/utilities.pw.spec.ts
@@ -1,27 +1,22 @@
 import { Direction } from "@microsoft/fast-web-utilities";
-import type { Page } from "@playwright/test";
 import { expect, test } from "@playwright/test";
 import { getDirection } from "./direction.js";
 import { whitespaceFilter } from "./whitespace-filter.js";
 
 test.describe("Utilities", () => {
-    let page: Page;
-
-    test.beforeAll(async ({ browser }) => {
-        page = await browser.newPage();
-    });
-
     test.describe("getDirection", () => {
         const content = `
             const Direction = ${JSON.stringify(Direction)};
             const getDirection = ${getDirection.toString()};
         `;
 
-        test.beforeEach(async () => {
+        test.beforeEach(async ({ page }) => {
             await page.addScriptTag({ content });
         });
 
-        test('should return "ltr" for an element with no `dir` attribute', async () => {
+        test('should return "ltr" for an element with no `dir` attribute', async ({
+            page,
+        }) => {
             await page.setContent(/* html */ `
                 <div></div>
             `);
@@ -33,7 +28,9 @@ test.describe("Utilities", () => {
             ).toBe(Direction.ltr);
         });
 
-        test('should return "ltr" for an element with `dir` attribute of "ltr"', async () => {
+        test('should return "ltr" for an element with `dir` attribute of "ltr"', async ({
+            page,
+        }) => {
             await page.setContent(/* html */ `
                 <div dir="ltr"></div>
             `);
@@ -45,7 +42,9 @@ test.describe("Utilities", () => {
             ).toBe(Direction.ltr);
         });
 
-        test('should return "rtl" for an element with a `dir` attribute of "rtl"', async () => {
+        test('should return "rtl" for an element with a `dir` attribute of "rtl"', async ({
+            page,
+        }) => {
             await page.setContent(/* html */ `
                 <div dir="rtl"></div>
             `);
@@ -57,7 +56,9 @@ test.describe("Utilities", () => {
             ).toBe(Direction.rtl);
         });
 
-        test('should return "ltr" for an element with a `dir` property of "ltr"', async () => {
+        test('should return "ltr" for an element with a `dir` property of "ltr"', async ({
+            page,
+        }) => {
             await page.setContent(/* html */ `
                 <div></div>
             `);
@@ -73,7 +74,9 @@ test.describe("Utilities", () => {
             ).toBe(Direction.ltr);
         });
 
-        test('should return "rtl" for an element with a `dir` property of "rtl"', async () => {
+        test('should return "rtl" for an element with a `dir` property of "rtl"', async ({
+            page,
+        }) => {
             await page.setContent(/* html */ `
                 <div></div>
             `);
@@ -93,11 +96,11 @@ test.describe("Utilities", () => {
     test.describe("whitespaceFilter", () => {
         const content = `const whitespaceFilter = ${whitespaceFilter.toString()}`;
 
-        test.beforeEach(async () => {
+        test.beforeEach(async ({ page }) => {
             await page.addScriptTag({ content });
         });
 
-        test("should return true when given an element node", async () => {
+        test("should return true when given an element node", async ({ page }) => {
             await page.setContent(/* html */ `
                 <span>
                     span
@@ -109,7 +112,7 @@ test.describe("Utilities", () => {
             expect(await element.evaluate(node => whitespaceFilter(node))).toBeTruthy();
         });
 
-        test("should return true when given a text node", async () => {
+        test("should return true when given a text node", async ({ page }) => {
             await page.setContent(/* html */ `
                 <span>
                     text
@@ -123,7 +126,9 @@ test.describe("Utilities", () => {
             ).toBeTruthy();
         });
 
-        test("should return false when given a text node which only contains spaces", async () => {
+        test("should return false when given a text node which only contains spaces", async ({
+            page,
+        }) => {
             await page.setContent(/* html */ `
                 <span>          </span>
             `);

--- a/packages/web-components/fast-ssr/package.json
+++ b/packages/web-components/fast-ssr/package.json
@@ -63,7 +63,7 @@
     "@microsoft/fast-element": "^2.0.0-beta.26",
     "@microsoft/fast-foundation": "^3.0.0-alpha.32",
     "@microsoft/api-extractor": "7.24.2",
-    "@playwright/test": "^1.25.2",
+    "@playwright/test": "^1.41.2",
     "@types/express": "^4.17.13",
     "@types/node": "^17.0.17",
     "chokidar-cli": "^3.0.0",

--- a/packages/web-components/fast-ssr/src/styles/fast-style.fixture.html
+++ b/packages/web-components/fast-ssr/src/styles/fast-style.fixture.html
@@ -124,7 +124,7 @@
         <script type="module" src="/fast-style.js"></script>
         <fast-card style="width: 300px">
             <!-- shadowroots must remain open for testing contained elements -->
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style
                     style-id="fast-card"
                     css=":host {
@@ -149,7 +149,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style
                                 style-id="fast-button"
                                 css=":host {
@@ -197,7 +197,7 @@
             </template>
         </fast-card>
         <fast-card style="width: 300px">
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style style-id="fast-card"></fast-style>
                 <img src="/placeholder.png" />
                 <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest)">
@@ -210,7 +210,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style style-id="fast-button"></fast-style>
                             <button class="control">
                                 <span>Button</span>
@@ -221,7 +221,7 @@
             </template>
         </fast-card>
         <fast-card style="width: 300px">
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style style-id="fast-card"></fast-style>
                 <img src="/placeholder.png" />
                 <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest)">
@@ -234,7 +234,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style style-id="fast-button"></fast-style>
                             <button class="control">
                                 <span>Button</span>
@@ -245,7 +245,7 @@
             </template>
         </fast-card>
         <fast-card style="width: 300px">
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style style-id="fast-card"></fast-style>
                 <img src="/placeholder.png" />
                 <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest)">
@@ -258,7 +258,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style style-id="fast-button"></fast-style>
                             <button class="control">
                                 <span>Button</span>
@@ -269,7 +269,7 @@
             </template>
         </fast-card>
         <fast-card style="width: 300px">
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style style-id="fast-card"></fast-style>
                 <img src="/placeholder.png" />
                 <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest)">
@@ -282,7 +282,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style style-id="fast-button"></fast-style>
                             <button class="control">
                                 <span>Button</span>
@@ -293,7 +293,7 @@
             </template>
         </fast-card>
         <fast-card style="width: 300px">
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style style-id="fast-card"></fast-style>
                 <img src="/placeholder.png" />
                 <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest)">
@@ -306,7 +306,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style style-id="fast-button"></fast-style>
                             <button class="control">
                                 <span>Button</span>
@@ -317,7 +317,7 @@
             </template>
         </fast-card>
         <fast-card style="width: 300px">
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style style-id="fast-card"></fast-style>
                 <img src="/placeholder.png" />
                 <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest)">
@@ -330,7 +330,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style style-id="fast-button"></fast-style>
                             <button class="control">
                                 <span>Button</span>
@@ -341,7 +341,7 @@
             </template>
         </fast-card>
         <fast-card style="width: 300px">
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style style-id="fast-card"></fast-style>
                 <img src="/placeholder.png" />
                 <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest)">
@@ -354,7 +354,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style style-id="fast-button"></fast-style>
                             <button class="control">
                                 <span>Button</span>
@@ -365,7 +365,7 @@
             </template>
         </fast-card>
         <fast-card style="width: 300px">
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style style-id="fast-card"></fast-style>
                 <img src="/placeholder.png" />
                 <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest)">
@@ -378,7 +378,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style style-id="fast-button"></fast-style>
                             <button class="control">
                                 <span>Button</span>
@@ -389,7 +389,7 @@
             </template>
         </fast-card>
         <fast-card style="width: 300px">
-            <template shadowroot="open">
+            <template shadowrootmode="open">
                 <fast-style style-id="fast-card"></fast-style>
                 <img src="/placeholder.png" />
                 <div style="padding: 0 10px 10px; color: var(--neutral-foreground-rest)">
@@ -402,7 +402,7 @@
                         Suspendisse volutpat auctor diam,vel mattis lorem venenatis in.
                     </p>
                     <fast-button>
-                        <template shadowroot="open">
+                        <template shadowrootmode="open">
                             <fast-style style-id="fast-button"></fast-style>
                             <button class="control">
                                 <span>Button</span>

--- a/yarn.lock
+++ b/yarn.lock
@@ -1784,14 +1784,7 @@
   dependencies:
     jest-get-type "^29.2.0"
 
-"@jest/schemas@^29.0.0":
-  version "29.0.0"
-  resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.0.0.tgz#5f47f5994dd4ef067fb7b4188ceac45f77fe952a"
-  integrity sha512-3Ab5HgYIIAnS0HjqJHQYZS+zXc4tUmTmBH3z83ajI6afXp8X3ZtdLX+nXx+I7LNkJD7uN9LAVhgnjDgZa2z0kA==
-  dependencies:
-    "@sinclair/typebox" "^0.24.1"
-
-"@jest/schemas@^29.4.3":
+"@jest/schemas@^29.0.0", "@jest/schemas@^29.4.3":
   version "29.4.3"
   resolved "https://registry.yarnpkg.com/@jest/schemas/-/schemas-29.4.3.tgz#39cf1b8469afc40b6f5a2baaa146e332c4151788"
   integrity sha512-VLYKXQmtmuEz6IxJsrZwzG9NvtkQsWNnWMsKxqWNu3+CnfzJQhp0WDDKWLVV9hLKr0l3SLLFRqcYHjhtyuDVxg==
@@ -1840,19 +1833,7 @@
     "@types/yargs" "^15.0.0"
     chalk "^4.0.0"
 
-"@jest/types@^29.2.1":
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.2.1.tgz#ec9c683094d4eb754e41e2119d8bdaef01cf6da0"
-  integrity sha512-O/QNDQODLnINEPAI0cl9U6zUIDXEWXt6IC1o2N2QENuos7hlGUIthlKyV4p6ki3TvXFX071blj8HUhgLGquPjw==
-  dependencies:
-    "@jest/schemas" "^29.0.0"
-    "@types/istanbul-lib-coverage" "^2.0.0"
-    "@types/istanbul-reports" "^3.0.0"
-    "@types/node" "*"
-    "@types/yargs" "^17.0.8"
-    chalk "^4.0.0"
-
-"@jest/types@^29.5.0":
+"@jest/types@^29.2.1", "@jest/types@^29.5.0":
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/@jest/types/-/types-29.5.0.tgz#f59ef9b031ced83047c67032700d8c807d6e1593"
   integrity sha512-qbu7kN6czmVRc3xWFQcAN03RAUamgppVUdXrvl1Wr3jlNF93o9mJbGcDWrwGB6ht44u7efB1qCFgVQmca24Uog==
@@ -3516,13 +3497,12 @@
     os-homedir "^1.0.1"
     regexpu-core "^4.5.4"
 
-"@playwright/test@^1.25.2":
-  version "1.25.2"
-  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.25.2.tgz#e726cf4844f096315c3954fdb3abf295cede43ba"
-  integrity sha512-6qPznIR4Fw02OMbqXUPMG6bFFg1hDVNEdihKy0t9K0dmRbus1DyP5Q5XFQhGwEHQkLG5hrSfBuu9CW/foqhQHQ==
+"@playwright/test@^1.41.2":
+  version "1.41.2"
+  resolved "https://registry.yarnpkg.com/@playwright/test/-/test-1.41.2.tgz#bd9db40177f8fd442e16e14e0389d23751cdfc54"
+  integrity sha512-qQB9h7KbibJzrDpkXkYvsmiDJK14FULCCZgEcoe2AvFAS64oCirWTwzTlAYEbKaRxWs5TFesE1Na6izMv3HfGg==
   dependencies:
-    "@types/node" "*"
-    playwright-core "1.25.2"
+    playwright "1.41.2"
 
 "@polka/url@^1.0.0-next.20":
   version "1.0.0-next.21"
@@ -3636,11 +3616,6 @@
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/@sideway/pinpoint/-/pinpoint-2.0.0.tgz#cff8ffadc372ad29fd3f78277aeb29e632cc70df"
   integrity sha512-RNiOoTPkptFtSVzQevY/yWtZwf/RxyVnPy/OcA9HBM3MlGDnBEYL5B41H0MTn0Uec8Hi+2qUtTfG2WWZBmMejQ==
-
-"@sinclair/typebox@^0.24.1":
-  version "0.24.50"
-  resolved "https://registry.yarnpkg.com/@sinclair/typebox/-/typebox-0.24.50.tgz#35ee4db4ab8f3a8ff56490c51f92445d2776451e"
-  integrity sha512-k8ETQOOQDg5FtK7y9KJWpsGLik+QlPmIi8zzl/dGUgshV2QitprkFlCR/AemjWOTyKn9UwSSGRTzLVotvgCjYQ==
 
 "@sinclair/typebox@^0.25.16":
   version "0.25.24"
@@ -11004,6 +10979,11 @@ fs.realpath@^1.0.0:
   resolved "https://registry.yarnpkg.com/fs.realpath/-/fs.realpath-1.0.0.tgz#1504ad2523158caa40db4a2787cb01411994ea4f"
   integrity sha1-FQStJSMVjKpA20onh8sBQRmU6k8=
 
+fsevents@2.3.2, fsevents@^2.1.2, fsevents@~2.3.1, fsevents@~2.3.2:
+  version "2.3.2"
+  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
+  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
+
 fsevents@^1.2.7:
   version "1.2.13"
   resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-1.2.13.tgz#f325cb0455592428bcf11b383370ef70e3bfcc38"
@@ -11011,11 +10991,6 @@ fsevents@^1.2.7:
   dependencies:
     bindings "^1.5.0"
     nan "^2.12.1"
-
-fsevents@^2.1.2, fsevents@~2.3.1, fsevents@~2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/fsevents/-/fsevents-2.3.2.tgz#8a526f78b8fdf4623b709e0b975c52c24c02fd1a"
-  integrity sha512-xiqMQR4xAeHTuB9uWm+fFRcIOgKBMiOBP+eXiyT7jsgVCq1bkVygt00oASowB7EdtpOHaaPgKt812P9ab+DDKA==
 
 fsevents@~2.1.1:
   version "2.1.3"
@@ -13177,19 +13152,7 @@ jest-util@^26.6.2:
     is-ci "^2.0.0"
     micromatch "^4.0.2"
 
-jest-util@^29.2.1:
-  version "29.2.1"
-  resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.2.1.tgz#f26872ba0dc8cbefaba32c34f98935f6cf5fc747"
-  integrity sha512-P5VWDj25r7kj7kl4pN2rG/RN2c1TLfYYYZYULnS/35nFDjBai+hBeo3MDrYZS7p6IoY3YHZnt2vq4L6mKnLk0g==
-  dependencies:
-    "@jest/types" "^29.2.1"
-    "@types/node" "*"
-    chalk "^4.0.0"
-    ci-info "^3.2.0"
-    graceful-fs "^4.2.9"
-    picomatch "^2.2.3"
-
-jest-util@^29.5.0:
+jest-util@^29.2.1, jest-util@^29.5.0:
   version "29.5.0"
   resolved "https://registry.yarnpkg.com/jest-util/-/jest-util-29.5.0.tgz#24a4d3d92fc39ce90425311b23c27a6e0ef16b8f"
   integrity sha512-RYMgG/MTadOr5t8KdhejfvUU82MxsCu5MF6KuDUHl+NuwzUt+Sm6jJWxTJVrDR1j5M/gJVCPKQEpWXY+yIQ6lQ==
@@ -16814,10 +16777,19 @@ pkg-up@^4.0.0:
   dependencies:
     find-up "^6.2.0"
 
-playwright-core@1.25.2:
-  version "1.25.2"
-  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.25.2.tgz#ea4baa398a4d45fcdfe48799482b599e3d0f033f"
-  integrity sha512-0yTbUE9lIddkEpLHL3u8PoCL+pWiZtj5A/j3U7YoNjcmKKDGBnCrgHJMzwd2J5vy6l28q4ki3JIuz7McLHhl1A==
+playwright-core@1.41.2:
+  version "1.41.2"
+  resolved "https://registry.yarnpkg.com/playwright-core/-/playwright-core-1.41.2.tgz#db22372c708926c697acc261f0ef8406606802d9"
+  integrity sha512-VaTvwCA4Y8kxEe+kfm2+uUUw5Lubf38RxF7FpBxLPmGe5sdNkSg5e3ChEigaGrX7qdqT3pt2m/98LiyvU2x6CA==
+
+playwright@1.41.2:
+  version "1.41.2"
+  resolved "https://registry.yarnpkg.com/playwright/-/playwright-1.41.2.tgz#4e760b1c79f33d9129a8c65cc27953be6dd35042"
+  integrity sha512-v0bOa6H2GJChDL8pAeLa/LZC4feoAMbSQm1/jF/ySsWWoaNItvrMP7GEkvEEFyCTUYKMxjQKaTSg5up7nR6/8A==
+  dependencies:
+    playwright-core "1.41.2"
+  optionalDependencies:
+    fsevents "2.3.2"
 
 please-upgrade-node@^3.2.0:
   version "3.2.0"


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR rewrites all Playwright tests in `fast-foundation` to be async/parallel.

## 👩‍💻 Reviewer Notes

The tests may be slower in this mode, which is why they were initially written to be synchronous. However, the synchronous approach has caused issues regarding cleanup between individual tests, as well as flakiness. The async approach is the recommended way to write Playwright tests.

## 📑 Test Plan

All tests in `fast-foundation` should pass as expected.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

## ⏭ Next Steps

The next step is to migrate all tests to use a standalone harness instead of Storybook. This will improve the performance of each test by reducing page load duration, and will allow us to more comfortably upgrade Storybook for local development.