### PR TITLE
Add information about non-browser rendering of hydratable markup and initial state

### DIFF
--- a/change/@microsoft-fast-html-b4d2eaa6-6071-46b4-895a-18c23115ba2e.json
+++ b/change/@microsoft-fast-html-b4d2eaa6-6071-46b4-895a-18c23115ba2e.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add information about non-browser rendering of hydratable markup and initial state",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -217,6 +217,10 @@ If your template includes JavaScript specific logic that does not conform to tho
 - `@microsoft/fast-html/rules/member-expression.yml`
 - `@microsoft/fast-html/rules/tag-function-to-template-literal.yml`
 
+### Non-browser HTML rendering
+
+One of the benefits of FAST declarative HTML templates is that the server can be stack agnostic as JavaScript does not need to be interpreted. FASTElement will expect hydratable content however and uses comments and datasets for tracking the binding logic. For more information on what that markup should look like, as well as an example of how initial state may be applied, read our [documentation](./RENDERING.md) to understand what markup should be generated for a hydratable experience.
+
 ## Acknowledgements
 
 This project has been heavily inspired by [Handlebars](https://handlebarsjs.com/) and [Vue.js](https://vuejs.org/).

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -43,7 +43,7 @@ TemplateElement.options({
 
 This will include the `<f-template>` custom element and all logic for interpreting the declarative HTML syntax for a FAST web component as well as the `shadowOptions` for any element an `<f-template>` has been used to define.
 
-It is necessary to set the initial `shadowOptions` of your custom elements to `null` otherwise a shadowRoot will be attached and cause a FOUC (Flash Of Unstyled Content).
+It is necessary to set the initial `shadowOptions` of your custom elements to `null` otherwise a shadowRoot will be attached and cause a FOUC (Flash Of Unstyled Content). For more information about how this affects hydration, check out our [document](./RENDERING.md#setting-shadow-options) on rendering DOM from non-browser.
 
 The template must be wrapped in `<f-template name="[custom-element-name]"><template>[template logic]</template></f-template>` with a `name` attribute for the custom elements name, and the template logic inside.
 

--- a/packages/web-components/fast-html/RENDERING.md
+++ b/packages/web-components/fast-html/RENDERING.md
@@ -150,7 +150,7 @@ A content binding syntax can be broken into parts:
 - `fe-b` - declares this as a FASTElement Binding.
 - `start|end` - indicates the start or end of the binding.
 - `number` - the number in order in the template of bindings, these increment for every binding.
-- `UUID` - a unique string identifying the binding.
+- `UUID` - a unique string identifying the binding. The examples shown here have been generated from a 10 character long string used in the [FAST SSR package](https://github.com/microsoft/fast/blob/main/packages/web-components/fast-ssr/src/template-parser/id-generator.ts).
 
 Separator:
 - `$$` - a separator string between the parts.

--- a/packages/web-components/fast-html/RENDERING.md
+++ b/packages/web-components/fast-html/RENDERING.md
@@ -163,13 +163,13 @@ An attribute binding is tracked using a dataset attribute with the name `data-fe
 
 Content bindings such as:
 ```html
-<h1>{{title}}</h1>
+<h1>{{text}}</h1>
 ```
 
 When combined with state such as:
 ```json
 {
-    "title": "Hello world"
+    "text": "Hello world"
 }
 ```
 
@@ -182,25 +182,25 @@ Should result in:
 
 Attribute binding such as:
 ```html
-<h1 title="{{title}}"></h1>
+<h1 text="{{text}}"></h1>
 ```
 
 Should result in:
 
 ```html
-<h1 data-fe-b="0" title="Hello world"></h1>
+<h1 data-fe-b="0" text="Hello world"></h1>
 ```
 
 If multiple attribute bindings exist on the same element, these will be separated by a space.
 
 Example:
 ```html
-<h1 title="{{title}}" subtitle="{{subtitle}}"></h1>
+<h1 text="{{text}}" subtitle="{{subtitle}}"></h1>
 ```
 
 Expected result:
 ```html
-<h1 data-fe-b="0 1" title="Hello" subtitle="world"></h1>
+<h1 data-fe-b="0 1" text="Hello" subtitle="world"></h1>
 ```
 
 **Mixed attribute and content example**
@@ -208,7 +208,7 @@ Expected result:
 Multiple attributes and content bindings such as:
 ```html
 <div show="{{show}}" appearance="{{appearance}}">
-    <h1>{{title}}</h1>
+    <h1>{{text}}</h1>
     <span>{{subtitle}}</span>
 </div>
 ```

--- a/packages/web-components/fast-html/RENDERING.md
+++ b/packages/web-components/fast-html/RENDERING.md
@@ -1,0 +1,311 @@
+# Non-browser HTML rendering
+
+1. [Initial State](#initial-state)
+2. [Hydrating Comments and Datasets](#hydration-comments-and-datasets)
+
+This document details information on rendering hydratable content and includes some pointers on how Dependency Injection can be used to create services that hydrate a custom elements state.
+
+## Initial State
+
+To create initial state this should be added somewhere accessible by your service, in this example a `<script>` tag can be used to provide a global initial state.
+
+Example:
+```html
+<script>
+    window.__INITIAL_STATE__ = {
+        text: "Hello world"
+    }
+</script>
+```
+
+Add a Dependency Injection service in your bundle to access properties in your state.
+
+Simple example (`initial-state.ts`):
+```typescript
+import { DI } from "@microsoft/fast-element/di.js";
+
+interface InitialState {
+    text: string;
+}
+
+export interface IInitialStateService {
+  init(): InitialState;
+}
+
+export class InitialStateService implements IInitialStateService {
+    private initialState: any;
+
+    constructor() {
+        this.initialState = window.__INITIAL_STATE__;
+    }
+
+    public init(...keys: Array<string>): InitialState {
+        const config: any = {};
+
+        for (let key of keys) {
+            config[key] = this.initialState[key];
+        }
+
+        return config;
+    }
+}
+
+export const initialStateFactory = DI.createContext<IInitialStateService>(
+  'i-initial-state-service',
+  (x) => x.singleton(InitialStateService)
+);
+```
+
+Include the DI service to your component.
+
+Example:
+```typescript
+import { attr, FASTElement, Observable } from "@microsoft/fast-element";
+import {
+    initialStateFactory,
+    InitialStateService,
+    type IInitialStateService,
+} from "./initial-state.js";
+import { inject } from '@microsoft/fast-element/di.js';
+
+export class MyComponent extends FASTElement {
+    @inject(initialStateFactory) initialStateService!: InitialStateService;
+
+    @attr
+    text: string = "";
+
+    @attr({
+        attribute: "defer-hydration",
+        mode: "boolean"
+    })
+    deferHydration?: boolean;
+
+    service!: IInitialStateService;
+
+    private shadowOptions = false;
+    public initialState = false;
+
+    connectedCallback() {
+        super.connectedCallback();
+
+        Observable.defineProperty(this.$fastController.definition, "shadowOptions");
+
+        Observable.getNotifier(this.$fastController.definition).subscribe(
+            {
+                handleChange: (value) => {
+                    if (value.shadowOptions) {
+                        this.shadowOptions = true;
+                        this.hasStateAndShadowOptions();
+                    }
+                },
+            },
+            "shadowOptions"
+        );
+
+        this.loadItemFromInitialState();
+    }
+
+    hasStateAndShadowOptions() {
+        if (this.shadowOptions && this.initialState) {
+            this.deferHydration = false;
+        }
+    }
+
+    loadItemFromInitialState(): void {
+        const initialState = this.initialStateService.init(["text"]);
+
+        this.text = initialState.text;
+
+        this.initialState = true;
+
+        this.hasStateAndShadowOptions();
+    }
+}
+
+MyComponent.define({
+    name: "my-component",
+    shadowOptions: null
+});
+```
+
+Notice that there is a `defer-hydration` attribute that gets removed once initial state has been applied and `shadowOptions` has also been defined. This allows us to ensure that the template has been found and parsed to the component and the initial state has been applied before we connect the component to the rendered HTML.
+
+Depending on your application structure it might be more maintainable to create an abstract class that extends `FASTElement` to re-use the service logic and the removal of `defer-hydration`.
+
+## Hydration Comments and Datasets
+
+When hydrating the HTML FAST uses the `HydratableElementController` which can be included in your bundle like so:
+
+```typescript
+import "@microsoft/fast-element/install-element-hydration.js";
+```
+
+The `HydratableElementController` will take over from the `ElementController` to use hydration "markers" such as comments and dataset attributes to rationalize bindings with existing HTML.
+
+### Bindings
+
+#### Syntax
+
+A content binding syntax can be broken into parts:
+- `fe-b` - declares this as a FASTElement Binding.
+- `start|end` - indicates the start or end of the binding.
+- `number` - the number in order in the template of bindings, these increment for every binding.
+- `UUID` - a unique string identifying the binding.
+
+Separator:
+- `$$` - a separator string between the parts.
+
+An attribute binding is tracked using a dataset attribute with the name `data-fe-b` followed by the binding number.
+
+#### Examples
+
+**Simple content example**
+
+Content bindings such as:
+```html
+<h1>{{title}}</h1>
+```
+
+When combined with state such as:
+```json
+{
+    "title": "Hello world"
+}
+```
+
+Should result in:
+```html
+<h1><!--fe-b$$start$$0$$ZJEYduCZlM$$fe-b-->Hello world<!--fe-b$$end$$0$$ZJEYduCZlM$$fe-b--></h1>
+```
+
+**Simple attribute example**
+
+Attribute binding such as:
+```html
+<h1 title="{{title}}"></h1>
+```
+
+Should result in:
+
+```html
+<h1 data-fe-b="0" title="Hello world"></h1>
+```
+
+If multiple attribute bindings exist on the same element, these will be separated by a space.
+
+Example:
+```html
+<h1 title="{{title}}" subtitle="{{subtitle}}"></h1>
+```
+
+Expected result:
+```html
+<h1 data-fe-b="0 1" title="Hello" subtitle="world"></h1>
+```
+
+**Mixed attribute and content example**
+
+Multiple attributes and content bindings such as:
+```html
+<div show="{{show}}" appearance="{{appearance}}">
+    <h1>{{title}}</h1>
+    <span>{{subtitle}}</span>
+</div>
+```
+
+Should result in:
+```html
+<div data-fe-b="0 1" show appearance="large">
+    <h1><!--fe-b$$start$$2$$ZJEYduCZlM$$fe-b-->Hello<!--fe-b$$end$$2$$ZJEYduCZlM$$fe-b--></h1>
+    <span><!--fe-b$$start$$3$$t01oHhokPY$$fe-b-->world<!--fe-b$$end$$3$$t01oHhokPY$$fe-b--></span>
+</div>
+```
+
+### Directives
+
+Directives are treated differently from bindings as they include a template. This means that in addition to the binding used to determine the logic for the directive FAST also requires a separate marker for the directive itself to demarkate the beginning and end of the template.
+
+#### Repeat
+
+Example repeat binding:
+```html
+<f-repeat value="{item in list}">
+    <span>{{item}}</span>
+</f-repeat>
+```
+
+Combined with state:
+```json
+[
+    "Bob",
+    "Alice",
+    "Sue"
+]
+```
+
+Should result in:
+```html
+<!--fe-b$$start$$0$$t01oHhokPY$$fe-b-->
+<!--fe-repeat$$start$$0$$fe-repeat-->
+<span>
+    <!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->Bob<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
+</span>
+<!--fe-repeat$$end$$0$$fe-repeat-->
+<!--fe-repeat$$start$$1$$fe-repeat-->
+<span>
+    <!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->Alice<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
+</span>
+<!--fe-repeat$$end$$1$$fe-repeat-->
+<!--fe-repeat$$start$$2$$fe-repeat-->
+<span>
+    <!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->Sue<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
+</span>
+<!--fe-repeat$$end$$2$$fe-repeat-->
+<!--fe-b$$end$$0$$t01oHhokPY$$fe-b-->
+```
+
+You may notice that the same UUID was used within the repeat markers, this is because they are templates and each UUID only needs to be unique to that template. The same is true for the binding number.
+
+#### When
+
+The when directive is either present in the DOM or not, and therefore does not need an extra marker for the template.
+
+Example when binding:
+```html
+<f-when value="{show}">
+    <span>{{text}}</span>
+</f-when>
+```
+
+Combined with state:
+```json
+{
+    "show": true,
+    "text": "Hello world"
+}
+```
+
+Should result in:
+```html
+<!--fe-b$$start$$0$$t01oHhokPY$$fe-b-->
+<span>
+    <!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->Hello world<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
+</span>
+<!--fe-b$$end$$0$$t01oHhokPY$$fe-b-->
+```
+
+If the when is evaluated to `falsy` then we can safely leave the binding markers only.
+
+Example state:
+```json
+{
+    "show": false,
+    "text": "Hello world"
+}
+```
+
+Should result in:
+```html
+<!--fe-b$$start$$0$$t01oHhokPY$$fe-b-->
+<!--fe-b$$end$$0$$t01oHhokPY$$fe-b-->
+```

--- a/packages/web-components/fast-html/RENDERING.md
+++ b/packages/web-components/fast-html/RENDERING.md
@@ -132,6 +132,32 @@ Notice that there is a `defer-hydration` attribute that gets removed once initia
 
 Depending on your application structure it might be more maintainable to create an abstract class that extends `FASTElement` to re-use the service logic and the removal of `defer-hydration`.
 
+## Setting shadow options
+
+You may notice in the example above we have set the `shadowOptions` to `null`, when using `define` on a `FASTElement` you must set your `shadowOptions` to `null` if you intend to set them later - they can only be set once. This way `FASTElement` will delay the creation of a shadowRoot so your declarative shadow DOM will not immediately get overwritten causing a FOUC (Flash of Unstyled Content). Then, when initializing the `TemplateElement` from `@microsoft/fast-html`, be sure to pass `shadowOptions` as a part of the component options so they can be set correctly and the `defer-hydration` can be removed.
+
+Example:
+```typescript
+import { FASTElement } from "@microsoft/fast-element";
+
+class MyComponent extends FASTElement {}
+
+MyComponent.define({
+    name: "my-component",
+    shadowOptions: null
+});
+
+TemplateElement.options({
+    "my-component": {
+        shadowOptions: {
+            mode: "open"
+        }
+    }
+}).define({
+    name: "f-template",
+});
+```
+
 ## Hydration Comments and Datasets
 
 When hydrating the HTML FAST uses the `HydratableElementController` which can be included in your bundle like so:


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change adds some documentation detailing how initial state can be applied to elements as well as what markers need to be added to the DOM on initial render.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.