### PR TITLE
Add the f-template component which can interpret a text binding and convert it to a ViewTemplate

### DIFF
--- a/change/@microsoft-fast-element-a0dc8892-ba16-4f59-8c59-9125aa60be70.json
+++ b/change/@microsoft-fast-element-a0dc8892-ba16-4f59-8c59-9125aa60be70.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Expose the fast registry and allow triggering definition updates",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/package-lock.json
+++ b/package-lock.json
@@ -6342,6 +6342,26 @@
         "@types/ms": "*"
       }
     },
+    "node_modules/@types/eslint": {
+      "version": "9.6.1",
+      "resolved": "https://registry.npmjs.org/@types/eslint/-/eslint-9.6.1.tgz",
+      "integrity": "sha512-FXx2pKgId/WyYo2jXw63kk7/+TY7u7AziEJxJAnSFzHlqTAS3Ync6SvgYAN/k4/PQpnnVuzoMuVnByKK2qp0ag==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "*",
+        "@types/json-schema": "*"
+      }
+    },
+    "node_modules/@types/eslint-scope": {
+      "version": "3.7.7",
+      "resolved": "https://registry.npmjs.org/@types/eslint-scope/-/eslint-scope-3.7.7.tgz",
+      "integrity": "sha512-MzMFlSLBqNF2gcHWO0G1vP/YQyfvrxZ0bF+u7mzUdZ1/xK4A4sru+nraZz5i3iEIk1l1uyicaDVTB4QbbEkAYg==",
+      "license": "MIT",
+      "dependencies": {
+        "@types/eslint": "*",
+        "@types/estree": "*"
+      }
+    },
     "node_modules/@types/estree": {
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/@types/estree/-/estree-1.0.6.tgz",
@@ -6988,133 +7008,148 @@
       }
     },
     "node_modules/@webassemblyjs/ast": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.12.1.tgz",
-      "integrity": "sha512-EKfMUOPRRUTy5UII4qJDGPpqfwjOmZ5jeGFwid9mnoqIFK+e0vqoi1qH56JpmZSzEL53jKnNzScdmftJyG5xWg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ast/-/ast-1.14.1.tgz",
+      "integrity": "sha512-nuBEDgQfm1ccRp/8bCQrx1frohyufl4JlbMMZ4P1wpeOfDhF6FQkxZJ1b/e+PLwr6X1Nhw6OLme5usuBWYBvuQ==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/helper-numbers": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6"
+        "@webassemblyjs/helper-numbers": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/floating-point-hex-parser": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.11.6.tgz",
-      "integrity": "sha512-ejAj9hfRJ2XMsNHk/v6Fu2dGS+i4UaXBXGemOfQ/JfQ6mdQg/WXtwleQRLLS4OvfDhv8rYnVwH27YJLMyYsxhw=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/floating-point-hex-parser/-/floating-point-hex-parser-1.13.2.tgz",
+      "integrity": "sha512-6oXyTOzbKxGH4steLbLNOu71Oj+C8Lg34n6CqRvqfS2O71BxY6ByfMDRhBytzknj9yGUPVJ1qIKhRlAwO1AovA==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-api-error": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.11.6.tgz",
-      "integrity": "sha512-o0YkoP4pVu4rN8aTJgAyj9hC2Sv5UlkzCHhxqWj8butaLvnpdc2jOwh4ewE6CX0txSfLn/UYaV/pheS2Txg//Q=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-api-error/-/helper-api-error-1.13.2.tgz",
+      "integrity": "sha512-U56GMYxy4ZQCbDZd6JuvvNV/WFildOjsaWD3Tzzvmw/mas3cXzRJPMjP83JqEsgSbyrmaGjBfDtV7KDXV9UzFQ==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-buffer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.12.1.tgz",
-      "integrity": "sha512-nzJwQw99DNDKr9BVCOZcLuJJUlqkJh+kVzVl6Fmq/tI5ZtEyWT1KZMyOXltXLZJmDtvLCDgwsyrkohEtopTXCw=="
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-buffer/-/helper-buffer-1.14.1.tgz",
+      "integrity": "sha512-jyH7wtcHiKssDtFPRB+iQdxlDf96m0E39yb0k5uJVhFGleZFoNw1c4aeIcVUPPbXUVJ94wwnMOAqUHyzoEPVMA==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-numbers": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.11.6.tgz",
-      "integrity": "sha512-vUIhZ8LZoIWHBohiEObxVm6hwP034jwmc9kuq5GdHZH0wiLVLIPcMCdpJzG4C11cHoQ25TFIQj9kaVADVX7N3g==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-numbers/-/helper-numbers-1.13.2.tgz",
+      "integrity": "sha512-FE8aCmS5Q6eQYcV3gI35O4J789wlQA+7JrqTTpJqn5emA4U2hvwJmvFRC0HODS+3Ye6WioDklgd6scJ3+PLnEA==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/floating-point-hex-parser": "1.11.6",
-        "@webassemblyjs/helper-api-error": "1.11.6",
+        "@webassemblyjs/floating-point-hex-parser": "1.13.2",
+        "@webassemblyjs/helper-api-error": "1.13.2",
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/helper-wasm-bytecode": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.11.6.tgz",
-      "integrity": "sha512-sFFHKwcmBprO9e7Icf0+gddyWYDViL8bpPjJJl0WHxCdETktXdmtWLGVzoHbqUcY4Be1LkNfwTmXOJUFZYSJdA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-bytecode/-/helper-wasm-bytecode-1.13.2.tgz",
+      "integrity": "sha512-3QbLKy93F0EAIXLh0ogEVR6rOubA9AoZ+WRYhNbFyuB70j3dRdwH9g+qXhLAO0kiYGlg3TxDV+I4rQTr/YNXkA==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/helper-wasm-section": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.12.1.tgz",
-      "integrity": "sha512-Jif4vfB6FJlUlSbgEMHUyk1j234GTNG9dBJ4XJdOySoj518Xj0oGsNi59cUQF4RRMS9ouBUxDDdyBVfPTypa5g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/helper-wasm-section/-/helper-wasm-section-1.14.1.tgz",
+      "integrity": "sha512-ds5mXEqTJ6oxRoqjhWDU83OgzAYjwsCV8Lo/N+oRsNDmx/ZDpqalmrtgOMkHwxsG0iI//3BwWAErYRHtgn0dZw==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/wasm-gen": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/wasm-gen": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/ieee754": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.11.6.tgz",
-      "integrity": "sha512-LM4p2csPNvbij6U1f19v6WR56QZ8JcHg3QIJTlSwzFcmx6WSORicYj6I63f9yU1kEUtrpG+kjkiIAkevHpDXrg==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/ieee754/-/ieee754-1.13.2.tgz",
+      "integrity": "sha512-4LtOzh58S/5lX4ITKxnAK2USuNEvpdVV9AlgGQb8rJDHaLeHciwG4zlGr0j/SNWlr7x3vO1lDEsuePvtcDNCkw==",
+      "license": "MIT",
       "dependencies": {
         "@xtuc/ieee754": "^1.2.0"
       }
     },
     "node_modules/@webassemblyjs/leb128": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.11.6.tgz",
