### PR TITLE
Feat: tooltip anchor can be set with element instance as well as id

### DIFF
--- a/change/@microsoft-fast-foundation-ebbe6f3c-ff1d-4efa-a7db-5e56848e04cc.json
+++ b/change/@microsoft-fast-foundation-ebbe6f3c-ff1d-4efa-a7db-5e56848e04cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "add anchorElement api to tooltip",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "stephcomeau@msn.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-foundation-ebbe6f3c-ff1d-4efa-a7db-5e56848e04cc.json
+++ b/change/@microsoft-fast-foundation-ebbe6f3c-ff1d-4efa-a7db-5e56848e04cc.json
@@ -3,5 +3,5 @@
   "comment": "add anchorElement api to tooltip",
   "packageName": "@microsoft/fast-foundation",
   "email": "stephcomeau@msn.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "prerelease"
 }

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -2139,8 +2139,9 @@ export class FASTTooltip extends FASTElement {
     anchor: string;
     // @internal
     protected anchorChanged(prev: string | undefined, next: string): void;
-    // @internal
     anchorElement: Element | null;
+    // (undocumented)
+    protected anchorElementChanged(prev: Element | null, next: Element | null): void;
     cleanup: () => void;
     // (undocumented)
     connectedCallback(): void;

--- a/packages/web-components/fast-foundation/src/tooltip/README.md
+++ b/packages/web-components/fast-foundation/src/tooltip/README.md
@@ -68,22 +68,24 @@ export const myTooltip = Tooltip.compose({
 
 #### Fields
 
-| Name        | Privacy | Type                   | Default | Description                                                  | Inherited From |
-| ----------- | ------- | ---------------------- | ------- | ------------------------------------------------------------ | -------------- |
-| `anchor`    | public  | `string`               |         | The id of the element the tooltip is anchored to.            |                |
-| `cleanup`   | public  | `() => void`           |         | Cleanup function for the tooltip positioner.                 |                |
-| `id`        | public  | `string`               |         | The tooltip ID attribute.                                    |                |
-| `placement` | public  | `TooltipPlacement`     |         | The placement of the tooltip relative to the anchor element. |                |
-| `show`      | public  | `boolean or undefined` |         | The visibility state of the tooltip.                         |                |
-| `visible`   | public  | `boolean or undefined` |         | Returns the current visibility of the tooltip.               |                |
+| Name            | Privacy | Type                   | Default | Description                                                                                                                                                        | Inherited From |
+| --------------- | ------- | ---------------------- | ------- | ------------------------------------------------------------------------------------------------------------------------------------------------------------------ | -------------- |
+| `anchor`        | public  | `string`               |         | The id of the element the tooltip is anchored to.                                                                                                                  |                |
+| `anchorElement` | public  | `Element or null`      |         | A reference to the anchor element. This can be assigned directly or by setting the \`anchor\` attribute. Setting either will override the previous anchor element. |                |
+| `cleanup`       | public  | `() => void`           |         | Cleanup function for the tooltip positioner.                                                                                                                       |                |
+| `id`            | public  | `string`               |         | The tooltip ID attribute.                                                                                                                                          |                |
+| `placement`     | public  | `TooltipPlacement`     |         | The placement of the tooltip relative to the anchor element.                                                                                                       |                |
+| `show`          | public  | `boolean or undefined` |         | The visibility state of the tooltip.                                                                                                                               |                |
+| `visible`       | public  | `boolean or undefined` |         | Returns the current visibility of the tooltip.                                                                                                                     |                |
 
 #### Methods
 
-| Name             | Privacy | Description                | Parameters                                               | Return | Inherited From |
-| ---------------- | ------- | -------------------------- | -------------------------------------------------------- | ------ | -------------- |
-| `idChanged`      | public  |                            | `prev: string, next: string`                             | `void` |                |
-| `showChanged`    | public  |                            | `prev: boolean or undefined, next: boolean or undefined` | `void` |                |
-| `setPositioning` | public  | Sets the tooltip position. |                                                          | `void` |                |
+| Name                   | Privacy   | Description                | Parameters                                               | Return | Inherited From |
+| ---------------------- | --------- | -------------------------- | -------------------------------------------------------- | ------ | -------------- |
+| `anchorElementChanged` | protected |                            | `prev: Element or null, next: Element or null`           | `void` |                |
+| `idChanged`            | public    |                            | `prev: string, next: string`                             | `void` |                |
+| `showChanged`          | public    |                            | `prev: boolean or undefined, next: boolean or undefined` | `void` |                |
+| `setPositioning`       | public    | Sets the tooltip position. |                                                          | `void` |                |
 
 #### Events
 

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
@@ -147,7 +147,7 @@ test.describe("Tooltip", () => {
     test("should change anchor element when the `anchor` attribute changes", async () => {
         await page.goto(fixtureURL("tooltip--tooltip"));
 
-        await root.evaluate(node => {
+        await root.evaluate((node: FASTTooltip) => {
             const newAnchor = document.createElement("div");
             newAnchor.id = "new-anchor";
 
@@ -158,12 +158,49 @@ test.describe("Tooltip", () => {
             await element.evaluate((node: FASTTooltip) => node.anchorElement?.id)
         ).toBe("anchor-default");
 
-        await element.evaluate(node => {
+        await element.evaluate((node: FASTTooltip) => {
             node.setAttribute("anchor", "new-anchor");
         });
 
         expect(
             await element.evaluate((node: FASTTooltip) => node.anchorElement?.id)
         ).toBe("new-anchor");
+    });
+
+    test("should change anchor element when the `anchorElement` property changes", async () => {
+        await root.evaluate((node: HTMLElement) => {
+            node.innerHTML = /* html */ `
+            <fast-tooltip anchor="anchor-default">
+                Tooltip
+            </fast-tooltip>
+            <fast-button id="anchor-default">
+                Hover or focus me
+            </fast-button>
+            <fast-button id="anchor-new">
+                Hover or focus me
+            </fast-button>
+        `;
+        });
+
+        expect(
+            await element.evaluate((node: FASTTooltip) => node.anchorElement?.id)
+        ).toBe("anchor-default");
+
+        await element.evaluate((node: FASTTooltip) => {
+            const newAnchor = document.getElementById("anchor-new");
+            node.anchorElement = newAnchor;
+        });
+
+        const anchor = page.locator("#anchor-new");
+
+        await expect(element).toHaveJSProperty("visible", false);
+
+        await expect(element).toBeHidden();
+
+        await anchor.focus();
+
+        await expect(element).toHaveJSProperty("visible", true);
+
+        await expect(element).toBeVisible();
     });
 });


### PR DESCRIPTION
The anchor element used by tooltip can currently only be set via an anchor reference.  This is limiting particularly in cross shadow dom scenarios.  This change exposes `anchorElement` as a public api where developers can set the tooltip anchor programmatically by passing an element instance.

### 🎫 Issues
ad hoc

## 📑 Test Plan
Added a basic swapping test

## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)
