### PR TITLE
Add parent context access to declarative HTML bindings

### DIFF
--- a/change/@microsoft-fast-html-62024830-8fe2-4f54-9b7c-abc4c000f200.json
+++ b/change/@microsoft-fast-html-62024830-8fe2-4f54-9b7c-abc4c000f200.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add parent context access to bindings",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -117,11 +117,11 @@ Where the right operand can be either a reference to a value (string e.g. `{{foo
     <ul><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul>
     ```
 
-    Should you need to refer to the parent element (not the individual item in the list), you can use `^`. This will map to what `html` tag template literal uses, `c.parent`.
+    Should you need to refer to the parent element (not the individual item in the list), you can use `../`. This will map to what `html` tag template literal uses, `c.parent`.
 
     Example:
     ```html
-    <ul><f-repeat value="{{item in list}}"><li>{{item}} - {{^title}}</li></f-repeat></ul>
+    <ul><f-repeat value="{{item in list}}"><li>{{item}} - {{../title}}</li></f-repeat></ul>
     ```
 
 - **partial & apply**

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -117,6 +117,13 @@ Where the right operand can be either a reference to a value (string e.g. `{{foo
     <ul><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul>
     ```
 
+    Should you need to refer to the parent element (not the individual item in the list), you can use `^`. This will map to what `html` tag template literal uses, `c.parent`.
+
+    Example:
+    ```html
+    <ul><f-repeat value="{{item in list}}"><li>{{item}} - {{^title}}</li></f-repeat></ul>
+    ```
+
 - **partial & apply**
 
     These directives are new to the declarative HTML model and allow for the ability to declare a `partial` directive containing a template partial which can then be referenced by an `apply` directive.

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -125,68 +125,70 @@ class TemplateElement extends FASTElement {
                     const { operator, left, right, rightIsValue } = getOperator(
                         behaviorConfig.value
                     );
-                    let whenLogic = (x: boolean) => pathResolver(left, self)(x);
+                    let whenLogic = (x: boolean, c: any) =>
+                        pathResolver(left, self)(x, c);
 
                     switch (operator) {
                         case "!":
-                            whenLogic = (x: boolean) => !pathResolver(left, self)(x);
+                            whenLogic = (x: boolean, c: any) =>
+                                !pathResolver(left, self)(x, c);
                             break;
                         case "==":
-                            whenLogic = (x: boolean) =>
-                                pathResolver(left, self)(x) ==
+                            whenLogic = (x: boolean, c: any) =>
+                                pathResolver(left, self)(x, c) ==
                                 (rightIsValue
                                     ? right
-                                    : pathResolver(right as string, self)(x));
+                                    : pathResolver(right as string, self)(x, c));
                             break;
                         case "!=":
-                            whenLogic = (x: boolean) =>
-                                pathResolver(left, self)(x) !=
+                            whenLogic = (x: boolean, c: any) =>
+                                pathResolver(left, self)(x, c) !=
                                 (rightIsValue
                                     ? right
-                                    : pathResolver(right as string, self)(x));
+                                    : pathResolver(right as string, self)(x, c));
                             break;
                         case "&&":
                         case "&amp;&amp;":
-                            whenLogic = (x: boolean) =>
-                                pathResolver(left, self)(x) &&
+                            whenLogic = (x: boolean, c: any) =>
+                                pathResolver(left, self)(x, c) &&
                                 (rightIsValue
                                     ? right
-                                    : pathResolver(right as string, self)(x));
+                                    : pathResolver(right as string, self)(x, c));
                             break;
                         case "||":
-                            whenLogic = (x: boolean) =>
-                                pathResolver(left, self)(x) ||
+                            whenLogic = (x: boolean, c: any) =>
+                                pathResolver(left, self)(x, c) ||
                                 (rightIsValue
                                     ? right
-                                    : pathResolver(right as string, self)(x));
+                                    : pathResolver(right as string, self)(x, c));
                             break;
                         case ">=":
-                            whenLogic = (x: boolean) =>
-                                pathResolver(left, self)(x) >=
+                            whenLogic = (x: boolean, c: any) =>
+                                pathResolver(left, self)(x, c) >=
                                 (rightIsValue
                                     ? right
-                                    : pathResolver(right as string, self)(x));
+                                    : pathResolver(right as string, self)(x, c));
                             break;
                         case ">":
-                            whenLogic = (x: boolean) =>
-                                pathResolver(left, self)(x) >
+                            whenLogic = (x: boolean, c: any) =>
+                                pathResolver(left, self)(x, c) >
                                 (rightIsValue
                                     ? right
-                                    : pathResolver(right as string, self)(x));
+                                    : pathResolver(right as string, self)(x, c));
                             break;
                         case "<=":
-                            whenLogic = (x: boolean) =>
-                                pathResolver(left, self)(x) <=
+                            whenLogic = (x: boolean, c: any) =>
+                                pathResolver(left, self)(x, c) <=
                                 (rightIsValue
                                     ? right
-                                    : pathResolver(right as string, self)(x));
+                                    : pathResolver(right as string, self)(x, c));
                             break;
                         case "<":
-                            whenLogic = (x: boolean) =>
-                                pathResolver(left, self)(x) <
+                            whenLogic = (x: boolean, c: any) =>
+                                pathResolver(left, self)(x, c) <
                                 (rightIsValue
                                     ? right
-                                    : pathResolver(right as string, self)(x));
+                                    : pathResolver(right as string, self)(x, c));
                             break;
                     }
 
@@ -211,7 +213,7 @@ class TemplateElement extends FASTElement {
 
                     externalValues.push(
                         repeat(
-                            x => pathResolver(valueAttr[2], self)(x),
+                            (x, c) => pathResolver(valueAttr[2], self)(x, c),
                             this.resolveTemplateOrBehavior(strings, values)
                         )
                     );
@@ -235,7 +237,7 @@ class TemplateElement extends FASTElement {
 
                     externalValues.push(
                         when(
-                            x => pathResolver(behaviorConfig.value, self)(x),
+                            (x, c) => pathResolver(behaviorConfig.value, self)(x, c),
                             () => this.partials[partial]
                         )
                     );
@@ -306,7 +308,8 @@ class TemplateElement extends FASTElement {
                         behaviorConfig.openingEndIndex,
                         behaviorConfig.closingStartIndex
                     );
-                    const binding = (x: any) => pathResolver(propName, self)(x);
+                    const binding = (x: any, c: any) =>
+                        pathResolver(propName, self)(x, c);
                     values.push(binding);
                     await this.resolveInnerHTML(
                         innerHTML.slice(behaviorConfig.closingEndIndex, innerHTML.length),
@@ -323,14 +326,16 @@ class TemplateElement extends FASTElement {
                         behaviorConfig.openingEndIndex,
                         behaviorConfig.closingStartIndex - 2
                     );
-                    const binding = (x: any) => pathResolver(propName, self)(x)();
+                    const binding = (x: any, c: any) =>
+                        pathResolver(propName, self)(x, c)();
                     values.push(binding);
                 } else {
                     const propName = innerHTML.slice(
                         behaviorConfig.openingEndIndex,
                         behaviorConfig.closingStartIndex
                     );
-                    const binding = (x: any) => pathResolver(propName, self)(x);
+                    const binding = (x: any, c: any) =>
+                        pathResolver(propName, self)(x, c);
                     values.push(binding);
                 }
 

--- a/packages/web-components/fast-html/src/components/utilities.spec.ts
+++ b/packages/web-components/fast-html/src/components/utilities.spec.ts
@@ -200,7 +200,7 @@ test.describe("utilities", async () => {
             expect(pathResolver("foo.bar.bat", true)({ bar: { bat: "baz" }}, {})).toEqual("baz");
         });
         test("should resolve a path with context", async () => {
-            expect(pathResolver("^foo")({}, {parent: {foo: "bar"}})).toEqual("bar");
+            expect(pathResolver("../foo")({}, {parent: {foo: "bar"}})).toEqual("bar");
         });
     });
 });

--- a/packages/web-components/fast-html/src/components/utilities.spec.ts
+++ b/packages/web-components/fast-html/src/components/utilities.spec.ts
@@ -188,16 +188,19 @@ test.describe("utilities", async () => {
 
     test.describe("pathResolver", async () => {
         test("should resolve a path with no nesting", async () => {
-            expect(pathResolver("foo")({ foo: "bar" })).toEqual("bar");
+            expect(pathResolver("foo")({ foo: "bar" }, {})).toEqual("bar");
         });
         test("should resolve a path with nesting", async () => {
-            expect(pathResolver("foo.bar.bat")({ foo: { bar: { bat: "baz" }} })).toEqual("baz");
+            expect(pathResolver("foo.bar.bat")({ foo: { bar: { bat: "baz" }} }, {})).toEqual("baz");
         });
         test("should resolve a path with no nesting and self reference", async () => {
-            expect(pathResolver("foo", true)("bar")).toEqual("bar");
+            expect(pathResolver("foo", true)("bar", {})).toEqual("bar");
         });
         test("should resolve a path with nesting and self reference", async () => {
-            expect(pathResolver("foo.bar.bat", true)({ bar: { bat: "baz" }})).toEqual("baz");
+            expect(pathResolver("foo.bar.bat", true)({ bar: { bat: "baz" }}, {})).toEqual("baz");
+        });
+        test("should resolve a path with context", async () => {
+            expect(pathResolver("^foo")({}, {parent: {foo: "bar"}})).toEqual("bar");
         });
     });
 });

--- a/packages/web-components/fast-html/src/components/utilities.ts
+++ b/packages/web-components/fast-html/src/components/utilities.ts
@@ -346,10 +346,11 @@ type AccessibleObject = { [key: string]: AccessibleObject };
 export function pathResolver(
     path: string,
     self: boolean = false
-): (accessibleObject: any) => any {
+): (accessibleObject: any, context: any) => any {
     let splitPath = path.split(".");
+    const firstChar = path[0];
 
-    if (self) {
+    if (self && firstChar !== "^") {
         if (splitPath.length > 1) {
             splitPath = splitPath.slice(1);
         } else {
@@ -359,13 +360,22 @@ export function pathResolver(
         }
     }
 
-    if (splitPath.length === 1) {
+    if (splitPath.length === 1 && firstChar !== "^") {
         return (accessibleObject: AccessibleObject) => {
             return accessibleObject?.[splitPath[0]];
         };
     }
 
-    return (accessibleObject: AccessibleObject) => {
+    return (accessibleObject: AccessibleObject, context: AccessibleObject) => {
+        if (firstChar === "^") {
+            splitPath[0] = splitPath[0].slice(1);
+            splitPath.unshift("parent");
+
+            return splitPath.reduce((previousAccessors, pathItem) => {
+                return previousAccessors?.[pathItem];
+            }, context);
+        }
+
         return splitPath.reduce((previousAccessors, pathItem) => {
             return previousAccessors?.[pathItem];
         }, accessibleObject);

--- a/packages/web-components/fast-html/src/fixtures/repeat/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/repeat/main.ts
@@ -4,6 +4,8 @@ import { FASTElement, observable } from "@microsoft/fast-element";
 class TestElement extends FASTElement {
     @observable
     list: Array<string> = ["Foo", "Bar"];
+
+    parent: string = "Bat";
 }
 TestElement.define({
     name: "test-element",

--- a/packages/web-components/fast-html/src/fixtures/repeat/repeat.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/repeat/repeat.fixture.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <f-template name="test-element">
-            <template><ul><f-repeat value="{{item in list}}"><li>{{item}} - {{^parent}}</li></f-repeat></ul></template>
+            <template><ul><f-repeat value="{{item in list}}"><li>{{item}} - {{../parent}}</li></f-repeat></ul></template>
         </f-template>
         <test-element>
             <template shadowrootmode="open"><ul><li>Foo - Bat</li><li>Bar - Bat</li></ul></template>

--- a/packages/web-components/fast-html/src/fixtures/repeat/repeat.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/repeat/repeat.fixture.html
@@ -7,10 +7,10 @@
     </head>
     <body>
         <f-template name="test-element">
-            <template><ul><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul></template>
+            <template><ul><f-repeat value="{{item in list}}"><li>{{item}} - {{^parent}}</li></f-repeat></ul></template>
         </f-template>
         <test-element>
-            <template shadowrootmode="open"><ul><li>Foo</li><li>Bar</li></ul></template>
+            <template shadowrootmode="open"><ul><li>Foo - Bat</li><li>Bar - Bat</li></ul></template>
         </test-element>
     </body>
 </html>

--- a/packages/web-components/fast-html/src/fixtures/repeat/repeat.html
+++ b/packages/web-components/fast-html/src/fixtures/repeat/repeat.html
@@ -1,1 +1,1 @@
-<ul><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul>
+<ul><f-repeat value="{{item in list}}"><li>{{item}} - {{^parent}}</li></f-repeat></ul>

--- a/packages/web-components/fast-html/src/fixtures/repeat/repeat.html
+++ b/packages/web-components/fast-html/src/fixtures/repeat/repeat.html
@@ -1,1 +1,1 @@
-<ul><f-repeat value="{{item in list}}"><li>{{item}} - {{^parent}}</li></f-repeat></ul>
+<ul><f-repeat value="{{item in list}}"><li>{{item}} - {{../parent}}</li></f-repeat></ul>

--- a/packages/web-components/fast-html/src/fixtures/repeat/repeat.json
+++ b/packages/web-components/fast-html/src/fixtures/repeat/repeat.json
@@ -1,4 +1,5 @@
 {
+    "parent": "Bat",
     "list": [
         "Foo",
         "Bar"

--- a/packages/web-components/fast-html/src/fixtures/repeat/repeat.spec.ts
+++ b/packages/web-components/fast-html/src/fixtures/repeat/repeat.spec.ts
@@ -8,8 +8,8 @@ test.describe("f-template", async () => {
         let customElementListItems = await customElement.locator("li");
 
         expect(await customElementListItems.count()).toEqual(2);
-        expect(await customElementListItems.nth(0).textContent()).toEqual("Foo");
-        expect(await customElementListItems.nth(1).textContent()).toEqual("Bar");
+        expect(await customElementListItems.nth(0).textContent()).toEqual("Foo - Bat");
+        expect(await customElementListItems.nth(1).textContent()).toEqual("Bar - Bat");
 
         await page.evaluate(() => {
             const customElement = document.getElementsByTagName("test-element");
@@ -25,8 +25,8 @@ test.describe("f-template", async () => {
 
         customElementListItems = await customElement.locator("li");
         expect(await customElementListItems.count()).toEqual(3);
-        expect(await customElementListItems.nth(0).textContent()).toEqual("A");
-        expect(await customElementListItems.nth(1).textContent()).toEqual("B");
-        expect(await customElementListItems.nth(2).textContent()).toEqual("C");
+        expect(await customElementListItems.nth(0).textContent()).toEqual("A - Bat");
+        expect(await customElementListItems.nth(1).textContent()).toEqual("B - Bat");
+        expect(await customElementListItems.nth(2).textContent()).toEqual("C - Bat");
     });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change adds the ability to refer to the parent context in declarative HTML bindings.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.