### PR TITLE
Fix: definition finding should account for anyOf arrays

### DIFF
--- a/packages/web-components/fast-html/src/components/schema.ts
+++ b/packages/web-components/fast-html/src/components/schema.ts
@@ -13,13 +13,13 @@ interface JSONSchemaCommon {
     properties?: any;
     items?: any;
     anyOf?: Array<any>;
+    $ref?: string;
 }
 
 export interface JSONSchema extends JSONSchemaCommon {
     $schema: string;
     $id: string;
     $defs?: Record<string, JSONSchemaDefinition>;
-    $ref?: string;
 }
 
 interface CachedPathCommon {


### PR DESCRIPTION
# Pull Request

## 📖 Description

With the addition of `anyOf` when defining properties we must account for that when searching for a `$def`.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.