### PR TITLE
Keep a f-repeat context when creating bindings for f-when

### DIFF
--- a/change/@microsoft-fast-html-9cab46dc-d71f-4d95-af56-6a19ba01b917.json
+++ b/change/@microsoft-fast-html-9cab46dc-d71f-4d95-af56-6a19ba01b917.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Keep a f-repeat context when creating bindings for f-when",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -173,7 +173,8 @@ class TemplateElement extends FASTElement {
                         innerHTML.slice(
                             behaviorConfig.openingTagEndIndex,
                             behaviorConfig.closingTagStartIndex
-                        )
+                        ),
+                        self
                     );
 
                     const { when } = await import("@microsoft/fast-element");

--- a/packages/web-components/fast-html/src/fixtures/repeat/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/repeat/main.ts
@@ -12,8 +12,31 @@ TestElement.define({
     shadowOptions: null,
 });
 
+class TestElementInnerWhen extends FASTElement {
+    @observable
+    list: Array<any> = [
+        {
+            show: true,
+            text: "Foo",
+        },
+        {
+            show: false,
+            text: "Bar",
+        },
+    ];
+}
+TestElementInnerWhen.define({
+    name: "test-element-inner-when",
+    shadowOptions: null,
+});
+
 TemplateElement.options({
     "test-element": {
+        shadowOptions: {
+            mode: "closed",
+        },
+    },
+    "test-element-inner-when": {
         shadowOptions: {
             mode: "closed",
         },

--- a/packages/web-components/fast-html/src/fixtures/repeat/repeat.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/repeat/repeat.fixture.html
@@ -9,8 +9,26 @@
         <f-template name="test-element">
             <template><ul><f-repeat value="{{item in list}}"><li>{{item}} - {{../parent}}</li></f-repeat></ul></template>
         </f-template>
+        <f-template name="test-element-inner-when">
+            <template>
+                <ul>
+                    <f-repeat value="{{item in list}}">
+                        <f-when value="{{item.show}}">
+                            <li>{{item.text}}</li>
+                        </f-when>
+                    </f-repeat>
+                </ul>
+            </template>
+        </f-template>
         <test-element>
             <template shadowrootmode="open"><ul><li>Foo - Bat</li><li>Bar - Bat</li></ul></template>
         </test-element>
+        <test-element-inner-when>
+            <template shadowrootmode="open">
+                <ul>
+                    <li>Foo</li>
+                </ul>
+            </template>
+        </test-element-inner-when>
     </body>
 </html>

--- a/packages/web-components/fast-html/src/fixtures/repeat/repeat.spec.ts
+++ b/packages/web-components/fast-html/src/fixtures/repeat/repeat.spec.ts
@@ -33,4 +33,13 @@ test.describe("f-template", async () => {
         expect(await customElementListItems.nth(1).textContent()).toEqual("B - Bat");
         expect(await customElementListItems.nth(2).textContent()).toEqual("C - Bat");
     });
+    test("create a repeat directive with an inner when", async ({ page }) => {
+        await page.goto("/repeat");
+
+        const customElement = await page.locator("test-element-inner-when");
+        let customElementListItems = await customElement.locator("li");
+
+        expect(await customElementListItems.count()).toEqual(1);
+        expect(await customElementListItems.nth(0).textContent()).toEqual("Foo");
+    });
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change keeps the context when using an `f-when` in an `f-repeat`.

### 🎫 Issues

Closes #7118

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.