### PR TITLE
Remove node parsing logic and use innerHTML, remove regex for perf

### DIFF
--- a/packages/web-components/fast-btr/src/components/template.ts
+++ b/packages/web-components/fast-btr/src/components/template.ts
@@ -19,11 +19,6 @@ class TemplateElement extends FASTElement {
     @attr
     public name?: string;
 
-    /**
-     * The binding regex used to identify declarative HTML bindings.
-     */
-    private bindingRegex: RegExp = /{{(?:.*?)}}/g;
-
     private openBinding: string = "{{";
 
     private closeBinding: string = "}}";
@@ -40,11 +35,10 @@ class TemplateElement extends FASTElement {
                     const template = this.getElementsByTagName("template").item(0);
 
                     if (template) {
-                        const childNodes = template.content.childNodes;
                         const strings: any[] = [];
                         const values: any[] = []; // these can be bindings, directives, etc.
 
-                        this.resolveChildNodes(childNodes, strings, values);
+                        this.resolveInnerHTML(this.innerHTML, strings, values);
 
                         (strings as any).raw = strings.map(value =>
                             String.raw({ raw: value })
@@ -66,148 +60,31 @@ class TemplateElement extends FASTElement {
     }
 
     /**
-     * Resolves child nodes
-     * @param childNode The child node to interpret.
+     * Resolver of the innerHTML string
+     * @param innerHTML - The innerHTML.
      * @param strings The strings array.
      * @param values The interpreted values.
      */
-    private resolveChildNodes(
-        childNodes: NodeListOf<ChildNode>,
+    private resolveInnerHTML(
+        innerHTML: string,
         strings: Array<string>,
         values: Array<any>
     ): void {
-        childNodes.forEach(childNode => {
-            switch (childNode.nodeType) {
-                case 1: // HTMLElement
-                    this.resolveHTMLElement(childNode, strings, values);
-                    break;
-                case 3: // text
-                    this.resolveTextBindings(childNode, strings, values);
-                    break;
-                default:
-                    break;
-            }
-        });
-    }
+        const bindingOpen = innerHTML.indexOf(this.openBinding);
+        const bindingClose = innerHTML.indexOf(this.closeBinding);
 
-    /**
-     * Resolves the last string in the array and appends a new string to it
-     * @param newString The new string for the template.
-     * @param strings The strings array.
-     * @param values The interpreted values.
-     */
-    private resolveLastStringItem(
-        newString: string,
-        strings: Array<string>,
-        stringsLength: number
-    ): void {
-        strings[stringsLength - 1] = `${strings[stringsLength - 1]}${newString}`;
-    }
+        if (bindingOpen !== -1 && bindingClose !== -1) {
+            strings.push(innerHTML.slice(0, bindingOpen));
+            values.push((x: any) => x[innerHTML.slice(bindingOpen + 2, bindingClose)]);
 
-    /**
-     * Resolves a string to either the previous string value or as a new string in the array
-     * @param newString The new string for the template.
-     * @param strings The strings array.
-     * @param values The interpreted values.
-     */
-    private resolveString(
-        newString: string,
-        strings: Array<string>,
-        values: Array<any>
-    ): void {
-        const stringsLength = strings.length;
-
-        if (stringsLength > values.length) {
-            this.resolveLastStringItem(newString, strings, stringsLength);
+            this.resolveInnerHTML(
+                innerHTML.slice(bindingClose + 2, innerHTML.length),
+                strings,
+                values
+            );
         } else {
-            strings.push(newString);
+            strings.push(innerHTML);
         }
-    }
-
-    /**
-     * Resolves an HTMLElement
-     * @param childNode The child node to interpret.
-     * @param strings The strings array.
-     * @param values The interpreted values.
-     */
-    private resolveHTMLElement(
-        childNode: ChildNode,
-        strings: Array<string>,
-        values: Array<any>
-    ): void {
-        const tagName = childNode.nodeName.toLowerCase();
-
-        strings.push(`<${tagName}`);
-
-        const attributes = (childNode as HTMLElement).attributes;
-
-        for (let i = 0, attributeLength = attributes.length; i < attributeLength; i++) {
-            const bindingAttr = attributes.item(i)?.value.match(this.bindingRegex);
-
-            this.resolveLastStringItem(" ", strings, strings.length);
-
-            if (bindingAttr) {
-                this.resolveLastStringItem(
-                    `${attributes.item(i)?.name}="`,
-                    strings,
-                    strings.length
-                );
-                // create a binding
-                const sansBindingStrings = bindingAttr[0]
-                    .replace(this.openBinding, "")
-                    .replace(this.closeBinding, "")
-                    .trim();
-                const bindingItem = (x: any) => x[sansBindingStrings];
-                values.push(bindingItem);
-                strings.push('"');
-            } else {
-                this.resolveString(
-                    ` ${attributes.item(i)?.name}="${attributes.item(i)?.value}"`,
-                    strings,
-                    values
-                );
-            }
-        }
-
-        this.resolveString(`>`, strings, values);
-
-        if (childNode.hasChildNodes()) {
-            this.resolveChildNodes(childNode.childNodes, strings, values);
-            this.resolveLastStringItem(`</${tagName}>`, strings, strings.length);
-        }
-    }
-
-    /**
-     * Resolve a text binding
-     * @param childNode The child node to interpret.
-     * @param strings The strings array.
-     * @param values The interpreted values.
-     */
-    private resolveTextBindings(
-        childNode: ChildNode,
-        strings: Array<string>,
-        values: Array<any>
-    ): void {
-        const textContent = childNode.textContent || "";
-        const bindingArray = textContent.match(this.bindingRegex);
-        const stringArray = textContent.split(this.bindingRegex);
-
-        if (bindingArray) {
-            bindingArray.forEach((htmlBindingItem, index) => {
-                // create a binding
-                const sansBindingStrings = htmlBindingItem
-                    .replace(this.openBinding, "")
-                    .replace(this.closeBinding, "")
-                    .trim();
-                const bindingItem = (x: any) => x[sansBindingStrings];
-                strings.push(stringArray[index]);
-                values.push(bindingItem);
-            });
-        } else {
-            strings.push(textContent);
-        }
-
-        strings.push("");
     }
 }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change simplifies the logic by using `innerHTML` to parse and removes the regex which had perf implications. This brings the implementation more inline with how the `html` tag template works.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.