### PR TITLE
Add a RenderableFASTElement and default shadow options

### DIFF
--- a/change/@microsoft-fast-html-f2182c6e-460a-4b78-9b2d-32177d0d098e.json
+++ b/change/@microsoft-fast-html-f2182c6e-460a-4b78-9b2d-32177d0d098e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add a RenderableFASTElement and default shadow options",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -30,20 +30,14 @@ MyCustomElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "my-custom-element": {
-        shadowOptions: {
-            mode: "closed",
-        }
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });
 ```
 
 This will include the `<f-template>` custom element and all logic for interpreting the declarative HTML syntax for a FAST web component as well as the `shadowOptions` for any element an `<f-template>` has been used to define.
 
-It is necessary to set the initial `shadowOptions` of your custom elements to `null` otherwise a shadowRoot will be attached and cause a FOUC (Flash Of Unstyled Content). For more information about how this affects hydration, check out our [document](./RENDERING.md#setting-shadow-options) on rendering DOM from non-browser.
+It is necessary to set the initial `shadowOptions` of your custom elements to `null` otherwise a shadowRoot will be attached and cause a FOUC (Flash Of Unstyled Content). For more information about how this affects hydration, check out our [document](./RENDERING.md#setting-shadow-options) on rendering DOM from a non-browser environment.
 
 The template must be wrapped in `<f-template name="[custom-element-name]"><template>[template logic]</template></f-template>` with a `name` attribute for the custom elements name, and the template logic inside.
 
@@ -57,6 +51,50 @@ Example:
 <f-template name="my-custom-element">
     <template>{{greeting}}</template>
 </f-template>
+```
+
+#### Non-browser HTML rendering
+
+One of the benefits of FAST declarative HTML templates is that the server can be stack agnostic as JavaScript does not need to be interpreted. By default `@microsoft/fast-html` will expect hydratable content and uses comments and datasets for tracking the binding logic. For more information on what that markup should look like, as well as an example of how initial state may be applied, read our [documentation](./RENDERING.md) to understand what markup should be generated for a hydratable experience. For the sake of brevity hydratable markup will be excluded from the README.
+
+#### Adding shadowOptions
+
+By default `shadowOptions` via the `TemplateElement` will be with `"mode": "open"` once the template has been set. To set each components `shadowOptions` you can pass an `options` object.
+
+Example:
+
+```typescript
+TemplateElement.options({
+    "my-custom-element": {
+        shadowOptions: {
+            mode: "closed",
+        }
+    },
+}).define({
+    name: "f-template",
+});
+```
+
+#### Using the RenderableFASTElement
+
+The exported abstract class `RenderableFASTElement` is available for automatic addition and removal of `defer-hydration` and `needs-hydration`. If you use `FASTElement` you will need to add `defer-hydration` and `needs-hydration` attributes to your rendered markup and remove them via your component.
+
+Example:
+```typescript
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+
+class MyCustomElement extends RenderableFASTElement {
+    // component logic
+}
+
+MyCustomElement.define({
+    name: "my-custom-element",
+    shadowOptions: null,
+});
+
+TemplateElement.define({
+    name: "f-template",
+});
 ```
 
 ### Syntax
@@ -216,10 +254,6 @@ If your template includes JavaScript specific logic that does not conform to tho
 - `@microsoft/fast-html/rules/call-expression-with-event-argument.yml`
 - `@microsoft/fast-html/rules/member-expression.yml`
 - `@microsoft/fast-html/rules/tag-function-to-template-literal.yml`
-
-### Non-browser HTML rendering
-
-One of the benefits of FAST declarative HTML templates is that the server can be stack agnostic as JavaScript does not need to be interpreted. FASTElement will expect hydratable content however and uses comments and datasets for tracking the binding logic. For more information on what that markup should look like, as well as an example of how initial state may be applied, read our [documentation](./RENDERING.md) to understand what markup should be generated for a hydratable experience.
 
 ## Acknowledgements
 

