### PR TITLE
Fix an issue where proxied data was not being re-assigned, stabilize observer map test

### DIFF
--- a/packages/web-components/fast-html/src/components/utilities.ts
+++ b/packages/web-components/fast-html/src/components/utilities.ts
@@ -1139,24 +1139,24 @@ export function assignObservables(
 
 /**
  * Assign a proxy to items in an array
- * @param data - The array item to proxy
+ * @param proxiableItem - The array item to proxy
  * @param originalItem - The original array item
  * @param schema - The schema mapping to the items in the array
  * @param rootSchema - The root schema assigned to the root property
  */
 function assignProxyToItemsInArray(
-    data: any,
+    proxiableItem: any,
     originalItem: any,
     schema: JSONSchema | JSONSchemaDefinition,
     rootSchema: JSONSchema
 ): void {
     const schemaProperties = getSchemaProperties(schema);
 
-    getObjectProperties(data, schemaProperties).forEach(key => {
-        Observable.defineProperty(data, key);
+    getObjectProperties(proxiableItem, schemaProperties).forEach(key => {
+        Observable.defineProperty(proxiableItem, key);
 
         originalItem[key] = assignProxyToItemsInObject(
-            data,
+            proxiableItem,
             key,
             originalItem[key],
             schemaProperties[key],
@@ -1202,7 +1202,7 @@ function assignProxyToItemsInObject(
 
     if (type === "object" && schemaProperties) {
         // navigate through all items in the object
-        getObjectProperties(data, schemaProperties).forEach(property => {
+        getObjectProperties(proxiedData, schemaProperties).forEach(property => {
             proxiedData[property] = assignProxyToItemsInObject(
                 target,
                 rootProperty,
@@ -1213,7 +1213,7 @@ function assignProxyToItemsInObject(
         });
 
         // assign a Proxy to the object
-        proxiedData = assignProxy(schema, rootSchema, target, rootProperty, data);
+        proxiedData = assignProxy(schema, rootSchema, target, rootProperty, proxiedData);
 
         // Add this target to the object's target list
         addTargetToObject(proxiedData, target, rootProperty);

--- a/packages/web-components/fast-html/src/fixtures/observer-map/main.ts
+++ b/packages/web-components/fast-html/src/fixtures/observer-map/main.ts
@@ -1,5 +1,5 @@
 import { FASTElement } from "@microsoft/fast-element";
-import { RenderableFASTElement, TemplateElement } from "../../components/index.js";
+import { TemplateElement } from "../../components/index.js";
 
 class ObserverMapTestElement extends FASTElement {
     public users: any[] = [
@@ -295,11 +295,6 @@ class ObserverMapTestElement extends FASTElement {
     };
 }
 
-RenderableFASTElement(ObserverMapTestElement).defineAsync({
-    name: "observer-map-test-element",
-    templateOptions: "defer-and-hydrate",
-});
-
 class ObserverMapInternalTestElement extends FASTElement {
     public selecteduserid?: number;
     public totalusers?: number;
@@ -319,10 +314,16 @@ class ObserverMapInternalTestElement extends FASTElement {
     }
 }
 
-RenderableFASTElement(ObserverMapInternalTestElement).defineAsync({
-    name: "observer-map-internal-test-element",
-    templateOptions: "defer-and-hydrate",
-});
+// Nested child components must be defined first
+(async () => {
+    await ObserverMapInternalTestElement.defineAsync({
+        name: "observer-map-internal-test-element",
+    });
+
+    await ObserverMapTestElement.defineAsync({
+        name: "observer-map-test-element",
+    });
+})();
 
 // Configure TemplateElement with observerMap enabled for this test
 TemplateElement.options({


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change ensures that the internal test element in observer map fixture is defined first, then the wrapping test element. It also ensures that proxied data is being re-assigned instead of the original data structure.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.