-      "integrity": "sha512-m7a0FhE67DQXgouf1tbN5XQcdWoNgaAuoULHIfGFIEVKA6tu/edls6XnIlkmS6FrXAquJRPni3ZZKjw6FSPjPQ==",
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/leb128/-/leb128-1.13.2.tgz",
+      "integrity": "sha512-Lde1oNoIdzVzdkNEAWZ1dZ5orIbff80YPdHx20mrHwHrVNNTjNr8E3xz9BdpcGqRQbAEa+fkrCb+fRFTl/6sQw==",
+      "license": "Apache-2.0",
       "dependencies": {
         "@xtuc/long": "4.2.2"
       }
     },
     "node_modules/@webassemblyjs/utf8": {
-      "version": "1.11.6",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.11.6.tgz",
-      "integrity": "sha512-vtXf2wTQ3+up9Zsg8sa2yWiQpzSsMyXj0qViVP6xKGCUT8p8YJ6HqI7l5eCnWx1T/FYdsv07HQs2wTFbbof/RA=="
+      "version": "1.13.2",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/utf8/-/utf8-1.13.2.tgz",
+      "integrity": "sha512-3NQWGjKTASY1xV5m7Hr0iPeXD9+RDobLll3T9d2AO+g3my8xy5peVyjSag4I50mR1bBSN/Ct12lo+R9tJk0NZQ==",
+      "license": "MIT"
     },
     "node_modules/@webassemblyjs/wasm-edit": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.12.1.tgz",
-      "integrity": "sha512-1DuwbVvADvS5mGnXbE+c9NfA8QRcZ6iKquqjjmR10k6o+zzsRVesil54DKexiowcFCPdr/Q0qaMgB01+SQ1u6g==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-edit/-/wasm-edit-1.14.1.tgz",
+      "integrity": "sha512-RNJUIQH/J8iA/1NzlE4N7KtyZNHi3w7at7hDjvRNm5rcUXa00z1vRz3glZoULfJ5mpvYhLybmVcwcjGrC1pRrQ==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/helper-wasm-section": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-opt": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1",
-        "@webassemblyjs/wast-printer": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/helper-wasm-section": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-opt": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1",
+        "@webassemblyjs/wast-printer": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-gen": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.12.1.tgz",
-      "integrity": "sha512-TDq4Ojh9fcohAw6OIMXqiIcTq5KUXTGRkVxbSo1hQnSy6lAM5GSdfwWeSxpAo0YzgsgF182E/U0mDNhuA0tW7w==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-gen/-/wasm-gen-1.14.1.tgz",
+      "integrity": "sha512-AmomSIjP8ZbfGQhumkNvgC33AY7qtMCXnN6bL2u2Js4gVCg8fp735aEiMSBbDR7UQIj90n4wKAFUSEd0QN2Ukg==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wasm-opt": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.12.1.tgz",
-      "integrity": "sha512-Jg99j/2gG2iaz3hijw857AVYekZe2SAskcqlWIZXjji5WStnOpVoat3gQfT/Q5tb2djnCjBtMocY/Su1GfxPBg==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-opt/-/wasm-opt-1.14.1.tgz",
+      "integrity": "sha512-PTcKLUNvBqnY2U6E5bdOQcSM+oVP/PmrDY9NzowJjislEjwP/C4an2303MCVS2Mg9d3AJpIGdUFIQQWbPds0Sw==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-buffer": "1.12.1",
-        "@webassemblyjs/wasm-gen": "1.12.1",
-        "@webassemblyjs/wasm-parser": "1.12.1"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-buffer": "1.14.1",
+        "@webassemblyjs/wasm-gen": "1.14.1",
+        "@webassemblyjs/wasm-parser": "1.14.1"
       }
     },
     "node_modules/@webassemblyjs/wasm-parser": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.12.1.tgz",
-      "integrity": "sha512-xikIi7c2FHXysxXe3COrVUPSheuBtpcfhbpFj4gmu7KRLYOzANztwUU0IbsqvMqzuNK2+glRGWCEqZo1WCLyAQ==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wasm-parser/-/wasm-parser-1.14.1.tgz",
+      "integrity": "sha512-JLBl+KZ0R5qB7mCnud/yyX08jWFw5MsoalJ1pQ4EdFlgj9VdXKGuENGsiCIjegI1W7p91rUlcB/LB5yRJKNTcQ==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
-        "@webassemblyjs/helper-api-error": "1.11.6",
-        "@webassemblyjs/helper-wasm-bytecode": "1.11.6",
-        "@webassemblyjs/ieee754": "1.11.6",
-        "@webassemblyjs/leb128": "1.11.6",
-        "@webassemblyjs/utf8": "1.11.6"
+        "@webassemblyjs/ast": "1.14.1",
+        "@webassemblyjs/helper-api-error": "1.13.2",
+        "@webassemblyjs/helper-wasm-bytecode": "1.13.2",
+        "@webassemblyjs/ieee754": "1.13.2",
+        "@webassemblyjs/leb128": "1.13.2",
+        "@webassemblyjs/utf8": "1.13.2"
       }
     },
     "node_modules/@webassemblyjs/wast-printer": {
-      "version": "1.12.1",
-      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.12.1.tgz",
-      "integrity": "sha512-+X4WAlOisVWQMikjbcvY2e0rwPsKQ9F688lksZhBcPycBBuii3O7m8FACbDMWDojpAqvjIncrG8J0XHKyQfVeA==",
+      "version": "1.14.1",
+      "resolved": "https://registry.npmjs.org/@webassemblyjs/wast-printer/-/wast-printer-1.14.1.tgz",
+      "integrity": "sha512-kPSSXE6De1XOR820C90RIo2ogvZG+c3KiHzqUoO/F34Y2shGzesfqv7o57xrxovZJH/MetF5UjroJ/R/3isoiw==",
+      "license": "MIT",
       "dependencies": {
-        "@webassemblyjs/ast": "1.12.1",
+        "@webassemblyjs/ast": "1.14.1",
         "@xtuc/long": "4.2.2"
       }
     },
@@ -7162,12 +7197,14 @@
     "node_modules/@xtuc/ieee754": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/@xtuc/ieee754/-/ieee754-1.2.0.tgz",
