### PR TITLE
Fix/React wrapper props fix

### DIFF
--- a/change/@microsoft-fast-react-wrapper-716de08b-9195-4a1b-8b6e-4fcf0114019e.json
+++ b/change/@microsoft-fast-react-wrapper-716de08b-9195-4a1b-8b6e-4fcf0114019e.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "change object passed to React.createElement function to include newElementProps",
+  "packageName": "@microsoft/fast-react-wrapper",
+  "email": "benjamin.ragsdale@thomsonreuters.com",
+  "dependentChangeType": "patch"
+}

--- a/packages/utilities/fast-react-wrapper/src/index.ts
+++ b/packages/utilities/fast-react-wrapper/src/index.ts
@@ -309,7 +309,10 @@ export function reactWrapper(
                     }
                 }
 
-                return React.createElement(name, newReactProps);
+                return React.createElement(name, {
+                    ...newReactProps,
+                    ...newElementProps,
+                });
             }
         }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

The current `React.createElement` function takes as an parameter the object `newReactProps` to pass props to the created React component. But we have noticed that some props are not being passed to our React components. When I tested this, I noticed these attributes were not getting passed to `newElementProps` object but not the `newReactProps`. 
		
This fix changes the second parameter passed in `React.createElement` to an object that includes both objects, spread. 
After making this fix, all attributes passed from our web components to their React counterparts.

This is my first attempt at contributing and I realize this change may have performance or other implications. I'm not sure this is the correct fix, but it does solve this issue for us. I'd be happy to test performance or anything else with a bit of guidance from your team. 

### 🎫 Issues

#6826

## 👩‍💻 Reviewer Notes

Please let me know if there's anything more you need from me or if there's something you think I'm missing.

## 📑 Test Plan

I ran Lerna tests (and noted this below in the checkbox for tests)
I'd like to test the performance implicaitons of this, but I'm not sure how to do that

## ✅ Checklist

### General

- [x] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](/docs/community/code-of-conduct/#our-standards) for this project.
