### PR TITLE
Fix the RenderableFASTElement to account for rendering when hydration is not needed

### DIFF
--- a/change/@microsoft-fast-html-46a53b56-06e0-4eb5-b49e-f817eb5e3e9e.json
+++ b/change/@microsoft-fast-html-46a53b56-06e0-4eb5-b49e-f817eb5e3e9e.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Fix the RenderableFASTElement to account for rendering when not hydrating and add an optional function to await if the user needs to perform additional hydratable actions",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/src/components/element.ts
+++ b/packages/web-components/fast-html/src/components/element.ts
@@ -10,18 +10,31 @@ export abstract class RenderableFASTElement extends FASTElement {
     constructor() {
         super();
 
-        this.setAttribute("defer-hydration", "");
-        this.setAttribute("needs-hydration", "");
+        // If the elements template has already been defined there is no need to defer hydration.
+        if (!this.$fastController?.definition?.shadowOptions) {
+            this.setAttribute("defer-hydration", "");
+            this.setAttribute("needs-hydration", "");
+        }
 
         Observable.defineProperty(this.$fastController.definition, "shadowOptions");
 
         Observable.getNotifier(this.$fastController.definition).subscribe(
             {
-                handleChange: () => {
+                handleChange: async () => {
+                    if (this.prepare) {
+                        await this.prepare();
+                    }
+
                     this.deferHydration = false;
                 },
             },
             "shadowOptions"
         );
     }
+
+    /**
+     * A user defined function for determining if the element is ready to be hydrated.
+     * This function will get called if it has been defined after the template is connected.
+     */
+    private async prepare?(): Promise<void>;
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change:
- Fixes an issue where adding components that have already been defined with a template should be possible
- Add an optional user defined function to await if the user needs to perform additional hydratable actions such as fetching intiial state to apply to the custom element

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.