### PR TITLE
Add search-bar powered by local search index

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -3749,24 +3749,69 @@
       }
     },
     "node_modules/@floating-ui/dom": {
-      "version": "1.6.6",
-      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.6.tgz",
-      "integrity": "sha512-qiTYajAnh3P+38kECeffMSQgbvXty2VB6rS+42iWR4FPIlZjLK84E9qtLnMTLIpPz2znD/TaFqaiavMUrS+Hcw==",
+      "version": "1.6.11",
+      "resolved": "https://registry.npmjs.org/@floating-ui/dom/-/dom-1.6.11.tgz",
+      "integrity": "sha512-qkMCxSR24v2vGkhYDo/UzxfJN3D4syqSjyuTFz6C7XcpU1pASPRieNI0Kj5VP3/503mOfYiGY891ugBX1GlABQ==",
       "dependencies": {
-        "@floating-ui/core": "^1.0.0",
-        "@floating-ui/utils": "^0.2.3"
+        "@floating-ui/core": "^1.6.0",
+        "@floating-ui/utils": "^0.2.8"
       }
     },
     "node_modules/@floating-ui/utils": {
-      "version": "0.2.3",
-      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.3.tgz",
-      "integrity": "sha512-XGndio0l5/Gvd6CLIABvsav9HHezgDFFhDfHk1bvLfr9ni8dojqLSvBbotJEjmIwNHL7vK4QzBJTdBRoB+c1ww=="
+      "version": "0.2.8",
+      "resolved": "https://registry.npmjs.org/@floating-ui/utils/-/utils-0.2.8.tgz",
+      "integrity": "sha512-kym7SodPp8/wloecOpcmSnWJsK7M0E5Wg8UcFA+uO4B9s5d0ywXOEro/8HM9x0rW+TljRzul/14UYz3TleT3ig=="
     },
     "node_modules/@gar/promisify": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/@gar/promisify/-/promisify-1.1.3.tgz",
       "integrity": "sha512-k2Ty1JcVojjJFwrg/ThKi2ujJ7XNLYaFGNB/bWT9wGR+oSMJHMa5w+CUq6p/pVrKeNNgA7pCqEcjSnHVoqJQFw==",
       "dev": true
