### PR TITLE
Allow shadowOptions to be observed

### DIFF
--- a/change/@microsoft-fast-element-17db0ea7-f7ca-4fde-b632-3f7b76094e31.json
+++ b/change/@microsoft-fast-element-17db0ea7-f7ca-4fde-b632-3f7b76094e31.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Allow shadowOptions to be observed",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-html-5e230d8e-5ebb-4d62-82d0-d7cac55b02a0.json
+++ b/change/@microsoft-fast-html-5e230d8e-5ebb-4d62-82d0-d7cac55b02a0.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add a shadowOptions dictionary for the TemplateElement",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-html-5e230d8e-5ebb-4d62-82d0-d7cac55b02a0.json
+++ b/change/@microsoft-fast-html-5e230d8e-5ebb-4d62-82d0-d7cac55b02a0.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Add a shadowOptions dictionary for the TemplateElement",
+  "comment": "Add an options method for the TemplateElement that can pass additional configuration details to components",
   "packageName": "@microsoft/fast-html",
   "email": "7559015+janechu@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/packages/web-components/fast-element/docs/api-report.api.md
+++ b/packages/web-components/fast-element/docs/api-report.api.md
@@ -311,6 +311,9 @@ export class ElementController<TElement extends HTMLElement = HTMLElement> exten
     // (undocumented)
     protected renderTemplate(template: ElementViewTemplate | null | undefined): void;
     static setStrategy(strategy: ElementControllerStrategy): void;
+    // (undocumented)
+    get shadowOptions(): ShadowRootOptions | undefined;
+    set shadowOptions(value: ShadowRootOptions | undefined);
     readonly source: TElement;
     get sourceLifetime(): SourceLifetime | undefined;
     // Warning: (ae-forgotten-export) The symbol "Stages" needs to be exported by the entry point index.d.ts
@@ -456,7 +459,7 @@ export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Co
     // @internal
     static registerBaseType(type: Function): void;
     readonly registry: CustomElementRegistry;
-    readonly shadowOptions?: ShadowRootOptions;
+    shadowOptions?: ShadowRootOptions;
     readonly styles?: ElementStyles;
     template?: ElementViewTemplate;
     readonly type: TType;

--- a/packages/web-components/fast-element/src/components/element-controller.spec.ts
+++ b/packages/web-components/fast-element/src/components/element-controller.spec.ts
@@ -57,11 +57,19 @@ describe("The ElementController", () => {
             expect(shadowRoot).to.be.instanceOf(ShadowRoot);
         });
 
