### PR TITLE
fix(combobox): close the combobox even if there's no selection

### DIFF
--- a/change/@microsoft-fast-foundation-47afe4a7-9451-4c4c-beba-70305e6b600e.json
+++ b/change/@microsoft-fast-foundation-47afe4a7-9451-4c4c-beba-70305e6b600e.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix(combobox): close the combobox even if there's no selection",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "zoepeterson@microsoft.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-47afe4a7-9451-4c4c-beba-70305e6b600e.json
+++ b/change/@microsoft-fast-foundation-47afe4a7-9451-4c4c-beba-70305e6b600e.json
@@ -1,7 +1,7 @@
 {
-  "type": "patch",
+  "type": "prerelease",
   "comment": "fix(combobox): close the combobox even if there's no selection",
   "packageName": "@microsoft/fast-foundation",
   "email": "zoepeterson@microsoft.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.pw.spec.ts
@@ -466,4 +466,58 @@ test.describe("Combobox", () => {
 
         await expect(element).toBeFocused();
     });
+
+    test("should close the listbox when the indicator is clicked", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
+
+        const indicator = element.locator(".indicator");
+
+        await element.evaluate((node: FASTCombobox) => {
+            node.open = true;
+        });
+
+        await expect(element).toHaveAttribute("open");
+
+        await indicator.click();
+
+        await expect(element).not.toHaveAttribute("open");
+    });
+
+    test("should not close the listbox when a disabled option is clicked", async () => {
+        await root.evaluate(node => {
+            node.innerHTML = /* html */ `
+                <fast-combobox>
+                    <fast-option>Option 1</fast-option>
+                    <fast-option disabled>Option 2</fast-option>
+                    <fast-option>Option 3</fast-option>
+                </fast-combobox>
+            `;
+        });
+
+        const options = element.locator("fast-option");
+
+        await element.evaluate((node: FASTCombobox) => {
+            node.open = true;
+        });
+
+        await expect(element).toHaveAttribute("open");
+
+        await options.nth(1).click({
+            force: true,
+        });
+
+        await expect(element).toHaveAttribute("open");
+
+        await options.nth(2).click();
+
+        await expect(element).not.toHaveAttribute("open");
+    });
 });

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -258,6 +258,7 @@ export class FASTCombobox extends FormAssociatedCombobox {
             ) as FASTListboxOption | null;
 
             if (!captured || captured.disabled) {
+                this.open = !this.open;
                 return;
             }
 

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -258,7 +258,7 @@ export class FASTCombobox extends FormAssociatedCombobox {
             ) as FASTListboxOption | null;
 
             if (!captured || captured.disabled) {
-                this.open = !this.open;
+                this.open = false;
                 return;
             }
 

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -248,24 +248,26 @@ export class FASTCombobox extends FormAssociatedCombobox {
      * @internal
      */
     public clickHandler(e: MouseEvent): boolean | void {
-        if (this.disabled) {
+        const captured = (e.target as HTMLElement).closest(
+            `option,[role=option]`
+        ) as FASTListboxOption | null;
+
+        if (this.disabled || captured?.disabled) {
             return;
         }
 
         if (this.open) {
-            const captured = (e.target as HTMLElement).closest(
-                `option,[role=option]`
-            ) as FASTListboxOption | null;
-
-            if (!captured || captured.disabled) {
-                this.open = false;
+            if (e.composedPath()[0] === this.control) {
+                this.open = true;
                 return;
             }
 
-            this.selectedOptions = [captured];
-            this.control.value = captured.text;
-            this.clearSelectionRange();
-            this.updateValue(true);
+            if (captured) {
+                this.selectedOptions = [captured];
+                this.control.value = captured.text;
+                this.clearSelectionRange();
+                this.updateValue(true);
+            }
         }
 
         this.open = !this.open;

--- a/packages/web-components/fast-foundation/src/combobox/combobox.ts
+++ b/packages/web-components/fast-foundation/src/combobox/combobox.ts
@@ -258,7 +258,6 @@ export class FASTCombobox extends FormAssociatedCombobox {
 
         if (this.open) {
             if (e.composedPath()[0] === this.control) {
-                this.open = true;
                 return;
             }
 


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

<!---
Provide some background and a description of your work.
What problem does this change solve?
Is this a breaking change, chore, fix, feature, etc?
-->

Fix issue where the combobox remains open if there's no selection.

<details>

<summary>Before</summary>

![close-combobox-bug](https://github.com/microsoft/fast/assets/48063210/ae0b2faf-a6f0-4e0a-80c6-819a46f94459)

</details>

<details>

<summary>After</summary>

![close-combobox-fixed](https://github.com/microsoft/fast/assets/48063210/775d1a68-d2c3-4a9f-aaf2-e88379bbb68e)

</details>

### 🎫 Issues

https://github.com/microsoft/fast/issues/5721
https://github.com/microsoft/fluentui/issues/30693

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

Test in Storybook and review the before/after GIFs.

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

Tested in Storybook.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)