### PR TITLE
feat(fast-test-harness): propagate shadow DOM options through template generation and SSR

### DIFF
--- a/change/@microsoft-fast-test-harness-7d33cb9f-2de0-478f-b74a-f86549461586.json
+++ b/change/@microsoft-fast-test-harness-7d33cb9f-2de0-478f-b74a-f86549461586.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add support for shadow DOM options in template generation and SSR rendering",
+  "packageName": "@microsoft/fast-test-harness",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-test-harness/DESIGN.md
+++ b/packages/fast-test-harness/DESIGN.md
@@ -71,8 +71,8 @@ flowchart TD
 | `src/fixtures/assertions.ts` | Custom Playwright assertion `toHaveCustomState` |
 | `src/build/dom-shim.ts` | Minimal DOM shim for running FAST Element's `css` and `html` tagged templates in Node.js |
 | `src/build/generate-stylesheets.ts` | Extracts compiled FAST `ElementStyles` JS modules into plain `.css` files |
-| `src/build/generate-templates.ts` | Converts compiled FAST `ViewTemplate` JS modules into declarative `<f-template>` HTML files |
-| `src/build/generate-webui-templates.ts` | Converts compiled FAST `ViewTemplate` JS modules into WebUI-compatible declarative shadow DOM `<template>` HTML files |
+| `src/build/generate-templates.ts` | Converts compiled FAST `ViewTemplate` JS modules into declarative `<f-template>` HTML files. Exports `definitionAsyncResolver`, `shadowOptionsToAttributes`, and the `ShadowOptionsResolver` type for resolving per-component shadow DOM options. |
+| `src/build/generate-webui-templates.ts` | Converts compiled FAST `ViewTemplate` JS modules into WebUI-compatible declarative shadow DOM `<template>` HTML files. Shares the shadow-options resolution pipeline with `generate-templates.ts`. |
 | `src/ssr/render.ts` | `createSSRRenderer` factory — scans for component build artifacts and uses the `@microsoft/fast-build` WASM module to produce SSR output |
 | `src/ssr/entry-client.ts` | SSR hydration entry point — defines `<f-template>` for the browser |
 | `server.mjs` | Node.js HTTP server with Vite middleware — serves CSR pages and handles SSR fixture generation |
