### PR TITLE
Fixes an issue with transforming innerHTML where the inner contents were not slicing correctly

### DIFF
--- a/change/@microsoft-fast-html-98036136-a981-4bed-ab60-a39d4f7a70f8.json
+++ b/change/@microsoft-fast-html-98036136-a981-4bed-ab60-a39d4f7a70f8.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fixes an issue with transforming innerHTML where the inner contents were not slicing correctly",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/src/components/utilities.spec.ts
+++ b/packages/web-components/fast-html/src/components/utilities.spec.ts
@@ -217,10 +217,13 @@ test.describe("utilities", async () => {
         test("should resolve multiple unescaped data bindings", async () => {
             expect(transformInnerHTML(`{{{foo}}}{{{bar}}}`)).toEqual(`<div :innerHTML="{{foo}}"></div><div :innerHTML="{{bar}}"></div>`);
         });
-        test("should resolve a unescaped data bindings in a mix of other data content bindings", async () => {
+        test("should resolve an unescaped data bindings in a mix of other data content bindings", async () => {
             expect(transformInnerHTML(`{{text1}}{{{foo}}}{{text2}}{{{bar}}}{{text3}}`)).toEqual(`{{text1}}<div :innerHTML="{{foo}}"></div>{{text2}}<div :innerHTML="{{bar}}"></div>{{text3}}`);
         });
-        test("should resolve a unescaped data bindings in a mix of other data attribute bindings and nesting", async () => {
+        test("should resolve default data bindings in sequence", async () => {
+            expect(transformInnerHTML(`{{text1}}{{text2}}`)).toEqual(`{{text1}}{{text2}}`);
+        });
+        test("should resolve an unescaped data bindings in a mix of other data attribute bindings and nesting", async () => {
             expect(
                 transformInnerHTML(
                     `<div data-foo="{{text1}}">{{{foo}}}</div><div data-bar="{{text2}}"></div>{{{bar}}}<div data-bat="{{text3}}"></div>`

--- a/packages/web-components/fast-html/src/components/utilities.ts
+++ b/packages/web-components/fast-html/src/components/utilities.ts
@@ -594,7 +594,7 @@ export function transformInnerHTML(innerHTML: string, index = 0): string {
 
         return transformInnerHTML(
             transformedInnerHTML,
-            index + nextBinding.closingStartIndex - 2
+            index + nextBinding.closingEndIndex
         );
     } else if (nextBinding) {
         return transformInnerHTML(


### PR DESCRIPTION
# Pull Request

## 📖 Description

This fixes a stack overflow issue due to incorrectly slicing inner HTML strings when evaluating templates.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.