+    },
+    "node_modules/@getcanary/docusaurus-theme-search-pagefind": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@getcanary/docusaurus-theme-search-pagefind/-/docusaurus-theme-search-pagefind-1.0.2.tgz",
+      "integrity": "sha512-DNXfzBJ8ooJdWvEjI+63Al6ywUmpaDFxJBIyDX+Lh95+0wEocpzfaFfDMP/5YVRYm8ZRCUAQwSZgKsRCQ5Ar7Q==",
+      "dependencies": {
+        "@getcanary/web": "^1.0.0",
+        "cli-progress": "^3.12.0",
+        "micromatch": "^4.0.7",
+        "pagefind": "^1.1.0"
+      },
+      "peerDependencies": {
+        "@docusaurus/core": "^2.0.0 || ^3.0.0",
+        "@getcanary/web": "^1.0.0",
+        "react": "^17 || ^18",
+        "react-dom": "^17 || ^18"
+      }
+    },
+    "node_modules/@getcanary/web": {
+      "version": "1.0.8",
+      "resolved": "https://registry.npmjs.org/@getcanary/web/-/web-1.0.8.tgz",
+      "integrity": "sha512-ZGx+mlRaWu/0tCP/ZxYYFahyooWIj1HIwxsV8We12uGeyf5+YxZKwdYpvJj+M24/dsOdcGOtrepOKJHNuLM48g==",
+      "dependencies": {
+        "@floating-ui/dom": "^1.6.8",
+        "@lit-labs/observers": "^2.0.2",
+        "@lit/context": "^1.1.2",
+        "@lit/task": "^1.0.1",
+        "@xstate/store": "^2.5.0",
+        "best-effort-json-parser": "^1.1.2",
+        "lit": "^3.1.4",
+        "marked": "^14.0.0",
+        "picomatch": "^4.0.2",
+        "prismjs": "^1.29.0"
+      }
+    },
+    "node_modules/@getcanary/web/node_modules/picomatch": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/picomatch/-/picomatch-4.0.2.tgz",
+      "integrity": "sha512-M7BAV6Rlcy5u+m6oPhAPFgJTzAioX/6B0DxyvDlo9l8+T3nLKbrczg2WLUyzd45L8RqfUMyGPzekbMvX2Ldkwg==",
+      "engines": {
+        "node": ">=12"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/jonschlinkert"
+      }
     },
     "node_modules/@hapi/bourne": {
       "version": "3.0.0",
@@ -4056,6 +4101,44 @@
       "version": "2.0.5",
       "resolved": "https://registry.npmjs.org/@leichtgewicht/ip-codec/-/ip-codec-2.0.5.tgz",
       "integrity": "sha512-Vo+PSpZG2/fmgmiNzYK9qWRh8h/CHrwD0mo1h1DzL4yzHNSfWYujGTYsWGreD000gcgmZ7K4Ys6Tx9TxtsKdDw=="
+    },
+    "node_modules/@lit-labs/observers": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit-labs/observers/-/observers-2.0.4.tgz",
+      "integrity": "sha512-x95jhDPGb+HtYU3hEdqkcLxb6v2JBP3tcajaiOijs1F/ZmOgRT0pRPn0v+jhhk8mAAbEO12SZJjPCmuysunssQ==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/@lit-labs/ssr-dom-shim": {
+      "version": "1.2.1",
+      "resolved": "https://registry.npmjs.org/@lit-labs/ssr-dom-shim/-/ssr-dom-shim-1.2.1.tgz",
+      "integrity": "sha512-wx4aBmgeGvFmOKucFKY+8VFJSYZxs9poN3SDNQFF6lT6NrQUnHiPB2PWz2sc4ieEcAaYYzN+1uWahEeTq2aRIQ=="
+    },
+    "node_modules/@lit/context": {
+      "version": "1.1.3",
+      "resolved": "https://registry.npmjs.org/@lit/context/-/context-1.1.3.tgz",
+      "integrity": "sha512-Auh37F4S0PZM93HTDfZWs97mmzaQ7M3vnTc9YvxAGyP3UItSK/8Fs0vTOGT+njuvOwbKio/l8Cx/zWL4vkutpQ==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.6.2 || ^2.0.0"
+      }
+    },
+    "node_modules/@lit/reactive-element": {
+      "version": "2.0.4",
+      "resolved": "https://registry.npmjs.org/@lit/reactive-element/-/reactive-element-2.0.4.tgz",
+      "integrity": "sha512-GFn91inaUa2oHLak8awSIigYz0cU0Payr1rcFsrkf5OJ5eSPxElyZfKh0f2p9FsTiZWXQdWGJeXZICEfXXYSXQ==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0"
+      }
+    },
+    "node_modules/@lit/task": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/@lit/task/-/task-1.0.1.tgz",
+      "integrity": "sha512-fVLDtmwCau8NywnFIXaJxsCZjzaIxnVq+cFRKYC1Y4tA4/0rMTvF6DLZZ2JE51BwzOluaKtgJX8x1QDsQtAaIw==",
+      "dependencies": {
+        "@lit/reactive-element": "^1.0.0 || ^2.0.0"
+      }
     },
     "node_modules/@mdx-js/mdx": {
       "version": "3.0.1",
@@ -4652,6 +4735,66 @@
       "dependencies": {
         "@octokit/openapi-types": "^12.11.0"
       }
+    },
+    "node_modules/@pagefind/darwin-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-arm64/-/darwin-arm64-1.1.1.tgz",
+      "integrity": "sha512-tZ9tysUmQpFs2EqWG2+E1gc+opDAhSyZSsgKmFzhnWfkK02YHZhvL5XJXEZDqYy3s1FAKhwjTg8XDxneuBlDZQ==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/darwin-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/darwin-x64/-/darwin-x64-1.1.1.tgz",
+      "integrity": "sha512-ChohLQ39dLwaxQv0jIQB/SavP3TM5K5ENfDTqIdzLkmfs3+JlzSDyQKcJFjTHYcCzQOZVeieeGq8PdqvLJxJxQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "darwin"
+      ]
+    },
+    "node_modules/@pagefind/linux-arm64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-arm64/-/linux-arm64-1.1.1.tgz",
+      "integrity": "sha512-H5P6wDoCoAbdsWp0Zx0DxnLUrwTGWGLu/VI1rcN2CyFdY2EGSvPQsbGBMrseKRNuIrJDFtxHHHyjZ7UbzaM9EA==",
+      "cpu": [
+        "arm64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/linux-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/linux-x64/-/linux-x64-1.1.1.tgz",
+      "integrity": "sha512-yJs7tTYbL2MI3HT+ngs9E1BfUbY9M4/YzA0yEM5xBo4Xl8Yu8Qg2xZTOQ1/F6gwvMrjCUFo8EoACs6LRDhtMrQ==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "linux"
+      ]
+    },
+    "node_modules/@pagefind/windows-x64": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/@pagefind/windows-x64/-/windows-x64-1.1.1.tgz",
+      "integrity": "sha512-b7/qPqgIl+lMzkQ8fJt51SfguB396xbIIR+VZ3YrL2tLuyifDJ1wL5mEm+ddmHxJ2Fki340paPcDan9en5OmAw==",
+      "cpu": [
+        "x64"
+      ],
+      "optional": true,
+      "os": [
+        "win32"
+      ]
     },
     "node_modules/@philpl/buble": {
       "version": "0.19.7",
@@ -6312,6 +6455,11 @@
         "@types/node": "*"
       }
     },
