### PR TITLE
Remove the component libraries doc which is empty

### DIFF
--- a/sites/website/sidebars.js
+++ b/sites/website/sidebars.js
@@ -41,7 +41,6 @@ module.exports = {
             },
             items: [
                 "advanced/working-with-custom-elements",
-                "advanced/component-libraries",
                 "advanced/dependency-injection",
             ],
         },

--- a/sites/website/src/docs/advanced/component-libraries.md
+++ b/sites/website/src/docs/advanced/component-libraries.md
@@ -1,9 +1,0 @@
----
-id: component-libraries
-title: Component Libraries
-sidebar_label: Component Libraries
-keywords:
-    - component libraries
----
-
-// TODO


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change removes the component library document. This will be written in the future, but we will go without it pre-launch of fast element 2.0.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.