### PR TITLE
Change client only bindings to single curly braces and categorize single, double, and tripe curly brace bindings

### DIFF
--- a/change/@microsoft-fast-html-d5ee6250-e24e-4cef-8d98-368747da972c.json
+++ b/change/@microsoft-fast-html-d5ee6250-e24e-4cef-8d98-368747da972c.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change client only bindings to single curly braces and categorize single, double, and tripe curly brace bindings",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -47,7 +47,15 @@ Example:
 
 ### Syntax
 
-All bindings use a handlebars syntax.
+All bindings use a handlebars-like syntax.
+
+Some bindings are only relevant to the browser, such as for click handlers or other pieces of dynamic interaction. As such, their bindings use single curly braces `{}`, this is to prevent an intial SSR (Server Side Rendering) or other build time rendering technologies from needing to interpret them.
+
+If a binding is relevant to both client and the back end rendering engine, it will use `{{}}` or `{{{}}}` depending on what type of data injection is being done.
+
+Browser-only bindings:
+- Event bindings
+- Attribute directives
 
 #### Content binding
 
@@ -60,45 +68,47 @@ All bindings use a handlebars syntax.
 Event bindings must include the `()` as well as being preceeded by `@` in keeping with `@microsoft/fast-element` tagged template `html` syntax.
 
 ```html
-<button @click="{{handleClick()}}"></button>
+<button @click="{handleClick()}"></button>
 ```
 
 In addition you may include an event or attribute or observable, events are denoted with `e` as a reserved letter.
 
 Event:
 ```html
-<button @click="{{handleClick(e)}}"></button>
+<button @click="{handleClick(e)}"></button>
 ```
 
 Attribute/Observable:
 ```html
-<button @click="{{handleClick(foo)}}"></button>
+<button @click="{handleClick(foo)}"></button>
 ```
 
 #### Directives
 
 Directives are assumed to be either an attribute directive or a directive that also serves a template. Both are prepended by `f-`. The logic of these directives and what their use cases are is explained in the [FAST html documentation](https://fast.design/docs/getting-started/html-directives).
 
+Attribute directives are part of [client side binding](#syntax) and therefore use the `{}` syntax.
+
 Attribute directives include:
 - **slotted**
 
     Example:
     ```html
-    <slot f-slotted="{{slottedNodes}}"></slot>
+    <slot f-slotted="{slottedNodes}"></slot>
     ```
 
 - **children**
 
     Example:
     ```html
-    <ul f-children="{{listItems}}"><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul>
+    <ul f-children="{listItems}"><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul>
     ```
 
 - **ref**
 
     Example:
     ```html
-    <video f-ref="{{video}}"></video>
+    <video f-ref="{video}"></video>
     ```
 
 Template directives include:

--- a/packages/web-components/fast-html/src/components/utilities.spec.ts
+++ b/packages/web-components/fast-html/src/components/utilities.spec.ts
@@ -9,6 +9,7 @@ test.describe("utilities", async () => {
 
             expect(templateResult?.type).toEqual("dataBinding");
             expect((templateResult as ContentDataBindingBehaviorConfig)?.subtype).toEqual("content");
+            expect((templateResult as ContentDataBindingBehaviorConfig)?.bindingType).toEqual("default");
             expect((templateResult as ContentDataBindingBehaviorConfig)?.openingStartIndex).toEqual(0);
             expect((templateResult as ContentDataBindingBehaviorConfig)?.openingEndIndex).toEqual(2);
             expect((templateResult as ContentDataBindingBehaviorConfig)?.closingStartIndex).toEqual(6);
@@ -24,6 +25,7 @@ test.describe("utilities", async () => {
             expect(templateResult?.type).toEqual("dataBinding");
             expect((templateResult as AttributeDataBindingBehaviorConfig)?.subtype).toEqual("attribute");
             expect((templateResult as AttributeDataBindingBehaviorConfig)?.aspect).toEqual(null);
+            expect((templateResult as AttributeDataBindingBehaviorConfig)?.bindingType).toEqual("default");
             expect((templateResult as AttributeDataBindingBehaviorConfig)?.openingStartIndex).toEqual(13);
             expect((templateResult as AttributeDataBindingBehaviorConfig)?.openingEndIndex).toEqual(15);
             expect((templateResult as AttributeDataBindingBehaviorConfig)?.closingStartIndex).toEqual(19);
@@ -31,16 +33,17 @@ test.describe("utilities", async () => {
         });
 
         test("get the next attribute event binding", async () => {
-            const innerHTML = "<input @click=\"{{handleClick()}}\">";
+            const innerHTML = "<input @click=\"{handleClick()}\">";
             const templateResult = getNextBehavior(innerHTML);
 
             expect(templateResult?.type).toEqual("dataBinding");
             expect((templateResult as AttributeDataBindingBehaviorConfig)?.subtype).toEqual("attribute");
             expect((templateResult as AttributeDataBindingBehaviorConfig)?.aspect).toEqual("@");
+            expect((templateResult as AttributeDirectiveBindingBehaviorConfig)?.bindingType).toEqual("client");
             expect((templateResult as AttributeDataBindingBehaviorConfig)?.openingStartIndex).toEqual(15);
-            expect((templateResult as AttributeDataBindingBehaviorConfig)?.openingEndIndex).toEqual(17);
-            expect((templateResult as AttributeDataBindingBehaviorConfig)?.closingStartIndex).toEqual(30);
-            expect((templateResult as AttributeDataBindingBehaviorConfig)?.closingEndIndex).toEqual(32);
+            expect((templateResult as AttributeDataBindingBehaviorConfig)?.openingEndIndex).toEqual(16);
+            expect((templateResult as AttributeDataBindingBehaviorConfig)?.closingStartIndex).toEqual(29);
+            expect((templateResult as AttributeDataBindingBehaviorConfig)?.closingEndIndex).toEqual(30);
         });
     });
 
@@ -79,40 +82,43 @@ test.describe("utilities", async () => {
 
     test.describe("attributes", async () => {
         test("children directive", async () => {
-            const innerHTML = "<ul f-children=\"{{list}}\"></ul>";
+            const innerHTML = "<ul f-children=\"{list}\"></ul>";
             const result = getNextBehavior(innerHTML);
 
             expect(result?.type).toEqual("dataBinding");
             expect((result as AttributeDirectiveBindingBehaviorConfig)?.subtype).toEqual("attributeDirective")
             expect((result as AttributeDirectiveBindingBehaviorConfig)?.name).toEqual("children");
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.bindingType).toEqual("client");
             expect((result as AttributeDirectiveBindingBehaviorConfig)?.openingStartIndex).toEqual(16);
-            expect((result as AttributeDirectiveBindingBehaviorConfig)?.openingEndIndex).toEqual(18);
-            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingStartIndex).toEqual(22);
-            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingEndIndex).toEqual(24);
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.openingEndIndex).toEqual(17);
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingStartIndex).toEqual(21);
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingEndIndex).toEqual(22);
         });
         test("slotted directive", async () => {
-            const innerHTML = "<slot f-slotted=\"{{slottedNodes}}\"></slot>";
+            const innerHTML = "<slot f-slotted=\"{slottedNodes}\"></slot>";
             const result = getNextBehavior(innerHTML);
 
             expect(result?.type).toEqual("dataBinding");
             expect((result as AttributeDirectiveBindingBehaviorConfig)?.subtype).toEqual("attributeDirective")
             expect((result as AttributeDirectiveBindingBehaviorConfig)?.name).toEqual("slotted");
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.bindingType).toEqual("client");
             expect((result as AttributeDirectiveBindingBehaviorConfig)?.openingStartIndex).toEqual(17);
-            expect((result as AttributeDirectiveBindingBehaviorConfig)?.openingEndIndex).toEqual(19);
-            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingStartIndex).toEqual(31);
-            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingEndIndex).toEqual(33);
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.openingEndIndex).toEqual(18);
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingStartIndex).toEqual(30);
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingEndIndex).toEqual(31);
         });
         test("ref directive", async () => {
-            const innerHTML = "<video f-ref=\"{{video}}\"></video>";
+            const innerHTML = "<video f-ref=\"{video}\"></video>";
             const result = getNextBehavior(innerHTML);
 
             expect(result?.type).toEqual("dataBinding");
             expect((result as AttributeDirectiveBindingBehaviorConfig)?.subtype).toEqual("attributeDirective")
             expect((result as AttributeDirectiveBindingBehaviorConfig)?.name).toEqual("ref");
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.bindingType).toEqual("client");
             expect((result as AttributeDirectiveBindingBehaviorConfig)?.openingStartIndex).toEqual(14);
-            expect((result as AttributeDirectiveBindingBehaviorConfig)?.openingEndIndex).toEqual(16);
-            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingStartIndex).toEqual(21);
-            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingEndIndex).toEqual(23);
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.openingEndIndex).toEqual(15);
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingStartIndex).toEqual(20);
+            expect((result as AttributeDirectiveBindingBehaviorConfig)?.closingEndIndex).toEqual(21);
         });
     });
 