-        it("if shadow options nullled, does not create shadow root", () => {
+        it("if shadow options nulled, does not create shadow root", () => {
             const { shadowRoot } = createController({ shadowOptions: null });
             expect(shadowRoot).to.equal(null);
         });
 
+        it("if shadow options updated, apply updates", () => {
+            const { element, shadowRoot, controller } = createController({ shadowOptions: null });
+            expect(shadowRoot).to.equal(null);
+
+            controller.definition.shadowOptions = { mode: "open" };
+
+            expect(element.shadowRoot).not.to.equal(null);
+        });
         it("if shadow options closed, does not expose shadow root", () => {
             const { shadowRoot } = createController({
                 shadowOptions: { mode: "closed" },

--- a/packages/web-components/fast-element/src/components/element-controller.ts
+++ b/packages/web-components/fast-element/src/components/element-controller.ts
@@ -174,9 +174,10 @@ export class ElementController<TElement extends HTMLElement = HTMLElement>
     }
 
     public set shadowOptions(value: ShadowRootOptions | undefined) {
-        this._shadowRootOptions = value;
+        // options on the shadowRoot can only be set once
+        if (this._shadowRootOptions === void 0 && value !== void 0) {
+            this._shadowRootOptions = value;
 
-        if (value !== void 0) {
             let shadowRoot = this.source.shadowRoot;
 
             if (shadowRoot) {

--- a/packages/web-components/fast-element/src/components/fast-definitions.ts
+++ b/packages/web-components/fast-element/src/components/fast-definitions.ts
@@ -133,7 +133,7 @@ export class FASTElementDefinition<
     /**
      * Options controlling the creation of the custom element's shadow DOM.
      */
-    public readonly shadowOptions?: ShadowRootOptions;
+    public shadowOptions?: ShadowRootOptions;
 
     /**
      * Options controlling how the custom element is defined with the platform.
@@ -257,3 +257,4 @@ export class FASTElementDefinition<
 }
 
 Observable.defineProperty(FASTElementDefinition.prototype, "template");
+Observable.defineProperty(FASTElementDefinition.prototype, "shadowOptions");

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -23,16 +23,18 @@ In your JS bundle you will need to include the `@microsoft/fast-html` package:
 
 ```typescript
 import { TemplateElement } from "@microsoft/fast-html";
-import { TestElement } from "./my-custom-element";
+import { MyCustomElement } from "./my-custom-element";
 
 MyCustomElement.define({
     name: "my-custom-element",
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "my-custom-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        }
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -23,13 +23,25 @@ In your JS bundle you will need to include the `@microsoft/fast-html` package:
 
 ```typescript
 import { TemplateElement } from "@microsoft/fast-html";
+import { TestElement } from "./my-custom-element";
 
-TemplateElement.define({
+MyCustomElement.define({
+    name: "my-custom-element",
+    shadowOptions: null,
+});
+
+TemplateElement.templateShadowOptions({
+    "my-custom-element": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });
 ```
 
-This will include the `<f-template>` custom element and all logic for interpreting the declarative HTML syntax for a FAST web component.
+This will include the `<f-template>` custom element and all logic for interpreting the declarative HTML syntax for a FAST web component as well as the `shadowOptions` for any element an `<f-template>` has been used to define.
+
+It is necessary to set the initial `shadowOptions` of your custom elements to `null` otherwise a shadowRoot will be attached and cause a FOUC (Flash Of Unstyled Content).
 
 The template must be wrapped in `<f-template name="[custom-element-name]"><template>[template logic]</template></f-template>` with a `name` attribute for the custom elements name, and the template logic inside.
 

--- a/packages/web-components/fast-html/docs/api-report.api.md
+++ b/packages/web-components/fast-html/docs/api-report.api.md
@@ -5,12 +5,20 @@
 ```ts
 
 import { FASTElement } from '@microsoft/fast-element';
+import { ShadowRootOptions } from '@microsoft/fast-element';
 
 // @public
 export class TemplateElement extends FASTElement {
     // (undocumented)
     connectedCallback(): void;
+    static elementShadowRootOptions: {
+        [key: string]: ShadowRootOptions | undefined;
+    };
     name?: string;
+    // (undocumented)
+    static templateShadowOptions(elementShadowRootOptions?: {
+        [key: string]: ShadowRootOptions | undefined;
+    }): typeof TemplateElement;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-html/docs/api-report.api.md
+++ b/packages/web-components/fast-html/docs/api-report.api.md
@@ -11,14 +11,11 @@ import { ShadowRootOptions } from '@microsoft/fast-element';
 export class TemplateElement extends FASTElement {
     // (undocumented)
     connectedCallback(): void;
-    static elementShadowRootOptions: {
-        [key: string]: ShadowRootOptions | undefined;
-    };
+    // Warning: (ae-forgotten-export) The symbol "ElementOptions" needs to be exported by the entry point index.d.ts
+    static elementOptions: ElementOptions;
     name?: string;
     // (undocumented)
-    static templateShadowOptions(elementShadowRootOptions?: {
-        [key: string]: ShadowRootOptions | undefined;
-    }): typeof TemplateElement;
+    static options(elementOptions?: ElementOptions): typeof TemplateElement;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -6,6 +6,7 @@ import {
     FASTElement,
     FASTElementDefinition,
     fastElementRegistry,
+    ShadowRootOptions,
     ViewTemplate,
 } from "@microsoft/fast-element";
 import { DOMPolicy } from "@microsoft/fast-element/dom-policy.js";
@@ -47,7 +48,22 @@ class TemplateElement extends FASTElement {
     @attr
     public name?: string;
 
+    /**
+     * The shadowRoot options per custom element
+     */
+    public static elementShadowRootOptions: {
+        [key: string]: ShadowRootOptions | undefined;
+    } = {};
+
     private partials: { [key: string]: ViewTemplate } = {};
+
+    public static templateShadowOptions(
+        elementShadowRootOptions: { [key: string]: ShadowRootOptions | undefined } = {}
+    ) {
+        this.elementShadowRootOptions = elementShadowRootOptions;
+
+        return this;
+    }
 
     connectedCallback(): void {
         super.connectedCallback();
@@ -70,6 +86,11 @@ class TemplateElement extends FASTElement {
                         );
 
                         if (registeredFastElement) {
+                            // set shadow options as defined by the f-template
+                            registeredFastElement.shadowOptions =
+                                TemplateElement.elementShadowRootOptions[
+                                    this.name as string
+                                ];
                             // all new elements will get the updated template
                             registeredFastElement.template =
                                 this.resolveTemplateOrBehavior(strings, values);

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -38,6 +38,12 @@ function allow(
     };
 }
 
+interface ElementOptions {
+    [key: string]: {
+        shadowOptions: ShadowRootOptions | undefined;
+    };
+}
+
 /**
  * The <f-template> custom element that will provide view logic to the element
  */
@@ -51,16 +57,12 @@ class TemplateElement extends FASTElement {
     /**
      * The shadowRoot options per custom element
      */
-    public static elementShadowRootOptions: {
-        [key: string]: ShadowRootOptions | undefined;
-    } = {};
+    public static elementOptions: ElementOptions = {};
 
     private partials: { [key: string]: ViewTemplate } = {};
 
-    public static templateShadowOptions(
-        elementShadowRootOptions: { [key: string]: ShadowRootOptions | undefined } = {}
-    ) {
-        this.elementShadowRootOptions = elementShadowRootOptions;
+    public static options(elementOptions: ElementOptions = {}) {
+        this.elementOptions = elementOptions;
 
         return this;
     }
@@ -91,9 +93,9 @@ class TemplateElement extends FASTElement {
                                 this.resolveTemplateOrBehavior(strings, values);
                             // set shadow options as defined by the f-template
                             registeredFastElement.shadowOptions =
-                                TemplateElement.elementShadowRootOptions[
+                                TemplateElement.elementOptions[
                                     this.name as string
-                                ];
+                                ]?.shadowOptions;
                         }
                     } else {
                         throw FAST.error(Message.noTemplateProvided, { name: this.name });

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -86,14 +86,14 @@ class TemplateElement extends FASTElement {
                         );
 
                         if (registeredFastElement) {
+                            // all new elements will get the updated template
+                            registeredFastElement.template =
+                                this.resolveTemplateOrBehavior(strings, values);
                             // set shadow options as defined by the f-template
                             registeredFastElement.shadowOptions =
                                 TemplateElement.elementShadowRootOptions[
                                     this.name as string
                                 ];
-                            // all new elements will get the updated template
-                            registeredFastElement.template =
-                                this.resolveTemplateOrBehavior(strings, values);
                         }
                     } else {
                         throw FAST.error(Message.noTemplateProvided, { name: this.name });

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -38,6 +38,9 @@ function allow(
     };
 }
 
+/**
+ * A dictionary of element options the TemplateElement will use to update the registered element
+ */
 interface ElementOptions {
     [key: string]: {
         shadowOptions: ShadowRootOptions | undefined;
@@ -55,7 +58,7 @@ class TemplateElement extends FASTElement {
     public name?: string;
 
     /**
-     * The shadowRoot options per custom element
+     * A dictionary of custom element options
      */
     public static elementOptions: ElementOptions = {};
 

--- a/packages/web-components/fast-html/src/fixtures/attribute/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/attribute/main.ts
@@ -10,9 +10,11 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/attribute/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/attribute/main.ts
@@ -7,8 +7,13 @@ class TestElement extends FASTElement {
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/binding/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/binding/main.ts
@@ -17,12 +17,16 @@ TestElementUnescaped.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-unescaped": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/binding/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/binding/main.ts
@@ -14,8 +14,16 @@ class TestElementUnescaped extends FASTElement {
 }
 TestElementUnescaped.define({
     name: "test-element-unescaped",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+    "test-element-unescaped": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/children/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/children/main.ts
@@ -13,9 +13,11 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/children/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/children/main.ts
@@ -10,8 +10,13 @@ class TestElement extends FASTElement {
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/dot-syntax/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/dot-syntax/main.ts
@@ -8,8 +8,13 @@ class TestElement extends FASTElement {
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/dot-syntax/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/dot-syntax/main.ts
@@ -11,9 +11,11 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/event/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/event/main.ts
@@ -19,8 +19,13 @@ class TestElement extends FASTElement {
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/event/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/event/main.ts
@@ -22,9 +22,11 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/partial/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/partial/main.ts
@@ -26,9 +26,11 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/partial/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/partial/main.ts
@@ -23,8 +23,13 @@ class TestElement extends FASTElement {
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/ref/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/ref/main.ts
@@ -6,8 +6,13 @@ class TestElement extends FASTElement {
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/ref/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/ref/main.ts
@@ -9,9 +9,11 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/repeat/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/repeat/main.ts
@@ -9,8 +9,13 @@ class TestElement extends FASTElement {
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/repeat/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/repeat/main.ts
@@ -12,9 +12,11 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/slotted/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/slotted/main.ts
@@ -11,8 +11,13 @@ class TestElement extends FASTElement {
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/slotted/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/slotted/main.ts
@@ -14,9 +14,11 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/when/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/when/main.ts
@@ -88,36 +88,56 @@ TestElementAnd.define({
     shadowOptions: null,
 });
 
-TemplateElement.templateShadowOptions({
+TemplateElement.options({
     "test-element": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-not": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-equals": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-not-equals": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-ge": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-gt": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-le": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-lt": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-or": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
     "test-element-and": {
-        mode: "closed",
+        shadowOptions: {
+            mode: "closed",
+        },
     },
 }).define({
     name: "f-template",

--- a/packages/web-components/fast-html/src/fixtures/when/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/when/main.ts
@@ -85,8 +85,40 @@ class TestElementAnd extends FASTElement {
 }
 TestElementAnd.define({
     name: "test-element-and",
+    shadowOptions: null,
 });
 
-TemplateElement.define({
+TemplateElement.templateShadowOptions({
+    "test-element": {
+        mode: "closed",
+    },
+    "test-element-not": {
+        mode: "closed",
+    },
+    "test-element-equals": {
+        mode: "closed",
+    },
+    "test-element-not-equals": {
+        mode: "closed",
+    },
+    "test-element-ge": {
+        mode: "closed",
+    },
+    "test-element-gt": {
+        mode: "closed",
+    },
+    "test-element-le": {
+        mode: "closed",
+    },
+    "test-element-lt": {
+        mode: "closed",
+    },
+    "test-element-or": {
+        mode: "closed",
+    },
+    "test-element-and": {
+        mode: "closed",
+    },
+}).define({
     name: "f-template",
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change:
- Observes changes to `shadowOptions` on FASTElement custom elements
- Updates the `shadowOptions` with `TemplateElement` from the `@microsoft/fast-html` package to allow a shadowRoot to be attached when the template is defined

## 👩‍💻 Reviewer Notes

This change should solve the FOUC from defining the template after the custom element has been defined.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.