### PR TITLE
Add anyOf with  to contexts

### DIFF
--- a/change/@microsoft-fast-html-b0c85295-af2d-4063-8faa-1a4b64555fcf.json
+++ b/change/@microsoft-fast-html-b0c85295-af2d-4063-8faa-1a4b64555fcf.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Add anyOf with ref to contexts",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/web-components/fast-html/src/components/schema.ts
+++ b/packages/web-components/fast-html/src/components/schema.ts
@@ -313,6 +313,14 @@ export class Schema {
                 context,
                 childRef
             );
+        } else if (childRef) {
+            if (schema.properties[splitPath[0]].anyOf) {
+                schema.properties[splitPath[0]].anyOf.push({
+                    [refPropertyName]: childRef,
+                });
+            } else {
+                schema.properties[splitPath[0]].anyOf = [{ [refPropertyName]: childRef }];
+            }
         }
     }
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change accounts for child custom element refs to exist within contexts (repeats).

### 🎫 Issues

Further improves work on #7179 

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.