--- a/packages/web-components/fast-html/src/fixtures/children/children.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/children/children.fixture.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <f-template name="test-element">
-            <template><ul f-children="{{listItems}}"><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul></template>
+            <template><ul f-children="{listItems}"><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul></template>
         </f-template>
         <test-element>
             <template shadowrootmode="open"><ul><li>Foo</li><li>Bar</li></ul></template>

--- a/packages/web-components/fast-html/src/fixtures/children/children.html
+++ b/packages/web-components/fast-html/src/fixtures/children/children.html
@@ -1,1 +1,1 @@
-<ul f-children="{{listItems}}"><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul>
+<ul f-children="{listItems}"><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul>

--- a/packages/web-components/fast-html/src/fixtures/event/event.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/event/event.fixture.html
@@ -14,9 +14,9 @@
         </test-element>
         <f-template name="test-element">
             <template>
-                <button @click="{{handleNoArgsClick()}}">No arguments</button>
-                <button @click="{{handleEventArgClick(e)}}">event argument</button>
-                <button @click="{{handleAttributeArgClick(foo)}}">attribute argument</button>
+                <button @click="{handleNoArgsClick()}">No arguments</button>
+                <button @click="{handleEventArgClick(e)}">event argument</button>
+                <button @click="{handleAttributeArgClick(foo)}">attribute argument</button>
             </template>
         </f-template>
         <script type="module" src="/event/main.js"></script>