@@ -129,6 +129,10 @@ The `fastPage` fixture factory reads these options and instantiates either `CSRF
 |----------|-------------|
 | `addStyleTag` | Buffers style options into `pendingStyles` until `setTemplate` is called. Only `{ content }` options are preserved — the content strings are serialized into the SSR generation request. Style options using `path` or `url` are not included in the SSR output. After `setTemplate`, calls pass through to the page directly. |
 | `setTemplate` | Builds a request body from the template options, posts it to `/generate-fixture`, navigates to the returned URL, and waits for stability. |
+
+| Property | Description |
+|----------|-------------|
+| `url` | Read-only getter exposing the generated SSR fixture URL after `setTemplate` resolves (e.g. `/ssr-<testId>.html`). `undefined` before the first `setTemplate` call. |
 
 **SSR request body construction**: The `setTemplate` override constructs a JSON body with these fields:
 
@@ -289,6 +293,8 @@ The `src/ssr/render.ts` module exports `createSSRRenderer`, a factory that scans
 4. Extracts `<body>` content from the rendered document.
 5. Returns `{ template, fixture, preloadLinks }`.
 
+**Shadow root attributes:** When parsing f-templates, the WASM `parse_f_templates` output may include `shadowrootAttributes` (e.g. `shadowrootdelegatesfocus`) sourced from the template generation step. If any non-default attributes are present beyond `shadowrootmode`, the `templatesMap` entry for that tag uses the object form `{ content, shadowrootAttributes }` so the renderer can propagate them onto the emitted `<template shadowroot...>` element. Tags with only the default `shadowrootmode` use the bare string form.
+
 ---
 
 ## Configuration Files
@@ -331,7 +337,7 @@ The `src/ssr/render.ts` module exports `createSSRRenderer`, a factory that scans
 | `@microsoft/fast-test-harness` | `test`, `expect`, `CSRFixture`, `SSRFixture`, `createSSRRenderer`, `ComponentRegistration`, `RenderResult`, `SSRRendererOptions`, build utilities (`installDomShim`, `generateStylesheets`, `generateFTemplates`, `generateWebuiTemplates`) |
 | `@microsoft/fast-test-harness/server.mjs` | `startServer` |
 | `@microsoft/fast-test-harness/ssr/render.js` | `createSSRRenderer`, `ComponentRegistration`, `RenderResult`, `SSRRendererOptions`, `renderTemplate`, `buildEntryHtml`, `buildState`, `parseDefaultValue` |
-| `@microsoft/fast-test-harness/build/*.js` | Build utilities: `installDomShim`, `generateStylesheets`, `generateFTemplates`, `generateWebuiTemplates` |
+| `@microsoft/fast-test-harness/build/*.js` | Build utilities: `installDomShim`, `generateStylesheets`, `generateFTemplates`, `generateWebuiTemplates`, `definitionAsyncResolver`, `shadowOptionsToAttributes`, `ShadowOptionsResolver` |
 | `@microsoft/fast-test-harness/playwright.config.mjs` | Shared Playwright configuration |
 | `@microsoft/fast-test-harness/vite.config.mjs` | Shared Vite configuration |
 | `@microsoft/fast-test-harness/public/*` | Static assets (base CSS reset) |

--- a/packages/fast-test-harness/README.md
+++ b/packages/fast-test-harness/README.md
@@ -264,7 +264,7 @@ CLI flags take precedence over environment variables.
 | Specifier | Contents |
 |-----------|----------|
 | `@microsoft/fast-test-harness` | `test`, `expect`, `CSRFixture`, `SSRFixture`, `toHaveCustomState`, `installDomShim`, `createSSRRenderer` |
-| `@microsoft/fast-test-harness/build/*.js` | `installDomShim`, `generateStylesheets`, `generateFTemplates`, `generateWebuiTemplates` |
+| `@microsoft/fast-test-harness/build/*.js` | `installDomShim`, `generateStylesheets`, `generateFTemplates`, `generateWebuiTemplates`, `definitionAsyncResolver`, `shadowOptionsToAttributes`, `ShadowOptionsResolver` |
 | `@microsoft/fast-test-harness/fixtures/*.js` | `CSRFixture`, `SSRFixture`, `toHaveCustomState`, extended `test` and `expect` |
 | `@microsoft/fast-test-harness/ssr/render.js` | `createSSRRenderer`, `renderTemplate`, `buildEntryHtml`, `buildState`, `parseDefaultValue` |
 | `@microsoft/fast-test-harness/server.mjs` | `startServer` |

--- a/packages/fast-test-harness/package.json
+++ b/packages/fast-test-harness/package.json
@@ -42,6 +42,7 @@
     },
     "./public/*": "./public/*",
     "./template.html": "./test/src/test-widget/test-widget.template.html",
+    "./input/template.html": "./test/src/test-widget/input/test-input.template.html",
     "./styles.css": "./test/src/test-widget/test-widget.styles.css",
     "./server.mjs": "./server.mjs",
     "./start.mjs": "./start.mjs",

--- a/packages/fast-test-harness/src/build/generate-templates.test.ts
+++ b/packages/fast-test-harness/src/build/generate-templates.test.ts
@@ -184,6 +184,32 @@ test.describe("generateFTemplates", () => {
         assert.ok(html.includes('<f-template name="fast-card"'));
     });
 
+    test("should preserve subdirectory structure in outDir", async () => {
+        const distDir = join(tempDir, "dist", "button");
+        await mkdir(distDir, { recursive: true });
+
+        await writeFile(
+            join(distDir, "button.template.js"),
+            `export const template = {
+                html: "<template><button>click</button></template>",
+                factories: {}
+            };`,
+        );
+
+        await generateFTemplates({
+            cwd: tempDir,
+            outDir: "src",
+            tagPrefix: "fast",
+            resolveShadowOptions: null,
+        });
+
+        const html = await readFile(
+            join(tempDir, "src", "button", "button.template.html"),
+            "utf8",
+        );
+        assert.ok(html.includes('<f-template name="fast-button"'));
+    });
+
     test("should skip modules without a template export", async () => {
         const distDir = join(tempDir, "dist");
         await mkdir(distDir, { recursive: true });
@@ -223,6 +249,60 @@ test.describe("generateFTemplates", () => {
 
         const html = await readFile(join(distDir, "text.template.html"), "utf8");
         assert.ok(html.startsWith("<!-- formatted -->"));
+    });
+
+    test("should add `shadowrootdelegatesfocus` by default when definition-async exists", async () => {
+        const distDir = join(tempDir, "dist");
+        await mkdir(distDir, { recursive: true });
+
+        await writeFile(
+            join(distDir, "input.template.js"),
+            `export const template = {
+                html: "<template><input /></template>",
+                factories: {}
+            };`,
+        );
+
+        await writeFile(
+            join(distDir, "input.definition-async.js"),
+            `export const definition = {
+                name: "fast-input",
+                shadowOptions: { delegatesFocus: true },
+            };`,
+        );
+
+        await generateFTemplates({
+            cwd: tempDir,
+            tagPrefix: "fast",
+        });
+
+        const html = await readFile(join(distDir, "input.template.html"), "utf8");
+        assert.ok(
+            html.includes("shadowrootdelegatesfocus"),
+            `should include delegatesFocus on f-template tag, got: ${html}`,
+        );
+        assert.ok(
+            html.includes("<f-template"),
+            `should still have f-template wrapper, got: ${html}`,
+        );
+    });
+
+    test("should not add `shadowrootdelegatesfocus` when no definition-async exists", async () => {
+        const distDir = join(tempDir, "dist");
+        await mkdir(distDir, { recursive: true });
+
+        await writeFile(
+            join(distDir, "div.template.js"),
+            `export const template = {
+                html: "<template><div>hello</div></template>",
+                factories: {}
+            };`,
+        );
+
+        await generateFTemplates({ cwd: tempDir, tagPrefix: "fast" });
+
+        const html = await readFile(join(distDir, "div.template.html"), "utf8");
+        assert.ok(!html.includes("shadowrootdelegatesfocus"));
     });
 });
 
@@ -283,7 +363,7 @@ test.describe("generateWebuiTemplates", () => {
         assert.ok(html.includes('<template shadowrootmode="open">'));
     });
 
-    test("should add shadowrootdelegatesfocus from definition-async", async () => {
+    test("should add shadowrootdelegatesfocus by default when definition-async exists", async () => {
         const distDir = join(tempDir, "dist");
         await mkdir(distDir, { recursive: true });
 
@@ -303,7 +383,10 @@ test.describe("generateWebuiTemplates", () => {
             };`,
         );
 
-        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "fast" });
+        await generateWebuiTemplates({
+            cwd: tempDir,
+            tagPrefix: "fast",
+        });
 
         const html = await readFile(join(distDir, "input.template-webui.html"), "utf8");
         assert.ok(
@@ -312,7 +395,7 @@ test.describe("generateWebuiTemplates", () => {
         );
     });
 
-    test("should not add shadowrootdelegatesfocus when absent", async () => {
+    test("should not add shadowrootdelegatesfocus when no definition-async exists", async () => {
         const distDir = join(tempDir, "dist");
         await mkdir(distDir, { recursive: true });
 

--- a/packages/fast-test-harness/src/build/generate-templates.ts
+++ b/packages/fast-test-harness/src/build/generate-templates.ts
@@ -79,6 +79,55 @@ export interface GenerateFTemplatesOptions {
      * Optional formatter function applied to generated HTML before writing.
      */
     format?: (html: string, filePath: string) => string | Promise<string>;
