### PR TITLE
Add logic to the when directive for a subset of operators

### DIFF
--- a/change/@microsoft-fast-html-ad397d9b-b0e1-4309-a3ac-48b054d979cb.json
+++ b/change/@microsoft-fast-html-ad397d9b-b0e1-4309-a3ac-48b054d979cb.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add logic to the when directive for a subset of operators",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -95,7 +95,20 @@ Template directives include:
     Example:
     ```html
     <f-when value="{{show}}">Hello world</f-when>
+    <f-when value="{{!show}}">Goodbye world</f-when>
     ```
+
+The following operators can also be used:
+- `==`
+- `!=`
+- `>=`
+- `>`
+- `<=`
+- `<`
+- `||`
+- `&&`
+
+Where the right operand can be either a reference to a value (string e.g. `{{foo == 'bar'}}`, boolean e.g. `{{foo == true}}`, number e.g. `{{foo == 3}}`) or another binding value.
 
 - **repeat**
 

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -13,6 +13,7 @@ import {
     DataBindingBehaviorConfig,
     getAllPartials,
     getNextBehavior,
+    getOperator,
     pathResolver,
     TemplateDirectiveBehaviorConfig,
 } from "./utilities.js";
@@ -121,11 +122,76 @@ class TemplateElement extends FASTElement {
 
                     const { when } = await import("@microsoft/fast-element");
 
+                    const { operator, left, right, rightIsValue } = getOperator(
+                        behaviorConfig.value
+                    );
+                    let whenLogic = (x: boolean) => pathResolver(left, self)(x);
+
+                    switch (operator) {
+                        case "!":
+                            whenLogic = (x: boolean) => !pathResolver(left, self)(x);
+                            break;
+                        case "==":
+                            whenLogic = (x: boolean) =>
+                                pathResolver(left, self)(x) ==
+                                (rightIsValue
+                                    ? right
+                                    : pathResolver(right as string, self)(x));
+                            break;
+                        case "!=":
+                            whenLogic = (x: boolean) =>
+                                pathResolver(left, self)(x) !=
+                                (rightIsValue
+                                    ? right
+                                    : pathResolver(right as string, self)(x));
+                            break;
+                        case "&&":
+                        case "&amp;&amp;":
+                            whenLogic = (x: boolean) =>
+                                pathResolver(left, self)(x) &&
+                                (rightIsValue
+                                    ? right
+                                    : pathResolver(right as string, self)(x));
+                            break;
+                        case "||":
+                            whenLogic = (x: boolean) =>
+                                pathResolver(left, self)(x) ||
+                                (rightIsValue
+                                    ? right
+                                    : pathResolver(right as string, self)(x));
+                            break;
+                        case ">=":
+                            whenLogic = (x: boolean) =>
+                                pathResolver(left, self)(x) >=
+                                (rightIsValue
+                                    ? right
+                                    : pathResolver(right as string, self)(x));
+                            break;
+                        case ">":
+                            whenLogic = (x: boolean) =>
+                                pathResolver(left, self)(x) >
+                                (rightIsValue
+                                    ? right
+                                    : pathResolver(right as string, self)(x));
+                            break;
+                        case "<=":
+                            whenLogic = (x: boolean) =>
+                                pathResolver(left, self)(x) <=
+                                (rightIsValue
+                                    ? right
+                                    : pathResolver(right as string, self)(x));
+                            break;
+                        case "<":
+                            whenLogic = (x: boolean) =>
+                                pathResolver(left, self)(x) <
+                                (rightIsValue
+                                    ? right
+                                    : pathResolver(right as string, self)(x));
+                            break;
+                    }
+
                     externalValues.push(
-                        when(
-                            x => pathResolver(behaviorConfig.value, self)(x),
-                            this.resolveTemplateOrBehavior(strings, values)
-                        )
+                        when(whenLogic, this.resolveTemplateOrBehavior(strings, values))
                     );
                 }
 

--- a/packages/web-components/fast-html/src/fixtures/when/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/when/main.ts
@@ -9,6 +9,84 @@ TestElement.define({
     name: "test-element",
 });
 
