### PR TITLE
Add GH token to deploy step, additional permissions and settings for the deployed branch

### DIFF
--- a/.github/workflows/cd-gh-pages.yml
+++ b/.github/workflows/cd-gh-pages.yml
@@ -7,6 +7,9 @@ env:
   GITHUB_SERVICE_USER: "Microsoft FAST Builds"
   GITHUB_SERVICE_EMAIL: "fastsvc@microsoft.com"
 
+permissions:
+  contents: write
+
 jobs:
   build:
     runs-on: ubuntu-latest
@@ -18,7 +21,6 @@ jobs:
     - uses: actions/checkout@v2
       with:
         fetch-depth: 0
-        token: ${{ secrets.GH_TOKEN }}
 
     - name: Set Git User
       run: |
@@ -53,6 +55,9 @@ jobs:
     - name: Deploy GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:
+        token: ${{ secrets.GH_TOKEN }}
         branch: gh-pages # The branch the action should deploy to.
         folder: sites/website/build # The folder the action should deploy.
         target-folder: docs # The folder on the branch to deploy to.
+        clean: true # Remove old files to clean up unique hash files.
+        single-commit: true # Only use a single commit to keep the branch free from git history.


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change simplifies the `gh-pages` branch to a single commit once the action is run, it also adds in write permissions and assigns a secret token on the deploy step.

## 👩‍💻 Reviewer Notes

Still running into permissions issues, this is a bit of a catch all to see if moving the token will change the `403`.