### PR TITLE
Add observable as an export path

### DIFF
--- a/change/@microsoft-fast-element-ef000a4c-4bfe-4306-bba8-aff31c5bffa1.json
+++ b/change/@microsoft-fast-element-ef000a4c-4bfe-4306-bba8-aff31c5bffa1.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add observervable export path",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-element/package.json
+++ b/packages/web-components/fast-element/package.json
@@ -86,6 +86,10 @@
       "types": "./dist/dts/dom-policy.d.ts",
       "default": "./dist/esm/dom-policy.js"
     },
+    "./observable.js": {
+      "types": "./dist/dts/observation/observable.d.ts",
+      "default": "./dist/esm/observation/observable.js"
+    },
     "./package.json": "./package.json"
   },
   "unpkg": "dist/fast-element.min.js",

--- a/packages/web-components/fast-element/src/observable.ts
+++ b/packages/web-components/fast-element/src/observable.ts
@@ -1,0 +1,23 @@
+/**
+ * Observable exports for easy access to the Observable API
+ */
+export {
+    Accessor,
+    Expression,
+    ExecutionContext,
+    ExpressionController,
+    ExpressionObserver,
+    ExpressionNotifier,
+    Observable,
+    observable,
+    ObservationRecord,
+    SourceLifetime,
+    volatile,
+} from "./observation/observable.js";
+
+export {
+    Notifier,
+    PropertyChangeNotifier,
+    Subscriber,
+    SubscriberSet,
+} from "./observation/notifier.js";


### PR DESCRIPTION
# Pull Request

## 📖 Description

The Observable API is very useful on it's own, but is unusable currently in non-browser environments such as NodeJS because importing it will pull in browser specific APIs. This export path allows only Observable to be targetted when importing.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.