### PR TITLE
Add chaining logic for f-when

### DIFF
--- a/change/@microsoft-fast-html-718a16b3-6a90-48ae-a28a-4593812510cd.json
+++ b/change/@microsoft-fast-html-718a16b3-6a90-48ae-a28a-4593812510cd.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Resolve chained expressions and fix an issue with single quotes in f-when binding",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -13,11 +13,13 @@ import { DOMPolicy } from "@microsoft/fast-element/dom-policy.js";
 import { Message } from "../interfaces.js";
 import {
     AttributeDirective,
+    ChainedExpression,
     DataBindingBehaviorConfig,
     getAllPartials,
+    getExpressionChain,
     getNextBehavior,
-    getOperator,
     pathResolver,
+    resolveWhen,
     TemplateDirectiveBehaviorConfig,
     transformInnerHTML,
 } from "./utilities.js";
@@ -176,75 +178,12 @@ class TemplateElement extends FASTElement {
 
                     const { when } = await import("@microsoft/fast-element");
 
-                    const { operator, left, right, rightIsValue } = getOperator(
-                        behaviorConfig.value
-                    );
-                    let whenLogic = (x: boolean, c: any) =>
-                        pathResolver(left, self)(x, c);
+                    const expressionChain = getExpressionChain(behaviorConfig.value);
 
-                    switch (operator) {
-                        case "!":
-                            whenLogic = (x: boolean, c: any) =>
-                                !pathResolver(left, self)(x, c);
-                            break;
-                        case "==":
-                            whenLogic = (x: boolean, c: any) =>
-                                pathResolver(left, self)(x, c) ==
-                                (rightIsValue
-                                    ? right
-                                    : pathResolver(right as string, self)(x, c));
-                            break;
-                        case "!=":
-                            whenLogic = (x: boolean, c: any) =>
-                                pathResolver(left, self)(x, c) !=
-                                (rightIsValue
-                                    ? right
-                                    : pathResolver(right as string, self)(x, c));
-                            break;
-                        case "&&":
-                        case "&amp;&amp;":
-                            whenLogic = (x: boolean, c: any) =>
-                                pathResolver(left, self)(x, c) &&
-                                (rightIsValue
-                                    ? right
-                                    : pathResolver(right as string, self)(x, c));
-                            break;
-                        case "||":
-                            whenLogic = (x: boolean, c: any) =>
-                                pathResolver(left, self)(x, c) ||
-                                (rightIsValue
-                                    ? right
-                                    : pathResolver(right as string, self)(x, c));
-                            break;
-                        case ">=":
-                            whenLogic = (x: boolean, c: any) =>
-                                pathResolver(left, self)(x, c) >=
-                                (rightIsValue
-                                    ? right
-                                    : pathResolver(right as string, self)(x, c));
-                            break;
-                        case ">":
-                            whenLogic = (x: boolean, c: any) =>
-                                pathResolver(left, self)(x, c) >
-                                (rightIsValue
-                                    ? right
-                                    : pathResolver(right as string, self)(x, c));
-                            break;
-                        case "<=":
-                            whenLogic = (x: boolean, c: any) =>
-                                pathResolver(left, self)(x, c) <=
-                                (rightIsValue
-                                    ? right
-                                    : pathResolver(right as string, self)(x, c));
-                            break;
-                        case "<":
-                            whenLogic = (x: boolean, c: any) =>
-                                pathResolver(left, self)(x, c) <
-                                (rightIsValue
-                                    ? right
-                                    : pathResolver(right as string, self)(x, c));
-                            break;
-                    }
+                    const whenLogic = resolveWhen(
+                        self,
+                        expressionChain as ChainedExpression
+                    );
 
                     externalValues.push(
                         when(whenLogic, this.resolveTemplateOrBehavior(strings, values))


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change:
- Fixes an issue with single quotes in f-when binding interpretation
- Adds ability to chain logic in f-when binding expression

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.