### PR TITLE
Remove alpha tag as there is no stable version for fast-html

### DIFF
--- a/change/@microsoft-fast-html-5e7702eb-3c09-4b89-a5ad-1f0387043f76.json
+++ b/change/@microsoft-fast-html-5e7702eb-3c09-4b89-a5ad-1f0387043f76.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Remove inclusion of alpha tag as there is no stable version yet",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/package.json
+++ b/packages/web-components/fast-html/package.json
@@ -79,7 +79,6 @@
       "major",
       "minor",
       "patch"
-    ],
-    "tag": "alpha"
+    ]
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change removes the redundant `alpha` git tag as there is no stable version as yet, so it can be published as `latest`.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.