### PR TITLE
fix: use Observable.defineProperty instead of observable decorator

### DIFF
--- a/change/@microsoft-fast-element-1c8a3d5b-c73b-45c9-8c58-e1b7bca16f72.json
+++ b/change/@microsoft-fast-element-1c8a3d5b-c73b-45c9-8c58-e1b7bca16f72.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: use Observable method instead of decorator in FASTElementDefinition class",
+  "packageName": "@microsoft/fast-element",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -1,5 +1,5 @@
 import { Constructable, isString, KernelServiceId } from "../interfaces.js";
-import { observable, Observable } from "../observation/observable.js";
+import { Observable } from "../observation/observable.js";
 import { createTypeRegistry, FAST, TypeRegistry } from "../platform.js";
 import { ComposableStyles, ElementStyles } from "../styles/element-styles.js";
 import type { ElementViewTemplate } from "../templating/template.js";
@@ -123,7 +123,6 @@ export class FASTElementDefinition<
     /**
      * The template to render for the custom element.
      */
-    @observable
     public template?: ElementViewTemplate;
 
     /**
@@ -256,3 +255,5 @@ export class FASTElementDefinition<
      */
     static readonly getForInstance = fastElementRegistry.getForInstance;
 }
+
+Observable.defineProperty(FASTElementDefinition.prototype, "template");


### PR DESCRIPTION
# Pull Request

## 📖 Description

The use of `@observable` in the `FASTElementDefinition` class causes the `__decorate` tslib helper function to be inlined in the dist builds.

## 👩‍💻 Reviewer Notes

There's another use of `Observable.defineProperty` in this module. It's in a loop that goes through attributes defined on the extending class (I think that's what's going on).

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.