+class TestElementNot extends FASTElement {
+    @attr({ mode: "boolean" })
+    hide: boolean = false;
+}
+TestElementNot.define({
+    name: "test-element-not",
+});
+
+class TestElementEquals extends FASTElement {
+    @attr({ attribute: "var-a" })
+    varA: number = 0;
+}
+TestElementEquals.define({
+    name: "test-element-equals",
+});
+
+class TestElementNotEquals extends FASTElement {
+    @attr({ attribute: "var-a" })
+    varA: number = 0;
+}
+TestElementNotEquals.define({
+    name: "test-element-not-equals",
+});
+
+class TestElementGe extends FASTElement {
+    @attr({ attribute: "var-a" })
+    varA: number = 0;
+}
+TestElementGe.define({
+    name: "test-element-ge",
+});
+
+class TestElementGt extends FASTElement {
+    @attr({ attribute: "var-a" })
+    varA: number = 0;
+}
+TestElementGt.define({
+    name: "test-element-gt",
+});
+
+class TestElementLe extends FASTElement {
+    @attr({ attribute: "var-a" })
+    varA: number = 0;
+}
+TestElementLe.define({
+    name: "test-element-le",
+});
+
+class TestElementLt extends FASTElement {
+    @attr({ attribute: "var-a" })
+    varA: number = 0;
+}
+TestElementLt.define({
+    name: "test-element-lt",
+});
+
+class TestElementOr extends FASTElement {
+    @attr({ attribute: "this-var", mode: "boolean" })
+    thisVar: boolean = false;
+
+    @attr({ attribute: "that-var", mode: "boolean" })
+    thatVar: boolean = false;
+}
+TestElementOr.define({
+    name: "test-element-or",
+});
+
+class TestElementAnd extends FASTElement {
+    @attr({ attribute: "this-var", mode: "boolean" })
+    thisVar: boolean = false;
+
+    @attr({ attribute: "that-var", mode: "boolean" })
+    thatVar: boolean = false;
+}
+TestElementAnd.define({
+    name: "test-element-and",
+});
+
 TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/when/when.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/when/when.fixture.html
@@ -6,6 +6,7 @@
         <script type="module" src="/when/main.js"></script>
     </head>
     <body>
+        <!-- boolean -->
         <f-template name="test-element">
             <template><f-when value="{{show}}">Hello world</f-when></template>
         </f-template>
@@ -15,5 +16,95 @@
         <test-element id="hide">
             <template shadowrootmode="open"></template>
         </test-element>