-      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA=="
+      "integrity": "sha512-DX8nKgqcGwsc0eJSqYt5lwP4DH5FlHnmuWWBRy7X0NcaGR0ZtuyeESgMwTYVEtxmsNGY+qit4QYT/MIYTOTPeA==",
+      "license": "BSD-3-Clause"
     },
     "node_modules/@xtuc/long": {
       "version": "4.2.2",
       "resolved": "https://registry.npmjs.org/@xtuc/long/-/long-4.2.2.tgz",
-      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ=="
+      "integrity": "sha512-NuHqBY1PB/D8xU6s/thBgOAiAP7HOYDQ32+BFZILJ8ivkUkAHQnWfn6WhL79Owj1qmUnoN/YPhktdIoucipkAQ==",
+      "license": "Apache-2.0"
     },
     "node_modules/@yarnpkg/lockfile": {
       "version": "1.1.0",
@@ -7202,9 +7239,10 @@
       }
     },
     "node_modules/acorn": {
-      "version": "8.12.0",
-      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.12.0.tgz",
-      "integrity": "sha512-RTvkC4w+KNXrM39/lWCUaG0IbRkWdCv7W/IOW9oU6SawyxulvkQy5HQPVTKxEjczcUvapcrw3cFx/60VN/NRNw==",
+      "version": "8.14.0",
+      "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.14.0.tgz",
+      "integrity": "sha512-cl669nCJTZBsL97OF4kUQm5g5hC2uihk0NxY3WENAC0TYdILVkAyHymAntgxGkl7K+t0cXIrH5siy5S4XkFycA==",
+      "license": "MIT",
       "bin": {
         "acorn": "bin/acorn"
       },
@@ -7232,14 +7270,6 @@
       },
       "engines": {
         "node": ">=0.4.0"
-      }
-    },
-    "node_modules/acorn-import-attributes": {
-      "version": "1.9.5",
-      "resolved": "https://registry.npmjs.org/acorn-import-attributes/-/acorn-import-attributes-1.9.5.tgz",
-      "integrity": "sha512-n02Vykv5uA3eHGM/Z2dQrcD56kL8TyDb2p1+0P83PClMnC/nc+anbQRhIOWnSq4Ke/KvDPrY3C9hDtC/A3eHnQ==",
-      "peerDependencies": {
-        "acorn": "^8"
       }
     },
     "node_modules/acorn-jsx": {
@@ -8456,9 +8486,9 @@
       "dev": true
     },
     "node_modules/browserslist": {
-      "version": "4.23.1",
-      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.23.1.tgz",
-      "integrity": "sha512-TUfofFo/KsK/bWZ9TWQ5O26tsWW4Uhmt8IYklbnUa70udB6P2wA7w7o4PY4muaEPBQaAX+CEnmmIA41NVHtPVw==",
+      "version": "4.24.4",
+      "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-4.24.4.tgz",
+      "integrity": "sha512-KDi1Ny1gSePi1vm0q4oxSF8b4DR44GF4BbmS2YdhPLOEqd8pDviZOGH/GsmRwoWJ2+5Lr085X7naowMwKHDG1A==",
       "funding": [
         {
           "type": "opencollective",
@@ -8473,11 +8503,12 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "caniuse-lite": "^1.0.30001629",
-        "electron-to-chromium": "^1.4.796",
-        "node-releases": "^2.0.14",
-        "update-browserslist-db": "^1.0.16"
+        "caniuse-lite": "^1.0.30001688",
+        "electron-to-chromium": "^1.5.73",
+        "node-releases": "^2.0.19",
+        "update-browserslist-db": "^1.1.1"
       },
       "bin": {
         "browserslist": "cli.js"
@@ -8723,9 +8754,9 @@
       }
     },
     "node_modules/caniuse-lite": {
-      "version": "1.0.30001638",
-      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001638.tgz",
-      "integrity": "sha512-5SuJUJ7cZnhPpeLHaH0c/HPAnAHZvS6ElWyHK9GSIbVOQABLzowiI2pjmpvZ1WEbkyz46iFd4UXlOHR5SqgfMQ==",
+      "version": "1.0.30001699",
+      "resolved": "https://registry.npmjs.org/caniuse-lite/-/caniuse-lite-1.0.30001699.tgz",
+      "integrity": "sha512-b+uH5BakXZ9Do9iK+CkDmctUSEqZl+SP056vc5usa0PL+ev5OHw003rZXcnjNDv3L8P5j6rwT6C0BPKSikW08w==",
       "funding": [
         {
           "type": "opencollective",
@@ -8739,7 +8770,8 @@
           "type": "github",
           "url": "https://github.com/sponsors/ai"
         }
-      ]
+      ],
+      "license": "CC-BY-4.0"
     },
     "node_modules/ccount": {
       "version": "2.0.1",
@@ -11952,9 +11984,10 @@
       }
     },
     "node_modules/electron-to-chromium": {
-      "version": "1.4.812",
-      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.4.812.tgz",
-      "integrity": "sha512-7L8fC2Ey/b6SePDFKR2zHAy4mbdp1/38Yk5TsARO66W3hC5KEaeKMMHoxwtuH+jcu2AYLSn9QX04i95t6Fl1Hg=="
+      "version": "1.5.97",
+      "resolved": "https://registry.npmjs.org/electron-to-chromium/-/electron-to-chromium-1.5.97.tgz",
+      "integrity": "sha512-HKLtaH02augM7ZOdYRuO19rWDeY+QSJ1VxnXFa/XDFLf07HvM90pALIJFgrO+UVaajI3+aJMMpojoUTLZyQ7JQ==",
+      "license": "ISC"
     },
     "node_modules/elkjs": {
       "version": "0.9.3",
@@ -12165,9 +12198,10 @@
       }
     },
     "node_modules/envinfo": {
-      "version": "7.13.0",
-      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.13.0.tgz",
-      "integrity": "sha512-cvcaMr7KqXVh4nyzGTVqTum+gAiL265x5jUWQIDLq//zOGbW+gSW/C+OWLleY/rs9Qole6AZLMXPbtIFQbqu+Q==",
+      "version": "7.14.0",
+      "resolved": "https://registry.npmjs.org/envinfo/-/envinfo-7.14.0.tgz",
+      "integrity": "sha512-CO40UI41xDQzhLB1hWyqUKgFhs250pNcGbyGKe1l/e4FSaI/+YE4IMG76GDt0In67WLPACIITC+sOi08x4wIvg==",
+      "license": "MIT",
       "bin": {
         "envinfo": "dist/cli.js"
       },
@@ -12326,9 +12360,10 @@
       }
     },
     "node_modules/escalade": {
-      "version": "3.1.2",
-      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.1.2.tgz",
-      "integrity": "sha512-ErCHMCae19vR8vQGe50xIsVomy19rg6gFu3+r3jkEO46suLMWBksvVyoGgQV+jOfl84ZSOSlmv6Gxa89PmTGmA==",
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/escalade/-/escalade-3.2.0.tgz",
+      "integrity": "sha512-WUj2qlxaQtO4g6Pq5c29GTcWGDyd8itL8zTlipgECz3JesAiiOKotd8JU6otB3PACgG6xkJUyVhboMS+bje/jA==",
+      "license": "MIT",
       "engines": {
         "node": ">=6"
       }
@@ -22924,9 +22959,10 @@
       }
     },
     "node_modules/node-releases": {
-      "version": "2.0.14",
-      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.14.tgz",
-      "integrity": "sha512-y10wOWt8yZpqXmOgRo77WaHEmhYQYGNA6y421PKsKYWEK8aW+cqAphborZDhqfyKrbZEN92CN1X2KbafY2s7Yw=="
+      "version": "2.0.19",
+      "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.19.tgz",
+      "integrity": "sha512-xxOWJsBKtzAq7DY0J+DTzuz58K8e7sJbdgwkbMWQe8UYB6ekmsQ45q0M/tJDsGaZmbC+l7n57UV8Hl5tHxO9uw==",
+      "license": "MIT"
     },
     "node_modules/noms": {
       "version": "0.0.0",
@@ -23987,9 +24023,10 @@
       }
     },
     "node_modules/picocolors": {
-      "version": "1.0.1",
-      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.0.1.tgz",
-      "integrity": "sha512-anP1Z8qwhkbmu7MFP5iTt+wQKXgwzf7zTyGlcdzabySa9vd0Xt392U0rVmz9poOaBj0uHJKyyo9/upk0HrEQew=="
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/picocolors/-/picocolors-1.1.1.tgz",
+      "integrity": "sha512-xceH2snhtb5M9liqDsmEw56le376mTZkEX/jEb/RxNFyegNul7eNslCXP9FDj/Lcu0X8KEyMceP2ntpaHrDEVA==",
+      "license": "ISC"
     },
     "node_modules/picomatch": {
       "version": "2.3.1",
@@ -29830,9 +29867,9 @@
       }
     },
     "node_modules/update-browserslist-db": {
-      "version": "1.0.16",
-      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.0.16.tgz",
-      "integrity": "sha512-KVbTxlBYlckhF5wgfyZXTWnMn7MMZjMu9XG8bPlliUOP9ThaF4QnhP8qrjrH7DRzHfSk0oQv1wToW+iA5GajEQ==",
+      "version": "1.1.2",
+      "resolved": "https://registry.npmjs.org/update-browserslist-db/-/update-browserslist-db-1.1.2.tgz",
+      "integrity": "sha512-PPypAm5qvlD7XMZC3BujecnaOxwhrtoFR+Dqkk5Aa/6DssiH0ibKoketaj9w8LP7Bont1rYeoV5plxD7RTEPRg==",
       "funding": [
         {
           "type": "opencollective",
@@ -29847,9 +29884,10 @@
           "url": "https://github.com/sponsors/ai"
         }
       ],
+      "license": "MIT",
       "dependencies": {
-        "escalade": "^3.1.2",
-        "picocolors": "^1.0.1"
+        "escalade": "^3.2.0",
+        "picocolors": "^1.1.1"
       },
       "bin": {
         "update-browserslist-db": "cli.js"
@@ -30311,18 +30349,18 @@
       }
     },
     "node_modules/webpack": {
-      "version": "5.94.0",
-      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.94.0.tgz",
-      "integrity": "sha512-KcsGn50VT+06JH/iunZJedYGUJS5FGjow8wb9c0v5n1Om8O1g4L6LjtfxwlXIATopoQu+vOXXa7gYisWxCoPyg==",
+      "version": "5.97.1",
+      "resolved": "https://registry.npmjs.org/webpack/-/webpack-5.97.1.tgz",
+      "integrity": "sha512-EksG6gFY3L1eFMROS/7Wzgrii5mBAFe4rIr3r2BTfo7bcc+DWwFZ4OJ/miOuHJO/A85HwyI4eQ0F6IKXesO7Fg==",
       "license": "MIT",
       "dependencies": {
-        "@types/estree": "^1.0.5",
-        "@webassemblyjs/ast": "^1.12.1",
-        "@webassemblyjs/wasm-edit": "^1.12.1",
-        "@webassemblyjs/wasm-parser": "^1.12.1",
-        "acorn": "^8.7.1",
-        "acorn-import-attributes": "^1.9.5",
-        "browserslist": "^4.21.10",
+        "@types/eslint-scope": "^3.7.7",
+        "@types/estree": "^1.0.6",
+        "@webassemblyjs/ast": "^1.14.1",
+        "@webassemblyjs/wasm-edit": "^1.14.1",
+        "@webassemblyjs/wasm-parser": "^1.14.1",
+        "acorn": "^8.14.0",
+        "browserslist": "^4.24.0",
         "chrome-trace-event": "^1.0.2",
         "enhanced-resolve": "^5.17.1",
         "es-module-lexer": "^1.2.1",
@@ -31452,10 +31490,22 @@
         "@types/express": "^4.17.21",
         "@types/node": "^17.0.17",
         "express": "^4.19.2",
-        "typescript": "~5.3.0"
+        "typescript": "~5.3.0",
+        "webpack": "^5.97.1",
+        "webpack-cli": "^6.0.1"
       },
       "peerDependencies": {
         "@microsoft/fast-element": "^2.0.1"
+      }
+    },
+    "packages/web-components/fast-btr/node_modules/@discoveryjs/json-ext": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/@discoveryjs/json-ext/-/json-ext-0.6.3.tgz",
+      "integrity": "sha512-4B4OijXeVNOPZlYA2oEwWOTkzyltLao+xbotHQeqN++Rv27Y6s818+n2Qkp8q+Fxhn0t/5lA5X1Mxktud8eayQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.17.0"
       }
     },
     "packages/web-components/fast-btr/node_modules/@types/node": {
@@ -31464,6 +31514,63 @@
       "integrity": "sha512-w+tIMs3rq2afQdsPJlODhoUEKzFP1ayaoyl1CcnwtIlsVe7K7bA1NGm4s3PraqTLlXnbIN84zuBlxBWo1u9BLw==",
       "dev": true,
       "license": "MIT"
+    },
+    "packages/web-components/fast-btr/node_modules/@webpack-cli/configtest": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/configtest/-/configtest-3.0.1.tgz",
+      "integrity": "sha512-u8d0pJ5YFgneF/GuvEiDA61Tf1VDomHHYMjv/wc9XzYj7nopltpG96nXN5dJRstxZhcNpV1g+nT6CydO7pHbjA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      }
+    },
+    "packages/web-components/fast-btr/node_modules/@webpack-cli/info": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/info/-/info-3.0.1.tgz",
+      "integrity": "sha512-coEmDzc2u/ffMvuW9aCjoRzNSPDl/XLuhPdlFRpT9tZHmJ/039az33CE7uH+8s0uL1j5ZNtfdv0HkfaKRBGJsQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      }
+    },
+    "packages/web-components/fast-btr/node_modules/@webpack-cli/serve": {
+      "version": "3.0.1",
+      "resolved": "https://registry.npmjs.org/@webpack-cli/serve/-/serve-3.0.1.tgz",
+      "integrity": "sha512-sbgw03xQaCLiT6gcY/6u3qBDn01CWw/nbaXl3gTdTFuJJ75Gffv3E3DBpgvY2fkkrdS1fpjaXNOmJlnbtKauKg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0",
+        "webpack-cli": "6.x.x"
+      },
+      "peerDependenciesMeta": {
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "packages/web-components/fast-btr/node_modules/commander": {
+      "version": "12.1.0",
+      "resolved": "https://registry.npmjs.org/commander/-/commander-12.1.0.tgz",
+      "integrity": "sha512-Vw8qHK3bZM9y/P10u3Vib8o/DdkvA2OtPtZvD871QKjy74Wj1WSKFILMPRPSdUSx5RFK1arlJzEtA4PkFgnbuA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
     },
     "packages/web-components/fast-btr/node_modules/typescript": {
       "version": "5.3.3",
@@ -31477,6 +31584,64 @@
       },
       "engines": {
         "node": ">=14.17"
+      }
+    },
+    "packages/web-components/fast-btr/node_modules/webpack-cli": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-cli/-/webpack-cli-6.0.1.tgz",
+      "integrity": "sha512-MfwFQ6SfwinsUVi0rNJm7rHZ31GyTcpVE5pgVA3hwFRb7COD4TzjUUwhGWKfO50+xdc2MQPuEBBJoqIMGt3JDw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@discoveryjs/json-ext": "^0.6.1",
+        "@webpack-cli/configtest": "^3.0.1",
+        "@webpack-cli/info": "^3.0.1",
+        "@webpack-cli/serve": "^3.0.1",
+        "colorette": "^2.0.14",
+        "commander": "^12.1.0",
+        "cross-spawn": "^7.0.3",
+        "envinfo": "^7.14.0",
+        "fastest-levenshtein": "^1.0.12",
+        "import-local": "^3.0.2",
+        "interpret": "^3.1.1",
+        "rechoir": "^0.8.0",
+        "webpack-merge": "^6.0.1"
+      },
+      "bin": {
+        "webpack-cli": "bin/cli.js"
+      },
+      "engines": {
+        "node": ">=18.12.0"
+      },
+      "funding": {
+        "type": "opencollective",
+        "url": "https://opencollective.com/webpack"
+      },
+      "peerDependencies": {
+        "webpack": "^5.82.0"
+      },
+      "peerDependenciesMeta": {
+        "webpack-bundle-analyzer": {
+          "optional": true
+        },
+        "webpack-dev-server": {
+          "optional": true
+        }
+      }
+    },
+    "packages/web-components/fast-btr/node_modules/webpack-merge": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/webpack-merge/-/webpack-merge-6.0.1.tgz",
+      "integrity": "sha512-hXXvrjtx2PLYx4qruKl+kyRSLc52V+cCvMxRjmKwoA+CBbbF5GfIBtR6kCvl0fYGqTUPKB+1ktVmTHqMOzgCBg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "clone-deep": "^4.0.1",
+        "flat": "^5.0.2",
+        "wildcard": "^2.0.1"
+      },
+      "engines": {
+        "node": ">=18.0.0"
       }
     },
     "packages/web-components/fast-element": {

--- a/packages/web-components/fast-btr/README.md
+++ b/packages/web-components/fast-btr/README.md
@@ -23,6 +23,14 @@ This approach should focus on flexibility for webapp/website developers and give
 
 ## Usage
 
+In your JS bundle you will need to include the `@microsoft/fast-btr` package:
+
+```typescript
+import "@microsoft/fast-btr";
+```
+
+This will include the `<f-template>` custom element and all logic for interpreting the declarative HTML template into a `ViewTemplate`.
+
 ### Initial Rendering
 
 The rendering using the Rust script could look as follows:
@@ -50,21 +58,21 @@ At some point before the prehydration script and the definition of the custom el
 ```html
 <f-template name="my-custom-element">
     <template>
-        <button @click="x.handleClick()" ?disabled="x.disabled">
-            ${x.greeting}
+        <button @click="{{ handleClick() }}" ?disabled="{{ disabled }}">
+            {{ greeting }}
         </button>
         <input
-            :value="x.value"
+            :value="{{ value }}"
         >
-        <f-when condition="x.hasFriends()">
+        <f-when condition="{{ hasFriends }}">
             <ul>
-                <f-repeat items="x.friends">
-                    <li>${x.friend}</li>
+                <f-repeat items="{{ friend in friends }}">
+                    <li>{{ friend }}</li>
                 </f-repeat>
             </ul>
         </f-when>
         <slot>
-            <f-slotted :items="x.items"></f-slotted>
+            <f-slotted :items="{{ items }}"></f-slotted>
         </slot>
     </template>
 </f-template>

--- a/packages/web-components/fast-btr/docs/api-report.api.md
+++ b/packages/web-components/fast-btr/docs/api-report.api.md
@@ -4,6 +4,15 @@
 
 ```ts
 
+import { FASTElement } from '@microsoft/fast-element';
+
+// @public
+export class TemplateElement extends FASTElement {
+    // (undocumented)
+    connectedCallback(): void;
+    name?: string;
+}
+
 // (No @packageDocumentation comment for this package)
 
 ```

--- a/packages/web-components/fast-btr/package.json
+++ b/packages/web-components/fast-btr/package.json
@@ -21,18 +21,20 @@
         "clean": "tsc -b --clean src",
         "clean:dist": "node ../../../build/clean.js dist",
         "build": "tsc -b src && npm run doc",
+        "build-app": "webpack",
+        "build-server": "tsc -b server",
         "doc": "api-extractor run --local",
         "doc:ci": "api-extractor run",
-        "prepublishOnly": "npm run clean && npm run build",
-        "build-server": "tsc -b server",
         "eslint": "eslint . --ext .ts",
         "eslint:fix": "eslint . --ext .ts --fix",
+        "prepublishOnly": "npm run clean && npm run build",
         "pretest": "npm run build-server && npm run build",
         "prettier:diff": "prettier --config ../../../.prettierrc \"**/*.{ts,html}\" --list-different",
         "prettier": "prettier --config ../../../.prettierrc --write \"**/*.{ts,html}\"",
-        "test": "playwright test --config=playwright.config.cjs",
+        "test": "npm run build-app && playwright test --config=playwright.config.cjs",
         "test-server": "node server/dist/server.js",
-        "install-playwright-browsers": "npm run playwright install"
+        "install-playwright-browsers": "npm run playwright install",
+        "dev": "npm run build && npm run build-app && npm run build-server && npm run test-server"
     },
     "description": "A package for facilitating rendering FAST Web Components in a non-browser environment.",
     "exports": {
@@ -42,6 +44,9 @@
         },
         "./package.json": "./package.json"
     },
+    "sideEffects": [
+        "./dist/esm/index.js"
+    ],
     "peerDependencies": {
         "@microsoft/fast-element": "^2.0.1"
     },
@@ -52,7 +57,9 @@
         "@types/express": "^4.17.21",
         "@types/node": "^17.0.17",
         "express": "^4.19.2",
-        "typescript": "~5.3.0"
+        "typescript": "~5.3.0",
+        "webpack": "^5.97.1",
+        "webpack-cli": "^6.0.1"
     },
     "beachball": {
         "disallowedChangeTypes": [

--- a/packages/web-components/fast-btr/server/main.ts
+++ b/packages/web-components/fast-btr/server/main.ts
@@ -1,0 +1,14 @@
+import { TemplateElement } from "@microsoft/fast-btr";
+import { attr, FASTElement } from "@microsoft/fast-element";
+
+class CustomElement extends FASTElement {
+    @attr
+    text: string = "Hello";
+}
+CustomElement.define({
+    name: "custom-element",
+});
+
+TemplateElement.define({
+    name: "f-template",
+});

--- a/packages/web-components/fast-btr/server/server.ts
+++ b/packages/web-components/fast-btr/server/server.ts
@@ -34,4 +34,7 @@ const app = express();
 app.get("/binding", (req: Request, res: Response) =>
     handlePathRequest("./src/fixtures/binding.fixture.html", "text/html", req, res)
 );
+app.get("/main.js", (req: Request, res: Response) =>
+    handlePathRequest("./server/dist/main.js", "text/javascript", req, res)
+);
 app.listen(PORT);

--- a/packages/web-components/fast-btr/server/tsconfig.json
+++ b/packages/web-components/fast-btr/server/tsconfig.json
@@ -5,5 +5,5 @@
 		"rootDir": ".",
 		"outDir": "dist"
 	},
-	"references": [{ "path": "../src"}]
+	"include": ["./server.ts"]
 }

--- a/packages/web-components/fast-btr/src/components/index.ts
+++ b/packages/web-components/fast-btr/src/components/index.ts
@@ -1,0 +1,1 @@
+export { TemplateElement } from "./template.js";

--- a/packages/web-components/fast-btr/src/components/template.ts
+++ b/packages/web-components/fast-btr/src/components/template.ts
@@ -61,8 +61,10 @@ class TemplateElement extends FASTElement {
 
                         if (registeredFastElement) {
                             // all new elements will get the updated template
-                            registeredFastElement.updateTemplate(
-                                ViewTemplate.create(strings, values, DOMPolicy.create())
+                            registeredFastElement.template = ViewTemplate.create(
+                                strings,
+                                values,
+                                DOMPolicy.create()
                             );
                         }
                     } else {

--- a/packages/web-components/fast-btr/src/components/template.ts
+++ b/packages/web-components/fast-btr/src/components/template.ts
@@ -1,0 +1,107 @@
+import {
+    attr,
+    FAST,
+    FASTElement,
+    FASTElementDefinition,
+    fastElementRegistry,
+    ViewTemplate,
+} from "@microsoft/fast-element";
+import { DOMPolicy } from "@microsoft/fast-element/dom-policy.js";
+import { Message } from "../interfaces.js";
+
+/**
+ * The <f-template> custom element that will provide view logic to the element
+ */
+class TemplateElement extends FASTElement {
+    /**
+     * The name of the custom element this template will be applied to
+     */
+    @attr
+    public name?: string;
+
+    private bindingRegex: RegExp = /{{(?:.*?)}}/g;
+
+    private openBinding: string = "{{";
+
+    private closeBinding: string = "}}";
+
+    connectedCallback(): void {
+        super.connectedCallback();
+
+        if (this.name) {
+            this.$fastController.definition.registry
+                .whenDefined(this.name)
+                .then(value => {
+                    const registeredFastElement: FASTElementDefinition | undefined =
+                        fastElementRegistry.getByType(value);
+                    const template = this.getElementsByTagName("template").item(0);
+
+                    if (template) {
+                        const childNodes = template.content.childNodes;
+                        const strings: any[] = [];
+                        const values: any[] = []; // these can be bindings, directives, etc.
+
+                        childNodes.forEach(childNode => {
+                            switch (childNode.nodeType) {
+                                case 1: // HTMLElement
+                                    break;
+                                case 3: // text
+                                    this.resolveTextBindings(childNode, strings, values);
+                                    break;
+                                default:
+                                    break;
+                            }
+                        });
+
+                        strings.push("");
+
+                        (strings as any).raw = strings.map(value =>
+                            String.raw({ raw: value })
+                        );
+
+                        if (registeredFastElement) {
+                            // all new elements will get the updated template
+                            registeredFastElement.updateTemplate(
+                                ViewTemplate.create(strings, values, DOMPolicy.create())
+                            );
+                        }
+                    } else {
+                        throw FAST.error(Message.noTemplateProvided, { name: this.name });
+                    }
+                });
+        }
+    }
+
+    /**
+     * Resolve a text binding
+     * @param childNode The child node to interpret.
+     * @param strings The strings array.
+     * @param values The interpreted values.
+     */
+    private resolveTextBindings(
+        childNode: ChildNode,
+        strings: Array<string>,
+        values: Array<any>
+    ) {
+        const textContent = childNode.textContent || "";
+        const bindingArray = textContent.match(this.bindingRegex);
+        const stringArray = textContent.split(this.bindingRegex);
+
+        if (bindingArray) {
+            bindingArray.forEach((htmlBindingItem, index) => {
+                // create a binding
+                const sansBindingStrings = htmlBindingItem
+                    .replace(this.openBinding, "")
+                    .replace(this.closeBinding, "")
+                    .trim();
+                const bindingItem = (x: any) => x[sansBindingStrings];
+                strings.push(stringArray[index]);
+                values.push(bindingItem);
+            });
+        } else {
+            strings.push(textContent);
+        }
+    }
+}
+
+export { TemplateElement };

--- a/packages/web-components/fast-btr/src/debug.ts
+++ b/packages/web-components/fast-btr/src/debug.ts
@@ -1,0 +1,3 @@
+export const debugMessages = {
+    [2000 /* noTemplateProvided */]: `The first child of the <f-template> must be a <template>, this is missing from ${name}.`,
+};

--- a/packages/web-components/fast-btr/src/fixtures/binding.fixture.html
+++ b/packages/web-components/fast-btr/src/fixtures/binding.fixture.html
@@ -6,14 +6,11 @@
     </head>
     <body>
         <custom-element text="Hello world">
-            <template shadowrootmode="open">
-                Hello world
-            </template>
+            <template shadowrootmode="open">Hello world</template>
         </custom-element>
         <f-template name="custom-element">
-            <template>
-                {{text}}
-            </template>
+            <template>{{text}}</template>
         </f-template>
+        <script type="module" src="/main.js"></script>
     </body>
 </html>

--- a/packages/web-components/fast-btr/src/index.spec.ts
+++ b/packages/web-components/fast-btr/src/index.spec.ts
@@ -1,6 +1,20 @@
 import { expect, test } from "@playwright/test";
 
-test("placeholder", async () => {
-    // TODO: update this with tests against fixtures
-    expect(1+1).toEqual(2);
+test.describe("f-template", async () => {
+    test("create a binding", async ({ page }) => {
+        await page.goto("/binding");
+
+        const customElement = await page.locator("custom-element");
+
+        await expect(await customElement.getAttribute("text")).toEqual("Hello world");
+        await expect((await customElement.textContent()) || "".includes("Hello world")).toBeTruthy();
+
+        await page.evaluate(() => {
+            const customElement = document.getElementsByTagName("custom-element");
+            customElement.item(0)?.setAttribute("text", "Hello pluto");
+        });
+
+        await expect(await customElement.getAttribute("text")).toEqual("Hello pluto");
+        await expect((await customElement.textContent()) || "".includes("Hello pluto")).toBeTruthy();
+    });
 });

--- a/packages/web-components/fast-btr/src/index.ts
+++ b/packages/web-components/fast-btr/src/index.ts
@@ -1,0 +1,6 @@
+import { FAST } from "@microsoft/fast-element";
+import { debugMessages } from "./debug.js";
+
+FAST.addMessages(debugMessages);
+
+export { TemplateElement } from "./components/index.js";

--- a/packages/web-components/fast-btr/src/interfaces.ts
+++ b/packages/web-components/fast-btr/src/interfaces.ts
@@ -1,0 +1,7 @@
+/**
+ * Warning and error messages.
+ * @internal
+ */
+export const enum Message {
+    noTemplateProvided = 2000,
+}

--- a/packages/web-components/fast-btr/webpack.config.js
+++ b/packages/web-components/fast-btr/webpack.config.js
@@ -1,0 +1,29 @@
+import path from "path";
+import { fileURLToPath } from "url";
+
+const __filename = fileURLToPath(import.meta.url);
+const __dirname = path.resolve(path.dirname(__filename), "./");
+
+export default {
+  entry: "./server/main.ts",
+  mode: "production",
+  output: {
+    filename: "main.js",
+    path: path.resolve(__dirname, "./server/dist"),
+  },
+  devServer: {
+    static: "./public",
+    port: 3001
+  },
+  resolve: {
+    extensions: [".ts", ".js"],
+    extensionAlias: {
+     ".js": [".js", ".ts"],
+    }
+  },
+  module: {
+    rules: [
+      { test: /\.([cm]?ts)$/, loader: "ts-loader" }
+    ]
+  },
+};

--- a/packages/web-components/fast-element/docs/api-report.api.md
+++ b/packages/web-components/fast-element/docs/api-report.api.md
@@ -428,7 +428,6 @@ export const FAST: FASTGlobal;
 export interface FASTElement extends HTMLElement {
     $emit(type: string, detail?: any, options?: Omit<CustomEventInit, "detail">): boolean | void;
     readonly $fastController: ElementController;
-    $update(): void;
     attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void;
     connectedCallback(): void;
     disconnectedCallback(): void;
@@ -461,7 +460,6 @@ export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Co
     readonly styles?: ElementStyles;
     template?: ElementViewTemplate;
     readonly type: TType;
-    updateTemplate: (template: ElementViewTemplate) => void;
 }
 
 // Warning: (ae-internal-missing-underscore) The name "fastElementRegistry" should be prefixed with an underscore because the declaration is marked as @internal
@@ -1052,9 +1050,9 @@ export function when<TSource = any, TReturn = any, TParent = any>(condition: Exp
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/components/fast-element.d.ts:67:5 - (ae-forgotten-export) The symbol "define" needs to be exported by the entry point index.d.ts
-// dist/dts/components/fast-element.d.ts:68:5 - (ae-forgotten-export) The symbol "compose" needs to be exported by the entry point index.d.ts
-// dist/dts/components/fast-element.d.ts:69:5 - (ae-forgotten-export) The symbol "from" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:60:5 - (ae-forgotten-export) The symbol "define" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:61:5 - (ae-forgotten-export) The symbol "compose" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:62:5 - (ae-forgotten-export) The symbol "from" needs to be exported by the entry point index.d.ts
 // dist/dts/styles/css-binding-directive.d.ts:35:9 - (ae-forgotten-export) The symbol "CSSBindingEntry" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-element/docs/api-report.api.md
+++ b/packages/web-components/fast-element/docs/api-report.api.md
@@ -974,8 +974,6 @@ export interface TypeRegistry<TDefinition extends TypeDefinition> {
     getForInstance(object: any): TDefinition | undefined;
     // (undocumented)
     register(definition: TDefinition): boolean;
-    // (undocumented)
-    reregister(definition: TDefinition): boolean;
 }
 
 // @public

--- a/packages/web-components/fast-element/docs/api-report.api.md
+++ b/packages/web-components/fast-element/docs/api-report.api.md
@@ -295,7 +295,7 @@ export class ElementController<TElement extends HTMLElement = HTMLElement> exten
     // (undocumented)
     protected disconnectBehaviors(): void;
     emit(type: string, detail?: any, options?: Omit<CustomEventInit, "detail">): void | boolean;
-    static forCustomElement(element: HTMLElement): ElementController;
+    static forCustomElement(element: HTMLElement, override?: boolean): ElementController;
     get isBound(): boolean;
     get isConnected(): boolean;
     get mainStyles(): ElementStyles | null;
@@ -428,6 +428,7 @@ export const FAST: FASTGlobal;
 export interface FASTElement extends HTMLElement {
     $emit(type: string, detail?: any, options?: Omit<CustomEventInit, "detail">): boolean | void;
     readonly $fastController: ElementController;
+    $update(): void;
     attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null): void;
     connectedCallback(): void;
     disconnectedCallback(): void;
@@ -458,9 +459,15 @@ export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Co
     readonly registry: CustomElementRegistry;
     readonly shadowOptions?: ShadowRootOptions;
     readonly styles?: ElementStyles;
-    readonly template?: ElementViewTemplate;
+    template?: ElementViewTemplate;
     readonly type: TType;
+    updateTemplate: (template: ElementViewTemplate) => void;
 }
+
+// Warning: (ae-incompatible-release-tags) The symbol "fastElementRegistry" is marked as @public, but its signature references "TypeRegistry" which is marked as @internal
+//
+// @public (undocumented)
+export const fastElementRegistry: TypeRegistry<FASTElementDefinition>;
 
 // @public
 export interface FASTGlobal {
@@ -958,6 +965,21 @@ export type TrustedTypesPolicy = {
     createHTML(html: string): string;
 };
 
+// Warning: (ae-forgotten-export) The symbol "TypeDefinition" needs to be exported by the entry point index.d.ts
+// Warning: (ae-internal-missing-underscore) The name "TypeRegistry" should be prefixed with an underscore because the declaration is marked as @internal
+//
+// @internal
+export interface TypeRegistry<TDefinition extends TypeDefinition> {
+    // (undocumented)
+    getByType(key: Function): TDefinition | undefined;
+    // (undocumented)
+    getForInstance(object: any): TDefinition | undefined;
+    // (undocumented)
+    register(definition: TDefinition): boolean;
+    // (undocumented)
+    reregister(definition: TDefinition): boolean;
+}
+
 // @public
 export interface UpdateQueue {
     enqueue(callable: Callable): void;
@@ -1030,9 +1052,9 @@ export function when<TSource = any, TReturn = any, TParent = any>(condition: Exp
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/components/fast-element.d.ts:60:5 - (ae-forgotten-export) The symbol "define" needs to be exported by the entry point index.d.ts
-// dist/dts/components/fast-element.d.ts:61:5 - (ae-forgotten-export) The symbol "compose" needs to be exported by the entry point index.d.ts
-// dist/dts/components/fast-element.d.ts:62:5 - (ae-forgotten-export) The symbol "from" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:67:5 - (ae-forgotten-export) The symbol "define" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:68:5 - (ae-forgotten-export) The symbol "compose" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:69:5 - (ae-forgotten-export) The symbol "from" needs to be exported by the entry point index.d.ts
 // dist/dts/styles/css-binding-directive.d.ts:35:9 - (ae-forgotten-export) The symbol "CSSBindingEntry" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-element/docs/api-report.api.md
+++ b/packages/web-components/fast-element/docs/api-report.api.md
@@ -464,9 +464,9 @@ export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Co
     updateTemplate: (template: ElementViewTemplate) => void;
 }
 
-// Warning: (ae-incompatible-release-tags) The symbol "fastElementRegistry" is marked as @public, but its signature references "TypeRegistry" which is marked as @internal
+// Warning: (ae-internal-missing-underscore) The name "fastElementRegistry" should be prefixed with an underscore because the declaration is marked as @internal
 //
-// @public (undocumented)
+// @internal
 export const fastElementRegistry: TypeRegistry<FASTElementDefinition>;
 
 // @public

--- a/packages/web-components/fast-element/src/components/element-controller.ts
+++ b/packages/web-components/fast-element/src/components/element-controller.ts
@@ -15,6 +15,7 @@ import type { ElementViewTemplate } from "../templating/template.js";
 import type { ElementView } from "../templating/view.js";
 import { UnobservableMutationObserver } from "../utilities.js";
 import { FASTElementDefinition } from "./fast-definitions.js";
+import type { FASTElement } from "./fast-element.js";
 import { HydrationMarkup, isHydratable } from "./hydration.js";
 
 const defaultEventOptions: CustomEventInit = {
@@ -552,6 +553,16 @@ export class ElementController<TElement extends HTMLElement = HTMLElement>
         if (definition === void 0) {
             throw FAST.error(Message.missingElementDefinition);
         }
+
+        Observable.getNotifier(definition).subscribe(
+            {
+                handleChange: () => {
+                    ElementController.forCustomElement(element as FASTElement, true);
+                    (element as FASTElement).$fastController.connect();
+                },
+            },
+            "template"
+        );
 
         return ((element as any).$fastController = new elementControllerStrategy(
             element,

--- a/packages/web-components/fast-element/src/components/element-controller.ts
+++ b/packages/web-components/fast-element/src/components/element-controller.ts
@@ -531,15 +531,19 @@ export class ElementController<TElement extends HTMLElement = HTMLElement>
     /**
      * Locates or creates a controller for the specified element.
      * @param element - The element to return the controller for.
+     * @param override - Reset the controller even if one has been defined.
      * @remarks
      * The specified element must have a {@link FASTElementDefinition}
      * registered either through the use of the {@link customElement}
      * decorator or a call to `FASTElement.define`.
      */
-    public static forCustomElement(element: HTMLElement): ElementController {
+    public static forCustomElement(
+        element: HTMLElement,
+        override: boolean = false
+    ): ElementController {
         const controller: ElementController = (element as any).$fastController;
 
-        if (controller !== void 0) {
+        if (controller !== void 0 && !override) {
             return controller;
         }
 

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -4,8 +4,6 @@ import { createTypeRegistry, FAST, TypeRegistry } from "../platform.js";
 import { ComposableStyles, ElementStyles } from "../styles/element-styles.js";
 import type { ElementViewTemplate } from "../templating/template.js";
 import { AttributeConfiguration, AttributeDefinition } from "./attributes.js";
-import { ElementController } from "./element-controller.js";
-import type { FASTElement } from "./fast-element.js";
 
 const defaultShadowOptions: ShadowRootInit = { mode: "open" };
 const defaultElementOptions: ElementDefinitionOptions = {};
@@ -199,29 +197,6 @@ export class FASTElementDefinition<
         this.styles = ElementStyles.normalize(nameOrConfig.styles);
 
         fastElementRegistry.register(this);
-
-        Observable.getNotifier(this).subscribe(
-            {
-                handleChange: () => {
-                    fastElementRegistry.reregister(this);
-
-                    const allElements = document.getElementsByTagName(this.name);
-
-                    for (
-                        let i = 0, allElementsLength = allElements.length;
-                        i < allElementsLength;
-                        i++
-                    ) {
-                        ElementController.forCustomElement(
-                            allElements[i] as FASTElement,
-                            true
-                        );
-                        (allElements[i] as FASTElement).$fastController.connect();
-                    }
-                },
-            },
-            "template"
-        );
     }
 
     /**

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -4,15 +4,18 @@ import { createTypeRegistry, FAST, TypeRegistry } from "../platform.js";
 import { ComposableStyles, ElementStyles } from "../styles/element-styles.js";
 import type { ElementViewTemplate } from "../templating/template.js";
 import { AttributeConfiguration, AttributeDefinition } from "./attributes.js";
+import type { FASTElement } from "./fast-element.js";
 
 const defaultShadowOptions: ShadowRootInit = { mode: "open" };
 const defaultElementOptions: ElementDefinitionOptions = {};
 const fastElementBaseTypes = new Set<Function>();
 
-const fastElementRegistry: TypeRegistry<FASTElementDefinition> = FAST.getById(
+export const fastElementRegistry: TypeRegistry<FASTElementDefinition> = FAST.getById(
     KernelServiceId.elementRegistry,
     () => createTypeRegistry<FASTElementDefinition>()
 );
+
+export { TypeRegistry };
 
 /**
  * Shadow root initialization options.
@@ -117,7 +120,26 @@ export class FASTElementDefinition<
     /**
      * The template to render for the custom element.
      */
-    public readonly template?: ElementViewTemplate;
+    public template?: ElementViewTemplate;
+
+    /**
+     * Set the template for the custom element.
+     */
+    public updateTemplate = (template: ElementViewTemplate) => {
+        this.template = template;
+
+        fastElementRegistry.reregister(this);
+
+        const allElements = document.getElementsByTagName(this.name);
+
+        for (
+            let i = 0, allElementsLength = allElements.length;
+            i < allElementsLength;
+            i++
+        ) {
+            (allElements[i] as FASTElement).$update();
+        }
+    };
 
     /**
      * The styles to associate with the custom element.

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -10,6 +10,10 @@ const defaultShadowOptions: ShadowRootInit = { mode: "open" };
 const defaultElementOptions: ElementDefinitionOptions = {};
 const fastElementBaseTypes = new Set<Function>();
 
+/**
+ * The FAST custom element registry
+ * @internal
+ */
 export const fastElementRegistry: TypeRegistry<FASTElementDefinition> = FAST.getById(
     KernelServiceId.elementRegistry,
     () => createTypeRegistry<FASTElementDefinition>()

--- a/packages/web-components/fast-element/src/components/fast-element.ts
+++ b/packages/web-components/fast-element/src/components/fast-element.ts
@@ -31,6 +31,14 @@ export interface FASTElement extends HTMLElement {
     ): boolean | void;
 
     /**
+     * Updates the FASTElement controller and definition.
+     * @remarks
+     * This method should only be triggered when core pieces of the elements
+     * definition require the element to update the controller and reconnect.
+     */
+    $update(): void;
+
+    /**
      * The connected callback for this FASTElement.
      * @remarks
      * This method is invoked by the platform whenever this FASTElement
@@ -81,6 +89,11 @@ function createFASTElement<T extends typeof HTMLElement>(
             options?: Omit<CustomEventInit, "detail">
         ): boolean | void {
             return this.$fastController.emit(type, detail, options);
+        }
+
+        public $update(): void {
+            ElementController.forCustomElement(this as any, true);
+            this.$fastController.connect();
         }
 
         public connectedCallback(): void {

--- a/packages/web-components/fast-element/src/components/fast-element.ts
+++ b/packages/web-components/fast-element/src/components/fast-element.ts
@@ -31,14 +31,6 @@ export interface FASTElement extends HTMLElement {
     ): boolean | void;
 
     /**
-     * Updates the FASTElement controller and definition.
-     * @remarks
-     * This method should only be triggered when core pieces of the elements
-     * definition require the element to update the controller and reconnect.
-     */
-    $update(): void;
-
-    /**
      * The connected callback for this FASTElement.
      * @remarks
      * This method is invoked by the platform whenever this FASTElement
@@ -89,11 +81,6 @@ function createFASTElement<T extends typeof HTMLElement>(
             options?: Omit<CustomEventInit, "detail">
         ): boolean | void {
             return this.$fastController.emit(type, detail, options);
-        }
-
-        public $update(): void {
-            ElementController.forCustomElement(this as any, true);
-            this.$fastController.connect();
         }
 
         public connectedCallback(): void {

--- a/packages/web-components/fast-element/src/index.ts
+++ b/packages/web-components/fast-element/src/index.ts
@@ -143,6 +143,8 @@ export {
     FASTElementDefinition,
     PartialFASTElementDefinition,
     ShadowRootOptions,
+    fastElementRegistry,
+    TypeRegistry,
 } from "./components/fast-definitions.js";
 export {
     attr,

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -70,7 +70,6 @@ export interface TypeDefinition {
  * @internal
  */
 export interface TypeRegistry<TDefinition extends TypeDefinition> {
-    reregister(definition: TDefinition): boolean;
     register(definition: TDefinition): boolean;
     getByType(key: Function): TDefinition | undefined;
     getForInstance(object: any): TDefinition | undefined;
@@ -86,14 +85,6 @@ export function createTypeRegistry<
     const typeToDefinition = new Map<Function, TDefinition>();
 
     return Object.freeze({
-        reregister(definition: TDefinition): boolean {
-            if (!typeToDefinition.has(definition.type)) {
-                return false;
-            }
-
-            typeToDefinition.set(definition.type, definition);
-            return true;
-        },
         register(definition: TDefinition): boolean {
             if (typeToDefinition.has(definition.type)) {
                 return false;

--- a/packages/web-components/fast-element/src/platform.ts
+++ b/packages/web-components/fast-element/src/platform.ts
@@ -70,6 +70,7 @@ export interface TypeDefinition {
  * @internal
  */
 export interface TypeRegistry<TDefinition extends TypeDefinition> {
+    reregister(definition: TDefinition): boolean;
     register(definition: TDefinition): boolean;
     getByType(key: Function): TDefinition | undefined;
     getForInstance(object: any): TDefinition | undefined;
@@ -85,6 +86,14 @@ export function createTypeRegistry<
     const typeToDefinition = new Map<Function, TDefinition>();
 
     return Object.freeze({
+        reregister(definition: TDefinition): boolean {
+            if (!typeToDefinition.has(definition.type)) {
+                return false;
+            }
+
+            typeToDefinition.set(definition.type, definition);
+            return true;
+        },
         register(definition: TDefinition): boolean {
             if (typeToDefinition.has(definition.type)) {
                 return false;


### PR DESCRIPTION
# Pull Request

## 📖 Description

This is some initial work to convert declarative HTML into a `ViewTemplate`.

## 👩‍💻 Reviewer Notes

Some of this is preliminary work to get a workflow established for creation of aspect bindings and other requirements for the declarative HTML. This work also exposes the `fastElementRegistry` as well as exposing some global values to trigger instantiated components to update their internal definitions after a new template has been applied.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

- Adding attribute bindings
- Adding logic for common directives such as `when`