### PR TITLE
Update vite integration instructions with proper tsconfig include

### DIFF
--- a/sites/website/versioned_docs/version-legacy/integrations/vite.md
+++ b/sites/website/versioned_docs/version-legacy/integrations/vite.md
@@ -60,7 +60,7 @@ In the root of your project folder, you will see a `tsconfig.js` file.  Replace 
     "forceConsistentCasingInFileNames": true,
     "useDefineForClassFields": false
   },
-  "include": ["src/*/.ts"]
+  "include": ["src/**/*.ts"]
 }
 ```
 


### PR DESCRIPTION
This is a simple documentation update.

The current tsconfig provided in the docs does not work at all. This updates the docs to include any ts file within the `src` directory.