### PR TITLE
Update schema to reference children schemas that tie an attribute to data

### DIFF
--- a/change/@microsoft-fast-html-00a629f9-6a3c-4cdf-8631-baf8d507efd4.json
+++ b/change/@microsoft-fast-html-00a629f9-6a3c-4cdf-8631-baf8d507efd4.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Update schema to reference children schemas that tie an attribute to data",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/src/components/schema.spec.ts
+++ b/packages/web-components/fast-html/src/components/schema.spec.ts
@@ -20,7 +20,8 @@ test.describe("Schema", async () => {
                 path: "a",
                 currentContext: null,
                 parentContext: null,
-            }
+            },
+            childrenMap: null,
         });
 
         const schemaA = schema.getSchema("a");
@@ -40,6 +41,7 @@ test.describe("Schema", async () => {
                 currentContext: null,
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         let schemaA = schema.getSchema("a");
@@ -55,6 +57,7 @@ test.describe("Schema", async () => {
                 currentContext: null,
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schemaA = schema.getSchema("a");
@@ -75,6 +78,7 @@ test.describe("Schema", async () => {
                 currentContext: "item",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         const schemaA = schema.getSchema("items");
@@ -98,6 +102,7 @@ test.describe("Schema", async () => {
                 currentContext: "item",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -108,6 +113,7 @@ test.describe("Schema", async () => {
                 currentContext: "item",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         const schemaA = schema.getSchema("items");
@@ -134,6 +140,7 @@ test.describe("Schema", async () => {
                 currentContext: null,
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -144,6 +151,7 @@ test.describe("Schema", async () => {
                 currentContext: "item",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         const schemaA = schema.getSchema("a");
@@ -166,6 +174,7 @@ test.describe("Schema", async () => {
                 currentContext: null,
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -176,6 +185,7 @@ test.describe("Schema", async () => {
                 currentContext: "item",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -186,6 +196,7 @@ test.describe("Schema", async () => {
                 currentContext: "item",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         const schemaA = schema.getSchema("a");
@@ -209,6 +220,7 @@ test.describe("Schema", async () => {
                 currentContext: null,
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -219,6 +231,7 @@ test.describe("Schema", async () => {
                 currentContext: "user",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -229,6 +242,7 @@ test.describe("Schema", async () => {
                 currentContext: "post",
                 parentContext: "user"
             },
+            childrenMap: null,
         });
 
         const schemaA = schema.getSchema("a");
@@ -252,6 +266,7 @@ test.describe("Schema", async () => {
                 currentContext: "user",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -262,6 +277,7 @@ test.describe("Schema", async () => {
                 currentContext: "user",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -272,6 +288,7 @@ test.describe("Schema", async () => {
                 currentContext: "post",
                 parentContext: "user"
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -282,6 +299,7 @@ test.describe("Schema", async () => {
                 currentContext: "post",
                 parentContext: null,
             },
+            childrenMap: null,
         });
 
         schema.addPath({
@@ -292,6 +310,7 @@ test.describe("Schema", async () => {
                 currentContext: "tag",
                 parentContext: "post"
             },
+            childrenMap: null,
         });
 
         const schemaA = schema.getSchema("a");
@@ -318,5 +337,158 @@ test.describe("Schema", async () => {
         expect(schemaA!.$defs?.["tag"]).toBeDefined();
         expect(schemaA!.$defs?.["tag"].$fast_context).toEqual("tags");
         expect(schemaA!.$defs?.["tag"].$fast_parent_contexts).toEqual([null, "user", "post"]);
+    });
+    test("should define an anyOf with a $ref to another schema", async () => {
+        const schema = new Schema("my-custom-element");
+
+        schema.addPath({
+            rootPropertyName: "a",
+            pathConfig: {
+                type: "default",
+                path: "a",
+                currentContext: null,
+                parentContext: null,
+            },
+            childrenMap: {
+                customElementName: "my-custom-element-2",
+                attributeName: "b",
+            },
+        });
+
+        const schemaA = schema.getSchema("a");
+
+        expect(schemaA).not.toBe(null);
+        expect(schemaA!.$id).toEqual("https://fast.design/schemas/my-custom-element/a.json");
+        expect(schemaA!.$schema).toEqual("https://json-schema.org/draft/2019-09/schema");
+        expect(schemaA!.anyOf).not.toBeUndefined();
+        expect(schemaA!.anyOf).toHaveLength(1);
+        expect(schemaA!.anyOf?.[0].$ref).toEqual("https://fast.design/schemas/my-custom-element-2/b.json");
+    });
+    test("should define an anyOf with a $ref to multiple schemas", async () => {
+        const schema = new Schema("my-custom-element");
+
+        schema.addPath({
+            rootPropertyName: "a",
+            pathConfig: {
+                type: "default",
+                path: "a",
+                currentContext: null,
+                parentContext: null,
+            },
+            childrenMap: {
+                customElementName: "my-custom-element-2",
+                attributeName: "b",
+            },
+        });
+        schema.addPath({
+            rootPropertyName: "a",
+            pathConfig: {
+                type: "default",
+                path: "a",
+                currentContext: null,
+                parentContext: null,
+            },
+            childrenMap: {
+                customElementName: "my-custom-element-3",
+                attributeName: "c",
+            },
+        });
+
+        const schemaA = schema.getSchema("a");
+
+        expect(schemaA).not.toBe(null);
+        expect(schemaA!.$id).toEqual("https://fast.design/schemas/my-custom-element/a.json");
+        expect(schemaA!.$schema).toEqual("https://json-schema.org/draft/2019-09/schema");
+        expect(schemaA!.anyOf).not.toBeUndefined();
+        expect(schemaA!.anyOf).toHaveLength(2);
+        expect(schemaA!.anyOf?.[0].$ref).toEqual("https://fast.design/schemas/my-custom-element-2/b.json");
+        expect(schemaA!.anyOf?.[1].$ref).toEqual("https://fast.design/schemas/my-custom-element-3/c.json");
+    });
+    test("should define an anyOf with a $ref to another schema in a nested object", async () => {
+        const schema = new Schema("my-custom-element");
+
+        schema.addPath({
+            rootPropertyName: "a",
+            pathConfig: {
+                type: "default",
+                path: "a.b",
+                currentContext: null,
+                parentContext: null,
+            },
+            childrenMap: null,
+        });
+
+        let schemaA = schema.getSchema("a");
+
+        schema.addPath({
+            rootPropertyName: "a",
+            pathConfig: {
+                type: "default",
+                path: "a.b.c",
+                currentContext: null,
+                parentContext: null,
+            },
+            childrenMap: {
+                customElementName: "my-custom-element-2",
+                attributeName: "test"
+            },
+        });
+
+        schemaA = schema.getSchema("a");
+
+        expect(schemaA!.properties.b.properties.c).toBeDefined();
+        expect(schemaA!.properties.b.properties.c.anyOf).not.toBeUndefined();
+        expect(schemaA!.properties.b.properties.c.anyOf[0].$ref).toEqual("https://fast.design/schemas/my-custom-element-2/test.json");
+    });
+    test("should define an anyOf with a $ref to multiple schemas in a nested object", async () => {
+        const schema = new Schema("my-custom-element");
+
+        schema.addPath({
+            rootPropertyName: "a",
+            pathConfig: {
+                type: "default",
+                path: "a.b",
+                currentContext: null,
+                parentContext: null,
+            },
+            childrenMap: null,
+        });
+
+        let schemaA = schema.getSchema("a");
+
+        schema.addPath({
+            rootPropertyName: "a",
+            pathConfig: {
+                type: "default",
+                path: "a.b.c",
+                currentContext: null,
+                parentContext: null,
+            },
+            childrenMap: {
+                customElementName: "my-custom-element-2",
+                attributeName: "test"
+            },
+        });
+
+        schema.addPath({
+            rootPropertyName: "a",
+            pathConfig: {
+                type: "default",
+                path: "a.b.c",
+                currentContext: null,
+                parentContext: null,
+            },
+            childrenMap: {
+                customElementName: "my-custom-element-3",
+                attributeName: "test-2"
+            },
+        });
+
+        schemaA = schema.getSchema("a");
+
+        expect(schemaA!.properties.b.properties.c).toBeDefined();
+        expect(schemaA!.properties.b.properties.c.anyOf).not.toBeUndefined();
+        expect(schemaA!.properties.b.properties.c.anyOf[0].$ref).toEqual("https://fast.design/schemas/my-custom-element-2/test.json");
+        expect(schemaA!.properties.b.properties.c.anyOf[1].$ref).toEqual("https://fast.design/schemas/my-custom-element-3/test-2.json");
     });
 });

--- a/packages/web-components/fast-html/src/components/template.ts
+++ b/packages/web-components/fast-html/src/components/template.ts
@@ -282,6 +282,7 @@ class TemplateElement extends FASTElement {
                     behaviorConfig.name
                 );
                 const binding = bindingResolver(
+                    null,
                     rootPropertyName,
                     valueAttr[2],
                     parentContext,
@@ -403,6 +404,7 @@ class TemplateElement extends FASTElement {
                     type
                 );
                 const binding = bindingResolver(
+                    strings.join(""),
                     rootPropertyName,
                     propName,
                     parentContext,
@@ -454,6 +456,7 @@ class TemplateElement extends FASTElement {
                         closingParenthesis
                     );
                     const binding = bindingResolver(
+                        strings.join(""),
                         rootPropertyName,
                         propName,
                         parentContext,
@@ -468,6 +471,7 @@ class TemplateElement extends FASTElement {
                             ...(arg !== "e" && arg !== ""
                                 ? [
                                       bindingResolver(
+                                          strings.join(""),
                                           rootPropertyName,
                                           arg,
                                           parentContext,
@@ -495,6 +499,7 @@ class TemplateElement extends FASTElement {
                     );
 
                     const binding = bindingResolver(
+                        strings.join(""),
                         rootPropertyName,
                         propName,
                         parentContext,

--- a/packages/web-components/fast-html/src/components/utilities.spec.ts
+++ b/packages/web-components/fast-html/src/components/utilities.spec.ts
@@ -10,6 +10,7 @@ import {
     transformInnerHTML,
     getExpressionChain,
     extractPathsFromChainedExpression,
+    getChildrenMap,
 } from "./utilities.js";
 
 test.describe("utilities", async () => {
@@ -459,6 +460,40 @@ test.describe("utilities", async () => {
 
             expect(paths.size).toEqual(1);
             expect(paths.has("app.user.profile.settings.theme")).toBe(true);
+        });
+    });
+
+    test.describe("getChildrenMap", async () => {
+        test("should get a ChildrenMap if an attribute is part of a custom element", async () => {
+            const childrenMap = getChildrenMap(`<template><my-element foo="`);
+
+            expect(childrenMap).not.toBeNull();
+            expect(childrenMap?.attributeName).toEqual("foo");
+            expect(childrenMap?.customElementName).toEqual("my-element");
+        });
+        test("should not get a ChildrenMap if an attribute is part of a non-custom element", async () => {
+            const childrenMap = getChildrenMap(`<template><button foo="`);
+
+            expect(childrenMap).toBeNull();
+        });
+        test("should remove any aspected attributes from an attribute name", async () => {
+            const childrenMap = getChildrenMap(`<template><my-element :foo="`);
+
+            expect(childrenMap).not.toBeNull();
+            expect(childrenMap?.attributeName).toEqual("foo");
+            expect(childrenMap?.customElementName).toEqual("my-element");
+        });
+        test("should not get a ChildreMap if the previous string indicates the binding was not an attribute", async () => {
+            const childrenMap = getChildrenMap(`<template><my-element>`);
+
+            expect(childrenMap).toBeNull();
+        });
+        test("should get a ChildrenMap if there are multiple attributes are listed before this attribute", async () => {
+            const childrenMap = getChildrenMap(`<template><my-element foo="" bar="" bat="`);
+
+            expect(childrenMap).not.toBeNull();
+            expect(childrenMap?.attributeName).toEqual("bat");
+            expect(childrenMap?.customElementName).toEqual("my-element");
         });
     });
 });

--- a/packages/web-components/fast-html/src/fixtures/observer-map/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/observer-map/main.ts
@@ -301,7 +301,8 @@ RenderableFASTElement(ObserverMapTestElement).defineAsync({
 });
 
 class ObserverMapInternalTestElement extends FASTElement {
-    public selectedUserId?: number;
+    public selecteduserid?: number;
+    public totalusers?: number;
 
     public a: any = {
         b: {},

--- a/packages/web-components/fast-html/src/fixtures/observer-map/observer-map.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/observer-map/observer-map.fixture.html
@@ -12,6 +12,7 @@
                 <template>
                     <observer-map-internal-test-element
                         :selecteduserid="{{selectedUserId}}"
+                        :totalusers="{{stats.totalUsers}}"
                     ></observer-map-internal-test-element>
                     <div class="stats">
                         <h2>Global Stats</h2>
@@ -121,7 +122,10 @@
             </f-template>
             <f-template name="observer-map-internal-test-element">
                 <template>
-                    {{selecteduserid}} <!-- because this is bound to an attribute property it must be lowercase -->
+                    selected user: {{selecteduserid}} <!-- because this is bound to an attribute property it must be lowercase -->
+                    <br>
+                    total users: {{totalusers}}
+                    <br>
                     <f-when value="{a}">
                         <span class="nested-define">{{a.b.c}}</span>
                     </f-when>


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change adds an `anyOf` with `$ref` to other schemas.

### 🎫 Issues

Closes #7179 

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

- Implement schema `$ref` lookup for `anyOf` containing `$ref` in the ObserverMap to further inform the creation of Proxy objects.