### PR TITLE
fix(tooltip): an attempt at fixing `aria-describedby`

### DIFF
--- a/change/@microsoft-fast-foundation-8f6fefd1-4aef-456b-9e38-d1a1d98671f0.json
+++ b/change/@microsoft-fast-foundation-8f6fefd1-4aef-456b-9e38-d1a1d98671f0.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(tooltip): fix anchor aria-describedby",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "olaf-k@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2145,10 +2145,12 @@ export class FASTTooltip extends FASTElement {
     // @internal
     anchorElement: Element | null;
     cleanup: () => void;
-    // (undocumented)
+    // @internal (undocumented)
     connectedCallback(): void;
     // @internal
     protected controlledVisibilityChanged(prev: boolean | undefined, next: boolean): void;
+    // @internal (undocumented)
+    disconnectedCallback(): void;
     // @internal
     protected focusinAnchorHandler: () => void;
     // @internal

--- a/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/button/button.pw.spec.ts
@@ -72,7 +72,6 @@ test.describe("Button", () => {
             ariaBusy: "false",
             ariaControls: "testId",
             ariaCurrent: "page",
-            ariaDescribedby: "testId",
             ariaDetails: "testId",
             ariaDisabled: "true",
             ariaErrormessage: "test",

--- a/packages/web-components/fast-foundation/src/button/button.template.ts
+++ b/packages/web-components/fast-foundation/src/button/button.template.ts
@@ -10,6 +10,7 @@ export function buttonTemplate<T extends FASTButton>(
     options: ButtonOptions = {}
 ): ElementViewTemplate<T> {
     return html<T>`
+    <template role="button" aria-describedby="${x => x.ariaDescribedby}">
         <button
             class="control"
             part="control"
@@ -28,7 +29,6 @@ export function buttonTemplate<T extends FASTButton>(
             aria-busy="${x => x.ariaBusy}"
             aria-controls="${x => x.ariaControls}"
             aria-current="${x => x.ariaCurrent}"
-            aria-describedby="${x => x.ariaDescribedby}"
             aria-details="${x => x.ariaDetails}"
             aria-disabled="${x => x.ariaDisabled}"
             aria-errormessage="${x => x.ariaErrormessage}"
@@ -53,5 +53,6 @@ export function buttonTemplate<T extends FASTButton>(
             </span>
             ${endSlotTemplate(options)}
         </button>
+</template>
     `;
 }

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
@@ -166,4 +166,18 @@ test.describe("Tooltip", () => {
             await element.evaluate((node: FASTTooltip) => node.anchorElement?.id)
         ).toBe("new-anchor");
     });
+
+    test('should update the attribute of the anchor element with the id of the tooltip', async () => {
+        await page.goto(fixtureURL("tooltip--tooltip"));
+
+        const anchor = page.locator("#anchor-default");
+
+        const tooltipId = await element.evaluate((node: FASTTooltip) => node.id)
+
+        await expect(anchor).toHaveAttribute("aria-describedby", tooltipId);
+
+        await element.evaluate((node: FASTTooltip) => node.remove())
+
+        await expect(anchor).not.toHaveAttribute("aria-describedby");
+    });
 });

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -284,14 +284,9 @@ export class FASTTooltip extends FASTElement {
             return;
         }
 
-        const anchorElementDescribedBy = this.anchorElement
-            .getAttribute("aria-describedby")
-            ?.concat(" ", this.id)
-            .trim();
-
-        if (anchorElementDescribedBy) {
-            this.anchorElement.setAttribute("aria-describedby", anchorElementDescribedBy);
-        }
+        let anchorElementDescribedBy = this.anchorElement.getAttribute("aria-describedby") || "";
+        anchorElementDescribedBy = anchorElementDescribedBy.concat(" ", this.id).trim();
+        this.anchorElement.setAttribute("aria-describedby", anchorElementDescribedBy);
     }
 
     /**
@@ -315,10 +310,23 @@ export class FASTTooltip extends FASTElement {
         document.addEventListener("keydown", this.keydownDocumentHandler);
     }
 
+    /**
+     * @internal
+     */
     public connectedCallback(): void {
         super.connectedCallback();
         this.anchorChanged(undefined, this.anchor);
     }
+
+    /**
+     * @internal
+     */
+    public disconnectedCallback(): void {
+        super.disconnectedCallback();
+        this.removeListeners();
+        this.removeAnchorAriaDescribedBy(this.id);
+    }
+
 
     /**
      * Hides the tooltip and emits a custom `dismiss` event.


### PR DESCRIPTION
# Pull Request

## 📖 Description

This is an attempt at fixing the following:
1. updating the anchor's `aria-describedby` even when the attribute does not exist in the first place
2. updating the anchor's `aria-describedby` when the tooltip is disconnected
3. removing event handlers when the tooltip is disconnected
4. making screen readers pick up `aria-describedby`

### 🎫 Issues

4 is a fix for #6442 

## 👩‍💻 Reviewer Notes

1 to 3 are straightforward and should not pose any issue hopefully.

to "solve" 4, moving `aria-describedby` to the custom element itself and adding `role="button"` seems to make the tooltip's text content picked up by screen readers.

Caveat:
- [minor] NVDA will indeed read the tooltip's content but will say "button" twice.
- [more annoying] VoiceOver picks up the tooltip's content but... hides it behind a unnecessarily complex UI: 
<img width="603" alt="Screenshot 2024-02-29 at 12 13 38" src="https://github.com/microsoft/fast/assets/1153034/bc451488-6bff-4663-a026-7566acc7ab37">

once you press Control-Option-Command-Slash as instructed, you are presented with a list of additional data:
<img width="616" alt="Screenshot 2024-02-29 at 12 14 38" src="https://github.com/microsoft/fast/assets/1153034/a051d338-f600-4ef2-bddd-a65a4054b6d3">

there is [a Safari ticket](https://bugs.webkit.org/show_bug.cgi?id=262895) that discusses the issue but nothing Fast can do at this point: it is a VO limitation.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
