### PR TITLE
change -n option to --token as this is present in the new docs

### DIFF
--- a/.github/workflows/cd-release-npm.yml
+++ b/.github/workflows/cd-release-npm.yml
@@ -66,7 +66,7 @@ jobs:
     - name: Publish NPM packages
       env:
         NPM_SECRET_TOKEN: ${{ secrets.NPM_TOKEN }}
-      run: npm run publish-ci -n $NPM_SECRET_TOKEN
+      run: npm run publish-ci -- --token "$NPM_SECRET_TOKEN"
 
   notify:
     runs-on: ubuntu-latest


### PR DESCRIPTION
# Pull Request

## 📖 Description

Looks like these options might have changed without a major package update. As such, following the documentation: https://microsoft.github.io/beachball/concepts/ci-integration.html#github-repo-github-actions

## 👩‍💻 Reviewer Notes

This is currently failing publish when triggered from github actions. This may fix the issue.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.