### PR TITLE
Allow PR validate workflow to manually be dispatched

### DIFF
--- a/.github/workflows/ci-validate-pr.yml
+++ b/.github/workflows/ci-validate-pr.yml
@@ -1,6 +1,7 @@
 name: Validate PRs
 
 on:
+  workflow_dispatch:
   push:
     branches:
     - master


### PR DESCRIPTION
# Pull Request

## 📖 Description

Allow the PR validate step to be manually dispatched. This will be helpful for testing against any branch prior to opening a PR.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.