--- a/packages/web-components/fast-html/RENDERING.md
+++ b/packages/web-components/fast-html/RENDERING.md
@@ -160,13 +160,7 @@ TemplateElement.options({
 
 ## Hydration Comments and Datasets
 
-When hydrating the HTML FAST uses the `HydratableElementController` which can be included in your bundle like so:
-
-```typescript
-import "@microsoft/fast-element/install-element-hydration.js";
-```
-
-The `HydratableElementController` will take over from the `ElementController` to use hydration "markers" such as comments and dataset attributes to rationalize bindings with existing HTML.
+When hydrating the HTML, FAST uses the `HydratableElementController` which will take over from the `ElementController` to use hydration "markers" such as comments and dataset attributes to rationalize bindings with existing HTML. By default the `@microsoft/fast-html` package will assume that component hydration will occur so rendering hydratable markup is required.
 
 ### Bindings
 

--- a/packages/web-components/fast-html/docs/api-report.api.md
+++ b/packages/web-components/fast-html/docs/api-report.api.md
@@ -26,8 +26,6 @@ export class TemplateElement extends FASTElement {
     name?: string;
     // (undocumented)
     static options(elementOptions?: ElementOptionsDictionary): typeof TemplateElement;
-    // (undocumented)
-    static setOptions(name: string): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-html/docs/api-report.api.md
+++ b/packages/web-components/fast-html/docs/api-report.api.md
@@ -7,15 +7,27 @@
 import { FASTElement } from '@microsoft/fast-element';
 import { ShadowRootOptions } from '@microsoft/fast-element';
 
+// @public (undocumented)
+export abstract class RenderableFASTElement extends FASTElement {
+    constructor();
+    // (undocumented)
+    deferHydration: boolean;
+    // (undocumented)
+    needsHydration: boolean;
+}
+
 // @public
 export class TemplateElement extends FASTElement {
+    constructor();
     // (undocumented)
     connectedCallback(): void;
-    // Warning: (ae-forgotten-export) The symbol "ElementOptions" needs to be exported by the entry point index.d.ts
-    static elementOptions: ElementOptions;
+    // Warning: (ae-forgotten-export) The symbol "ElementOptionsDictionary" needs to be exported by the entry point index.d.ts
+    static elementOptions: ElementOptionsDictionary;
     name?: string;
     // (undocumented)
-    static options(elementOptions?: ElementOptions): typeof TemplateElement;
+    static options(elementOptions?: ElementOptionsDictionary): typeof TemplateElement;
+    // (undocumented)
+    static setOptions(name: string): void;
 }
 
 // (No @packageDocumentation comment for this package)

--- a/packages/web-components/fast-html/src/components/element.ts
+++ b/packages/web-components/fast-html/src/components/element.ts
@@ -1,0 +1,27 @@
+import { attr, FASTElement, Observable } from "@microsoft/fast-element";
+
+export abstract class RenderableFASTElement extends FASTElement {
+    @attr({ mode: "boolean", attribute: "defer-hydration" })
+    deferHydration: boolean = true;
+
+    @attr({ mode: "boolean", attribute: "needs-hydration" })
+    needsHydration: boolean = true;
+
+    constructor() {
+        super();
+
+        this.setAttribute("defer-hydration", "");
+        this.setAttribute("needs-hydration", "");
+
+        Observable.defineProperty(this.$fastController.definition, "shadowOptions");
+
+        Observable.getNotifier(this.$fastController.definition).subscribe(
+            {
+                handleChange: () => {
+                    this.deferHydration = false;
+                },
+            },
+            "shadowOptions"
+        );
+    }
+}

--- a/packages/web-components/fast-html/src/components/index.ts
+++ b/packages/web-components/fast-html/src/components/index.ts
@@ -1,1 +1,2 @@
 export { TemplateElement } from "./template.js";
+export { RenderableFASTElement } from "./element.js";

--- a/packages/web-components/fast-html/src/fixtures/attribute/attribute.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/attribute/attribute.fixture.html
@@ -6,7 +6,9 @@
     </head>
     <body>
         <test-element type="checkbox">
-            <template shadowrootmode="open"><input type="checkbox" disabled></template>
+            <template shadowrootmode="open">
+                <input disabled data-fe-b-0 type="checkbox">
+            </template>
         </test-element>
         <f-template name="test-element">
             <template><input type="{{type}}" disabled></template>

--- a/packages/web-components/fast-html/src/fixtures/attribute/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/attribute/main.ts
@@ -1,7 +1,7 @@
-import { TemplateElement } from "@microsoft/fast-html";
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+import { attr } from "@microsoft/fast-element";
 
-class TestElement extends FASTElement {
+class TestElement extends RenderableFASTElement {
     @attr
     type: string = "radio";
 }
@@ -10,12 +10,6 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/binding/binding.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/binding/binding.fixture.html
@@ -6,10 +6,14 @@
     </head>
     <body>
         <test-element text="Hello world">
-            <template shadowrootmode="open">Hello world</template>
+            <template shadowrootmode="open">
+                <!--fe-b$$start$$0$$ZJEYduCZlM$$fe-b-->Hello world<!--fe-b$$end$$0$$ZJEYduCZlM$$fe-b-->
+            </template>
         </test-element>
         <test-element-unescaped>
-            <template shadowrootmode="open"><p>Hello world</p></template>
+            <template shadowrootmode="open">
+                <div><p><!--fe-b$$start$$0$$ZJEYduCZlM$$fe-b-->Hello world<!--fe-b$$end$$0$$ZJEYduCZlM$$fe-b--></p></div>
+            </template>
         </test-element-unescaped>
         <f-template name="test-element">
             <template>{{text}}</template>

--- a/packages/web-components/fast-html/src/fixtures/binding/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/binding/main.ts
@@ -1,15 +1,16 @@
-import { TemplateElement } from "@microsoft/fast-html";
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+import { attr } from "@microsoft/fast-element";
 
-class TestElement extends FASTElement {
+class TestElement extends RenderableFASTElement {
     @attr
     text: string = "Hello";
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-class TestElementUnescaped extends FASTElement {
+class TestElementUnescaped extends RenderableFASTElement {
     public html = `<p>Hello world</p>`;
 }
 TestElementUnescaped.define({
@@ -17,17 +18,6 @@ TestElementUnescaped.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-unescaped": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/children/children.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/children/children.fixture.html
@@ -10,7 +10,14 @@
             <template><ul f-children="{listItems}"><f-repeat value="{{item in list}}"><li>{{item}}</li></f-repeat></ul></template>
         </f-template>
         <test-element>
-            <template shadowrootmode="open"><ul><li>Foo</li><li>Bar</li></ul></template>
+            <template shadowrootmode="open">
+                <ul data-fe-b-0>
+                <!--fe-b$$start$$1$$t01oHhokPY$$fe-b-->
+                <!--fe-repeat$$start$$0$$fe-repeat--><li><!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->Foo<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b--></li><!--fe-repeat$$end$$0$$fe-repeat-->
+                <!--fe-repeat$$start$$1$$fe-repeat--><li><!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->Bar<!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b--></li><!--fe-repeat$$end$$1$$fe-repeat-->
+                <!--fe-b$$end$$1$$t01oHhokPY$$fe-b-->
+                </ul>
+            </template>
         </test-element>
     </body>
 </html>

--- a/packages/web-components/fast-html/src/fixtures/children/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/children/main.ts
@@ -1,7 +1,7 @@
-import { TemplateElement } from "@microsoft/fast-html";
-import { FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+import { observable } from "@microsoft/fast-element";
 
-class TestElement extends FASTElement {
+class TestElement extends RenderableFASTElement {
     @observable
     listItems: Node[] = [];
 
@@ -13,12 +13,6 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/dot-syntax/dot-syntax.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/dot-syntax/dot-syntax.fixture.html
@@ -10,7 +10,7 @@
             <template>{{object.foo}}</template>
         </f-template>
         <test-element>
-            <template shadowrootmode="open">bar</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$t01oHhokPY$$fe-b-->bar<!--fe-b$$end$$0$$t01oHhokPY$$fe-b--></template>
         </test-element>
     </body>
 </html>

--- a/packages/web-components/fast-html/src/fixtures/dot-syntax/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/dot-syntax/main.ts
@@ -1,7 +1,6 @@
-import { TemplateElement } from "@microsoft/fast-html";
-import { FASTElement } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
-class TestElement extends FASTElement {
+class TestElement extends RenderableFASTElement {
     public object: any = {
         foo: "bar",
     };
@@ -11,12 +10,6 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/event/event.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/event/event.fixture.html
@@ -7,9 +7,10 @@
     <body>
         <test-element foo="bar">
             <template shadowrootmode="open">
-                <button>No arguments</button>
-                <button>event argument</button>
-                <button>attribute argument</button>
+                <button data-fe-b-0>No arguments</button>
+                <button data-fe-b-1>event argument</button>
+                <button data-fe-b-2>attribute argument</button>
+                <button data-fe-b-3>modify foo</button>
             </template>
         </test-element>
         <f-template name="test-element">

--- a/packages/web-components/fast-html/src/fixtures/event/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/event/main.ts
@@ -1,7 +1,7 @@
-import { TemplateElement } from "@microsoft/fast-html";
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+import { attr } from "@microsoft/fast-element";
 
-class TestElement extends FASTElement {
+class TestElement extends RenderableFASTElement {
     @attr
     foo: string = "";
 
@@ -26,12 +26,6 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/partial/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/partial/main.ts
@@ -26,12 +26,6 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/ref/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/ref/main.ts
@@ -1,7 +1,6 @@
-import { TemplateElement } from "@microsoft/fast-html";
-import { FASTElement } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
-class TestElement extends FASTElement {
+class TestElement extends RenderableFASTElement {
     public video: HTMLVideoElement | null = null;
 }
 TestElement.define({
@@ -9,12 +8,6 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/ref/ref.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/ref/ref.fixture.html
@@ -10,7 +10,7 @@
             <template><video f-ref="{video}"></video></template>
         </f-template>
         <test-element>
-            <template shadowrootmode="open"><video></video></template>
+            <template shadowrootmode="open"><video data-fe-b-0></video></template>
         </test-element>
     </body>
 </html>

--- a/packages/web-components/fast-html/src/fixtures/repeat/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/repeat/main.ts
@@ -1,7 +1,7 @@
-import { TemplateElement } from "@microsoft/fast-html";
-import { FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+import { observable } from "@microsoft/fast-element";
 
-class TestElement extends FASTElement {
+class TestElement extends RenderableFASTElement {
     @observable
     list: Array<string> = ["Foo", "Bar"];
 
@@ -12,7 +12,7 @@ TestElement.define({
     shadowOptions: null,
 });
 
-class TestElementInnerWhen extends FASTElement {
+class TestElementInnerWhen extends RenderableFASTElement {
     @observable
     list: Array<any> = [
         {
@@ -30,17 +30,6 @@ TestElementInnerWhen.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-inner-when": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/repeat/repeat.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/repeat/repeat.fixture.html
@@ -21,12 +21,29 @@
             </template>
         </f-template>
         <test-element>
-            <template shadowrootmode="open"><ul><li>Foo - Bat</li><li>Bar - Bat</li></ul></template>
+            <template shadowrootmode="open">
+                <ul>
+                    <!--fe-b$$start$$0$$EVAQBRnUUH$$fe-b-->
+                    <!--fe-repeat$$start$$0$$fe-repeat-->
+                    <li><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Foo<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b--></li>
+                    <!--fe-repeat$$end$$0$$fe-repeat-->
+                    <!--fe-repeat$$start$$1$$fe-repeat-->
+                    <li><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Bar<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--> - <!--fe-b$$start$$1$$vEbKKUHmwU$$fe-b-->Bat<!--fe-b$$end$$1$$vEbKKUHmwU$$fe-b--></li>
+                    <!--fe-repeat$$end$$1$$fe-repeat-->
+                    <!--fe-b$$end$$0$$EVAQBRnUUH$$fe-b-->
+                </ul>
+            </template>
         </test-element>
         <test-element-inner-when>
             <template shadowrootmode="open">
                 <ul>
-                    <li>Foo</li>
+                    <!--fe-b$$start$$0$$EVAQBRnUUH$$fe-b-->
+                    <!--fe-repeat$$start$$0$$fe-repeat-->
+                    <!--fe-b$$start$$0$$BJtvnvqlxr$$fe-b-->
+                    <li><!--fe-b$$start$$0$$vEbKKUHmwU$$fe-b-->Foo<!--fe-b$$end$$0$$vEbKKUHmwU$$fe-b--></li>
+                    <!--fe-b$$end$$0$$BJtvnvqlxr$$fe-b-->
+                    <!--fe-repeat$$end$$0$$fe-repeat-->
+                    <!--fe-b$$end$$0$$EVAQBRnUUH$$fe-b-->
                 </ul>
             </template>
         </test-element-inner-when>

--- a/packages/web-components/fast-html/src/fixtures/slotted/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/slotted/main.ts
@@ -1,7 +1,7 @@
-import { TemplateElement } from "@microsoft/fast-html";
-import { FASTElement, observable } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+import { observable } from "@microsoft/fast-element";
 
-class TestElement extends FASTElement {
+class TestElement extends RenderableFASTElement {
     @observable
     slottedNodes: Node[] = [];
 
@@ -14,12 +14,6 @@ TestElement.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
@@ -10,7 +10,7 @@
             <template><slot f-slotted="{slottedNodes}"></slot></template>
         </f-template>
         <test-element>
-            <template shadowrootmode="open"><slot></slot></template>
+            <template shadowrootmode="open"><slot data-fe-b-0></slot></template>
             <ul><li>Foo</li><li>Bar</li></ul>
         </test-element>
     </body>

--- a/packages/web-components/fast-html/src/fixtures/when/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/when/main.ts
@@ -1,71 +1,79 @@
-import { TemplateElement } from "@microsoft/fast-html";
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+import { attr } from "@microsoft/fast-element";
 
-class TestElement extends FASTElement {
+class TestElement extends RenderableFASTElement {
     @attr({ mode: "boolean" })
     show: boolean = false;
 }
 TestElement.define({
     name: "test-element",
+    shadowOptions: null,
 });
 
-class TestElementNot extends FASTElement {
+class TestElementNot extends RenderableFASTElement {
     @attr({ mode: "boolean" })
     hide: boolean = false;
 }
 TestElementNot.define({
     name: "test-element-not",
+    shadowOptions: null,
 });
 
-class TestElementEquals extends FASTElement {
+class TestElementEquals extends RenderableFASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
 TestElementEquals.define({
     name: "test-element-equals",
+    shadowOptions: null,
 });
 
-class TestElementNotEquals extends FASTElement {
+class TestElementNotEquals extends RenderableFASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
 TestElementNotEquals.define({
     name: "test-element-not-equals",
+    shadowOptions: null,
 });
 
-class TestElementGe extends FASTElement {
+class TestElementGe extends RenderableFASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
 TestElementGe.define({
     name: "test-element-ge",
+    shadowOptions: null,
 });
 
-class TestElementGt extends FASTElement {
+class TestElementGt extends RenderableFASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
 TestElementGt.define({
     name: "test-element-gt",
+    shadowOptions: null,
 });
 
-class TestElementLe extends FASTElement {
+class TestElementLe extends RenderableFASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
 TestElementLe.define({
     name: "test-element-le",
+    shadowOptions: null,
 });
 
-class TestElementLt extends FASTElement {
+class TestElementLt extends RenderableFASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
 TestElementLt.define({
     name: "test-element-lt",
+    shadowOptions: null,
 });
 
-class TestElementOr extends FASTElement {
+class TestElementOr extends RenderableFASTElement {
     @attr({ attribute: "this-var", mode: "boolean" })
     thisVar: boolean = false;
 
@@ -74,9 +82,10 @@ class TestElementOr extends FASTElement {
 }
 TestElementOr.define({
     name: "test-element-or",
+    shadowOptions: null,
 });
 
-class TestElementAnd extends FASTElement {
+class TestElementAnd extends RenderableFASTElement {
     @attr({ attribute: "this-var", mode: "boolean" })
     thisVar: boolean = false;
 
@@ -88,57 +97,6 @@ TestElementAnd.define({
     shadowOptions: null,
 });
 
-TemplateElement.options({
-    "test-element": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-not": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-equals": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-not-equals": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-ge": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-gt": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-le": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-lt": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-or": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-    "test-element-and": {
-        shadowOptions: {
-            mode: "closed",
-        },
-    },
-}).define({
+TemplateElement.define({
     name: "f-template",
 });

--- a/packages/web-components/fast-html/src/fixtures/when/when.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/when/when.fixture.html
@@ -11,100 +11,100 @@
             <template><f-when value="{{show}}">Hello world</f-when></template>
         </f-template>
         <test-element id="show" show>
-            <template shadowrootmode="open">Hello world</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Hello world<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element>
         <test-element id="hide">
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element>
         <!-- not -->
         <f-template name="test-element-not">
             <template><f-when value="{{!hide}}">Hello world</f-when></template>
         </f-template>
         <test-element-not id="show-not">
-            <template shadowrootmode="open">Hello world</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Hello world<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-not>
         <test-element-not id="hide-not" hide>
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-not>
         <!-- equals -->
         <f-template name="test-element-equals">
             <template><f-when value="{{varA == 3}}">Equals 3</f-when></template>
         </f-template>
         <test-element-equals id="equals-true" var-a="3">
-            <template shadowrootmode="open">Equals 3</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Equals 3<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-equals>
         <test-element-equals id="equals-false" var-a="4">
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-equals>
         <!-- not equals -->
         <f-template name="test-element-not-equals">
             <template><f-when value="{{varA != 3}}">Not equals 3</f-when></template>
         </f-template>
         <test-element-not-equals id="not-equals-true" var-a="4">
-            <template shadowrootmode="open">Not equals 3</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Not equals 3<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-not-equals>
         <test-element-not-equals id="not-equals-false" var-a="3">
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-not-equals>
         <!-- greater than or equals -->
         <f-template name="test-element-ge">
             <template><f-when value="{{varA >= 2}}">Two and Over</f-when></template>
         </f-template>
         <test-element-ge id="ge-true" var-a="3">
-            <template shadowrootmode="open">Two and Over</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Two and Over<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-ge>
         <test-element-ge id="ge-false" var-a="0">
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-ge>
         <!-- greater than -->
         <f-template name="test-element-gt">
             <template><f-when value="{{varA > 2}}">Over two</f-when></template>
         </f-template>
         <test-element-gt id="gt-true" var-a="3">
-            <template shadowrootmode="open">Over two</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Over two<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-gt>
         <test-element-gt id="gt-false" var-a="0">
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-gt>
         <!-- less than or equals -->
         <f-template name="test-element-le">
             <template><f-when value="{{varA <= 2}}">Two and Under</f-when></template>
         </f-template>
         <test-element-le id="le-true" var-a="2">
-            <template shadowrootmode="open">Two and Under</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Two and Under<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-le>
         <test-element-le id="le-false" var-a="4">
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-le>
         <!-- less than -->
         <f-template name="test-element-lt">
             <template><f-when value="{{varA < 2}}">Under two</f-when></template>
         </f-template>
         <test-element-lt id="lt-true" var-a="1">
-            <template shadowrootmode="open">Under two</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->Under two<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-lt>
         <test-element-lt id="lt-false" var-a="3">
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-lt>
         <!-- or -->
         <f-template name="test-element-or">
             <template><f-when value="{{thisVar || thatVar}}">This or That</f-when></template>
         </f-template>
         <test-element-or id="or-true" this-var="3">
-            <template shadowrootmode="open">This or That</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->This or That<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-or>
         <test-element-or id="or-false">
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-or>
         <!-- and -->
         <f-template name="test-element-and">
             <template><f-when value="{{thisVar && thatVar}}">This and That</f-when></template>
         </f-template>
         <test-element-and id="and-true" this-var that-var>
-            <template shadowrootmode="open">This and That</template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b-->This and That<!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-and>
         <test-element-and id="and-false" this-var>
-            <template shadowrootmode="open"></template>
+            <template shadowrootmode="open"><!--fe-b$$start$$0$$MRl5Rw6tl3$$fe-b--><!--fe-b$$end$$0$$MRl5Rw6tl3$$fe-b--></template>
         </test-element-and>
     </body>
 </html>

--- a/packages/web-components/fast-html/src/index.ts
+++ b/packages/web-components/fast-html/src/index.ts
@@ -3,4 +3,4 @@ import { debugMessages } from "./debug.js";
 
 FAST.addMessages(debugMessages);
 
-export { TemplateElement } from "./components/index.js";
+export { RenderableFASTElement, TemplateElement } from "./components/index.js";


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change:
- Requires that using `@microsoft/fast-html` rendered markup include hydratable markup.
- Adds default shadowOptions so they do not need to be passed
- Adds a `RenderableFASTElement` export which will automatically add and remove the `defer-hydration` attributes

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.