### PR TITLE
Fix documentation site contrast ratios and link text underline in articles

### DIFF
--- a/sites/website/src/css/custom.css
+++ b/sites/website/src/css/custom.css
@@ -171,6 +171,7 @@ html[data-theme="dark"] .DocSearch-Hit[aria-selected="true"] a mark {
     --base-layer-luminance: 0.09;
     --wrapper-gutter: 20px;
     --wrapper-max-width: 8px;
+    --ifm-link-color: #fb2360;
     background-color: var(--fill-color);
     color: var(--neutral-foreground-rest);
     font-family: var(--body-font);
@@ -303,6 +304,31 @@ li {
 [role="banner"] code {
     background-color: rgba(0, 0, 0, 0.1);
     border: 0.1rem solid rgba(255, 255, 255, 0.1);
+}
+
+/**
+ * Color contrast overrides
+ */
+
+article {
+    --ifm-link-decoration: underline;
+}
+
+.navbar__link--active {
+    --ifm-link-color: #ff4ca3;
+}
+
+.menu__link--active,
+.breadcrumbs__link[itemprop="name"] {
+    --ifm-link-color: #ff4088;
+}
+
+a code {
+    --ifm-link-color: #ff5ac4;
+}
+
+html[data-theme="dark"] {
+    --ifm-table-stripe-background: #202021;
 }
 
 @media screen and (min-width: 900px) {


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change modifies some small color updates for the documentation site to meet accessibility compliance with link contrast ratios and text-decoration.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.