+    "node_modules/@types/trusted-types": {
+      "version": "2.0.7",
+      "resolved": "https://registry.npmjs.org/@types/trusted-types/-/trusted-types-2.0.7.tgz",
+      "integrity": "sha512-ScaPdn1dQczgbl0QFTeTOmVHFULt394XJgOQNoyVhZ6r2vLnMLJfBPd53SB52T/3G36VI1/g2MZaX0cwDuXsfw=="
+    },
     "node_modules/@types/unist": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/@types/unist/-/unist-3.0.2.tgz",
@@ -6785,6 +6933,23 @@
       },
       "peerDependenciesMeta": {
         "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@xstate/store": {
+      "version": "2.6.0",
+      "resolved": "https://registry.npmjs.org/@xstate/store/-/store-2.6.0.tgz",
+      "integrity": "sha512-pHiGIn378yPSCY36f/8iFF1KtKTKpGINqUVJH/dYydzWT+uXc4zKUQ+XUk0qTHchTvBXQ/UivRox2Q19ZnzTjw==",
+      "peerDependencies": {
+        "react": "^18.2.0",
+        "solid-js": "^1.7.6"
+      },
+      "peerDependenciesMeta": {
+        "react": {
+          "optional": true
+        },
+        "solid-js": {
           "optional": true
         }
       }
@@ -7755,6 +7920,11 @@
       "integrity": "sha512-NzUnlZexiaH/46WDhANlyR2bXRopNg4F/zuSA3OpZnllCUgRaOF2znDioDWrmbNVsuZk6l9pMquQB38cfBZwkQ==",
       "dev": true
     },
+    "node_modules/best-effort-json-parser": {
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/best-effort-json-parser/-/best-effort-json-parser-1.1.2.tgz",
+      "integrity": "sha512-RD7tyk24pNCDwEKFACauR6Lqp5m6BHUrehwyhN/pA8V3QYWq8Y+hk9vHZvKiThZsdEFTaUqN49duVsamgCd8/g=="
+    },
     "node_modules/big-integer": {
       "version": "1.6.52",
       "resolved": "https://registry.npmjs.org/big-integer/-/big-integer-1.6.52.tgz",
@@ -8692,6 +8862,54 @@
       "dev": true,
       "dependencies": {
         "restore-cursor": "^3.1.0"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress": {
+      "version": "3.12.0",
+      "resolved": "https://registry.npmjs.org/cli-progress/-/cli-progress-3.12.0.tgz",
+      "integrity": "sha512-tRkV3HJ1ASwm19THiiLIXLO7Im7wlTuKnvkYaTkyoAPefqjNg7W7DHKUlGRxy9vxDvbyCYQkQozvptuMkGCg8A==",
+      "dependencies": {
+        "string-width": "^4.2.3"
+      },
+      "engines": {
+        "node": ">=4"
+      }
+    },
+    "node_modules/cli-progress/node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress/node_modules/emoji-regex": {
+      "version": "8.0.0",
+      "resolved": "https://registry.npmjs.org/emoji-regex/-/emoji-regex-8.0.0.tgz",
+      "integrity": "sha512-MSjYzcWNOA0ewAHpz0MxpYFvwg6yjy1NG3xteoqz644VCo/RPgnr1/GGt+ic3iJTzQ8Eu3TdM14SawnVUmGE6A=="
+    },
+    "node_modules/cli-progress/node_modules/string-width": {
+      "version": "4.2.3",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-4.2.3.tgz",
+      "integrity": "sha512-wKyQRQpjJ0sIp62ErSZdGsjMJWsap5oRNihHhu6G7JVO/9jIB6UyevL+tXuOqrng8j/cxKTWyWUwvSTriiZz/g==",
+      "dependencies": {
+        "emoji-regex": "^8.0.0",
+        "is-fullwidth-code-point": "^3.0.0",
+        "strip-ansi": "^6.0.1"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
+    "node_modules/cli-progress/node_modules/strip-ansi": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
+      "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dependencies": {
+        "ansi-regex": "^5.0.1"
       },
       "engines": {
         "node": ">=8"
@@ -18207,6 +18425,34 @@
         "url": "https://github.com/chalk/wrap-ansi?sponsor=1"
       }
     },
+    "node_modules/lit": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit/-/lit-3.2.1.tgz",
+      "integrity": "sha512-1BBa1E/z0O9ye5fZprPtdqnc0BFzxIxTTOO/tQFmyC/hj1O3jL4TfmLBw0WEwjAokdLwpclkvGgDJwTIh0/22w==",
+      "dependencies": {
+        "@lit/reactive-element": "^2.0.4",
+        "lit-element": "^4.1.0",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-element": {
+      "version": "4.1.1",
+      "resolved": "https://registry.npmjs.org/lit-element/-/lit-element-4.1.1.tgz",
+      "integrity": "sha512-HO9Tkkh34QkTeUmEdNYhMT8hzLid7YlMlATSi1q4q17HE5d9mrrEHJ/o8O2D0cMi182zK1F3v7x0PWFjrhXFew==",
+      "dependencies": {
+        "@lit-labs/ssr-dom-shim": "^1.2.0",
+        "@lit/reactive-element": "^2.0.4",
+        "lit-html": "^3.2.0"
+      }
+    },
+    "node_modules/lit-html": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/lit-html/-/lit-html-3.2.1.tgz",
+      "integrity": "sha512-qI/3lziaPMSKsrwlxH/xMgikhQ0EGOX2ICU73Bi/YHFvz2j/yMCIrw4+puF2IpQ4+upd3EWbvnHM9+PnJn48YA==",
+      "dependencies": {
+        "@types/trusted-types": "^2.0.2"
+      }
+    },
     "node_modules/loader-runner": {
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/loader-runner/-/loader-runner-4.3.0.tgz",
@@ -18955,6 +19201,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/wooorm"
+      }
+    },
+    "node_modules/marked": {
+      "version": "14.1.2",
+      "resolved": "https://registry.npmjs.org/marked/-/marked-14.1.2.tgz",
+      "integrity": "sha512-f3r0yqpz31VXiDB/wj9GaOB0a2PRLQl6vJmXiFrniNwjkKdvakqJRULhjFKJpxOchlCRiG5fcacoUZY5Xa6PEQ==",
+      "bin": {
+        "marked": "bin/marked.js"
+      },
+      "engines": {
+        "node": ">= 18"
       }
     },
     "node_modules/mdast-util-directive": {
@@ -23302,6 +23559,21 @@
       "dev": true,
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pagefind": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/pagefind/-/pagefind-1.1.1.tgz",
+      "integrity": "sha512-U2YR0dQN5B2fbIXrLtt/UXNS0yWSSYfePaad1KcBPTi0p+zRtsVjwmoPaMQgTks5DnHNbmDxyJUL5TGaLljK3A==",
+      "bin": {
+        "pagefind": "lib/runner/bin.cjs"
+      },
+      "optionalDependencies": {
+        "@pagefind/darwin-arm64": "1.1.1",
+        "@pagefind/darwin-x64": "1.1.1",
+        "@pagefind/linux-arm64": "1.1.1",
+        "@pagefind/linux-x64": "1.1.1",
+        "@pagefind/windows-x64": "1.1.1"
       }
     },
     "node_modules/pako": {
@@ -31181,6 +31453,8 @@
         "@docusaurus/theme-live-codeblock": "^3.2.1",
         "@docusaurus/theme-mermaid": "^3.2.1",
         "@docusaurus/types": "^3.2.1",
+        "@getcanary/docusaurus-theme-search-pagefind": "^1.0.2",
+        "@getcanary/web": "^1.0.8",
         "@mdx-js/react": "^3.0.1",
         "@microsoft/api-documenter": "^7.24.2",
         "@types/react": "^18.3.1",

--- a/sites/website/docusaurus.config.js
+++ b/sites/website/docusaurus.config.js
@@ -17,6 +17,33 @@ module.exports = {
     themes: [
         "@docusaurus/theme-live-codeblock",
         "@docusaurus/theme-mermaid",
+        [
+            require.resolve("@getcanary/docusaurus-theme-search-pagefind"),
+            {
+                maxPages: 300,
+                pagefind: {
+                    ranking: {
+                        pageLength: 1,
+                    },
+                },
+                styles: {
+                    "--canary-color-primary-c": 0.18,
+                    "--canary-color-primary-h": 3,
+                },
+                tags: [
+                    {
+                        name: "V2",
+                        pattern: "**/*",
+                        options: { ignore: ["**/docs/1.x/**"] },
+                    },
+                    { name: "V1", pattern: "**/docs/1.x/**" },
+                ],
+                tabs: [
+                    { name: "Docs", pattern: "**/*", options: { ignore: ["**/api/**"] } },
+                    { name: "API", pattern: "**/api/**" },
+                ],
+            },
+        ],
     ],
     staticDirectories: ["static"],
     themeConfig: {

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -35,6 +35,8 @@
     "@docusaurus/theme-live-codeblock": "^3.2.1",
     "@docusaurus/theme-mermaid": "^3.2.1",
     "@docusaurus/types": "^3.2.1",
+    "@getcanary/docusaurus-theme-search-pagefind": "^1.0.2",
+    "@getcanary/web": "^1.0.8",
     "@mdx-js/react": "^3.0.1",
     "@microsoft/api-documenter": "^7.24.2",
     "@types/react": "^18.3.1",


### PR DESCRIPTION
# Pull Request
Add search bar to the documentation site.

## 📖 Description

Currently, the documentation site does not have a search bar.
I implemented a search bar using:
- [Pagefind](https://pagefind.app/)
- [Canary](https://github.com/fastrepl/canary?tab=readme-ov-file#2-tiny-web-components-for-building-a-search-bar)'s UI component

Both are MIT licensed.

Video:
(Colors are configurable in the Docusaurus config)

https://github.com/user-attachments/assets/3654c61d-86bd-4ea2-bcb2-0616979897cc

Notes:

- V2 and V1 are split. (Red tags in the video)
- The documentation (without API reference) and the API reference are split. (Small tabs in the video)
- **If you want to try locally, run `npm run build` at least once, before running `npm run start`. Because Pagefind index is generated in production build.**

### 🎫 Issues
None

## 👩‍💻 Reviewer Notes

None

## 📑 Test Plan

None

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

None