+        <!-- not -->
+        <f-template name="test-element-not">
+            <template><f-when value="{{!hide}}">Hello world</f-when></template>
+        </f-template>
+        <test-element-not id="show-not">
+            <template shadowrootmode="open">Hello world</template>
+        </test-element-not>
+        <test-element-not id="hide-not" hide>
+            <template shadowrootmode="open"></template>
+        </test-element-not>
+        <!-- equals -->
+        <f-template name="test-element-equals">
+            <template><f-when value="{{varA == 3}}">Equals 3</f-when></template>
+        </f-template>
+        <test-element-equals id="equals-true" var-a="3">
+            <template shadowrootmode="open">Equals 3</template>
+        </test-element-equals>
+        <test-element-equals id="equals-false" var-a="4">
+            <template shadowrootmode="open"></template>
+        </test-element-equals>
+        <!-- not equals -->
+        <f-template name="test-element-not-equals">
+            <template><f-when value="{{varA != 3}}">Not equals 3</f-when></template>
+        </f-template>
+        <test-element-not-equals id="not-equals-true" var-a="4">
+            <template shadowrootmode="open">Not equals 3</template>
+        </test-element-not-equals>
+        <test-element-not-equals id="not-equals-false" var-a="3">
+            <template shadowrootmode="open"></template>
+        </test-element-not-equals>
+        <!-- greater than or equals -->
+        <f-template name="test-element-ge">
+            <template><f-when value="{{varA >= 2}}">Two and Over</f-when></template>
+        </f-template>
+        <test-element-ge id="ge-true" var-a="3">
+            <template shadowrootmode="open">Two and Over</template>
+        </test-element-ge>
+        <test-element-ge id="ge-false" var-a="0">
+            <template shadowrootmode="open"></template>
+        </test-element-ge>
+        <!-- greater than -->
+        <f-template name="test-element-gt">
+            <template><f-when value="{{varA > 2}}">Over two</f-when></template>
+        </f-template>
+        <test-element-gt id="gt-true" var-a="3">
+            <template shadowrootmode="open">Over two</template>
+        </test-element-gt>
+        <test-element-gt id="gt-false" var-a="0">
+            <template shadowrootmode="open"></template>
+        </test-element-gt>
+        <!-- less than or equals -->
+        <f-template name="test-element-le">
+            <template><f-when value="{{varA <= 2}}">Two and Under</f-when></template>
+        </f-template>
+        <test-element-le id="le-true" var-a="2">
+            <template shadowrootmode="open">Two and Under</template>
+        </test-element-le>
+        <test-element-le id="le-false" var-a="4">
+            <template shadowrootmode="open"></template>
+        </test-element-le>
+        <!-- less than -->
+        <f-template name="test-element-lt">
+            <template><f-when value="{{varA < 2}}">Under two</f-when></template>
+        </f-template>
+        <test-element-lt id="lt-true" var-a="1">
+            <template shadowrootmode="open">Under two</template>
+        </test-element-lt>
+        <test-element-lt id="lt-false" var-a="3">
+            <template shadowrootmode="open"></template>
+        </test-element-lt>
+        <!-- or -->
+        <f-template name="test-element-or">
+            <template><f-when value="{{thisVar || thatVar}}">This or That</f-when></template>
+        </f-template>
+        <test-element-or id="or-true" this-var="3">
+            <template shadowrootmode="open">This or That</template>
+        </test-element-or>
+        <test-element-or id="or-false">
+            <template shadowrootmode="open"></template>
+        </test-element-or>
+        <!-- and -->
+        <f-template name="test-element-and">
+            <template><f-when value="{{thisVar && thatVar}}">This and That</f-when></template>
+        </f-template>
+        <test-element-and id="and-true" this-var that-var>
+            <template shadowrootmode="open">This and That</template>
+        </test-element-and>
+        <test-element-and id="and-false" this-var>
+            <template shadowrootmode="open"></template>
+        </test-element-and>
     </body>
 </html>

--- a/packages/web-components/fast-html/src/fixtures/when/when.html
+++ b/packages/web-components/fast-html/src/fixtures/when/when.html
@@ -1,1 +1,10 @@
 <f-when value="{{show}}">Hello world</f-when>
+<f-when value="{{!show}}">Hello world</f-when>
+<f-when value="{{varA == 3}}">Equals 3</f-when>
+<f-when value="{{varA != 3}}">Not equals 3</f-when>
+<f-when value="{{varA >= 2}}">Two and Over</f-when>
+<f-when value="{{varA > 2}}">Over two</f-when>
+<f-when value="{{varA <= 2}}">Two and Under</f-when>
+<f-when value="{{varA < 2}}">Under two</f-when>
+<f-when value="{{thisVar || thatVar}}">This or That</f-when>
+<f-when value="{{thisVar && thatVar}}">This and That</f-when>

