### PR TITLE
Change the router to use peerDependency for fast-element

### DIFF
--- a/change/@microsoft-fast-router-86ba00b4-329b-480f-a226-77947ce80499.json
+++ b/change/@microsoft-fast-router-86ba00b4-329b-480f-a226-77947ce80499.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change the router to use peerDependency for fast-element",
+  "packageName": "@microsoft/fast-router",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -31017,12 +31017,10 @@
       "name": "@microsoft/fast-router",
       "version": "1.0.0-alpha.28",
       "license": "MIT",
-      "dependencies": {
-        "@microsoft/fast-element": "^2.0.0"
-      },
       "devDependencies": {
         "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
         "@microsoft/api-extractor": "^7.47.0",
+        "@microsoft/fast-element": "^2.0.0",
         "@types/chai": "^4.2.11",
         "@types/karma": "^6.3.3",
         "@types/mocha": "^7.0.2",
@@ -31054,6 +31052,9 @@
         "typescript": "~4.7.0",
         "webpack": "^5.92.1",
         "webpack-cli": "^5.1.4"
+      },
+      "peerDependencies": {
+        "@microsoft/fast-element": "^2.0.0"
       }
     },
     "packages/web-components/fast-router/node_modules/acorn-walk": {

--- a/packages/web-components/fast-router/package.json
+++ b/packages/web-components/fast-router/package.json
@@ -48,6 +48,7 @@
   "devDependencies": {
     "@jsdevtools/coverage-istanbul-loader": "^3.0.5",
     "@microsoft/api-extractor": "^7.47.0",
+    "@microsoft/fast-element": "^2.0.0",
     "@types/chai": "^4.2.11",
     "@types/karma": "^6.3.3",
     "@types/mocha": "^7.0.2",
@@ -80,7 +81,7 @@
     "webpack": "^5.92.1",
     "webpack-cli": "^5.1.4"
   },
-  "dependencies": {
+  "peerDependencies": {
     "@microsoft/fast-element": "^2.0.0"
   },
   "beachball": {


### PR DESCRIPTION
# Pull Request

## 📖 Description

The `@microsoft/fast-router` is erroneously using `@microsoft/fast-element` as a direct dependency, this is causing issues during publishing and is the incorrect dependency structure for the package.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.
