### PR TITLE
Feat: avoid multiple tooltips showing up simultaneously

### DIFF
--- a/change/@microsoft-fast-foundation-4786c45d-89df-454b-b082-2f8c29e0e84d.json
+++ b/change/@microsoft-fast-foundation-4786c45d-89df-454b-b082-2f8c29e0e84d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "improve tooltip show/hide behavior",
+  "packageName": "@microsoft/fast-foundation",
+  "email": "scomeau@qti.qualcomm.com",
+  "dependentChangeType": "prerelease"
+}

--- a/packages/web-components/fast-foundation/docs/api-report.md
+++ b/packages/web-components/fast-foundation/docs/api-report.md
@@ -635,7 +635,10 @@ export function display(displayValue: CSSDisplayPropertyValue): string;
 
 // @public
 export const DividerOrientation: {
-    readonly horizontal: "horizontal";
+    readonly horizontal: "horizontal"; /**
+    * Divider roles
+    * @public
+    */
     readonly vertical: "vertical";
 };
 
@@ -2146,6 +2149,12 @@ export class FASTTooltip extends FASTElement {
     connectedCallback(): void;
     // @internal
     protected controlledVisibilityChanged(prev: boolean | undefined, next: boolean): void;
+    // (undocumented)
+    disconnectedCallback(): void;
+    // @internal
+    protected documentFocusoutHandler: () => void;
+    // @internal
+    protected documentMouseMoveHandler: () => void;
     // @internal
     protected focusinAnchorHandler: () => void;
     // @internal
@@ -2590,7 +2599,10 @@ export type RadioControl = Pick<HTMLInputElement, "checked" | "disabled" | "focu
 
 // @public
 export const RadioGroupOrientation: {
-    readonly horizontal: "horizontal";
+    readonly horizontal: "horizontal"; /**
+    * Radio Group orientation
+    * @public
+    */
     readonly vertical: "vertical";
 };
 

--- a/packages/web-components/fast-foundation/src/tooltip/stories/tooltip.stories.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/stories/tooltip.stories.ts
@@ -59,3 +59,14 @@ TooltipPlacements.args = {
     })),
 };
 TooltipPlacements.parameters = { controls: { include: [] } };
+
+export const TooltipMultiple: Story<FASTTooltip> = renderComponent(
+    html<StoryArgs<FASTTooltip>>`
+        <fast-button id="button1">Button 1</fast-button>
+        <fast-button id="button2">Button 2</fast-button>
+        <fast-tooltip anchor="button1">Tooltip 1</fast-tooltip>
+        <fast-tooltip anchor="button2">Tooltip 2</fast-tooltip>
+    `
+).bind({});
+TooltipMultiple.args = {};
+TooltipMultiple.parameters = { controls: { include: [] } };

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
@@ -166,4 +166,69 @@ test.describe("Tooltip", () => {
             await element.evaluate((node: FASTTooltip) => node.anchorElement?.id)
         ).toBe("new-anchor");
     });
+
+    test("should hide a focus driven tooltip when the mouse is moved", async () => {
+        await root.evaluate((node: HTMLElement) => {
+            node.innerHTML = /* html */ `
+                <fast-tooltip anchor="anchor-default">
+                    Tooltip
+                </fast-tooltip>
+                <fast-button id="anchor-default">
+                    Hover or focus me
+                </fast-button>
+            `;
+        });
+
+        const anchor = page.locator("#anchor-default");
+
+        await expect(element).toHaveJSProperty("visible", false);
+
+        await expect(element).toBeHidden();
+
+        await anchor.focus();
+
+        await expect(element).toHaveJSProperty("visible", true);
+
+        await expect(element).toBeVisible();
+
+        await page.mouse.move(10, 10);
+
+        await expect(element).toBeHidden();
+    });
+
+    test("should hide a hover driven tooltip when focus moves in the document", async () => {
+        await root.evaluate((node: HTMLElement) => {
+            node.innerHTML = /* html */ `
+                <fast-tooltip anchor="anchor-default">
+                    Tooltip
+                </fast-tooltip>
+                <fast-button id="anchor-default">
+                    Hover or focus me
+                </fast-button>
+                <fast-button id="button1">
+                    Hover or focus me
+                </fast-button>
+                <fast-button id="button2">
+                    Hover or focus me
+                </fast-button>
+            `;
+        });
+
+        const anchor = page.locator("#anchor-default");
+        const button1 = page.locator("#button1");
+        const button2 = page.locator("#button2");
+
+        await expect(element).toHaveJSProperty("visible", false);
+
+        await expect(element).toBeHidden();
+
+        await button1.focus();
+        await anchor.hover();
+
+        await expect(element).toHaveJSProperty("visible", true);
+        await expect(element).toBeVisible();
+
+        await button2.focus();
+        await expect(element).toBeHidden();
+    });
 });

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.pw.spec.ts
@@ -167,68 +167,76 @@ test.describe("Tooltip", () => {
         ).toBe("new-anchor");
     });
 