--- a/packages/web-components/fast-html/src/fixtures/event/event.html
+++ b/packages/web-components/fast-html/src/fixtures/event/event.html
@@ -1,3 +1,3 @@
-<button @click="{{handleNoArgsClick()}}"></button>
-<button @click="{{handleEventArgClick(e)}}"></button>
-<button @click="{{handleAttributeArgClick(foo)}}"></button>
+<button @click="{handleNoArgsClick()}"></button>
+<button @click="{handleEventArgClick(e)}"></button>
+<button @click="{handleAttributeArgClick(foo)}"></button>

--- a/packages/web-components/fast-html/src/fixtures/ref/ref.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/ref/ref.fixture.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <f-template name="test-element">
-            <template><video f-ref="{{video}}"></video></template>
+            <template><video f-ref="{video}"></video></template>
         </f-template>
         <test-element>
             <template shadowrootmode="open"><video></video></template>

--- a/packages/web-components/fast-html/src/fixtures/ref/ref.html
+++ b/packages/web-components/fast-html/src/fixtures/ref/ref.html
@@ -1,1 +1,1 @@
-<video f-ref="{{video}}"></video>
+<video f-ref="{video}"></video>

--- a/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
@@ -7,7 +7,7 @@
     </head>
     <body>
         <f-template name="test-element">
-            <template><slot f-slotted="{{slottedNodes}}"></slot></template>
+            <template><slot f-slotted="{slottedNodes}"></slot></template>
         </f-template>
         <test-element>
             <template shadowrootmode="open"><slot></slot></template>

--- a/packages/web-components/fast-html/src/fixtures/slotted/slotted.html
+++ b/packages/web-components/fast-html/src/fixtures/slotted/slotted.html
@@ -1,1 +1,1 @@
-<slot f-slotted="{{slottedNodes}}"></slot>
+<slot f-slotted="{slottedNodes}"></slot>


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change categorizes bindings into 3 binding types, "client" `{}`, "default" `{{}}`, and "unescaped" `{{{}}}` (functionality to be added in a different PR.

The update to the syntax allows a server or build time rendering solution to ignore client side bindings as they are not needed until interaction on the client.

### 🎫 Issues

Resolves #7104 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.