### PR TITLE
chore: adjust docs link color to ensure accessibility

### DIFF
--- a/sites/website/src/css/custom.css
+++ b/sites/website/src/css/custom.css
@@ -316,7 +316,7 @@ article {
 
 .navbar__link--active {
     --ifm-link-color: #ff4ca3;
-    --ifm-link-hover-color: #FC4579;
+    --ifm-link-hover-color: #fc4579;
 }
 
 .menu__link--active,

--- a/sites/website/src/css/custom.css
+++ b/sites/website/src/css/custom.css
@@ -316,6 +316,7 @@ article {
 
 .navbar__link--active {
     --ifm-link-color: #ff4ca3;
+    --ifm-link-hover-color: #FC4579;
 }
 
 .menu__link--active,


### PR DESCRIPTION
# Pull Request

## 📖 Description
Fixes an a11y issue with the "Docs" link on the documentation site where appropriate contrast is not met.

### 🎫 Issues
n/a
