### PR TITLE
add filter support to f-slotted attribute

### DIFF
--- a/change/@microsoft-fast-html-8b040ddd-b291-494f-ac1d-7fbd352cc642.json
+++ b/change/@microsoft-fast-html-8b040ddd-b291-494f-ac1d-7fbd352cc642.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: supports filter in f-slotted directive",
+  "packageName": "@microsoft/fast-html",
+  "email": "machi@microsoft.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -147,7 +147,7 @@ Attribute directives include:
     Example:
     ```html
     <slot f-slotted="{slottedNodes}"></slot>
-    <slot f-slotted="{slottedNodes filter elements}"></slot>
+    <slot f-slotted="{slottedNodes filter elements()}"></slot>
     <slot f-slotted="{slottedNodes filter elements(div, p)}"></slot>
     ```
 

--- a/packages/web-components/fast-html/README.md
+++ b/packages/web-components/fast-html/README.md
@@ -109,6 +109,8 @@ Attribute directives include:
     Example:
     ```html
     <slot f-slotted="{slottedNodes}"></slot>
+    <slot f-slotted="{slottedNodes filter elements}"></slot>
+    <slot f-slotted="{slottedNodes filter elements(div, p)}"></slot>
     ```
 
 - **children**

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -284,26 +284,18 @@ class TemplateElement extends FASTElement {
                 {
                     const { slotted } = await import("@microsoft/fast-element");
 
-                    const parts = propName
-                        .trim()
-                        .replace(/\n/g, " ")
-                        .replace(/\s{2,}/g, " ")
-                        .split(" filter ");
+                    const parts = propName.trim().split(" filter ");
                     const slottedOption = {
                         property: parts[0],
                     };
 
                     if (parts[1]) {
-                        const matches = parts[1].match(/(\w+)(\(([^)]*)\))?/);
-                        const filterName = matches?.[1];
-                        const filterParams = matches?.[3] ?? undefined;
-
-                        switch (filterName) {
-                            case "elements":
-                                Object.assign(slottedOption, {
-                                    filter: elements(filterParams),
-                                });
-                                break;
+                        if (parts[1].startsWith("elements(")) {
+                            let params = parts[1].replace("elements(", "");
+                            params = params.substring(0, params.lastIndexOf(")"));
+                            Object.assign(slottedOption, {
+                                filter: elements(params || undefined),
+                            });
                         }
                     }
 

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -1,5 +1,6 @@
 import {
     attr,
+    elements,
     DOMAspect,
     DOMSink,
     FAST,
@@ -264,7 +265,26 @@ class TemplateElement extends FASTElement {
                 {
                     const { slotted } = await import("@microsoft/fast-element");
 
-                    externalValues.push(slotted(propName));
+                    const parts = propName.split(" ");
+                    const slottedOption = {
+                        property: parts[0],
+                    };
+
+                    if (parts[1] === "filter" && parts[2]) {
+                        const matches = parts[2].match(/(\w+)(\(([^)]*)\))?/);
+                        const filterName = matches?.[1];
+                        const filterParams = matches?.[3] ?? undefined;
+
+                        switch (filterName) {
+                            case "elements":
+                                Object.assign(slottedOption, {
+                                    filter: elements(filterParams),
+                                });
+                                break;
+                        }
+                    }
+
+                    externalValues.push(slotted(slottedOption));
                 }
 
                 break;

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -265,7 +265,11 @@ class TemplateElement extends FASTElement {
                 {
                     const { slotted } = await import("@microsoft/fast-element");
 
-                    const parts = propName.split(" ");
+                    const parts = propName
+                        .trim()
+                        .replace(/\n/g, " ")
+                        .replace(/\s{2,}/g, " ")
+                        .split(" ");
                     const slottedOption = {
                         property: parts[0],
                     };

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -269,13 +269,13 @@ class TemplateElement extends FASTElement {
                         .trim()
                         .replace(/\n/g, " ")
                         .replace(/\s{2,}/g, " ")
-                        .split(" ");
+                        .split(" filter ");
                     const slottedOption = {
                         property: parts[0],
                     };
 
-                    if (parts[1] === "filter" && parts[2]) {
-                        const matches = parts[2].match(/(\w+)(\(([^)]*)\))?/);
+                    if (parts[1]) {
+                        const matches = parts[1].match(/(\w+)(\(([^)]*)\))?/);
                         const filterName = matches?.[1];
                         const filterParams = matches?.[3] ?? undefined;
 

--- a/packages/web-components/fast-html/src/fixtures/ref/ref.spec.ts
+++ b/packages/web-components/fast-html/src/fixtures/ref/ref.spec.ts
@@ -4,12 +4,8 @@ test.describe("f-template", async () => {
     test("create a ref directive", async ({ page }) => {
         await page.goto("/ref");
 
-        const isVideo = await page.evaluate(() => {
-            const customElement = document.getElementsByTagName("test-element");
+        const element = page.locator("test-element");
 
-            return (customElement.item(0) as any)?.video instanceof HTMLVideoElement;
-        });
-
-        expect(isVideo).toEqual(true);
+        await expect(element).toHaveJSProperty("video.nodeName", "VIDEO");
     });
 });

--- a/packages/web-components/fast-html/src/fixtures/slotted/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/slotted/main.ts
@@ -5,9 +5,15 @@ class TestElement extends FASTElement {
     @observable
     slottedNodes: Node[] = [];
 
-    slottedNodesChanged() {
-        this.classList.add(`class-${this.slottedNodes.length}`);
+    @observable
+    slottedFooNodes: Node[] = [];
+
+    slottedFooNodesChanged() {
+        this.classList.add(`class-${this.slottedFooNodes.length}`);
     }
+
+    @observable
+    slottedBarNodes: Node[] = [];
 }
 TestElement.define({
     name: "test-element",

--- a/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
@@ -16,9 +16,6 @@
         <test-element>
             <template shadowrootmode="open">
                 <slot></slot>
-            </template>
-            <template shadowrootmode="open">
-                <slot></slot>
                 <slot name="foo" data-fe-b-0></slot>
                 <slot name="bar"></slot>
             </template>

--- a/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
@@ -15,9 +15,9 @@
         </f-template>
         <test-element>
             <template shadowrootmode="open">
-                <slot></slot>
-                <slot name="foo" data-fe-b-0></slot>
-                <slot name="bar"></slot>
+                <slot data-fe-b-0></slot>
+                <slot name="foo" data-fe-b-1></slot>
+                <slot name="bar" data-fe-b-2></slot>
             </template>
             <div>Slotted</div>
             Not slotted

--- a/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
@@ -8,7 +8,7 @@
     <body>
         <f-template name="test-element">
             <template>
-                <slot f-slotted="{slottedNodes filter elements}"></slot>
+                <slot f-slotted="{slottedNodes filter elements()}"></slot>
                 <slot name="foo" f-slotted="{slottedFooNodes}"></slot>
                 <slot name="bar" f-slotted="{slottedBarNodes filter elements(p, ol)}"></slot>
             </template>

--- a/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/slotted/slotted.fixture.html
@@ -7,11 +7,23 @@
     </head>
     <body>
         <f-template name="test-element">
-            <template><slot f-slotted="{slottedNodes}"></slot></template>
+            <template>
+                <slot f-slotted="{slottedNodes filter elements}"></slot>
+                <slot name="foo" f-slotted="{slottedFooNodes}"></slot>
+                <slot name="bar" f-slotted="{slottedBarNodes filter elements(p, ol)}"></slot>
+            </template>
         </f-template>
         <test-element>
-            <template shadowrootmode="open"><slot></slot></template>
-            <ul><li>Foo</li><li>Bar</li></ul>
+            <template shadowrootmode="open">
+                <slot></slot>
+                <slot name="foo"></slot>
+                <slot name="bar"></slot>
+            </template>
+            <div>Slotted</div>
+            Not slotted
+            <ul slot="foo"><li>Item 1</li><li>Item 2</li></ul>
+            <div slot="bar"></div>
+            <p slot="bar"></p>
         </test-element>
     </body>
 </html>

--- a/packages/web-components/fast-html/src/fixtures/slotted/slotted.spec.ts
+++ b/packages/web-components/fast-html/src/fixtures/slotted/slotted.spec.ts
@@ -1,30 +1,29 @@
-import { expect, test } from "@playwright/test";
+import { expect, type Locator, test } from "@playwright/test";
 
-test.describe("f-template", async () => {
-    test("create a slotted directive", async ({ page }) => {
+test.describe("f-template", () => {
+    let element: Locator;
+    test.beforeEach(async ({ page }) => {
         await page.goto("/slotted");
+        element = page.locator("test-element");
+    });
 
-        const classCount1 = await page.evaluate(() => {
-            const customElement = document.getElementsByTagName("test-element");
+    test("create a slotted directive", async () => {
+        await expect(element).toHaveJSProperty("classList.length", 2);
 
-            return (customElement.item(0) as any)?.classList.length;
-        });
-
-        expect(classCount1).toEqual(2);
-
-        await page.evaluate(() => {
-            const customElement = document.getElementsByTagName("test-element");
-
+        await element.evaluate((node) => {
             const newElement = document.createElement("button");
-            customElement.item(0)?.append(newElement);
+            newElement.slot = "foo";
+            node.append(newElement);
         });
 
-        const classCount2 = await page.evaluate(() => {
-            const customElement = document.getElementsByTagName("test-element");
+        await expect(element).toHaveJSProperty("classList.length", 3);
+    });
 
-            return (customElement.item(0) as any)?.classList.length;
-        });
+    test("slotted nodes are filtered by elements()", async () => {
+        await expect(element).toHaveJSProperty("slottedNodes.length", 1);
+    });
 
-        expect(classCount2).toEqual(3);
+    test("slotted nodes are filtered by elements() with query", async () => {
+        await expect(element).toHaveJSProperty("slottedBarNodes.length", 1);
     });
 });


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

Currently, the `f-slotted` directive only supports `{propertyName}` syntax, which maps to `slotted("propertyName")`. But we can't use the filter feature of `slotted` directive. This PR adds support to the `elements()` filter:

```html
<slot f-slotted="{foo filter elements()}"></slot>
```

```html
<slot f-slotted="{foo filter elements(div, p, ul)}"></slot>
```

### 🎫 Issues

* Resolves: #7138

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.