### PR TITLE
Patch bump to correct missing latest tag from package

### DIFF
--- a/beachball.config.js
+++ b/beachball.config.js
@@ -11,4 +11,5 @@ module.exports = {
         // This one is especially important (otherwise dependabot would be blocked by change file requirements)
         "package-lock.json",
     ],
+    bumpDeps: false
 };

--- a/change/@microsoft-fast-element-161de870-eea2-44b4-a75d-2bc3f19a3b11.json
+++ b/change/@microsoft-fast-element-161de870-eea2-44b4-a75d-2bc3f19a3b11.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Patch bumping to apply latest tag to the package",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change includes:
- A change file for `@microsoft/fast-element` to patch bump which should apply latest tag when published through the CI pipeline
- Not allow bumping dependencies as both of these are in prerelease which does not correctly apply in beachball

## 📑 Test Plan

I have tested the outcome of these changes with `beachball bump` locally.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.