### PR TITLE
Add unescaped bindings to declarative HTML syntax

### DIFF
--- a/packages/web-components/fast-html/src/fixtures/binding/binding.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/binding/binding.fixture.html
@@ -8,8 +8,14 @@
         <test-element text="Hello world">
             <template shadowrootmode="open">Hello world</template>
         </test-element>
+        <test-element-unescaped>
+            <template shadowrootmode="open"><p>Hello world</p></template>
+        </test-element-unescaped>
         <f-template name="test-element">
             <template>{{text}}</template>
+        </f-template>
+        <f-template name="test-element-unescaped">
+            <template>{{{html}}}</template>
         </f-template>
         <script type="module" src="/binding/main.js"></script>
     </body>

--- a/packages/web-components/fast-html/src/fixtures/binding/binding.spec.ts
+++ b/packages/web-components/fast-html/src/fixtures/binding/binding.spec.ts
@@ -17,4 +17,12 @@ test.describe("f-template", async () => {
         await expect(await customElement.getAttribute("text")).toEqual("Hello pluto");
         await expect(customElement).toHaveText("Hello pluto");
     });
+    test("create an unescaped binding", async ({ page }) => {
+        await page.goto("/binding");
+
+        const customElement = await page.locator("test-element-unescaped");
+
+        await expect(await customElement.locator("p").count()).toEqual(1);
+        await expect(customElement).toHaveText("Hello world");
+    });
 });

--- a/packages/web-components/fast-html/src/fixtures/binding/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/binding/main.ts
@@ -9,6 +9,13 @@ TestElement.define({
     name: "test-element",
 });
 
+class TestElementUnescaped extends FASTElement {
+    public html = `<p>Hello world</p>`;
+}
+TestElementUnescaped.define({
+    name: "test-element-unescaped",
+});
+
 TemplateElement.define({
     name: "f-template",
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds the interpretation of triple `{{{}}}` bindings to be interpreted to unescaped HTML.

### 🎫 Issues

Closes #7094

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.