### PR TITLE
fix(fast-html): replace RenderableFASTElement with a mixin function

### DIFF
--- a/change/@microsoft-fast-html-2c73ef1a-df0e-4441-bde3-cffe1891a077.json
+++ b/change/@microsoft-fast-html-2c73ef1a-df0e-4441-bde3-cffe1891a077.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "convert RenderableFASTElement to a mixin function",
+  "packageName": "@microsoft/fast-html",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/docs/api-report.api.md
+++ b/packages/web-components/fast-html/docs/api-report.api.md
@@ -4,15 +4,12 @@
 
 ```ts
 
+import { Constructable } from '@microsoft/fast-element';
 import { FASTElement } from '@microsoft/fast-element';
 import { ShadowRootOptions } from '@microsoft/fast-element';
 
-// @public (undocumented)
-export abstract class RenderableFASTElement extends FASTElement {
-    constructor();
-    // (undocumented)
-    deferHydration: boolean;
-}
+// @public
+export function RenderableFASTElement<T extends Constructable<FASTElement>>(BaseCtor: T): T;
 
 // @public
 export class TemplateElement extends FASTElement {

--- a/packages/web-components/fast-html/src/components/element.ts
+++ b/packages/web-components/fast-html/src/components/element.ts
@@ -1,24 +1,42 @@
-import { attr, FASTElement } from "@microsoft/fast-element";
+import { attr, type Constructable, type FASTElement } from "@microsoft/fast-element";
 
-export abstract class RenderableFASTElement extends FASTElement {
-    @attr({ mode: "boolean", attribute: "defer-hydration" })
-    deferHydration: boolean = true;
+/**
+ * A mixin function that extends a base class with additional functionality for
+ * rendering and hydration.
+ *
+ * @param BaseCtor - The base class to extend.
+ * @returns A new class that extends the provided base class with additional functionality for rendering and hydration.
+ * @public
+ */
+export function RenderableFASTElement<T extends Constructable<FASTElement>>(
+    BaseCtor: T
+): T {
+    const C = class extends BaseCtor {
+        deferHydration: boolean = true;
 
-    constructor() {
-        super();
+        constructor(...args: any[]) {
+            super(...args);
 
-        if (this.prepare) {
-            this.prepare().then(() => {
+            if (this.prepare) {
+                this.prepare().then(() => {
+                    this.deferHydration = false;
+                });
+            } else {
                 this.deferHydration = false;
-            });
-        } else {
-            this.deferHydration = false;
+            }
         }
-    }
 
-    /**
-     * A user defined function for determining if the element is ready to be hydrated.
-     * This function will get called if it has been defined after the template is connected.
-     */
-    private async prepare?(): Promise<void>;
+        /**
+         * A user defined function for determining if the element is ready to be hydrated.
+         * This function will get called if it has been defined after the template is connected.
+         */
+        public async prepare?(): Promise<void>;
+    };
+
+    attr({ mode: "boolean", attribute: "defer-hydration" })(
+        C.prototype,
+        "deferHydration"
+    );
+
+    return C;
 }

--- a/packages/web-components/fast-html/src/fixtures/attribute/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/attribute/main.ts
@@ -1,11 +1,11 @@
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
-import { attr } from "@microsoft/fast-element";
+import { attr, FASTElement } from "@microsoft/fast-element";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     @attr
     type: string = "radio";
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });

--- a/packages/web-components/fast-html/src/fixtures/binding/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/binding/main.ts
@@ -1,19 +1,19 @@
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
-import { attr } from "@microsoft/fast-element";
+import { attr, FASTElement } from "@microsoft/fast-element";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     @attr
     text: string = "Hello";
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementUnescaped extends RenderableFASTElement {
+class TestElementUnescaped extends FASTElement {
     public html = `<p>Hello world</p>`;
 }
-TestElementUnescaped.defineAsync({
+RenderableFASTElement(TestElementUnescaped).defineAsync({
     name: "test-element-unescaped",
     templateOptions: "defer-and-hydrate",
 });

--- a/packages/web-components/fast-html/src/fixtures/children/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/children/main.ts
@@ -1,14 +1,14 @@
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
-import { observable } from "@microsoft/fast-element";
+import { FASTElement, observable } from "@microsoft/fast-element";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     @observable
     listItems: Node[] = [];
 
     @observable
     list: Array<string> = ["Foo", "Bar"];
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });

--- a/packages/web-components/fast-html/src/fixtures/dot-syntax/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/dot-syntax/main.ts
@@ -1,11 +1,12 @@
+import { FASTElement } from "@microsoft/fast-element";
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     public object: any = {
         foo: "bar",
     };
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });

--- a/packages/web-components/fast-html/src/fixtures/event/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/event/main.ts
@@ -1,7 +1,7 @@
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
-import { attr } from "@microsoft/fast-element";
+import { attr, FASTElement } from "@microsoft/fast-element";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     @attr
     foo: string = "";
 
@@ -21,7 +21,7 @@ class TestElement extends RenderableFASTElement {
         this.foo = "modified-by-click";
     }
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });

--- a/packages/web-components/fast-html/src/fixtures/partial/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/partial/main.ts
@@ -1,6 +1,7 @@
+import { FASTElement } from "@microsoft/fast-element";
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     public items = [
         {
             text: "Hello",
@@ -20,7 +21,7 @@ class TestElement extends RenderableFASTElement {
         },
     ];
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });

--- a/packages/web-components/fast-html/src/fixtures/ref/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/ref/main.ts
@@ -1,9 +1,10 @@
+import { FASTElement } from "@microsoft/fast-element";
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     public video: HTMLVideoElement | null = null;
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });

--- a/packages/web-components/fast-html/src/fixtures/repeat/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/repeat/main.ts
@@ -1,18 +1,18 @@
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
-import { observable } from "@microsoft/fast-element";
+import { FASTElement, observable } from "@microsoft/fast-element";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     @observable
     list: Array<string> = ["Foo", "Bar"];
 
     parent: string = "Bat";
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementInnerWhen extends RenderableFASTElement {
+class TestElementInnerWhen extends FASTElement {
     @observable
     list: Array<any> = [
         {
@@ -25,7 +25,7 @@ class TestElementInnerWhen extends RenderableFASTElement {
         },
     ];
 }
-TestElementInnerWhen.defineAsync({
+RenderableFASTElement(TestElementInnerWhen).defineAsync({
     name: "test-element-inner-when",
     templateOptions: "defer-and-hydrate",
 });

--- a/packages/web-components/fast-html/src/fixtures/slotted/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/slotted/main.ts
@@ -1,7 +1,7 @@
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
-import { observable } from "@microsoft/fast-element";
+import { FASTElement, observable } from "@microsoft/fast-element";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     @observable
     slottedNodes: Node[] = [];
 
@@ -15,7 +15,7 @@ class TestElement extends RenderableFASTElement {
     @observable
     slottedBarNodes: Node[] = [];
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });

--- a/packages/web-components/fast-html/src/fixtures/when/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/when/main.ts
@@ -1,98 +1,98 @@
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
-import { attr } from "@microsoft/fast-element";
+import { attr, FASTElement } from "@microsoft/fast-element";
 
-class TestElement extends RenderableFASTElement {
+class TestElement extends FASTElement {
     @attr({ mode: "boolean" })
     show: boolean = false;
 }
-TestElement.defineAsync({
+RenderableFASTElement(TestElement).defineAsync({
     name: "test-element",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementNot extends RenderableFASTElement {
+class TestElementNot extends FASTElement {
     @attr({ mode: "boolean" })
     hide: boolean = false;
 }
-TestElementNot.defineAsync({
+RenderableFASTElement(TestElementNot).defineAsync({
     name: "test-element-not",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementEquals extends RenderableFASTElement {
+class TestElementEquals extends FASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
-TestElementEquals.defineAsync({
+RenderableFASTElement(TestElementEquals).defineAsync({
     name: "test-element-equals",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementNotEquals extends RenderableFASTElement {
+class TestElementNotEquals extends FASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
-TestElementNotEquals.defineAsync({
+RenderableFASTElement(TestElementNotEquals).defineAsync({
     name: "test-element-not-equals",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementGe extends RenderableFASTElement {
+class TestElementGe extends FASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
-TestElementGe.defineAsync({
+RenderableFASTElement(TestElementGe).defineAsync({
     name: "test-element-ge",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementGt extends RenderableFASTElement {
+class TestElementGt extends FASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
-TestElementGt.defineAsync({
+RenderableFASTElement(TestElementGt).defineAsync({
     name: "test-element-gt",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementLe extends RenderableFASTElement {
+class TestElementLe extends FASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
-TestElementLe.defineAsync({
+RenderableFASTElement(TestElementLe).defineAsync({
     name: "test-element-le",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementLt extends RenderableFASTElement {
+class TestElementLt extends FASTElement {
     @attr({ attribute: "var-a" })
     varA: number = 0;
 }
-TestElementLt.defineAsync({
+RenderableFASTElement(TestElementLt).defineAsync({
     name: "test-element-lt",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementOr extends RenderableFASTElement {
+class TestElementOr extends FASTElement {
     @attr({ attribute: "this-var", mode: "boolean" })
     thisVar: boolean = false;
 
     @attr({ attribute: "that-var", mode: "boolean" })
     thatVar: boolean = false;
 }
-TestElementOr.defineAsync({
+RenderableFASTElement(TestElementOr).defineAsync({
     name: "test-element-or",
     templateOptions: "defer-and-hydrate",
 });
 
-class TestElementAnd extends RenderableFASTElement {
+class TestElementAnd extends FASTElement {
     @attr({ attribute: "this-var", mode: "boolean" })
     thisVar: boolean = false;
 
     @attr({ attribute: "that-var", mode: "boolean" })
     thatVar: boolean = false;
 }
-TestElementAnd.defineAsync({
+RenderableFASTElement(TestElementAnd).defineAsync({
     name: "test-element-and",
     templateOptions: "defer-and-hydrate",
 });


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR replaces the `RenderableFASTElement` class with a mixin function, which allows the necessary hydration attributes and behaviors to be added to a component class without changing the base extending class.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.