### PR TITLE
fix: prevent toolbar from stealing focus when focus has already been moved

### DIFF
--- a/change/@microsoft-fast-foundation-452bb1d9-58ef-4cb0-a6fa-0ed41d1ad057.json
+++ b/change/@microsoft-fast-foundation-452bb1d9-58ef-4cb0-a6fa-0ed41d1ad057.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: prevent toolbar from stealing focus when focus has already been moved in the document",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "=",
+  "dependentChangeType": "patch"
+}

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
@@ -9,6 +9,7 @@ import { ARIAGlobalStatesAndProperties } from "../patterns/aria-global.js";
 import { StartEnd, StartEndOptions } from "../patterns/start-end.js";
 import { applyMixins } from "../utilities/apply-mixins.js";
 import { getDirection } from "../utilities/direction.js";
+import { getRootActiveElement } from "../utilities/root-active-element.js";
 
 /**
  * Toolbar configuration options
@@ -241,9 +242,8 @@ export class Toolbar extends FoundationElement {
 
         // If the previously active item is still focusable, adjust the active index to the
         // index of that item.
-        const adjustedActiveIndex = this.focusableElements.indexOf(
-            previousFocusedElement
-        );
+        const adjustedActiveIndex =
+            this.focusableElements.indexOf(previousFocusedElement);
         this.activeIndex = Math.max(0, adjustedActiveIndex);
 
         this.setFocusableElements();
@@ -258,7 +258,14 @@ export class Toolbar extends FoundationElement {
     private setFocusedElement(activeIndex: number = this.activeIndex): void {
         this.activeIndex = activeIndex;
         this.setFocusableElements();
-        this.focusableElements[this.activeIndex]?.focus();
+        if (
+            this.focusableElements[this.activeIndex] &&
+            // Don't focus the toolbar element if some event handlers moved
+            // the focus on another element in the page.
+            this.contains(getRootActiveElement(this))
+        ) {
+            this.focusableElements[this.activeIndex].focus();
+        }
     }
 
     /**

--- a/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
+++ b/packages/web-components/fast-foundation/src/toolbar/toolbar.ts
@@ -242,8 +242,9 @@ export class Toolbar extends FoundationElement {
 
         // If the previously active item is still focusable, adjust the active index to the
         // index of that item.
-        const adjustedActiveIndex =
-            this.focusableElements.indexOf(previousFocusedElement);
+        const adjustedActiveIndex = this.focusableElements.indexOf(
+            previousFocusedElement
+        );
         this.activeIndex = Math.max(0, adjustedActiveIndex);
 
         this.setFocusableElements();

--- a/packages/web-components/fast-foundation/src/utilities/root-active-element.ts
+++ b/packages/web-components/fast-foundation/src/utilities/root-active-element.ts
@@ -1,0 +1,10 @@
+// returns the active element in the shadow context of the element in question.
+export function getRootActiveElement(element: Element): Element | null {
+    const rootNode = element.getRootNode();
+
+    if (rootNode instanceof ShadowRoot) {
+        return rootNode.activeElement;
+    }
+
+    return document.activeElement;
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description
Essentially a cherry-pick of #6888 into archives/fast-element

### 🎫 Issues

<!---
* List and link relevant issues here.
-->

## 👩‍💻 Reviewer Notes

<!---
Provide some notes for reviewers to help them provide targeted feedback and testing.

Do you recommend a smoke test for this PR? What steps should be followed?
Are there particular areas of the code the reviewer should focus on?
-->

## 📑 Test Plan

<!---
Please provide a summary of the tests affected by this work and any unique strategies employed in testing the features/fixes.
-->

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific

<!--- Review the list and put an x in the boxes that apply. -->
<!--- Remove this section if not applicable. -->

- [ ] I have added a new component
- [ ] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)

## ⏭ Next Steps

<!---
If there is relevant follow-up work to this PR, please list any existing issues or provide brief descriptions of what you would like to do next.
-->