### PR TITLE
Add enumerated hydration binding markers

### DIFF
--- a/change/@microsoft-fast-element-d8fc1632-3727-43ae-b5a2-de9d3a91d47b.json
+++ b/change/@microsoft-fast-element-d8fc1632-3727-43ae-b5a2-de9d3a91d47b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add enumerated hydration binding markers",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-html-4a8ab298-12f3-427d-adb9-f38aee45f39f.json
+++ b/change/@microsoft-fast-html-4a8ab298-12f3-427d-adb9-f38aee45f39f.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Update documentation on attribute binding markers",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-element/src/components/hydration.spec.ts
+++ b/packages/web-components/fast-element/src/components/hydration.spec.ts
@@ -243,7 +243,7 @@ describe("HydrationMarkup", () => {
             el.setAttribute(`${HydrationMarkup.attributeMarkerName}-0`, "");
             el.setAttribute(`${HydrationMarkup.attributeMarkerName}-1`, "");
             el.setAttribute(`${HydrationMarkup.attributeMarkerName}-2`, "");
-            expect(HydrationMarkup.parseAttributeBinding(el)).to.eql([0, 1, 2]);
+            expect(HydrationMarkup.parseEnumeratedAttributeBinding(el)).to.eql([0, 1, 2]);
         });
     });
 

--- a/packages/web-components/fast-element/src/components/hydration.spec.ts
+++ b/packages/web-components/fast-element/src/components/hydration.spec.ts
@@ -238,6 +238,13 @@ describe("HydrationMarkup", () => {
             el.setAttribute(HydrationMarkup.attributeMarkerName, "0 1 2");
             expect(HydrationMarkup.parseAttributeBinding(el)).to.eql([0, 1, 2]);
         });
+        it("should return the binding ids as numbers when assigned enumerated marker attributes", () => {
+            const el = document.createElement("div");
+            el.setAttribute(`${HydrationMarkup.attributeMarkerName}-0`, "");
+            el.setAttribute(`${HydrationMarkup.attributeMarkerName}-1`, "");
+            el.setAttribute(`${HydrationMarkup.attributeMarkerName}-2`, "");
+            expect(HydrationMarkup.parseAttributeBinding(el)).to.eql([0, 1, 2]);
+        });
     });
 
     describe("repeat parser", () => {

--- a/packages/web-components/fast-element/src/components/hydration.ts
+++ b/packages/web-components/fast-element/src/components/hydration.ts
@@ -70,6 +70,22 @@ export const HydrationMarkup = Object.freeze({
             : attr.split(this.attributeBindingSeparator).map(i => parseInt(i));
     },
     /**
+     * Returns the indexes of the ViewBehaviorFactories affecting
+     * attributes for the element, or null if no factories were found.
+     *
+     * Uses the alternative syntax of data-fe-b-<number>
+     */
+    parseEnumeratedAttributeBinding(node: Element): null | number[] {
+        const attrs: number[] = [];
+        let count = 0;
+
+        while (node.hasAttribute(`${this.attributeMarkerName}-${count}`)) {
+            attrs.push(count++);
+        }
+
+        return count === 0 ? null : attrs;
+    },
+    /**
      * Parses the ViewBehaviorFactory index from string data. Returns
      * the binding index or null if the index cannot be retrieved.
      */

--- a/packages/web-components/fast-element/src/hydration/target-builder.ts
+++ b/packages/web-components/fast-element/src/hydration/target-builder.ts
@@ -134,7 +134,9 @@ function targetElement(
     targets: ViewBehaviorTargets
 ) {
     // Check for attributes and map any factories.
-    const attrFactoryIds = HydrationMarkup.parseAttributeBinding(node);
+    const attrFactoryIds =
+        HydrationMarkup.parseAttributeBinding(node) ??
+        HydrationMarkup.parseEnumeratedAttributeBinding(node);
 
     if (attrFactoryIds !== null) {
         for (const id of attrFactoryIds) {

--- a/packages/web-components/fast-html/RENDERING.md
+++ b/packages/web-components/fast-html/RENDERING.md
@@ -181,7 +181,7 @@ A content binding syntax can be broken into parts:
 Separator:
 - `$$` - a separator string between the parts.
 
-An attribute binding is tracked using a dataset attribute with the name `data-fe-b` followed by the binding number.
+An attribute binding is tracked using a dataset attribute with the name `data-fe-b-<binding number>`.
 
 #### Examples
 
@@ -214,7 +214,7 @@ Attribute binding such as:
 Should result in:
 
 ```html
-<h1 data-fe-b="0" text="Hello world"></h1>
+<h1 data-fe-b-0 text="Hello world"></h1>
 ```
 
 If multiple attribute bindings exist on the same element, these will be separated by a space.
@@ -226,7 +226,7 @@ Example:
 
 Expected result:
 ```html
-<h1 data-fe-b="0 1" text="Hello" subtitle="world"></h1>
+<h1 data-fe-b-0 data-fe-b-1 text="Hello" subtitle="world"></h1>
 ```
 
 **Mixed attribute and content example**
@@ -241,7 +241,7 @@ Multiple attributes and content bindings such as:
 
 Should result in:
 ```html
-<div data-fe-b="0 1" show appearance="large">
+<div data-fe-b-0 data-fe-b-1 show appearance="large">
     <h1><!--fe-b$$start$$2$$ZJEYduCZlM$$fe-b-->Hello<!--fe-b$$end$$2$$ZJEYduCZlM$$fe-b--></h1>
     <span><!--fe-b$$start$$3$$t01oHhokPY$$fe-b-->world<!--fe-b$$end$$3$$t01oHhokPY$$fe-b--></span>
 </div>


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change adds enumerated binding markers.

Due to the non-browser environment expected from SSR we must remove the assumption that an element is tracking it's internal attributes and so enumerating the binding markers allows a non-browser environment to add a hydration marker after/before every binding instead of having to create additional logic to track the number of attributes within an element tag.

### 🎫 Issues

Closes #7120 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.