### PR TITLE
Allow proxied data to have more than one target to notify of updates

### DIFF
--- a/packages/web-components/fast-html/src/fixtures/observer-map/observer-map.fixture.html
+++ b/packages/web-components/fast-html/src/fixtures/observer-map/observer-map.fixture.html
@@ -13,18 +13,13 @@
                     <observer-map-internal-test-element
                         :selecteduserid="{{selectedUserId}}"
                         :totalusers="{{stats.totalUsers}}"
+                        :metrics="{{stats.metrics}}"
                     ></observer-map-internal-test-element>
                     <div class="stats">
                         <h2>Global Stats</h2>
                         <div class="nested-info">
                             <strong>Total Users:</strong> {{stats.totalUsers}} |
                             <strong>Active Users:</strong> {{stats.activeUsers}}
-                        </div>
-                        <div class="nested-info">
-                            <strong>Engagement:</strong>
-                            Daily: {{stats.metrics.engagement.daily}},
-                            Weekly: {{stats.metrics.engagement.weekly}},
-                            Monthly: {{stats.metrics.engagement.monthly}}
                         </div>
                         <div class="nested-info">
                             <strong>Performance:</strong>
@@ -126,6 +121,14 @@
                     <br>
                     total users: {{totalusers}}
                     <br>
+                    <div class="stats">
+                        <div class="nested-info">
+                            <strong>Engagement:</strong>
+                            Daily: {{metrics.engagement.daily}},
+                            Weekly: {{metrics.engagement.weekly}},
+                            Monthly: {{metrics.engagement.monthly}}
+                        </div>
+                    </div>
                     <f-when value="{a}">
                         <span class="nested-define">{{a.b.c}}</span>
                     </f-when>


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change allows multiple targets to be notified when proxied data triggers a `set` or `deleteProperty`.

### 🎫 Issues

Closes #7182 

## 📑 Test Plan

Observer map fixture updated to account for passing objects to child components.

## ✅ Checklist

### General

<!--- Review the list and put an x in the boxes that apply. -->

- [ ] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.