### PR TITLE
Remove private flag on initial @microsoft/fast-html package

### DIFF
--- a/change/@microsoft-fast-html-6767d25e-8a0b-47c9-8790-6cf2f5e5025e.json
+++ b/change/@microsoft-fast-html-6767d25e-8a0b-47c9-8790-6cf2f5e5025e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update private flag for initial release",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/package.json
+++ b/packages/web-components/fast-html/package.json
@@ -1,7 +1,6 @@
 {
     "name": "@microsoft/fast-html",
     "version": "1.0.0-alpha.0",
-    "private": true,
     "type": "module",
     "author": {
         "name": "Microsoft",


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change removes the `private` flag on the `@microsoft/fast-html` for initial `1.0.0-alpha.1` release.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.