--- a/packages/web-components/fast-html/src/fixtures/when/when.spec.ts
+++ b/packages/web-components/fast-html/src/fixtures/when/when.spec.ts
@@ -1,7 +1,7 @@
 import { expect, test } from "@playwright/test";
 
 test.describe("f-template", async () => {
-    test("create a when directive", async ({ page }) => {
+    test("create a when directive for a boolean: true", async ({ page }) => {
         await page.goto("/when");
 
         const customElementShow = await page.locator("#show");
@@ -19,5 +19,86 @@ test.describe("f-template", async () => {
 
         await expect(customElementShow).not.toHaveText("Hello world");
         await expect(customElementHide).toHaveText("Hello world");
+    });
+    test("create a when directive for a boolean: false", async ({ page }) => {
+        await page.goto("/when");
+
+        const customElementShow = await page.locator("#show-not");
+        const customElementHide = await page.locator("#hide-not");
+
+        await expect(customElementShow).toHaveText("Hello world");
+        await expect(customElementHide).not.toHaveText("Hello world");
+    });
+    test("create a when directive value uses equals", async ({ page }) => {
+        await page.goto("/when");
+
+        const customElementShow = await page.locator("#equals-true");
+        const customElementHide = await page.locator("#equals-false");
+
+        await expect(customElementShow).toHaveText("Equals 3");
+        await expect(customElementHide).not.toHaveText("Equals 3");
+    });
+    test("create a when directive value uses not equals", async ({ page }) => {
+        await page.goto("/when");
+
+        const customElementShow = await page.locator("#not-equals-true");
+        const customElementHide = await page.locator("#not-equals-false");
+
+        await expect(customElementShow).toHaveText("Not equals 3");
+        await expect(customElementHide).not.toHaveText("Not equals 3");
+    });
+    test("create a when directive value uses greater than or equals", async ({ page }) => {
+        await page.goto("/when");
+
+        const customElementShow = await page.locator("#ge-true");
+        const customElementHide = await page.locator("#ge-false");
+
+        await expect(customElementShow).toHaveText("Two and Over");
+        await expect(customElementHide).not.toHaveText("Two and Over");
+    });
+    test("create a when directive value uses greater than", async ({ page }) => {
+        await page.goto("/when");
+
+        const customElementShow = await page.locator("#gt-true");
+        const customElementHide = await page.locator("#gt-false");
+
+        await expect(customElementShow).toHaveText("Over two");
+        await expect(customElementHide).not.toHaveText("Over two");
+    });
+    test("create a when directive value uses less than or equals", async ({ page }) => {
+        await page.goto("/when");
+
+        const customElementShow = await page.locator("#le-true");
+        const customElementHide = await page.locator("#le-false");
+
+        await expect(customElementShow).toHaveText("Two and Under");
+        await expect(customElementHide).not.toHaveText("Two and Under");
+    });
+    test("create a when directive value uses less than", async ({ page }) => {
+        await page.goto("/when");
+
+        const customElementShow = await page.locator("#lt-true");
+        const customElementHide = await page.locator("#lt-false");
+
+        await expect(customElementShow).toHaveText("Under two");
+        await expect(customElementHide).not.toHaveText("Under two");
+    });
+    test("create a when directive value uses or", async ({ page }) => {
+        await page.goto("/when");
+
+        const customElementShow = await page.locator("#or-true");
+        const customElementHide = await page.locator("#or-false");
+
+        await expect(customElementShow).toHaveText("This or That");
+        await expect(customElementHide).not.toHaveText("This or That");
+    });
+    test("create a when directive value uses and", async ({ page }) => {
+        await page.goto("/when");
+
+        const customElementShow = await page.locator("#and-true");
+        const customElementHide = await page.locator("#and-false");
+
+        await expect(customElementShow).toHaveText("This and That");
+        await expect(customElementHide).not.toHaveText("This and That");
     });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change adds a subset of operators to the `f-when` directive in declarative HTML.

The allowed syntax now looks like:
```html
<f-when value="{{show}}">Hello world</f-when>
<f-when value="{{!show}}">Hello world</f-when>
<f-when value="{{varA == 3}}">Equals 3</f-when>
<f-when value="{{varA != 3}}">Not equals 3</f-when>
<f-when value="{{varA >= 2}}">Two and Over</f-when>
<f-when value="{{varA > 2}}">Over two</f-when>
<f-when value="{{varA <= 2}}">Two and Under</f-when>
<f-when value="{{varA < 2}}">Under two</f-when>
<f-when value="{{thisVar || thatVar}}">This or That</f-when>
<f-when value="{{thisVar && thatVar}}">This and That</f-when>
```

### 🎫 Issues

Closes #7099 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.