+
+    /**
+     * Resolves shadow DOM options for a given template module path.
+     * Returns a `shadowOptions` object (e.g. `{ delegatesFocus: true }`) or
+     * `undefined` if the component has no special shadow options.
+     *
+     * Defaults to {@link definitionAsyncResolver}, which loads a companion
+     * `*.definition-async.js` module next to each template. Set to `null`
+     * to disable shadow options resolution.
+     *
+     * @default definitionAsyncResolver
+     */
+    resolveShadowOptions?: ShadowOptionsResolver | null;
+}
+
+/**
+ * A function that resolves shadow DOM options for a template module.
+ * Receives the absolute path to the compiled `*.template.js` file and
+ * returns shadow options or `undefined`.
+ */
+export type ShadowOptionsResolver = (
+    templateJsPath: string,
+) => Record<string, unknown> | undefined | Promise<Record<string, unknown> | undefined>;
+
+/**
+ * Convention-based resolver that loads a companion `*.definition-async.js`
+ * module next to the template module and returns its `shadowOptions`.
+ *
+ * For a template at `dist/textarea/textarea.template.js`, this looks for
+ * `dist/textarea/textarea.definition-async.js`.
+ *
+ * This is the default resolver used by {@link generateFTemplates} and
+ * {@link generateWebuiTemplates} when `resolveShadowOptions` is not
+ * specified.
+ */
+export async function definitionAsyncResolver(
+    templateJsPath: string,
+): Promise<Record<string, unknown> | undefined> {
+    const dir = path.dirname(templateJsPath);
+    const base = path.basename(templateJsPath, ".template.js");
+    const defAsyncPath = path.resolve(dir, `${base}.definition-async.js`);
+
+    try {
+        const mod = await import(pathToFileURL(defAsyncPath).href);
+        const definition = mod.definition ?? mod.default;
+        return definition?.shadowOptions;
+    } catch {
+        return undefined;
+    }
 }
 
 export interface ViewTemplate {
@@ -308,6 +357,33 @@ export function convertTemplate(
     return `<f-template name="${componentName}" shadowrootmode="open">\n${fInner}\n</f-template>\n`;
 }
 
+/**
+ * Convert a `shadowOptions` object (e.g. `{ delegatesFocus: true }`) into
+ * DSD template attribute entries (e.g. `{ shadowrootdelegatesfocus: "" }`).
+ */
+export function shadowOptionsToAttributes(
+    shadowOptions: Record<string, unknown> | undefined,
+): Record<string, string> {
+    const attrs: Record<string, string> = {};
+    if (!shadowOptions) {
+        return attrs;
+    }
+
+    for (const [key, value] of Object.entries(shadowOptions)) {
+        if (key === "mode") {
+            continue;
+        }
+        const attrName = `shadowroot${key.toLowerCase()}`;
+        if (value === true) {
+            attrs[attrName] = "";
+        } else if (typeof value === "string" && value !== "") {
+            attrs[attrName] = value;
+        }
+    }
+
+    return attrs;
+}
+
 export async function generateFTemplates(
     options: GenerateFTemplatesOptions = {},
 ): Promise<void> {
@@ -337,7 +413,20 @@ export async function generateFTemplates(
                 continue;
             }
 
+            // Resolve shadow options and inject them into the <f-template> tag.
+            const resolver =
+                options.resolveShadowOptions === null
+                    ? undefined
+                    : (options.resolveShadowOptions ?? definitionAsyncResolver);
+            const shadowOpts = resolver ? await resolver(jsFilePath) : undefined;
+            const shadowAttrs = shadowOptionsToAttributes(shadowOpts);
             let html = fTemplateHtml;
+            if (Object.keys(shadowAttrs).length > 0) {
+                const extraAttrs = Object.entries(shadowAttrs)
+                    .map(([k, v]) => (v ? ` ${k}="${v}"` : ` ${k}`))
+                    .join("");
+                html = html.replace(/(<f-template[^>]*)(>)/, `$1${extraAttrs}$2`);
+            }
 
             if (options.format) {
                 try {
@@ -351,8 +440,9 @@ export async function generateFTemplates(
                 }
             }
 
+            const relativeDir = path.relative(distDir, path.dirname(jsFilePath));
             const fTemplatePath = outDir
-                ? path.resolve(outDir, `${componentBaseName}.template.html`)
+                ? path.resolve(outDir, relativeDir, `${componentBaseName}.template.html`)
                 : path.resolve(
                       path.dirname(jsFilePath),
                       `${componentBaseName}.template.html`,

--- a/packages/fast-test-harness/src/build/generate-webui-templates.test.ts
+++ b/packages/fast-test-harness/src/build/generate-webui-templates.test.ts
@@ -103,7 +103,7 @@ test.describe("generateWebuiTemplates", () => {
         assert.ok(html.startsWith("<!-- webui-formatted -->"));
     });
 
-    test("should add shadowrootdelegatesfocus from definition-async", async () => {
+    test("should add shadowrootdelegatesfocus by default when definition-async exists", async () => {
         const distDir = join(tempDir, "dist");
         await mkdir(distDir, { recursive: true });
 
@@ -123,7 +123,10 @@ test.describe("generateWebuiTemplates", () => {
             };`,
         );
 
-        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "fast" });
+        await generateWebuiTemplates({
+            cwd: tempDir,
+            tagPrefix: "fast",
+        });
 
         const html = await readFile(join(distDir, "input.template-webui.html"), "utf8");
         assert.ok(
@@ -132,7 +135,7 @@ test.describe("generateWebuiTemplates", () => {
         );
     });
 
-    test("should not add shadowrootdelegatesfocus when absent", async () => {
+    test("should not add shadowrootdelegatesfocus when no definition-async exists", async () => {
         const distDir = join(tempDir, "dist");
         await mkdir(distDir, { recursive: true });
 

--- a/packages/fast-test-harness/src/build/generate-webui-templates.ts
+++ b/packages/fast-test-harness/src/build/generate-webui-templates.ts
@@ -24,7 +24,13 @@ import { pathToFileURL } from "node:url";
 import { styleText } from "node:util";
 import { closeExpression, openExpression } from "@microsoft/fast-html/syntax.js";
 import { installDomShim } from "./dom-shim.js";
-import { convertTemplate, type ViewTemplate } from "./generate-templates.js";
+import {
+    convertTemplate,
+    definitionAsyncResolver,
+    type ShadowOptionsResolver,
+    shadowOptionsToAttributes,
+    type ViewTemplate,
+} from "./generate-templates.js";
 
 const stylesMarker = `${openExpression}styles${closeExpression}`;
 const escapedStylesMarker = new RegExp(
@@ -69,33 +75,19 @@ export interface GenerateWebuiTemplatesOptions {
      * Optional formatter function applied to generated HTML before writing.
      */
     format?: (html: string, filePath: string) => string | Promise<string>;
-}
 
-/**
- * Try to load shadow options from a companion `*.definition-async.js`
- * module next to the template module. Returns an object with template
- * attribute strings to add (e.g. `shadowrootdelegatesfocus`).
- */
-async function loadShadowAttributes(
-    templateJsPath: string,
-): Promise<Record<string, string>> {
-    const dir = path.dirname(templateJsPath);
-    const base = path.basename(templateJsPath, ".template.js");
-    const defAsyncPath = path.resolve(dir, `${base}.definition-async.js`);
-
-    const attrs: Record<string, string> = {};
-
-    try {
-        const mod = await import(pathToFileURL(defAsyncPath).href);
-        const definition = mod.definition ?? mod.default;
-        if (definition?.shadowOptions?.delegatesFocus) {
-            attrs.shadowrootdelegatesfocus = "";
-        }
-    } catch {
-        // No definition-async module or it failed to load — skip.
-    }
-
-    return attrs;
+    /**
+     * Resolves shadow DOM options for a given template module path.
+     * Returns a `shadowOptions` object (e.g. `{ delegatesFocus: true }`) or
+     * `undefined` if the component has no special shadow options.
+     *
+     * Defaults to {@link definitionAsyncResolver}, which loads a companion
+     * `*.definition-async.js` module next to each template. Set to `null`
+     * to disable shadow options resolution.
+     *
+     * @default definitionAsyncResolver
+     */
+    resolveShadowOptions?: ShadowOptionsResolver | null;
 }
 
 /**
@@ -169,7 +161,12 @@ export async function generateWebuiTemplates(
                 continue;
             }
 
-            const shadowAttrs = await loadShadowAttributes(jsFilePath);
+            const resolver =
+                options.resolveShadowOptions === null
+                    ? undefined
+                    : (options.resolveShadowOptions ?? definitionAsyncResolver);
+            const shadowOpts = resolver ? await resolver(jsFilePath) : undefined;
+            const shadowAttrs = shadowOptionsToAttributes(shadowOpts);
             let html = fTemplateToWebui(fTemplateHtml, shadowAttrs);
 
             if (options.format) {
@@ -184,8 +181,13 @@ export async function generateWebuiTemplates(
                 }
             }
 
+            const relativeDir = path.relative(distDir, path.dirname(jsFilePath));
             const webuiPath = outDir
-                ? path.resolve(outDir, `${componentBaseName}.template-webui.html`)
+                ? path.resolve(
+                      outDir,
+                      relativeDir,
+                      `${componentBaseName}.template-webui.html`,
+                  )
                 : path.resolve(
                       path.dirname(jsFilePath),
                       `${componentBaseName}.template-webui.html`,

--- a/packages/fast-test-harness/src/fixtures/ssr-fixture.pw.spec.ts
+++ b/packages/fast-test-harness/src/fixtures/ssr-fixture.pw.spec.ts
@@ -271,6 +271,28 @@ test.describe("SSR: addStyleTag buffering", () => {
     });
 });
 
+test.describe("SSR: url property", () => {
+    test.use({ tagName: "test-widget", ssr: true });
+
+    test("should be undefined before `setTemplate()` is called", async ({ fastPage }) => {
+        expect((fastPage as any).url).toBeUndefined();
+    });
+
+    test("should be set after `setTemplate()` is called", async ({ fastPage }) => {
+        await fastPage.setTemplate();
+
+        expect((fastPage as any).url).toBeDefined();
+        expect((fastPage as any).url).toMatch(/^\/ssr-.*\.html$/);
+    });
+
+    test("should match the page URL pathname", async ({ fastPage, page }) => {
+        await fastPage.setTemplate();
+
+        const pageUrl = new URL(page.url());
+        expect((fastPage as any).url).toBe(pageUrl.pathname);
+    });
+});
+
 test.describe("SSR: multiple elements", () => {
     test.use({ tagName: "test-widget", ssr: true });
 

--- a/packages/fast-test-harness/src/fixtures/ssr-fixture.ts
+++ b/packages/fast-test-harness/src/fixtures/ssr-fixture.ts
@@ -13,6 +13,19 @@ export class SSRFixture extends CSRFixture {
     private templateRendered = false;
 
     /**
+     * The internal reference to the generated fixture URL.
+     */
+    private _url?: string;
+
+    /**
+     * The URL of the generated SSR fixture page. This is set after {@link setTemplate}
+     * is called and the page navigates to the generated fixture.
+     */
+    public get url(): string | undefined {
+        return this._url;
+    }
+
+    /**
      * Creates an instance of the SSRFixture.
      *
      * @param page - The Playwright page object.
@@ -125,7 +138,8 @@ export class SSRFixture extends CSRFixture {
             throw new Error(`Invalid response from server: ${JSON.stringify(result)}`);
         }
 
-        await this.page.goto(result.url);
+        this._url = result.url;
+        await this.page.goto(this._url!);
 
         await this.waitForStability();
 

--- a/packages/fast-test-harness/src/ssr/render.test.ts
+++ b/packages/fast-test-harness/src/ssr/render.test.ts
@@ -333,4 +333,33 @@ test.describe("createSSRRenderer", () => {
         // Without matching templates the WASM renderer should still produce output.
         assert.ok("fixture" in result);
     });
+
+    test("should propagate shadowrootdelegatesfocus to DSD output", () => {
+        const { render } = createSSRRenderer({
+            tagPrefix: "test",
+            packageName: "@microsoft/fast-test-harness",
+            distDir: "test/src/test-widget",
+        });
+
+        const result = render({ tagName: "test-input", innerHTML: "" });
+
+        assert.ok(
+            result.fixture.includes("shadowrootdelegatesfocus"),
+            `DSD output should include shadowrootdelegatesfocus, got: ${result.fixture}`,
+        );
+    });
+
+    test("should not include shadowrootdelegatesfocus for components without it", () => {
+        const { render } = createSSRRenderer({
+            tagPrefix: "test",
+            components: [{ name: "widget", packageName: "@microsoft/fast-test-harness" }],
+        });
+
+        const result = render({ tagName: "test-widget", innerHTML: "hello" });
+
+        assert.ok(
+            !result.fixture.includes("shadowrootdelegatesfocus"),
+            `DSD output should not include shadowrootdelegatesfocus, got: ${result.fixture}`,
+        );
+    });
 });

--- a/packages/fast-test-harness/src/ssr/render.ts
+++ b/packages/fast-test-harness/src/ssr/render.ts
@@ -432,7 +432,6 @@ export function createSSRRenderer(options: SSRRendererOptions): {
     // Populate maps and collect default state from CEM.
     const defaultStateByTag = new Map<string, Record<string, unknown>>();
     for (const art of artifacts) {
-        const tagName = `${tagPrefix}-${art.componentName}`;
         if (art.fTemplate) {
             fTemplatesByName.set(art.componentName, art.fTemplate);
         }
@@ -456,17 +455,37 @@ export function createSSRRenderer(options: SSRRendererOptions): {
 
     // Inject styles into f-templates, then parse into the WASM
     // templates map (tag-name → inner template content).
-    const templatesMap: Record<string, string> = {};
+    const templatesMap: Record<
+        string,
+        | string
+        | {
+              content: string;
+              shadowrootAttributes: Array<{ name: string; value: string | null }>;
+          }
+    > = {};
     for (const [name, fTemplate] of fTemplatesByName) {
         const styled = renderTemplate(fTemplate, styleUrlsByName.get(name) ?? "");
         fTemplatesByName.set(name, styled);
 
-        const parsed: Array<{ name: string | null; content: string }> = JSON.parse(
-            wasm.parse_f_templates(styled),
-        );
+        const parsed: Array<{
+            name: string | null;
+            content: string;
+            shadowrootAttributes?: Array<{ name: string; value: string | null }>;
+        }> = JSON.parse(wasm.parse_f_templates(styled));
         const entry = parsed.find((t: any) => t.name !== null);
         if (entry) {
-            templatesMap[`${tagPrefix}-${name}`] = entry.content;
+            const tagName = `${tagPrefix}-${name}`;
+            const attrs = entry.shadowrootAttributes ?? [];
+            // Use the object format when there are extra shadowroot attributes
+            // beyond the default shadowrootmode, so the WASM renderer can
+            // propagate them (e.g. shadowrootdelegatesfocus) onto the DSD
+            // <template> element.
+            const hasExtraAttrs = attrs.some(
+                a => a.name !== "shadowrootmode" && a.name !== "shadowroot",
+            );
+            templatesMap[tagName] = hasExtraAttrs
+                ? { content: entry.content, shadowrootAttributes: attrs }
+                : entry.content;
         } else {
             console.warn(`No named template found for ${tagPrefix}-${name}`);
         }

--- a/packages/fast-test-harness/test/src/test-widget/input/test-input.template.html
+++ b/packages/fast-test-harness/test/src/test-widget/input/test-input.template.html
@@ -1,0 +1,5 @@
+<f-template name="test-input" shadowrootmode="open" shadowrootdelegatesfocus>
+    <template>
+        <input />
+    </template>
+</f-template>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds support for shadow DOM options (e.g. `delegatesFocus`, `mode`) throughout the test harness template generation and SSR rendering pipeline, so SSR-rendered components produce declarative shadow roots that match their client-side definitions.

Also adds a `url` property to `SSRFixture` for tests that need to control the page URL during SSR rendering.

Key changes:

- Template generation now reads shadow options from component definitions and emits matching `shadowrootmode` / `shadowrootdelegatesfocus` attributes via a pluggable resolver (`resolveShadowOptions`).
- SSR rendering propagates shadow options through to the rendered output.
- `SSRFixture` gains a `url` option.

## 📑 Test Plan

- New unit tests cover the shadow-options resolution path in `generate-templates` and `generate-webui-templates`, plus SSR `render` behavior.
- New Playwright spec verifies the `SSRFixture` `url` property.
- All existing tests pass locally via `npm run test -w @microsoft/fast-test-harness`.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.