-    test("should hide a focus driven tooltip when the mouse is moved", async () => {
+    test("should hide a focus driven tooltip when another tooltip is hovered", async () => {
         await root.evaluate((node: HTMLElement) => {
             node.innerHTML = /* html */ `
-                <fast-tooltip anchor="anchor-default">
+                <fast-tooltip anchor="anchor-default" id="tooltip-default">
+                    Tooltip
+                </fast-tooltip>
+                <fast-tooltip anchor="anchor-hover" id="tooltip-hover">
                     Tooltip
                 </fast-tooltip>
                 <fast-button id="anchor-default">
-                    Hover or focus me
+                    Focus me
+                </fast-button>
+                <fast-button id="anchor-hover">
+                    Hover me
                 </fast-button>
             `;
         });
 
-        const anchor = page.locator("#anchor-default");
+        const anchorDefault = page.locator("#anchor-default");
+        const anchorHover = page.locator("#anchor-hover");
+        const tooltipDefault = page.locator("#tooltip-default");
 
-        await expect(element).toHaveJSProperty("visible", false);
+        await expect(tooltipDefault).toHaveJSProperty("visible", false);
 
-        await expect(element).toBeHidden();
+        await expect(tooltipDefault).toBeHidden();
 
-        await anchor.focus();
+        await anchorDefault.focus();
 
-        await expect(element).toHaveJSProperty("visible", true);
+        await expect(tooltipDefault).toHaveJSProperty("visible", true);
 
-        await expect(element).toBeVisible();
+        await expect(tooltipDefault).toBeVisible();
 
-        await page.mouse.move(10, 10);
+        await anchorHover.hover();
 
-        await expect(element).toBeHidden();
+        await expect(tooltipDefault).toBeHidden();
     });
 
     test("should hide a hover driven tooltip when focus moves in the document", async () => {
         await root.evaluate((node: HTMLElement) => {
             node.innerHTML = /* html */ `
-                <fast-tooltip anchor="anchor-default">
+                <fast-tooltip anchor="anchor-default" id="tooltip-default">
+                    Tooltip
+                </fast-tooltip>
+                <fast-tooltip anchor="anchor-focus" id="tooltip-focus">
                     Tooltip
                 </fast-tooltip>
                 <fast-button id="anchor-default">
                     Hover or focus me
                 </fast-button>
-                <fast-button id="button1">
-                    Hover or focus me
-                </fast-button>
-                <fast-button id="button2">
+                <fast-button id="anchor-focus">
                     Hover or focus me
                 </fast-button>
             `;
         });
 
-        const anchor = page.locator("#anchor-default");
-        const button1 = page.locator("#button1");
-        const button2 = page.locator("#button2");
+        const anchorDefault = page.locator("#anchor-default");
+        const anchorFocus = page.locator("#anchor-focus");
+        const tooltipDefault = page.locator("#tooltip-default");
 
-        await expect(element).toHaveJSProperty("visible", false);
+        await expect(tooltipDefault).toHaveJSProperty("visible", false);
 
-        await expect(element).toBeHidden();
+        await expect(tooltipDefault).toBeHidden();
 
-        await button1.focus();
-        await anchor.hover();
+        await anchorDefault.hover();
 
-        await expect(element).toHaveJSProperty("visible", true);
-        await expect(element).toBeVisible();
+        await expect(tooltipDefault).toHaveJSProperty("visible", true);
+        await expect(tooltipDefault).toBeVisible();
 
-        await button2.focus();
-        await expect(element).toBeHidden();
+        await anchorFocus.focus();
+        await expect(tooltipDefault).toHaveJSProperty("visible", false);
+        await expect(tooltipDefault).toBeHidden();
     });
 });

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -484,7 +484,7 @@ export class FASTTooltip extends FASTElement {
         if (this._visible) {
             if (!this.controlledVisibility) {
                 document.removeEventListener("mousemove", this.documentMouseMoveHandler);
-                document.removeEventListener("focusin", this.documentFocusoutHandler);
+                document.removeEventListener("focusout", this.documentFocusoutHandler);
                 document.removeEventListener("keydown", this.keydownDocumentHandler);
             }
             this._visible = false;

--- a/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
+++ b/packages/web-components/fast-foundation/src/tooltip/tooltip.ts
@@ -144,7 +144,6 @@ export class FASTTooltip extends FASTElement {
      */
     protected documentMouseMoveHandler = (): void => {
         // focus generated tooltips are hidden when mouse moves
-        console.debug("mouse");
         if (!this.isHovered) {
             this.hideTooltip();
         }
@@ -156,7 +155,6 @@ export class FASTTooltip extends FASTElement {
      * @internal
      */
     protected documentFocusoutHandler = (): void => {
-        console.debug("focusout");
         // hover generated tooltips are hidden when focus moves
         if (getRootActiveElement(this) !== this.anchorElement) {
             this.hideTooltip();
@@ -468,9 +466,11 @@ export class FASTTooltip extends FASTElement {
     private showTooltip(): void {
         if (!this._visible) {
             this._visible = true;
-            document.addEventListener("mousemove", this.documentMouseMoveHandler);
-            document.addEventListener("focusout", this.documentFocusoutHandler);
-            document.addEventListener("keydown", this.keydownDocumentHandler);
+            if (!this.controlledVisibility) {
+                document.addEventListener("mousemove", this.documentMouseMoveHandler);
+                document.addEventListener("focusout", this.documentFocusoutHandler);
+                document.addEventListener("keydown", this.keydownDocumentHandler);
+            }
             Updates.enqueue(() => this.setPositioning());
         }
     }
@@ -482,9 +482,11 @@ export class FASTTooltip extends FASTElement {
      */
     public hideTooltip(): void {
         if (this._visible) {
-            document.removeEventListener("mousemove", this.documentMouseMoveHandler);
-            document.removeEventListener("focusin", this.documentFocusoutHandler);
-            document.removeEventListener("keydown", this.keydownDocumentHandler);
+            if (!this.controlledVisibility) {
+                document.removeEventListener("mousemove", this.documentMouseMoveHandler);
+                document.removeEventListener("focusin", this.documentFocusoutHandler);
+                document.removeEventListener("keydown", this.keydownDocumentHandler);
+            }
             this._visible = false;
             this.cleanup?.();
         }


### PR DESCRIPTION
## 📖 Description
The current tooltip behavior can show multiple tooltips at the same time, most commonly a tooltip that shows because an element has been focused remains visible when another element is hovered. Or a hovered tooltip remains visible as the user tabs to other controls.

After this change an active tooltip monitors mouse movement and focus changes as the document level so a hover driven tooltip is dismissed when another element is focused, and a focus driven tooltip is dismissed when the mouse moves. 

Also ensured we removed listeners on disconnect.

### 🎫 Issues

Multiple user focus driven tooltips can show up simultaneously and could easily overlap:

![image](https://github.com/microsoft/fast/assets/7649425/2d726aef-0625-4425-a886-0447840f0ad2)


## ✅ Checklist

### General
- [x] I have included a change request file using `$ yarn change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.

### Component-specific
- [ ] I have added a new component
- [x] I have modified an existing component
- [ ] I have updated the [definition file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#definition)
- [ ] I have updated the [configuration file](https://github.com/microsoft/fast/blob/master/packages/web-components/fast-components/CONTRIBUTING.md#configuration)