### PR TITLE
Add further docs on client side bindings and hydration markers

### DIFF
--- a/change/@microsoft-fast-html-9d4421c0-5569-451d-8a32-ff02e3ec471d.json
+++ b/change/@microsoft-fast-html-9d4421c0-5569-451d-8a32-ff02e3ec471d.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add further docs on client side bindings and hydration markers",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/RENDERING.md
+++ b/packages/web-components/fast-html/RENDERING.md
@@ -260,6 +260,12 @@ Should result in:
 
 You may notice that the same UUID was used within the repeat markers, this is because they are templates and each UUID only needs to be unique to that template. The same is true for the binding number. Additionally, a binding wraps the repeat markers, even if the array is empty, this binding must be rendered.
 
+Example result of an empty array:
+```html
+<!--fe-b$$start$$0$$t01oHhokPY$$fe-b-->
+<!--fe-b$$end$$0$$t01oHhokPY$$fe-b-->
+```
+
 #### When
 
 The when directive is either present in the DOM or not, and therefore does not need an extra marker for the template.
@@ -302,6 +308,38 @@ Should result in:
 ```html
 <!--fe-b$$start$$0$$t01oHhokPY$$fe-b-->
 <!--fe-b$$end$$0$$t01oHhokPY$$fe-b-->
+```
+
+### Client Side Bindings
+
+Client side bindings are bindings which the client needs, but they are not necessary as part of an initial render. These must still be accounted for when creating hydration comments however, as the template needs to know which elements to attach these bindings to. There are two types of client side bindings, events and attribute directives. These do not require state as they are bound to class methods or properties.
+
+#### Event Bindings
+
+Event bindings such as `@keydown` and `@click` can be represented with hydration comments.
+
+Example event binding:
+```html
+<button @click="{handleClick(e)}">Button</button>
+```
+
+Should result in:
+```html
+<button data-fe-b-0>Button</button>
+```
+
+#### Attribute Directives
+
+Attribute directives such as `f-slotted` and `f-ref` can be represented with hydration comments.
+
+Example `f-ref` binding:
+```html
+<button f-ref="{button}">Button</button>
+```
+
+Should result in:
+```html
+<button data-fe-b-0>Button</button>
 ```
 
 #### More Examples


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change adds docs on client side bindings of attribute directives and events.

### 🎫 Issues

Closes #7162 

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.