### PR TITLE
Change dependent change default to none

### DIFF
--- a/change/@microsoft-fast-element-161de870-eea2-44b4-a75d-2bc3f19a3b11.json
+++ b/change/@microsoft-fast-element-161de870-eea2-44b4-a75d-2bc3f19a3b11.json
@@ -3,5 +3,5 @@
   "comment": "Patch bumping to apply latest tag to the package",
   "packageName": "@microsoft/fast-element",
   "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@microsoft-fast-element-b679d332-e9c0-4e4a-984b-c06481f24caa.json
+++ b/change/@microsoft-fast-element-b679d332-e9c0-4e4a-984b-c06481f24caa.json
@@ -3,5 +3,5 @@
   "comment": "fast-element: Simplify conditional checks in element-controller",
   "packageName": "@microsoft/fast-element",
   "email": "abaris@null.net",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
   "scripts": {
     "bump": "beachball bump",
     "build": "npm run build --workspaces --if-present",
-    "change": "beachball change",
+    "change": "beachball change --dependent-change-type none",
     "checkchange": "beachball check  --scope \"!sites/*\" --changehint \"Run 'npm run change' to generate a change file\"",
     "check": "beachball check ",
     "build:gh-pages": "npm run build -w fast-site",


### PR DESCRIPTION
# Pull Request

## 📖 Description

It seems beachball has an issue with dependent change types being patch bumped and attempting to release with the bumpDeps configuration option being set. This changes the current changes in the change folder to bump dependentChangeType to none and to default to dependentChangeType none for future changes.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.