### PR TITLE
Added tokens for github pages workflow

### DIFF
--- a/.github/workflows/cd-gh-pages.yml
+++ b/.github/workflows/cd-gh-pages.yml
@@ -3,6 +3,10 @@ name: Deploy GitHub Pages
 on:
   workflow_dispatch:
 
+env:
+  GITHUB_SERVICE_USER: "Microsoft FAST Builds"
+  GITHUB_SERVICE_EMAIL: "fastsvc@microsoft.com"
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -14,6 +18,12 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
+        token: ${{ secrets.GH_TOKEN }}
+
+    - name: Set Git User
+      run: |
+        git config --global user.name "${{ env.GITHUB_SERVICE_USER }}"
+        git config --global user.email "${{ env.GITHUB_SERVICE_EMAIL }}"
 
     - name: Get yarn cache directory path
       id: yarn-cache-dir-path


### PR DESCRIPTION
# Pull Request

## 📖 Description

The repository does not have permissions to add commits to a branch on GitHub, this adds to the github pages deploy workflow the same tokens used for npm package publishing which must perform a similar action and so should work.

## 👩‍💻 Reviewer Notes

Initial attempt at manually running the workflow ended in a `403`, in theory this change should grant the permissions needed to apply commits to the `gh-pages` branch.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ yarn change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.