### PR TITLE
Update documentation for non-decorator use case without class initializer

### DIFF
--- a/sites/website/src/docs/advanced/working-without-decorators.md
+++ b/sites/website/src/docs/advanced/working-without-decorators.md
@@ -35,7 +35,11 @@ This accepts the same configuration options as the `@attr` so for example to bin
 import { FASTElement, html, css } from '@microsoft/fast-element';
 
 export class MyElement extends FASTElement {
-  currentCount = 42;
+  constructor() {
+    super();
+
+    this.currentCount = 42;
+  }
 }
 
 MyElement.define({
@@ -55,6 +59,9 @@ MyElement.define({
 <my-element current-count="42">
 ```
 
+:::note
+In the above example we are setting the `currentCount` in the constructor and not as a class initializer, this is due to a difference in how decorators are elevated and initialized.
+
 If you need to add a converter to your attribute:
 
 ```javascript
@@ -70,7 +77,11 @@ const converter = {
 };
 
 export class MyElement extends FASTElement {
-  currentCount = 42;
+  constructor() {
+    super();
+
+    this.currentCount = 42;
+  }
 }
 
 MyElement.define({


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change updates documentation for non-decorator syntax. Due to how decorators work and the sequence in which they are initialized you can't currently use class initializers with non-decorator syntax.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.