### PR TITLE
Update the ArrayObserver to better account for sort and reverse

### DIFF
--- a/change/@microsoft-fast-element-65a1eb8c-3989-49a5-811f-fcc4274e53d6.json
+++ b/change/@microsoft-fast-element-65a1eb8c-3989-49a5-811f-fcc4274e53d6.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Update the ArrayObserver to better account for sort and reverse",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-element/docs/api-report.api.md
+++ b/packages/web-components/fast-element/docs/api-report.api.md
@@ -19,15 +19,18 @@ export type AddViewBehaviorFactory = (factory: ViewBehaviorFactory) => string;
 
 // @public
 export interface ArrayObserver extends SubscriberSet {
+    addSort(sort: Sort): void;
     addSplice(splice: Splice): void;
     flush(): void;
     readonly lengthObserver: LengthObserver;
     reset(oldCollection: any[] | undefined): void;
+    readonly sortObserver: SortObserver;
     strategy: SpliceStrategy | null;
 }
 
 // @public
 export const ArrayObserver: Readonly<{
+    readonly sorted: 0;
     readonly enable: () => void;
 }>;
 
@@ -774,7 +777,7 @@ export function repeat<TSource = any, TArray extends ReadonlyArray<any> = Readon
 export class RepeatBehavior<TSource = any> implements ViewBehavior, Subscriber {
     constructor(directive: RepeatDirective);
     bind(controller: ViewController): void;
-    handleChange(source: any, args: Splice[] | ExpressionObserver): void;
+    handleChange(source: any, args: Splice[] | Sort[] | ExpressionObserver): void;
     unbind(): void;
     // @internal (undocumented)
     views: SyntheticView[];
@@ -820,6 +823,21 @@ export class SlottedDirective extends NodeObservationDirective<SlottedDirectiveO
 
 // @public
 export interface SlottedDirectiveOptions<T = any> extends NodeBehaviorOptions<T>, AssignedNodesOptions {
+}
+
+// @public
+export class Sort {
+    constructor(sorted?: number[] | undefined);
+    // (undocumented)
+    sorted?: number[] | undefined;
+}
+
+// @public
+export function sortedCount<T>(array: readonly T[]): number;
+
+// @public
+export interface SortObserver extends Subscriber {
+    sorted: number;
 }
 
 // @public

--- a/packages/web-components/fast-element/src/debug.ts
+++ b/packages/web-components/fast-element/src/debug.ts
@@ -13,7 +13,7 @@ const FAST: FASTGlobal = globalThis.FAST;
 
 const debugMessages = {
     [1101 /* needsArrayObservation */]:
-        "Must call enableArrayObservation before observing arrays.",
+        "Must call ArrayObserver.enable() before observing arrays.",
     [1201 /* onlySetDOMPolicyOnce */]: "The DOM Policy can only be set once.",
     [1202 /* bindingInnerHTMLRequiresTrustedTypes */]:
         "To bind innerHTML, you must use a TrustedTypesPolicy.",

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -39,6 +39,9 @@ export {
     Splice,
     SpliceStrategy,
     SpliceStrategySupport,
+    Sort,
+    SortObserver,
+    sortedCount,
 } from "./observation/arrays.js";
 export { UpdateQueue, Updates } from "./observation/update-queue.js";
 

--- a/packages/web-components/fast-element/src/observation/arrays.spec.ts
+++ b/packages/web-components/fast-element/src/observation/arrays.spec.ts
@@ -140,10 +140,10 @@ describe("The ArrayObserver", () => {
         const array = [1, 2, 3, 4];
         array.reverse();
 
-        expect(array).members([4, 3, 2, 1]);
+        expect(array).ordered.members([4, 3, 2, 1]);
 
         Array.prototype.reverse.call(array);
-        expect(array).members([1, 2, 3, 4]);
+        expect(array).ordered.members([1, 2, 3, 4]);
 
         const observer = Observable.getNotifier<ArrayObserver>(array);
         let changeArgs: Sort[] | null = null;
@@ -155,7 +155,7 @@ describe("The ArrayObserver", () => {
         });
 
         array.reverse();
-        expect(array).members([4, 3, 2, 1]);
+        expect(array).ordered.members([4, 3, 2, 1]);
 
         await Updates.next();
 
@@ -170,7 +170,7 @@ describe("The ArrayObserver", () => {
         );
         changeArgs = null;
         array.reverse();
-        expect(array).members([1, 2, 3, 4]);
+        expect(array).ordered.members([1, 2, 3, 4]);
 
         await Updates.next();
 
@@ -227,15 +227,15 @@ describe("The ArrayObserver", () => {
 
     it("observes sorts", async () => {
         ArrayObserver.enable();
-        let array = [1, 3, 2, 4];
+        let array = [1, 3, 2, 4, 3];
 
         array.sort((a, b) => b - a);
-        expect(array).members([4, 3, 2, 1]);
+        expect(array).ordered.members([4, 3, 3, 2, 1]);
 
         Array.prototype.sort.call(array, (a, b) => a - b);
-        expect(array).members([1, 2, 3, 4]);
+        expect(array).ordered.members([1, 2, 3, 3, 4]);
 
-        array = [1, 3, 2, 4];
+        array = [1, 3, 2, 4, 3];
         const observer = Observable.getNotifier<ArrayObserver>(array);
         let changeArgs: Sort[] | null = null;
 
@@ -246,7 +246,7 @@ describe("The ArrayObserver", () => {
         });
 
         array.sort((a, b) => b - a);
-        expect(array).members([4, 3, 2, 1]);
+        expect(array).ordered.members([4, 3, 3, 2, 1]);
 
         await Updates.next();
 
@@ -255,6 +255,7 @@ describe("The ArrayObserver", () => {
             [
                 3,
                 1,
+                4,
                 2,
                 0
             ]

--- a/packages/web-components/fast-element/src/observation/arrays.ts
+++ b/packages/web-components/fast-element/src/observation/arrays.ts
@@ -700,8 +700,10 @@ let defaultMutationStrategy: SpliceStrategy = Object.freeze({
     ): any[] {
         const map = new Map();
 
-        for (let i = 0, ii = (array || []).length; i < ii; ++i) {
-            map.set(array[i], i);
+        for (let i = 0, ii = array.length; i < ii; ++i) {
+            const mapValue = map.get(array[i]) || [];
+
+            map.set(array[i], [...mapValue, i]);
         }
 
         const result = sort.apply(array, args);
@@ -709,9 +711,12 @@ let defaultMutationStrategy: SpliceStrategy = Object.freeze({
         (array as any).sorted++;
 
         const sortedItems: number[] = [];
-        for (let i = 0, ii = (array || []).length; i < ii; ++i) {
-            const newIndex = map.get(array[i]);
-            sortedItems.push(newIndex);
+
+        for (let i = 0, ii = array.length; i < ii; ++i) {
+            const indexs = map.get(array[i]);
+            sortedItems.push(indexs[0]);
+
+            map.set(array[i], indexs.splice(1));
         }
 
         observer.addSort(new Sort(sortedItems));

--- a/packages/web-components/fast-element/src/observation/arrays.ts
+++ b/packages/web-components/fast-element/src/observation/arrays.ts
@@ -54,6 +54,18 @@ export class Splice {
 }
 
 /**
+ * A sort array indicates new index positions of array items.
+ * @public
+ */
+export class Sort {
+    /**
+     * Creates a sort update.
+     * @param sorted - The updated index of sorted items.
+     */
+    public constructor(public sorted?: number[]) {}
+}
+
+/**
  * Indicates what level of feature support the splice
  * strategy provides.
  * @public
@@ -598,8 +610,7 @@ function project(array: unknown[], changes: Splice[]): Splice[] {
  * splices needed to represent the change from the old array to the new array.
  * @public
  */
-
-let defaultSpliceStrategy: SpliceStrategy = Object.freeze({
+let defaultMutationStrategy: SpliceStrategy = Object.freeze({
     support: SpliceStrategySupport.optimized,
 
     normalize(
@@ -653,7 +664,15 @@ let defaultSpliceStrategy: SpliceStrategy = Object.freeze({
         args: any[]
     ): any {
         const result = reverse.apply(array, args);
-        observer.reset(array);
+        (array as any).sorted++;
+
+        const sortedItems: number[] = [];
+        for (let i = array.length - 1; i >= 0; i--) {
+            sortedItems.push(i);
+        }
+
+        observer.addSort(new Sort(sortedItems));
+
         return result;
     },
 
@@ -679,8 +698,24 @@ let defaultSpliceStrategy: SpliceStrategy = Object.freeze({
         sort: typeof Array.prototype.sort,
         args: any[]
     ): any[] {
+        const map = new Map();
+
+        for (let i = 0, ii = (array || []).length; i < ii; ++i) {
+            map.set(array[i], i);
+        }
+
         const result = sort.apply(array, args);
-        observer.reset(array);
+
+        (array as any).sorted++;
+
+        const sortedItems: number[] = [];
+        for (let i = 0, ii = (array || []).length; i < ii; ++i) {
+            const newIndex = map.get(array[i]);
+            sortedItems.push(newIndex);
+        }
+
+        observer.addSort(new Sort(sortedItems));
+
         return result;
     },
 
@@ -726,14 +761,20 @@ export const SpliceStrategy = Object.freeze({
      * @param strategy - The splice strategy to use.
      */
     setDefaultStrategy(strategy: SpliceStrategy) {
-        defaultSpliceStrategy = strategy;
+        defaultMutationStrategy = strategy;
     },
 } as const);
 
-function setNonEnumerable(target: any, property: string, value: any): void {
+function setNonEnumerable(
+    target: any,
+    property: string,
+    value: any,
+    writable: boolean = true
+): void {
     Reflect.defineProperty(target, property, {
         value,
         enumerable: false,
+        writable,
     });
 }
 
@@ -746,6 +787,18 @@ export interface LengthObserver extends Subscriber {
      * The length of the observed array.
      */
     length: number;
+}
+
+/**
+ * Observes array sort.
+ * @public
+ */
+export interface SortObserver extends Subscriber {
+    /**
+     * The sorted times on the observed array, this should be incremented every time
+     * an item in the array changes location.
+     */
+    sorted: number;
 }
 
 /**
@@ -764,10 +817,21 @@ export interface ArrayObserver extends SubscriberSet {
     readonly lengthObserver: LengthObserver;
 
     /**
+     * The sort observer for the array.
+     */
+    readonly sortObserver: SortObserver;
+
+    /**
      * Adds a splice to the list of changes.
      * @param splice - The splice to add.
      */
     addSplice(splice: Splice): void;
+
+    /**
+     * Adds a sort to the list of changes.
+     * @param sort - The sort to add.
+     */
+    addSort(sort: Sort): void;
 
     /**
      * Indicates that a reset change has occurred.
@@ -784,9 +848,11 @@ export interface ArrayObserver extends SubscriberSet {
 class DefaultArrayObserver extends SubscriberSet implements ArrayObserver {
     private oldCollection: any[] | undefined = void 0;
     private splices: Splice[] | undefined = void 0;
+    private sorts: Sort[] | undefined = void 0;
     private needsQueue: boolean = true;
     private _strategy: SpliceStrategy | null = null;
     private _lengthObserver: LengthObserver | undefined = void 0;
+    private _sortObserver: SortObserver | undefined = void 0;
 
     public get strategy(): SpliceStrategy | null {
         return this._strategy;
@@ -807,6 +873,27 @@ class DefaultArrayObserver extends SubscriberSet implements ArrayObserver {
                     if (this.length !== array.length) {
                         this.length = array.length;
                         Observable.notify(observer, "length");
+                    }
+                },
+            };
+
+            this.subscribe(observer);
+        }
+
+        return observer;
+    }
+
+    public get sortObserver(): SortObserver {
+        let observer = this._sortObserver;
+
+        if (observer === void 0) {
+            const array = this.subject;
+            this._sortObserver = observer = {
+                sorted: array.sorted,
+                handleChange() {
+                    if (this.sorted !== array.sorted) {
+                        this.sorted = array.sorted;
+                        Observable.notify(observer, "sorted");
                     }
                 },
             };
@@ -839,6 +926,16 @@ class DefaultArrayObserver extends SubscriberSet implements ArrayObserver {
         this.enqueue();
     }
 
+    public addSort(sort: Sort) {
+        if (this.sorts === void 0) {
+            this.sorts = [sort];
+        } else {
+            this.sorts.push(sort);
+        }
+
+        this.enqueue();
+    }
+
     public reset(oldCollection: any[] | undefined): void {
         this.oldCollection = oldCollection;
         this.enqueue();
@@ -846,23 +943,27 @@ class DefaultArrayObserver extends SubscriberSet implements ArrayObserver {
 
     public flush(): void {
         const splices = this.splices;
+        const sorts = this.sorts;
         const oldCollection = this.oldCollection;
 
-        if (splices === void 0 && oldCollection === void 0) {
+        if (splices === void 0 && oldCollection === void 0 && sorts === void 0) {
             return;
         }
 
         this.needsQueue = true;
         this.splices = void 0;
+        this.sorts = void 0;
         this.oldCollection = void 0;
 
-        this.notify(
-            (this._strategy ?? defaultSpliceStrategy).normalize(
-                oldCollection,
-                this.subject,
-                splices
-            )
-        );
+        sorts !== void 0
+            ? this.notify(sorts)
+            : this.notify(
+                  (this._strategy ?? defaultMutationStrategy).normalize(
+                      oldCollection,
+                      this.subject,
+                      splices
+                  )
+              );
     }
 
     private enqueue(): void {
@@ -880,6 +981,7 @@ let enabled = false;
  * @public
  */
 export const ArrayObserver = Object.freeze({
+    sorted: 0,
     /**
      * Enables the array observation mechanism.
      * @remarks
@@ -902,6 +1004,7 @@ export const ArrayObserver = Object.freeze({
 
         if (!(proto as any).$fastPatch) {
             setNonEnumerable(proto, "$fastPatch", 1);
+            setNonEnumerable(proto, "sorted", 0);
 
             [
                 proto.pop,
@@ -916,7 +1019,7 @@ export const ArrayObserver = Object.freeze({
                     const o = this.$fastController as ArrayObserver;
                     return o === void 0
                         ? method.apply(this, args)
-                        : (o.strategy ?? defaultSpliceStrategy)[method.name](
+                        : (o.strategy ?? defaultMutationStrategy)[method.name](
                               this,
                               o,
                               method,
@@ -947,4 +1050,25 @@ export function lengthOf<T>(array: readonly T[]): number {
 
     Observable.track(arrayObserver.lengthObserver, "length");
     return array.length;
+}
+
+/**
+ * Enables observing the sorted property of an array.
+ * @param array - The array to observe the sorted property of.
+ * @returns The sorted property.
+ * @public
+ */
+export function sortedCount<T>(array: readonly T[]): number {
+    if (!array) {
+        return 0;
+    }
+
+    let arrayObserver = (array as any).$fastController as ArrayObserver;
+    if (arrayObserver === void 0) {
+        ArrayObserver.enable();
+        arrayObserver = Observable.getNotifier<ArrayObserver>(array);
+    }
+
+    Observable.track(arrayObserver.sortObserver, "sorted");
+    return (array as any).sorted;
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change updates the `ArrayObserver` to use some array tracking when applying `sort` or `reverse`. This will retain state to overcome the problem seen in #6919. No updates are required by developers.

### 🎫 Issues

Closes #6919

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/master/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/master/CODE_OF_CONDUCT.md#our-standards) for this project.