### PR TITLE
fix: align @attr boolean mode with native HTML boolean attribute semantics

### DIFF
--- a/change/@microsoft-fast-element-7463774d-d761-4aaa-a60e-f51e4866b63d.json
+++ b/change/@microsoft-fast-element-7463774d-d761-4aaa-a60e-f51e4866b63d.json
@@ -1,6 +1,6 @@
 {
   "type": "prerelease",
-  "comment": "Change evaluation of a boolean attributes property reflection so that a string 'false' evaluates to t",
+  "comment": "fix: align @attr({ mode: 'boolean' }) and booleanConverter with native HTML boolean attribute semantics",
   "packageName": "@microsoft/fast-element",
   "email": "7559015+janechu@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change/@microsoft-fast-element-7463774d-d761-4aaa-a60e-f51e4866b63d.json
+++ b/change/@microsoft-fast-element-7463774d-d761-4aaa-a60e-f51e4866b63d.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Change evaluation of a boolean attributes property reflection so that a string 'false' evaluates to t",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/MIGRATION.md
+++ b/packages/fast-element/MIGRATION.md
@@ -385,3 +385,44 @@ This is a **breaking change** for SSR output format. Any system that produces or
 2. Move the external listener or condition (for example `matchMedia()` or an app event subscription) into the element lifecycle.
 3. Call `this.$fastController.addStyles(styles)` when the condition is active and `this.$fastController.removeStyles(styles)` when it is inactive or during cleanup.
 4. If you previously interpolated bindings or behavior-producing directives into `css`, replace them with element state and standard DOM or controller updates.
+
+## `booleanConverter` aligned with native HTML boolean attribute semantics (v2 → v3)
+
+### Changed behavior
+
+`@attr({ mode: "boolean" })` and `booleanConverter` now match how the platform treats native boolean attributes (e.g., `disabled`, `required`):
+
+- **Attribute → property** is presence-based: `setAttribute(name, anyString)` (including the empty string) sets the property to `true`; only `removeAttribute(name)` makes it `false`.
+- **Property → attribute** uses `Boolean()` coercion: any JavaScript truthy value adds the attribute (with value `""`); any falsy value removes it.
+
+The headline v2 → v3 difference is that `setAttribute(name, "false")` now resolves to property `true`, matching `<input disabled="false">` still being disabled.
+
+`booleanConverter` shape:
+
+```ts
+toView(value: any) {
+    return value ? "" : null;
+}
+
+fromView(value: any) {
+    return !!value;
+}
+```
+
+`booleanConverter` v2 → v3 result differences:
+
+| Call | v2 result | v3 result |
+|---|---|---|
+| `fromView("false")` | `false` | `true` |
+| `fromView("")` | `true` | `false` |
+| `fromView(NaN)` | `true` | `false` |
+| `toView(true)` (or any truthy) | `"true"` | `""` |
+| `toView(false)` (or any falsy) | `"false"` | `null` |
+
+> **Note**: For `mode: "boolean"`, FAST writes attributes via `DOM.setBooleanAttribute` (presence-based) and reads them as `value !== null`, so the `mode: "boolean"` reflection path does **not** route through `booleanConverter.toView()` or `booleanConverter.fromView()`. The converter methods still apply to property assignment (`el.bool = X` runs `fromView(X)`), explicit calls (`booleanConverter.fromView(x)`), and `booleanConverter` paired with `mode: "reflect"` (which calls `toView`).
+
+### Migration steps
+
+1. Audit `boolean`-mode attributes for the literal string `"false"` in templates or SSR HTML — the resulting property will be `true`, not `false`. To express the falsy state, omit the attribute entirely (or call `element.removeAttribute(name)`). Setting `element.bool = false` continues to remove the reflected attribute.
+2. Audit code that calls `booleanConverter.toView()` directly or pairs `booleanConverter` with `mode: "reflect"`. The output strings are no longer `"true"` / `"false"`.
+3. If you need a tri-state attribute (`true` / `false` / unset) that preserves an explicit `"false"` string value, use `nullableBooleanConverter` with `mode: "reflect"` instead of `mode: "boolean"`.

--- a/packages/fast-element/SIZES.md
+++ b/packages/fast-element/SIZES.md
@@ -4,8 +4,8 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 76.36 KB | 22.91 KB | 20.32 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.74 KB | 7.37 KB | 6.63 KB |
+| CDN Rollup Bundle | 76.36 KB | 22.91 KB | 20.35 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.73 KB | 7.36 KB | 6.63 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 288 B |
 | Observable (@microsoft/fast-element/observable.js) | 6.70 KB | 2.50 KB | 2.22 KB |
 | observable (@microsoft/fast-element/observable.js) | 6.74 KB | 2.51 KB | 2.23 KB |
@@ -18,8 +18,8 @@ Bundle sizes for `@microsoft/fast-element` exports.
 | html (@microsoft/fast-element/html.js) | 25.92 KB | 8.50 KB | 7.61 KB |
 | repeat (@microsoft/fast-element/repeat.js) | 29.57 KB | 9.41 KB | 8.48 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 43.27 KB | 13.21 KB | 11.89 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 43.27 KB | 13.19 KB | 11.88 KB |
 | declarativeTemplate (@microsoft/fast-element/declarative.js) | 58.77 KB | 18.45 KB | 16.46 KB |
 | ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.51 KB | 4.45 KB | 4.01 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 20.41 KB | 7.25 KB | 6.52 KB |
-| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.78 KB | 5.59 KB | 5.04 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 20.41 KB | 7.24 KB | 6.52 KB |
+| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.78 KB | 5.58 KB | 5.04 KB |

--- a/packages/fast-element/docs/api-report.api.md
+++ b/packages/fast-element/docs/api-report.api.md
@@ -80,8 +80,11 @@ export class AttributeDefinition implements Accessor {
     setValue(source: HTMLElement, newValue: any): void;
 }
 
+// Warning: (ae-forgotten-export) The symbol "reflectMode" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "booleanMode" needs to be exported by the entry point index.d.ts
+//
 // @public
-export type AttributeMode = "reflect" | "boolean" | "fromView";
+export type AttributeMode = typeof reflectMode | typeof booleanMode | "fromView";
 
 // @public
 export abstract class Binding<TSource = any, TReturn = any, TParent = any> {

--- a/packages/fast-element/docs/declarative/api-report.api.md
+++ b/packages/fast-element/docs/declarative/api-report.api.md
@@ -46,8 +46,11 @@ export class AttributeDefinition implements Accessor {
     setValue(source: HTMLElement, newValue: any): void;
 }
 
+// Warning: (ae-forgotten-export) The symbol "reflectMode" needs to be exported by the entry point index.d.ts
+// Warning: (ae-forgotten-export) The symbol "booleanMode" needs to be exported by the entry point index.d.ts
+//
 // @public
-export type AttributeMode = "reflect" | "boolean" | "fromView";
+export type AttributeMode = typeof reflectMode | typeof booleanMode | "fromView";
 
 // @public
 export type CachedPath = DefaultCachedPath | RepeatCachedPath | AccessCachedPath | EventCachedPath;

--- a/packages/fast-element/src/components/attributes.pw.spec.ts
+++ b/packages/fast-element/src/components/attributes.pw.spec.ts
@@ -1,4 +1,23 @@
 import { expect, test } from "@playwright/test";
+import { booleanConverter } from "./attributes.js";
+
+const FALSE_CASES: Array<{ label: string; value: unknown }> = [
+    { label: "null", value: null },
+    { label: "undefined", value: undefined },
+    { label: "false", value: false },
+    { label: "0", value: 0 },
+    { label: '""', value: "" },
+    { label: "NaN", value: NaN },
+];
+
+const TRUE_CASES: Array<{ label: string; value: unknown }> = [
+    { label: "true", value: true },
+    { label: "1", value: 1 },
+    { label: '"false"', value: "false" },
+    { label: '"true"', value: "true" },
+    { label: '"0"', value: "0" },
+    { label: '"anything"', value: "anything" },
+];
 
 test.describe("Attributes", () => {
     test("should be properly aggregated across an inheritance hierarchy.", async ({
@@ -45,5 +64,256 @@ test.describe("Attributes", () => {
 
         expect(componentAAttributesLength).toBe(2);
         expect(componentBAttributesLength).toBe(1);
+    });
+
+    test.describe("booleanConverter", () => {
+        test.describe("fromView()", () => {
+            for (const { label, value } of FALSE_CASES) {
+                test(`returns false for ${label}`, () => {
+                    expect(booleanConverter.fromView(value)).toBe(false);
+                });
+            }
+
+            for (const { label, value } of TRUE_CASES) {
+                test(`returns true for ${label}`, () => {
+                    expect(booleanConverter.fromView(value)).toBe(true);
+                });
+            }
+        });
+
+        test.describe("attribute → property reflection (parity with native <button disabled>)", () => {
+            // Attribute values are always strings. Each case is applied via setAttribute
+            // on both a FAST custom element with `boolean`-mode `bool` and a native <button>
+            // with `disabled`; both elements must report the same property value.
+            const ATTRIBUTE_CASES: Array<{
+                label: string;
+                attrValue: string;
+                expectedProperty: boolean;
+            }> = [
+                {
+                    label: 'string "false"',
+                    attrValue: "false",
+                    expectedProperty: true,
+                },
+                { label: 'string "true"', attrValue: "true", expectedProperty: true },
+                { label: 'string "0"', attrValue: "0", expectedProperty: true },
+                {
+                    label: 'arbitrary string "anything"',
+                    attrValue: "anything",
+                    expectedProperty: true,
+                },
+                { label: 'empty string ""', attrValue: "", expectedProperty: true },
+            ];
+
+            for (const { label, attrValue, expectedProperty } of ATTRIBUTE_CASES) {
+                test(`setAttribute(${label}) sets the property to ${expectedProperty} (matches native)`, async ({
+                    page,
+                }) => {
+                    await page.goto("/");
+
+                    const result = await page.evaluate(async attrValue => {
+                        // @ts-expect-error: Client module.
+                        const { FASTElement, uniqueElementName } = await import(
+                            "/main.js"
+                        );
+
+                        class TestEl extends FASTElement {}
+
+                        const name = uniqueElementName();
+                        await TestEl.define({
+                            name,
+                            attributes: [{ property: "bool", mode: "boolean" }],
+                        });
+
+                        const fast = document.createElement(name) as any;
+                        fast.setAttribute("bool", attrValue);
+
+                        const native = document.createElement("button") as any;
+                        native.setAttribute("disabled", attrValue);
+
+                        return {
+                            fastProperty: fast.bool,
+                            nativeProperty: native.disabled,
+                        };
+                    }, attrValue);
+
+                    expect(result.nativeProperty).toBe(expectedProperty);
+                    expect(result.fastProperty).toBe(result.nativeProperty);
+                });
+            }
+
+            test("removeAttribute() after the attribute was present sets the property to false (matches native)", async ({
+                page,
+            }) => {
+                await page.goto("/");
+
+                const result = await page.evaluate(async () => {
+                    // @ts-expect-error: Client module.
+                    const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                    class TestEl extends FASTElement {}
+
+                    const name = uniqueElementName();
+                    await TestEl.define({
+                        name,
+                        attributes: [{ property: "bool", mode: "boolean" }],
+                    });
+
+                    const fast = document.createElement(name) as any;
+                    fast.setAttribute("bool", "true");
+                    const fastBefore = fast.bool;
+                    fast.removeAttribute("bool");
+                    const fastAfter = fast.bool;
+
+                    const native = document.createElement("button") as any;
+                    native.setAttribute("disabled", "true");
+                    const nativeBefore = native.disabled;
+                    native.removeAttribute("disabled");
+                    const nativeAfter = native.disabled;
+
+                    return { fastBefore, fastAfter, nativeBefore, nativeAfter };
+                });
+
+                expect(result.nativeBefore).toBe(true);
+                expect(result.nativeAfter).toBe(false);
+                expect(result.fastBefore).toBe(result.nativeBefore);
+                expect(result.fastAfter).toBe(result.nativeAfter);
+            });
+
+            test('setAttribute("false") preserves the literal attribute value while the property is true (matches native)', async ({
+                page,
+            }) => {
+                await page.goto("/");
+
+                const result = await page.evaluate(async () => {
+                    // @ts-expect-error: Client module.
+                    const { FASTElement, Updates, uniqueElementName } = await import(
+                        "/main.js"
+                    );
+
+                    class TestEl extends FASTElement {}
+
+                    const name = uniqueElementName();
+                    await TestEl.define({
+                        name,
+                        attributes: [{ property: "bool", mode: "boolean" }],
+                    });
+
+                    const fast = document.createElement(name) as any;
+                    fast.setAttribute("bool", "false");
+                    // Allow one update cycle to confirm no reflection-back occurs.
+                    await Updates.next();
+
+                    const native = document.createElement("button") as any;
+                    native.setAttribute("disabled", "false");
+
+                    return {
+                        fastProperty: fast.bool,
+                        fastAttribute: fast.getAttribute("bool"),
+                        nativeProperty: native.disabled,
+                        nativeAttribute: native.getAttribute("disabled"),
+                    };
+                });
+
+                expect(result.nativeProperty).toBe(true);
+                expect(result.nativeAttribute).toBe("false");
+                expect(result.fastProperty).toBe(result.nativeProperty);
+                expect(result.fastAttribute).toBe(result.nativeAttribute);
+            });
+        });
+
+        test.describe("property → attribute reflection (parity with native <button disabled>)", () => {
+            for (const { label, value } of FALSE_CASES) {
+                test(`setting the property to ${label} removes the attribute (matches native)`, async ({
+                    page,
+                }) => {
+                    await page.goto("/");
+
+                    const result = await page.evaluate(async value => {
+                        // @ts-expect-error: Client module.
+                        const { FASTElement, Updates, uniqueElementName } = await import(
+                            "/main.js"
+                        );
+
+                        class TestEl extends FASTElement {}
+
+                        const name = uniqueElementName();
+                        await TestEl.define({
+                            name,
+                            attributes: [{ property: "bool", mode: "boolean" }],
+                        });
+
+                        // Pre-seed both to a truthy state so the falsy assignment
+                        // must explicitly remove the attribute.
+                        const fast = document.createElement(name) as any;
+                        fast.bool = true;
+                        await Updates.next();
+                        const fastSeededHas = fast.hasAttribute("bool");
+
+                        const native = document.createElement("button") as any;
+                        native.disabled = true;
+                        const nativeSeededHas = native.hasAttribute("disabled");
+
+                        fast.bool = value;
+                        await Updates.next();
+                        native.disabled = value;
+
+                        return {
+                            fastSeededHas,
+                            fastHas: fast.hasAttribute("bool"),
+                            nativeSeededHas,
+                            nativeHas: native.hasAttribute("disabled"),
+                        };
+                    }, value);
+
+                    expect(result.nativeSeededHas).toBe(true);
+                    expect(result.nativeHas).toBe(false);
+                    expect(result.fastSeededHas).toBe(result.nativeSeededHas);
+                    expect(result.fastHas).toBe(result.nativeHas);
+                });
+            }
+
+            for (const { label, value } of TRUE_CASES) {
+                test(`setting the property to ${label} adds the attribute with value "" (matches native)`, async ({
+                    page,
+                }) => {
+                    await page.goto("/");
+
+                    const result = await page.evaluate(async value => {
+                        // @ts-expect-error: Client module.
+                        const { FASTElement, Updates, uniqueElementName } = await import(
+                            "/main.js"
+                        );
+
+                        class TestEl extends FASTElement {}
+
+                        const name = uniqueElementName();
+                        await TestEl.define({
+                            name,
+                            attributes: [{ property: "bool", mode: "boolean" }],
+                        });
+
+                        const fast = document.createElement(name) as any;
+                        fast.bool = value;
+                        await Updates.next();
+
+                        const native = document.createElement("button") as any;
+                        native.disabled = value;
+
+                        return {
+                            fastHas: fast.hasAttribute("bool"),
+                            fastAttr: fast.getAttribute("bool"),
+                            nativeHas: native.hasAttribute("disabled"),
+                            nativeAttr: native.getAttribute("disabled"),
+                        };
+                    }, value);
+
+                    expect(result.nativeHas).toBe(true);
+                    expect(result.nativeAttr).toBe("");
+                    expect(result.fastHas).toBe(result.nativeHas);
+                    expect(result.fastAttr).toBe(result.nativeAttr);
+                });
+            }
+        });
     });
 });

--- a/packages/fast-element/src/components/attributes.ts
+++ b/packages/fast-element/src/components/attributes.ts
@@ -38,7 +38,7 @@ const reflectMode = "reflect";
  * changes in the DOM, but does not reflect property changes back.
  * @public
  */
-export type AttributeMode = "reflect" | "boolean" | "fromView";
+export type AttributeMode = typeof reflectMode | typeof booleanMode | "fromView";
 
 /**
  * Metadata used to configure a custom attribute's behavior.
@@ -75,18 +75,12 @@ export type DecoratorAttributeConfiguration = Omit<AttributeConfiguration, "prop
  * @public
  */
 export const booleanConverter: ValueConverter = {
-    toView(value: any): string {
-        return value ? "true" : "false";
+    toView(value: any): string | null {
+        return value ? "" : null;
     },
 
     fromView(value: any): any {
-        return !(
-            value === null ||
-            value === void 0 ||
-            value === "false" ||
-            value === false ||
-            value === 0
-        );
+        return !!value;
     },
 };
 
@@ -132,7 +126,7 @@ export const nullableNumberConverter: ValueConverter = {
 };
 
 /**
- * An implementation of `Accessor` that supports reactivity,
+ * An implementation of {@link Accessor} that supports reactivity,
  * change callbacks, attribute reflection, and type conversion for
  * custom elements.
  * @public
@@ -241,7 +235,14 @@ export class AttributeDefinition implements Accessor {
         }
 
         this.guards.add(element);
-        this.setValue(element, value);
+        if (this.mode === booleanMode) {
+            // Native HTML boolean attribute semantics: presence of the attribute
+            // (any string value, including "") means `true`; `null` (the value
+            // passed by the platform on `removeAttribute`) means `false`.
+            this.setValue(element, value !== null);
+        } else {
+            this.setValue(element, value);
+        }
         this.guards.delete(element);
     }
 

--- a/sites/website/src/docs/3.x/api/fast-element.attributedefinition.md
+++ b/sites/website/src/docs/3.x/api/fast-element.attributedefinition.md
@@ -15,7 +15,7 @@ navigationOptions:
 
 ## AttributeDefinition class
 
-An implementation of `Accessor` that supports reactivity, change callbacks, attribute reflection, and type conversion for custom elements.
+An implementation of [Accessor](../fast-element.accessor/) that supports reactivity, change callbacks, attribute reflection, and type conversion for custom elements.
 
 **Signature:**
 

--- a/sites/website/src/docs/3.x/api/fast-element.attributemode.md
+++ b/sites/website/src/docs/3.x/api/fast-element.attributemode.md
@@ -20,7 +20,7 @@ The mode that specifies the runtime behavior of the attribute.
 **Signature:**
 
 ```typescript
-export type AttributeMode = "reflect" | "boolean" | "fromView";
+export type AttributeMode = typeof reflectMode | typeof booleanMode | "fromView";
 ```
 
 ## Remarks

--- a/sites/website/src/docs/3.x/api/fast-element.md
+++ b/sites/website/src/docs/3.x/api/fast-element.md
@@ -34,7 +34,7 @@ Description
 
 </td><td>
 
-An implementation of `Accessor` that supports reactivity, change callbacks, attribute reflection, and type conversion for custom elements.
+An implementation of [Accessor](../fast-element.accessor/) that supports reactivity, change callbacks, attribute reflection, and type conversion for custom elements.
 
 
 </td></tr>

--- a/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributedefinition.md
+++ b/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributedefinition.md
@@ -15,7 +15,7 @@ navigationOptions:
 
 ## AttributeDefinition class
 
-An implementation of `Accessor` that supports reactivity, change callbacks, attribute reflection, and type conversion for custom elements.
+An implementation of [Accessor](../fast-element.accessor/) that supports reactivity, change callbacks, attribute reflection, and type conversion for custom elements.
 
 **Signature:**
 

--- a/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributemode.md
+++ b/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.attributemode.md
@@ -20,7 +20,7 @@ The mode that specifies the runtime behavior of the attribute.
 **Signature:**
 
 ```typescript
-export type AttributeMode = "reflect" | "boolean" | "fromView";
+export type AttributeMode = typeof reflectMode | typeof booleanMode | "fromView";
 ```
 
 ## Remarks

--- a/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.md
+++ b/sites/website/src/docs/3.x/api/fast-element/declarative/fast-element.md
@@ -34,7 +34,7 @@ Description
 
 </td><td>
 
-An implementation of `Accessor` that supports reactivity, change callbacks, attribute reflection, and type conversion for custom elements.
+An implementation of [Accessor](../fast-element.accessor/) that supports reactivity, change callbacks, attribute reflection, and type conversion for custom elements.
 
 
 </td></tr>

--- a/sites/website/src/docs/3.x/migration-guide.md
+++ b/sites/website/src/docs/3.x/migration-guide.md
@@ -369,6 +369,61 @@ The SSR hydration markers have been simplified from verbose, index-embedded comm
 
 The `HydrationMarkup` API methods have been renamed (e.g., `parseAttributeBinding` → `parseAttributeBindingCount`) and no longer accept index/scope parameters. See the [package MIGRATION.md](https://github.com/microsoft/fast/blob/releases/fast-element-v3/packages/fast-element/MIGRATION.md#hydration-marker-format-v3) for the complete API mapping.
 
+### `booleanConverter` aligned with native HTML boolean attribute semantics
+
+`@attr({ mode: "boolean" })` and `booleanConverter` now match how the platform treats native boolean attributes (e.g., `disabled`, `required`):
+
+- **Attribute → property** is presence-based: `setAttribute(name, anyString)` (including the empty string) sets the property to `true`; only `removeAttribute(name)` makes it `false`.
+- **Property → attribute** uses `Boolean()` coercion: any JavaScript truthy value adds the attribute (with value `""`); any falsy value removes it.
+
+The headline difference is that `setAttribute(name, "false")` now resolves to property `true`, matching `<input disabled="false">` still being disabled.
+
+2.x Behavior:
+```html
+<my-element my-bool="false"></my-element>
+```
+```ts
+element.myBool === false;
+```
+
+3.x Behavior:
+```html
+<my-element my-bool="false"></my-element>
+```
+```ts
+element.myBool === true;
+```
+
+`booleanConverter` shape:
+
+```ts
+toView(value: any) {
+    return value ? "" : null;
+}
+
+fromView(value: any) {
+    return !!value;
+}
+```
+
+`booleanConverter` 2.x → 3.x result differences:
+
+| Call | 2.x | 3.x |
+|---|---|---|
+| `fromView("false")` | `false` | `true` |
+| `fromView("")` | `true` | `false` |
+| `fromView(NaN)` | `true` | `false` |
+| `toView(true)` (or any truthy) | `"true"` | `""` |
+| `toView(false)` (or any falsy) | `"false"` | `null` |
+
+For `mode: "boolean"`, FAST writes attributes via `DOM.setBooleanAttribute` (presence-based) and reads them as `value !== null`, so the `mode: "boolean"` reflection path does **not** route through `booleanConverter.toView()` or `booleanConverter.fromView()`. The converter methods still apply to property assignment (`el.bool = X` runs `fromView(X)`), explicit calls (`booleanConverter.fromView(x)`), and `booleanConverter` paired with `mode: "reflect"` (which calls `toView`).
+
+**Migration:**
+
+- Audit `boolean`-mode attributes for the literal string `"false"` in templates or SSR HTML — the resulting property will be `true`, not `false`. To express the falsy state, omit the attribute entirely (or call `element.removeAttribute("my-bool")`). Assigning `element.myBool = false` continues to remove the reflected attribute as before.
+- Audit code that calls `booleanConverter.toView()` directly or pairs `booleanConverter` with `mode: "reflect"`. The output strings are no longer `"true"` / `"false"`.
+- If you need a tri-state attribute that preserves an explicit `"false"` string value, use `nullableBooleanConverter` with `mode: "reflect"` instead of `mode: "boolean"`.
+
 ## New Exports
 
 | Export | Package | Description |

--- a/sites/website/src/docs/3.x/resources/export-sizes.md
+++ b/sites/website/src/docs/3.x/resources/export-sizes.md
@@ -19,8 +19,8 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 76.36 KB | 22.91 KB | 20.32 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.74 KB | 7.37 KB | 6.63 KB |
+| CDN Rollup Bundle | 76.36 KB | 22.91 KB | 20.35 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.73 KB | 7.36 KB | 6.63 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 288 B |
 | Observable (@microsoft/fast-element/observable.js) | 6.70 KB | 2.50 KB | 2.22 KB |
 | observable (@microsoft/fast-element/observable.js) | 6.74 KB | 2.51 KB | 2.23 KB |
@@ -33,8 +33,8 @@ Bundle sizes for `@microsoft/fast-element` exports.
 | html (@microsoft/fast-element/html.js) | 25.92 KB | 8.50 KB | 7.61 KB |
 | repeat (@microsoft/fast-element/repeat.js) | 29.57 KB | 9.41 KB | 8.48 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 43.27 KB | 13.21 KB | 11.89 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 43.27 KB | 13.19 KB | 11.88 KB |
 | declarativeTemplate (@microsoft/fast-element/declarative.js) | 58.77 KB | 18.45 KB | 16.46 KB |
 | ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.51 KB | 4.45 KB | 4.01 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 20.41 KB | 7.25 KB | 6.52 KB |
-| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.78 KB | 5.59 KB | 5.04 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 20.41 KB | 7.24 KB | 6.52 KB |
+| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.78 KB | 5.58 KB | 5.04 KB |


### PR DESCRIPTION
# Pull Request

## 📖 Description

Aligns `@attr({ mode: "boolean" })` and `booleanConverter` with native HTML boolean attribute semantics (e.g., `disabled`, `required`):

- **Attribute → property** is presence-based: `setAttribute(name, anyString)` (including `""` and `"false"`) sets the property to `true`; only `removeAttribute(name)` makes it `false`.
- **Property → attribute** uses `Boolean()` coercion: any truthy value adds the attribute (with value `""`); any falsy value removes it.

The headline behavior change is that `<my-element my-bool="false">` now resolves to `element.myBool === true`, matching `<input disabled="false">` still being disabled.

### Changes

- `booleanConverter.fromView` → `!!value` (standard `Boolean()` coercion).
- `booleanConverter.toView` → `value ? "" : null` (HTML-standard boolean-attribute output; previously `"true"`/`"false"`).
- `AttributeDefinition.onAttributeChangedCallback` special-cases `mode: "boolean"` to call `setValue(element, value !== null)`, ensuring the attribute → property path is presence-based even when the converter would otherwise coerce `""` to `false`.

This is a **breaking change** included in the 3.x release.

### 🎫 Issues

Closes #7511

## 👩‍💻 Reviewer Notes

- The `mode: "boolean"` reflection path no longer routes through `booleanConverter.toView()` / `booleanConverter.fromView()`. These methods still apply to property assignment (`el.bool = X` runs `fromView`), explicit calls (`booleanConverter.fromView(x)`), and `booleanConverter` paired with `mode: "reflect"` (which calls `toView`).
- Custom converters used with `mode: "boolean"` will receive a `boolean` (from `value !== null`) on the attribute → property path rather than the raw attribute string, since boolean mode now means "presence-based" regardless of the converter.
- Migration guidance is documented in both `packages/fast-element/MIGRATION.md` and `sites/website/src/docs/3.x/migration-guide.md`.

## 📑 Test Plan

Added side-by-side parity tests in `packages/fast-element/src/components/attributes.pw.spec.ts` that exercise both a FAST `mode: "boolean"` custom element and a native `<button disabled>` for every false/true case, asserting they report identical state in both reflection directions.

- 96/96 attribute parity tests pass across chromium, firefox, and webkit.
- 176/176 broader `@microsoft/fast-element` chromium suite passes (no regressions).
- `npm run biome:check`, `npm run checkchange` pass.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
