### PR TITLE
feat: propagate <f-template> host attributes onto rendered host element

### DIFF
--- a/change/@microsoft-fast-build-b3bddb40-ecab-4fd0-b47f-780c158e9dd7.json
+++ b/change/@microsoft-fast-build-b3bddb40-ecab-4fd0-b47f-780c158e9dd7.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: propagate host attributes from inner <template> of <f-template> onto the rendered host element opening tag during SSR (static, {{expr}}, and ?name=\"{{expr}}\" bindings; author-provided host attributes win on conflict; client-only attribute prefixes @, :, f-ref, f-slotted, f-children are skipped)",
+  "packageName": "@microsoft/fast-build",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/change/@microsoft-fast-build-b3bddb40-ecab-4fd0-b47f-780c158e9dd7.json
+++ b/change/@microsoft-fast-build-b3bddb40-ecab-4fd0-b47f-780c158e9dd7.json
@@ -3,5 +3,5 @@
   "comment": "feat: propagate host attributes from inner <template> of <f-template> onto the rendered host element opening tag during SSR (static, {{expr}}, and ?name=\"{{expr}}\" bindings; author-provided host attributes win on conflict; client-only attribute prefixes @, :, f-ref, f-slotted, f-children are skipped)",
   "packageName": "@microsoft/fast-build",
   "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@microsoft-fast-html-9cc7ea2d-c00b-4d16-bf99-e33b955c0c24.json
+++ b/change/@microsoft-fast-html-9cc7ea2d-c00b-4d16-bf99-e33b955c0c24.json
@@ -3,5 +3,5 @@
   "comment": "feat: SSR-rendered output now includes host attributes declared on the inner <template> element of an <f-template> (e.g. tabindex=\"0\"), with author-provided host attributes winning on conflict and client-only prefixes (@, :, f-ref, f-slotted, f-children) skipped",
   "packageName": "@microsoft/fast-html",
   "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "patch"
+  "dependentChangeType": "none"
 }

--- a/change/@microsoft-fast-html-9cc7ea2d-c00b-4d16-bf99-e33b955c0c24.json
+++ b/change/@microsoft-fast-html-9cc7ea2d-c00b-4d16-bf99-e33b955c0c24.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: SSR-rendered output now includes host attributes declared on the inner <template> element of an <f-template> (e.g. tabindex=\"0\"), with author-provided host attributes winning on conflict and client-only prefixes (@, :, f-ref, f-slotted, f-children) skipped",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "patch"
+}

--- a/crates/microsoft-fast-build/DESIGN.md
+++ b/crates/microsoft-fast-build/DESIGN.md
@@ -52,7 +52,7 @@ render_template(template, state_str)
 | `expression.rs` | Boolean expression evaluator for `<f-when value="{{…}}">` |
 | `hydration.rs` | `HydrationScope` — binding index tracking and named marker generation per template scope |
 | `json.rs` | Hand-rolled JSON parser producing `JsonValue` |
-| `locator.rs` | `Locator` struct — maps element names to template strings; glob scanner; `<f-template>` parser |
+| `locator.rs` | `Locator` struct — maps element names to template strings; glob scanner; `<f-template>` parser. Also captures the inner `<template>` element's attributes as **host attributes** for propagation onto the rendered host element opening tag. |
 | `error.rs` | `RenderError` enum with `Display` impl and helpers |
 | `wasm.rs` | WASM bindings (`#[cfg(target_arch = "wasm32")]`) — exposes `render`, `render_with_templates`, `render_entry_with_templates`, and `parse_f_templates` to JavaScript |
 
@@ -247,8 +247,28 @@ A custom element is any opening tag whose name contains a hyphen, excluding `f-w
      - **Client-only attrs** (`@event`, `:prop`, attribute directives) — stripped as usual.
      - No `data-fe-c` marker is added — root elements at entry level have no parent hydration scope.
    - **Nested custom elements** (`is_entry: false`): `strip_client_only_attrs` removes client-only attrs after binding resolution. If the element carries `{{expr}}` or `{expr}` attribute bindings and is inside a parent hydration scope, those bindings are counted and `data-fe-c-{start}-{count}` is injected.
-8. **Strip client-only binding attributes** (`@attr` event bindings, `:attr` property bindings, and `f-ref`/`f-slotted`/`f-children` attribute directives) from all tags inside the rendered shadow template. `:attr` bindings contribute to child state in step 4 but are still removed from the rendered HTML — they are resolved by the FAST client runtime. The `data-fe-c` binding count is preserved — these bindings are still counted so the FAST client runtime allocates the correct number of binding slots.
-9. **Emit Declarative Shadow DOM** with hydration attributes:
+8. **Template host attribute propagation.** Attributes declared on the inner `<template>` element of the source `<f-template>` are merged onto the rendered host opening tag built in step 7. `merge_template_host_attrs` (in `directive.rs`) splices the surviving attributes in just before the closing `>`, resolving any bindings against `child_root` — the same child state used to render the shadow template (the root state with the host element's HTML attributes overlaid).
+   - **Client-only attrs are skipped**: any template host attr whose name starts with `@` (event) or `:` (property binding), or whose lowercased name is `f-ref`, `f-slotted`, or `f-children`, is dropped — none of these have any meaning on a server-rendered host element.
+   - **Author attributes win.** Attributes already present on the host element opening tag (the author markup) are preserved verbatim. Template host attrs whose lowercased name matches an existing author attribute are skipped. For `?name="{{expr}}"` template attrs, the dedupe key is the bare `name` (without the leading `?`).
+   - **Static `name="value"`** → emitted verbatim with the value HTML-escaped. **Static boolean `name`** (no `=`) → emitted bare.
+   - **`name="{{expr}}"`** → resolved against `child_root`. `String` / `Number` / `Bool` values are emitted as `name="value"` (HTML-escaped); `Array` / `Object` / `Null` and missing values are stripped.
+   - **`?name="{{expr}}"`** → evaluated as a boolean against `child_root`; the bare `name` (without the leading `?`) is emitted when truthy and skipped when falsy.
+   - Applies to **both** root entry-level custom elements (`is_entry: true`) and nested custom elements (`is_entry: false`).
+   - **No `data-fe-c` hydration marker is allocated** for propagated template host attrs — they are static or initial-render-only attributes on the host element, not client-side bindings.
+
+   *Worked example.* Given the template
+   ```html
+   <f-template name="my-el">
+       <template tabindex="0" ?disabled="{{isDisabled}}">…</template>
+   </f-template>
+   ```
+   the author markup `<my-el disabled></my-el>` and state `{"isDisabled": false}` render as
+   ```html
+   <my-el disabled tabindex="0">…</my-el>
+   ```
+   — the author's `disabled` is preserved verbatim, the template's `?disabled` is dropped by the dedupe rule, and `tabindex="0"` is appended.
+9. **Strip client-only binding attributes** (`@attr` event bindings, `:attr` property bindings, and `f-ref`/`f-slotted`/`f-children` attribute directives) from all tags inside the rendered shadow template. `:attr` bindings contribute to child state in step 4 but are still removed from the rendered HTML — they are resolved by the FAST client runtime. The `data-fe-c` binding count is preserved — these bindings are still counted so the FAST client runtime allocates the correct number of binding slots.
+10. **Emit Declarative Shadow DOM** with hydration attributes:
    ```html
    <my-button label="Hi">
      <template shadowrootmode="open" shadowroot="open">[shadow DOM]</template>
@@ -448,9 +468,9 @@ For each glob pattern:
 - Uses `parse_element_attributes` to get the `name` attribute value (supports both `"` and `'` quoting).
 - Collects all unique `shadowroot`-prefixed attributes from the `<f-template>` opening tag, preserving boolean attributes as `None` and lowercasing attribute names.
 - Extracts the inner HTML between `>` and `</f-template>`.
-- Calls `extract_template_content` on the inner HTML to get the content inside the `<template>` element.
+- Calls `extract_template_content` on the inner HTML to get the content **and the attributes** declared on the inner `<template>` element. The returned attribute list is preserved as the template's **host attributes**, available later via `Locator::get_host_attributes` and merged onto the rendered host opening tag by `merge_template_host_attrs` (see the **Custom elements** section above).
 
-Returns a `Vec<FTemplate>` containing the optional name, template content, and the collected shadowroot attributes. The locator stores those attributes with the template definition so custom-element rendering can apply them to the emitted Declarative Shadow DOM `<template>`.
+Returns a `Vec<FTemplate>` containing the optional name, template content, the collected shadowroot attributes, and the inner `<template>` element's host attributes. The locator stores the shadowroot attributes with the template definition so custom-element rendering can apply them to the emitted Declarative Shadow DOM `<template>`, and stores the host attributes so they can be merged onto the rendered host element opening tag.
 
 ### Glob matching
 

--- a/crates/microsoft-fast-build/src/directive.rs
+++ b/crates/microsoft-fast-build/src/directive.rs
@@ -360,6 +360,18 @@ pub fn render_custom_element(
     // Build the final opening tag, resolving {{expr}} attrs and injecting hydration attrs.
     let element_open = build_element_open_tag(&open_tag_base, open_tag_content, root, loop_vars, parent_hydration, is_entry);
 
+    // Merge attributes declared on the template's inner `<template>` element
+    // onto the rendered host opening tag. Author attributes on the host element
+    // always win on conflicts; client-only template attrs (`@`, `:`, `f-ref`,
+    // `f-slotted`, `f-children`) are skipped; `{{expr}}` / `?name="{{expr}}"`
+    // bindings resolve against `child_root` (the same state used for the shadow
+    // template).
+    let element_open = merge_template_host_attrs(
+        element_open,
+        locator.get_host_attributes(&tag_name),
+        child_root,
+    );
+
     // Extract the light DOM children (for non-self-closing elements).
     let (children, after) = if is_self_closing {
         (String::new(), tag_end)
@@ -377,6 +389,155 @@ pub fn render_custom_element(
     );
 
     Ok((output, after))
+}
+
+/// Merge `template_host_attrs` (parsed from the inner `<template …>` element)
+/// onto the already-built host opening tag string `element_open`.
+///
+/// Behaviour:
+/// - Skip client-only template attrs (`@event`, `:prop`, `f-ref`, `f-slotted`,
+///   `f-children`); these have no meaning on a server-rendered host element.
+/// - Skip any template attr whose dedupe key already appears as an author
+///   attribute on the host element — author attributes always win. The dedupe
+///   key for `?name="{{expr}}"` is the bare `name` (lowercased); for everything
+///   else it is the lowercased attribute name.
+/// - Static `name="value"` → emit ` name="html-escaped(value)"`.
+/// - `name="{{expr}}"` → resolve via `resolve_value` against `child_root`;
+///   emit ` name="resolved"` for `String` / `Number` / `Bool`; skip otherwise.
+/// - `?name="{{expr}}"` → evaluate via `evaluate` against `child_root`; emit
+///   bare ` name` when truthy; skip when falsy.
+/// - Static boolean attribute `name` → emit ` name` (no value).
+///
+/// Returns `element_open` unchanged when no attributes survive the filter.
+fn merge_template_host_attrs(
+    element_open: String,
+    template_host_attrs: &[(String, Option<String>)],
+    child_root: &JsonValue,
+) -> String {
+    if template_host_attrs.is_empty() {
+        return element_open;
+    }
+
+    // Author attribute names already present on the rendered opening tag.
+    // `element_open` always ends with `>` and never `/>` (custom elements are
+    // always rendered as non-self-closing here), so parsing the full string
+    // gives the complete attribute set including any `data-fe-c-*` marker.
+    let author_attrs = parse_element_attributes(&element_open);
+    let author_names: Vec<String> = author_attrs
+        .into_iter()
+        .map(|(name, _)| name.to_lowercase())
+        .collect();
+
+    let mut injected = String::new();
+    for (name, value) in template_host_attrs {
+        if is_client_only_attr(name) {
+            continue;
+        }
+        let dedupe_key = if let Some(bare) = name.strip_prefix('?') {
+            bare.to_lowercase()
+        } else {
+            name.to_lowercase()
+        };
+        if author_names.contains(&dedupe_key) {
+            continue;
+        }
+        format_template_host_attr(&mut injected, name, value.as_deref(), child_root);
+    }
+
+    if injected.is_empty() {
+        return element_open;
+    }
+
+    // `element_open` always ends with `>`; splice the new attrs just before it.
+    let gt_pos = match element_open.rfind('>') {
+        Some(p) => p,
+        None => return element_open,
+    };
+    let mut out = String::with_capacity(element_open.len() + injected.len());
+    out.push_str(&element_open[..gt_pos]);
+    out.push_str(&injected);
+    out.push_str(&element_open[gt_pos..]);
+    out
+}
+
+fn is_client_only_attr(name: &str) -> bool {
+    name.starts_with('@')
+        || name.starts_with(':')
+        || name.eq_ignore_ascii_case("f-ref")
+        || name.eq_ignore_ascii_case("f-slotted")
+        || name.eq_ignore_ascii_case("f-children")
+}
+
+/// Append the formatted representation of a single template-host attribute to
+/// `out`. Each emitted attribute is prefixed with a single space so it slots in
+/// before the closing `>` of the host opening tag.
+fn format_template_host_attr(
+    out: &mut String,
+    name: &str,
+    value: Option<&str>,
+    child_root: &JsonValue,
+) {
+    if let Some(bare) = name.strip_prefix('?') {
+        let expr = value
+            .and_then(|v| v.trim().strip_prefix("{{").and_then(|v| v.strip_suffix("}}")))
+            .map(|e| e.trim());
+        if let Some(expr) = expr {
+            if evaluate(expr, child_root, &[]) {
+                out.push(' ');
+                out.push_str(bare);
+            }
+        }
+        return;
+    }
+
+    match value {
+        None => {
+            // Static boolean attribute on the template element.
+            out.push(' ');
+            out.push_str(name);
+        }
+        Some(v) => {
+            let trimmed = v.trim();
+            if let Some(expr) = trimmed
+                .strip_prefix("{{")
+                .and_then(|s| s.strip_suffix("}}"))
+            {
+                let resolved = resolve_value(expr.trim(), child_root, &[])
+                    .unwrap_or(JsonValue::Null);
+                match resolved {
+                    JsonValue::String(s) => {
+                        out.push(' ');
+                        out.push_str(name);
+                        out.push_str("=\"");
+                        out.push_str(&html_escape(&s));
+                        out.push('"');
+                    }
+                    JsonValue::Number(n) => {
+                        out.push(' ');
+                        out.push_str(name);
+                        out.push_str("=\"");
+                        out.push_str(&n.to_string());
+                        out.push('"');
+                    }
+                    JsonValue::Bool(b) => {
+                        out.push(' ');
+                        out.push_str(name);
+                        out.push_str("=\"");
+                        out.push_str(if b { "true" } else { "false" });
+                        out.push('"');
+                    }
+                    // Array / Object / Null → cannot be expressed as an HTML attribute value.
+                    _ => {}
+                }
+            } else {
+                out.push(' ');
+                out.push_str(name);
+                out.push_str("=\"");
+                out.push_str(&html_escape(v));
+                out.push('"');
+            }
+        }
+    }
 }
 
 fn build_shadowroot_template_attrs(attrs: &[(String, Option<String>)]) -> String {

--- a/crates/microsoft-fast-build/src/locator.rs
+++ b/crates/microsoft-fast-build/src/locator.rs
@@ -8,12 +8,14 @@ pub(crate) struct FTemplate {
     pub name: Option<String>,
     pub content: String,
     pub shadowroot_attributes: Vec<(String, Option<String>)>,
+    pub host_attributes: Vec<(String, Option<String>)>,
 }
 
 #[derive(Debug, Clone, PartialEq, Eq)]
 struct TemplateDefinition {
     content: String,
     shadowroot_attributes: Vec<(String, Option<String>)>,
+    host_attributes: Vec<(String, Option<String>)>,
 }
 
 pub struct Locator {
@@ -83,6 +85,7 @@ impl Locator {
             templates.insert(element, TemplateDefinition {
                 content: template.content,
                 shadowroot_attributes: template.shadowroot_attributes,
+                host_attributes: template.host_attributes,
             });
         }
 
@@ -92,22 +95,48 @@ impl Locator {
     /// Create a Locator from an explicit map (useful for testing without filesystem).
     ///
     /// This API only carries template content. Shadowroot-prefixed attributes for
-    /// Declarative Shadow DOM are empty for these entries. Use [`Locator::from_patterns`]
-    /// with `<f-template>` metadata, or call [`Locator::add_template_with_shadowroot_attrs`]
-    /// for templates that need shadowroot attributes.
+    /// Declarative Shadow DOM and host attributes are empty for these entries. Use
+    /// [`Locator::from_patterns`] with `<f-template>` metadata, or call
+    /// [`Locator::add_template_with_attrs`] for templates that need shadowroot
+    /// or host attributes.
     pub fn from_templates(templates: HashMap<String, String>) -> Self {
         let templates = templates
             .into_iter()
-            .map(|(name, content)| (name, TemplateDefinition { content, shadowroot_attributes: Vec::new() }))
+            .map(|(name, content)| (name, TemplateDefinition {
+                content,
+                shadowroot_attributes: Vec::new(),
+                host_attributes: Vec::new(),
+            }))
             .collect();
         Locator { templates }
     }
 
-    #[cfg_attr(not(target_arch = "wasm32"), allow(dead_code))]
-    pub(crate) fn from_template_definitions(templates: HashMap<String, (String, Vec<(String, Option<String>)>)>) -> Self {
+    /// Create a Locator from explicit template metadata.
+    ///
+    /// Each map value is `(content, shadowroot_attributes, host_attributes)`.
+    /// `shadowroot_attributes` are forwarded to the Declarative Shadow DOM
+    /// `<template>` tag; `host_attributes` are merged onto the rendered host
+    /// element's opening tag (author attributes win on conflicts).
+    pub fn from_template_definitions(
+        templates: HashMap<
+            String,
+            (
+                String,
+                Vec<(String, Option<String>)>,
+                Vec<(String, Option<String>)>,
+            ),
+        >,
+    ) -> Self {
         let templates = templates
             .into_iter()
-            .map(|(name, (content, shadowroot_attributes))| (name, TemplateDefinition { content, shadowroot_attributes }))
+            .map(|(name, (content, shadowroot_attributes, host_attributes))| (
+                name,
+                TemplateDefinition {
+                    content,
+                    shadowroot_attributes,
+                    host_attributes,
+                },
+            ))
             .collect();
         Locator { templates }
     }
@@ -115,30 +144,41 @@ impl Locator {
     /// Add a template directly.
     ///
     /// This only stores template content. Shadowroot-prefixed attributes for
-    /// Declarative Shadow DOM are empty for this entry. Use
-    /// [`Locator::add_template_with_shadowroot_attrs`] when the rendered shadow
-    /// `<template>` needs attributes such as `shadowrootmode`.
+    /// Declarative Shadow DOM and host attributes are empty for this entry.
+    /// Use [`Locator::add_template_with_attrs`] when the rendered shadow
+    /// `<template>` needs attributes such as `shadowrootmode`, or when host
+    /// attributes from the source `<f-template>`'s inner `<template>` should
+    /// be merged onto the host element opening tag.
     pub fn add_template(&mut self, element_name: &str, content: &str) {
         self.templates.insert(element_name.to_string(), TemplateDefinition {
             content: content.to_string(),
             shadowroot_attributes: Vec::new(),
+            host_attributes: Vec::new(),
         });
     }
 
-    /// Add a template directly with shadowroot-prefixed attributes.
+    /// Add a template directly with shadowroot-prefixed attributes and host
+    /// attributes that should be merged onto the rendered host element.
     ///
-    /// Only attributes whose names begin with `shadowroot` are retained. Names
-    /// are normalized to lowercase and duplicate names are ignored, matching
-    /// `<f-template>` parsing. Use `None` for boolean attributes.
-    pub fn add_template_with_shadowroot_attrs(
+    /// `shadowroot_attrs` are filtered by [`collect_shadowroot_attributes`]:
+    /// only attributes whose names begin with `shadowroot` are retained, names
+    /// are normalized to lowercase, and duplicates are ignored. Use `None` for
+    /// boolean attributes.
+    ///
+    /// `host_attrs` are stored verbatim in source order — the renderer is
+    /// responsible for filtering client-only attributes and resolving any
+    /// `{{expr}}` / `?name="{{expr}}"` bindings against the child state.
+    pub fn add_template_with_attrs(
         &mut self,
         element_name: &str,
         content: &str,
-        attrs: &[(String, Option<String>)],
+        shadowroot_attrs: &[(String, Option<String>)],
+        host_attrs: &[(String, Option<String>)],
     ) {
         self.templates.insert(element_name.to_string(), TemplateDefinition {
             content: content.to_string(),
-            shadowroot_attributes: collect_shadowroot_attributes(attrs),
+            shadowroot_attributes: collect_shadowroot_attributes(shadowroot_attrs),
+            host_attributes: host_attrs.to_vec(),
         });
     }
 
@@ -150,6 +190,13 @@ impl Locator {
         self.templates
             .get(element_name)
             .map(|template| template.shadowroot_attributes.as_slice())
+            .unwrap_or(&[])
+    }
+
+    pub fn get_host_attributes(&self, element_name: &str) -> &[(String, Option<String>)] {
+        self.templates
+            .get(element_name)
+            .map(|template| template.host_attributes.as_slice())
             .unwrap_or(&[])
     }
 
@@ -194,12 +241,13 @@ pub(crate) fn parse_f_templates(html: &str) -> Vec<FTemplate> {
             None => break,
         };
         let inner_html = &html[inner_start..inner_end];
-        let content = extract_template_content(inner_html);
+        let (content, host_attributes) = extract_template_content(inner_html);
 
         results.push(FTemplate {
             name,
             content,
             shadowroot_attributes,
+            host_attributes,
         });
         search_start = inner_end + end_tag.len();
     }
@@ -220,22 +268,27 @@ fn collect_shadowroot_attributes(attrs: &[(String, Option<String>)]) -> Vec<(Str
     results
 }
 
-/// Extract the inner content of the first `<template>` element found in `html`.
-/// Returns the trimmed content between `<template ...>` and `</template>`.
-fn extract_template_content(html: &str) -> String {
+/// Extract the inner content and the opening-tag attributes of the first
+/// `<template>` element found in `html`. Returns the trimmed inner content
+/// and the attributes parsed from the inner `<template …>` opening tag.
+///
+/// If no `<template>` element is found, returns the trimmed input with an
+/// empty attribute list.
+fn extract_template_content(html: &str) -> (String, Vec<(String, Option<String>)>) {
     let open = match html.find("<template") {
         Some(i) => i,
-        None => return html.trim().to_string(),
+        None => return (html.trim().to_string(), Vec::new()),
     };
-    let tag_end = match html[open..].find('>') {
-        Some(i) => open + i + 1,
-        None => return html.trim().to_string(),
+    let tag_end = match find_tag_end(html, open) {
+        Some(i) => i,
+        None => return (html.trim().to_string(), Vec::new()),
     };
     let close = match html[tag_end..].find("</template>") {
         Some(i) => tag_end + i,
-        None => return html.trim().to_string(),
+        None => return (html.trim().to_string(), Vec::new()),
     };
-    html[tag_end..close].trim().to_string()
+    let attrs = parse_element_attributes(&html[open..tag_end]);
+    (html[tag_end..close].trim().to_string(), attrs)
 }
 
 
@@ -401,6 +454,7 @@ mod tests {
         assert_eq!(results[0].name, Some("my-button".to_string()));
         assert_eq!(results[0].content, "<button>{{label}}</button>");
         assert!(results[0].shadowroot_attributes.is_empty());
+        assert!(results[0].host_attributes.is_empty());
     }
 
     #[test]
@@ -415,8 +469,10 @@ mod tests {
         assert_eq!(results.len(), 2);
         assert_eq!(results[0].name, Some("my-a".to_string()));
         assert_eq!(results[0].content, "<span>A</span>");
+        assert!(results[0].host_attributes.is_empty());
         assert_eq!(results[1].name, Some("my-b".to_string()));
         assert_eq!(results[1].content, "<div>B</div>");
+        assert!(results[1].host_attributes.is_empty());
     }
 
     #[test]
@@ -427,6 +483,7 @@ mod tests {
         let results = parse_f_templates(html);
         assert_eq!(results.len(), 1);
         assert_eq!(results[0].name, None);
+        assert!(results[0].host_attributes.is_empty());
     }
 
     #[test]
@@ -444,10 +501,43 @@ mod tests {
                 ("shadowrootclonable".to_string(), Some("true".to_string())),
             ]
         );
+        assert!(results[0].host_attributes.is_empty());
     }
 
     #[test]
-    fn test_add_template_with_shadowroot_attrs_preserves_attrs() {
+    fn test_parse_f_templates_host_attributes() {
+        let html = r#"<f-template name="my-el">
+    <template tabindex="0" @click="{handle()}" attr="{{val}}"><span>x</span></template>
+</f-template>"#;
+        let results = parse_f_templates(html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(
+            results[0].host_attributes,
+            vec![
+                ("tabindex".to_string(), Some("0".to_string())),
+                ("@click".to_string(), Some("{handle()}".to_string())),
+                ("attr".to_string(), Some("{{val}}".to_string())),
+            ]
+        );
+    }
+
+    #[test]
+    fn test_parse_f_templates_host_attributes_with_quoted_gt() {
+        // A `>` inside a quoted attribute value must not terminate the opening tag.
+        let html = r#"<f-template name="my-el">
+    <template data-x="a>b"><span>x</span></template>
+</f-template>"#;
+        let results = parse_f_templates(html);
+        assert_eq!(results.len(), 1);
+        assert_eq!(results[0].content, "<span>x</span>");
+        assert_eq!(
+            results[0].host_attributes,
+            vec![("data-x".to_string(), Some("a>b".to_string()))]
+        );
+    }
+
+    #[test]
+    fn test_add_template_with_attrs_shadowroot_only() {
         let mut locator = Locator::from_templates(std::collections::HashMap::new());
         let attrs = vec![
             ("shadowrootmode".to_string(), Some("closed".to_string())),
@@ -455,16 +545,55 @@ mod tests {
             ("shadowrootclonable".to_string(), Some("true".to_string())),
         ];
 
-        locator.add_template_with_shadowroot_attrs("my-el", "<span>shadow</span>", &attrs);
+        locator.add_template_with_attrs("my-el", "<span>shadow</span>", &attrs, &[]);
 
         assert_eq!(locator.get_template("my-el"), Some("<span>shadow</span>"));
         assert_eq!(locator.get_shadowroot_attributes("my-el"), attrs.as_slice());
+        assert!(locator.get_host_attributes("my-el").is_empty());
+    }
+
+    #[test]
+    fn test_add_template_with_attrs_shadowroot_and_host() {
+        let mut locator = Locator::from_templates(std::collections::HashMap::new());
+        let shadowroot_attrs = vec![
+            ("shadowrootmode".to_string(), Some("closed".to_string())),
+        ];
+        let host_attrs = vec![
+            ("tabindex".to_string(), Some("0".to_string())),
+            ("?disabled".to_string(), Some("{{isDisabled}}".to_string())),
+        ];
+
+        locator.add_template_with_attrs(
+            "my-el",
+            "<span>x</span>",
+            &shadowroot_attrs,
+            &host_attrs,
+        );
+
+        assert_eq!(locator.get_template("my-el"), Some("<span>x</span>"));
+        assert_eq!(locator.get_shadowroot_attributes("my-el"), shadowroot_attrs.as_slice());
+        assert_eq!(locator.get_host_attributes("my-el"), host_attrs.as_slice());
     }
 
     #[test]
     fn test_extract_template_content_basic() {
         let html = "    <template>\n        <button>click</button>\n    </template>\n";
-        let content = extract_template_content(html);
+        let (content, attrs) = extract_template_content(html);
         assert_eq!(content, "<button>click</button>");
+        assert!(attrs.is_empty());
+    }
+
+    #[test]
+    fn test_extract_template_content_with_attrs() {
+        let html = "<template tabindex=\"0\" ?disabled=\"{{isDisabled}}\"><span>x</span></template>";
+        let (content, attrs) = extract_template_content(html);
+        assert_eq!(content, "<span>x</span>");
+        assert_eq!(
+            attrs,
+            vec![
+                ("tabindex".to_string(), Some("0".to_string())),
+                ("?disabled".to_string(), Some("{{isDisabled}}".to_string())),
+            ]
+        );
     }
 }

--- a/crates/microsoft-fast-build/src/wasm.rs
+++ b/crates/microsoft-fast-build/src/wasm.rs
@@ -90,16 +90,17 @@ pub fn parse_f_templates(html: &str) -> String {
             None => "null".to_string(),
         };
         parts.push(format!(
-            "{{\"name\":{},\"content\":\"{}\",\"shadowrootAttributes\":{}}}",
+            "{{\"name\":{},\"content\":\"{}\",\"shadowrootAttributes\":{},\"hostAttributes\":{}}}",
             name_json,
             escape_json_str(&template.content),
-            shadowroot_attributes_json(&template.shadowroot_attributes)
+            attribute_pairs_json(&template.shadowroot_attributes),
+            attribute_pairs_json(&template.host_attributes)
         ));
     }
     format!("[{}]", parts.join(","))
 }
 
-fn shadowroot_attributes_json(attrs: &[(String, Option<String>)]) -> String {
+fn attribute_pairs_json(attrs: &[(String, Option<String>)]) -> String {
     let mut parts = Vec::with_capacity(attrs.len());
     for (name, value) in attrs {
         let value_json = match value {
@@ -132,7 +133,17 @@ fn escape_json_str(s: &str) -> String {
 
 fn parse_templates_map(
     templates_json: &str,
-) -> Result<HashMap<String, (String, Vec<(String, Option<String>)>)>, JsValue> {
+) -> Result<
+    HashMap<
+        String,
+        (
+            String,
+            Vec<(String, Option<String>)>,
+            Vec<(String, Option<String>)>,
+        ),
+    >,
+    JsValue,
+> {
     let parsed = json::parse(templates_json).map_err(|e| {
         JsValue::from_str(&format!("Failed to parse templates JSON: {}", e.message))
     })?;
@@ -142,7 +153,7 @@ fn parse_templates_map(
             for (k, v) in obj {
                 match v {
                     json::JsonValue::String(s) => {
-                        map.insert(k, (s, Vec::new()));
+                        map.insert(k, (s, Vec::new(), Vec::new()));
                     }
                     json::JsonValue::Object(template) => {
                         map.insert(k.clone(), parse_template_metadata(&k, &template)?);
@@ -164,7 +175,14 @@ fn parse_templates_map(
 fn parse_template_metadata(
     template_name: &str,
     template: &HashMap<String, json::JsonValue>,
-) -> Result<(String, Vec<(String, Option<String>)>), JsValue> {
+) -> Result<
+    (
+        String,
+        Vec<(String, Option<String>)>,
+        Vec<(String, Option<String>)>,
+    ),
+    JsValue,
+> {
     let content = match template.get("content") {
         Some(json::JsonValue::String(content)) => content.clone(),
         _ => {
@@ -175,8 +193,10 @@ fn parse_template_metadata(
         }
     };
 
-    let attrs = match template.get("shadowrootAttributes") {
-        Some(json::JsonValue::Array(attrs)) => parse_shadowroot_attributes(template_name, attrs)?,
+    let shadowroot_attrs = match template.get("shadowrootAttributes") {
+        Some(json::JsonValue::Array(attrs)) => {
+            parse_attribute_pairs(template_name, "shadowroot", attrs)?
+        }
         Some(json::JsonValue::Null) | None => Vec::new(),
         Some(_) => {
             return Err(JsValue::from_str(&format!(
@@ -186,11 +206,25 @@ fn parse_template_metadata(
         }
     };
 
-    Ok((content, attrs))
+    let host_attrs = match template.get("hostAttributes") {
+        Some(json::JsonValue::Array(attrs)) => {
+            parse_attribute_pairs(template_name, "host", attrs)?
+        }
+        Some(json::JsonValue::Null) | None => Vec::new(),
+        Some(_) => {
+            return Err(JsValue::from_str(&format!(
+                "Template metadata for '{}' must use an array hostAttributes property",
+                template_name
+            )));
+        }
+    };
+
+    Ok((content, shadowroot_attrs, host_attrs))
 }
 
-fn parse_shadowroot_attributes(
+fn parse_attribute_pairs(
     template_name: &str,
+    kind: &str,
     attrs: &[json::JsonValue],
 ) -> Result<Vec<(String, Option<String>)>, JsValue> {
     let mut parsed = Vec::with_capacity(attrs.len());
@@ -199,8 +233,8 @@ fn parse_shadowroot_attributes(
             json::JsonValue::Object(attr) => attr,
             _ => {
                 return Err(JsValue::from_str(&format!(
-                    "Template metadata for '{}' contains a non-object shadowroot attribute",
-                    template_name
+                    "Template metadata for '{}' contains a non-object {} attribute",
+                    template_name, kind
                 )));
             }
         };
@@ -208,8 +242,8 @@ fn parse_shadowroot_attributes(
             Some(json::JsonValue::String(name)) => name.clone(),
             _ => {
                 return Err(JsValue::from_str(&format!(
-                    "Template metadata for '{}' contains a shadowroot attribute without a string name",
-                    template_name
+                    "Template metadata for '{}' contains a {} attribute without a string name",
+                    template_name, kind
                 )));
             }
         };
@@ -218,8 +252,8 @@ fn parse_shadowroot_attributes(
             Some(json::JsonValue::Null) | None => None,
             _ => {
                 return Err(JsValue::from_str(&format!(
-                    "Template metadata for '{}' contains a shadowroot attribute with a non-string value",
-                    template_name
+                    "Template metadata for '{}' contains a {} attribute with a non-string value",
+                    template_name, kind
                 )));
             }
         };
@@ -246,6 +280,44 @@ mod tests {
             .expect("template should be present")
             .1;
         assert!(attrs.is_empty());
+    }
+
+    #[test]
+    fn parse_templates_map_treats_null_host_attributes_as_empty() {
+        let templates = match parse_templates_map(
+            r#"{"test-element":{"content":"<span></span>","hostAttributes":null}}"#,
+        ) {
+            Ok(templates) => templates,
+            Err(_) => panic!("template metadata with null hostAttributes should parse"),
+        };
+
+        let attrs = &templates
+            .get("test-element")
+            .expect("template should be present")
+            .2;
+        assert!(attrs.is_empty());
+    }
+
+    #[test]
+    fn parse_templates_map_reads_host_attributes() {
+        let templates = match parse_templates_map(
+            r#"{"test-element":{"content":"<span></span>","hostAttributes":[{"name":"tabindex","value":"0"},{"name":"disabled","value":null}]}}"#,
+        ) {
+            Ok(templates) => templates,
+            Err(_) => panic!("template metadata with hostAttributes should parse"),
+        };
+
+        let host = &templates
+            .get("test-element")
+            .expect("template should be present")
+            .2;
+        assert_eq!(
+            host,
+            &vec![
+                ("tabindex".to_string(), Some("0".to_string())),
+                ("disabled".to_string(), None),
+            ]
+        );
     }
 }
 

--- a/crates/microsoft-fast-build/tests/common/mod.rs
+++ b/crates/microsoft-fast-build/tests/common/mod.rs
@@ -19,6 +19,34 @@ pub fn make_locator(entries: &[(&str, &str)]) -> Locator {
     Locator::from_templates(templates)
 }
 
+/// Build a `Locator` where each entry specifies host attributes that should be
+/// merged onto the rendered host element opening tag. `host_attrs` mirrors the
+/// shape produced by `<f-template>` parsing: `(name, Option<value>)` pairs in
+/// source order. `None` denotes a static boolean attribute (no `=`).
+pub fn make_locator_with_host_attrs(
+    entries: &[(&str, &str, &[(&str, Option<&str>)])],
+) -> Locator {
+    let mut templates: HashMap<
+        String,
+        (
+            String,
+            Vec<(String, Option<String>)>,
+            Vec<(String, Option<String>)>,
+        ),
+    > = HashMap::new();
+    for (name, content, host_attrs) in entries {
+        let host = host_attrs
+            .iter()
+            .map(|(n, v)| ((*n).to_string(), v.map(|s| s.to_string())))
+            .collect();
+        templates.insert(
+            (*name).to_string(),
+            ((*content).to_string(), Vec::new(), host),
+        );
+    }
+    Locator::from_template_definitions(templates)
+}
+
 pub fn empty_root() -> JsonValue {
     JsonValue::Object(HashMap::new())
 }

--- a/crates/microsoft-fast-build/tests/host_attributes.rs
+++ b/crates/microsoft-fast-build/tests/host_attributes.rs
@@ -1,0 +1,295 @@
+mod common;
+use common::make_locator_with_host_attrs;
+use microsoft_fast_build::{render_entry_template_with_locator, render_template_with_locator};
+
+// ── static template host attribute propagation ────────────────────────────────
+
+#[test]
+fn test_template_static_host_attr_propagates() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("tabindex", Some("0"))],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el></my-el>"#,
+        r#"{}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    assert!(
+        result.contains(r#"<my-el tabindex="0">"#),
+        "expected template tabindex on host: {result}"
+    );
+}
+
+#[test]
+fn test_template_static_host_attr_with_value_html_escapes() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("data-x", Some("<&>"))],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el></my-el>"#,
+        r#"{}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    assert!(
+        result.contains(r#"<my-el data-x="&lt;&amp;&gt;">"#),
+        "expected HTML-escaped value on host: {result}"
+    );
+}
+
+#[test]
+fn test_template_static_bool_host_attr_propagates() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("hidden", None)],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el></my-el>"#,
+        r#"{}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    assert!(
+        result.contains("<my-el hidden>"),
+        "expected static boolean attr on host: {result}"
+    );
+}
+
+// ── author wins on conflicts ──────────────────────────────────────────────────
+
+#[test]
+fn test_author_attr_overrides_template_host_attr() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("id", Some("from-template"))],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el id="from-author"></my-el>"#,
+        r#"{}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    assert!(
+        result.contains(r#"id="from-author""#),
+        "author id should be preserved: {result}"
+    );
+    assert!(
+        !result.contains(r#"id="from-template""#),
+        "template id should NOT appear: {result}"
+    );
+}
+
+#[test]
+fn test_author_disabled_wins_over_template_bool_binding() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("?disabled", Some("{{isDisabled}}"))],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el disabled></my-el>"#,
+        r#"{"isDisabled": false}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    assert!(
+        result.contains("<my-el disabled"),
+        "author disabled should remain even when template binding is falsy: {result}"
+    );
+}
+
+// ── client-only template host attributes are skipped ──────────────────────────
+
+#[test]
+fn test_client_only_template_host_attrs_skipped() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[
+            ("@click", Some("{x()}")),
+            (":title", Some("{t}")),
+            ("f-ref", Some("{r}")),
+            ("f-slotted", Some("{s}")),
+            ("f-children", Some("{c}")),
+        ],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el></my-el>"#,
+        r#"{}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    let host_open_end = result.find('>').expect("opening tag should end");
+    let host_open = &result[..=host_open_end];
+    assert!(!host_open.contains('@'), "@event must not appear: {host_open}");
+    assert!(!host_open.contains(':'), ":prop must not appear: {host_open}");
+    assert!(
+        !host_open.to_lowercase().contains("f-ref"),
+        "f-ref must not appear: {host_open}"
+    );
+    assert!(
+        !host_open.to_lowercase().contains("f-slotted"),
+        "f-slotted must not appear: {host_open}"
+    );
+    assert!(
+        !host_open.to_lowercase().contains("f-children"),
+        "f-children must not appear: {host_open}"
+    );
+}
+
+// ── ?attr="{{expr}}" boolean binding ──────────────────────────────────────────
+
+#[test]
+fn test_template_host_bool_binding_truthy() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("?disabled", Some("{{isDisabled}}"))],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el></my-el>"#,
+        r#"{"isDisabled": true}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    let host_open_end = result.find('>').expect("opening tag should end");
+    let host_open = &result[..=host_open_end];
+    assert!(
+        host_open.contains(" disabled"),
+        "bare `disabled` should appear when binding is truthy: {host_open}"
+    );
+    assert!(
+        !host_open.contains("?disabled"),
+        "`?` prefix must not leak through: {host_open}"
+    );
+    assert!(
+        !host_open.contains("disabled="),
+        "no `=` should be emitted for boolean binding: {host_open}"
+    );
+}
+
+#[test]
+fn test_template_host_bool_binding_falsy() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("?disabled", Some("{{isDisabled}}"))],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el></my-el>"#,
+        r#"{"isDisabled": false}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    let host_open_end = result.find('>').expect("opening tag should end");
+    let host_open = &result[..=host_open_end];
+    assert!(
+        !host_open.contains("disabled"),
+        "no `disabled` should appear when binding is falsy: {host_open}"
+    );
+}
+
+// ── attr="{{expr}}" value binding ─────────────────────────────────────────────
+
+#[test]
+fn test_template_host_value_binding_resolves_primitive() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("title", Some("{{tip}}"))],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el></my-el>"#,
+        r#"{"tip": "hello"}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    assert!(
+        result.contains(r#"<my-el title="hello">"#),
+        "primitive value should be emitted: {result}"
+    );
+}
+
+#[test]
+fn test_template_host_value_binding_strips_nonprimitive() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("title", Some("{{obj}}"))],
+    )]);
+    let result = render_template_with_locator(
+        r#"<my-el></my-el>"#,
+        r#"{"obj": {"a": 1}}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    let host_open_end = result.find('>').expect("opening tag should end");
+    let host_open = &result[..=host_open_end];
+    assert!(
+        !host_open.contains("title"),
+        "object value should not produce a `title` attribute: {host_open}"
+    );
+}
+
+// ── entry-mode propagation ────────────────────────────────────────────────────
+
+#[test]
+fn test_template_host_attr_propagates_in_entry_mode() {
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("tabindex", Some("0"))],
+    )]);
+    let result = render_entry_template_with_locator(
+        r#"<my-el></my-el>"#,
+        r#"{}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    assert!(
+        result.contains(r#"<my-el tabindex="0">"#),
+        "expected template tabindex on entry host: {result}"
+    );
+}
+
+#[test]
+fn test_template_host_value_binding_resolves_against_child_root_in_entry_mode() {
+    // Entry mode: when the author element has a state-relevant attribute, the
+    // child state is built from root + the attr overlay. Template-host bindings
+    // resolve against that child state, so `tip` from the attribute overlay
+    // wins over `tip` in the root.
+    let locator = make_locator_with_host_attrs(&[(
+        "my-el",
+        "<span>x</span>",
+        &[("title", Some("{{tip}}"))],
+    )]);
+    let result = render_entry_template_with_locator(
+        r#"<my-el tip="from-attr"></my-el>"#,
+        r#"{"tip": "from-root"}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+    assert!(
+        result.contains(r#"title="from-attr""#),
+        "title should resolve against the child state (attribute overlay): {result}"
+    );
+}

--- a/packages/fast-build/DESIGN.md
+++ b/packages/fast-build/DESIGN.md
@@ -109,6 +109,7 @@ Template HTML files are scanned for `<f-template>` elements. Each `<f-template>`
 - The `name` attribute value becomes the element name key in the templates map.
 - The inner content of the `<template>` child element becomes the raw template string sent to the WASM renderer.
 - Any `shadowroot`-prefixed attributes on `<f-template>` become `shadowrootAttributes` metadata that the WASM renderer applies to the emitted Declarative Shadow DOM `<template>`.
+- Any attributes declared on the inner `<template>` element become `hostAttributes` metadata (parallel to `shadowrootAttributes`). The WASM renderer merges these onto the rendered host element opening tag, with author host attributes winning on conflicts. See the [`microsoft-fast-build` DESIGN.md](../../crates/microsoft-fast-build/DESIGN.md) for the full propagation rules (client-only attrs are skipped, `{{expr}}` / `?name="{{expr}}"` are resolved against the element's child state, etc.).
 - A file may contain multiple `<f-template>` elements (each becomes a separate entry).
 - If an `<f-template>` has no `name` attribute, a warning is printed to stderr and it is skipped.
 
@@ -116,7 +117,7 @@ Template HTML files are scanned for `<f-template>` elements. Each `<f-template>`
 
 | Function | Role |
 |----------|------|
-| `parseFTemplates(html, filePath, wasm)` | Calls `wasm.parse_f_templates(html)` and emits warnings for nameless templates |
+| `parseFTemplates(html, filePath, wasm)` | Calls `wasm.parse_f_templates(html)` and emits warnings for nameless templates. Returns `{name, content, shadowrootAttributes, hostAttributes}` entries. |
 
 The `<f-template>` parsing logic lives exclusively in the Rust crate (`locator::parse_f_templates`) and is exposed via the `wasm.parse_f_templates` WASM export. The JS layer only handles warnings and file I/O; it contains no duplicate parsing logic.
 
@@ -154,7 +155,7 @@ Four WASM functions are available; the CLI uses the entry renderer when template
 | `wasm.render_entry_with_templates(entry, templatesJson, state?, strategy)` | CLI entry HTML rendering when at least one template was loaded. Omitted state renders as `{}`. `strategy` is `"camelCase"` or `"none"`. |
 | `wasm.parse_f_templates(html)` | Parsing `<f-template>` elements from each matched HTML file |
 
-`templatesJson` is a JSON-stringified object mapping element names to template metadata objects. Each object contains the raw inner template string extracted from `<template>` inside `<f-template>` and any forwarded `shadowrootAttributes`. The WASM renderer uses this map to resolve custom element tags and inject Declarative Shadow DOM, copying `shadowroot*` attributes to the emitted `<template>`. It normalizes `shadowrootmode` and legacy `shadowroot` for compatibility: when neither has a non-empty value, it emits `shadowrootmode="open" shadowroot="open"`; when exactly one has a non-empty value, that value is mirrored to the other; when both have explicit non-empty values, both are preserved as authored, even if they conflict.
+`templatesJson` is a JSON-stringified object mapping element names to template metadata objects. Each object contains the raw inner template string extracted from `<template>` inside `<f-template>`, any forwarded `shadowrootAttributes`, and a `hostAttributes` array carrying the attributes declared on the inner `<template>` element. The WASM renderer uses this map to resolve custom element tags and inject Declarative Shadow DOM, copying `shadowroot*` attributes to the emitted `<template>` and merging `hostAttributes` onto the rendered host element opening tag (author host attributes win on conflicts; client-only attrs and `{{expr}}` / `?name="{{expr}}"` bindings are handled by the WASM renderer — see the [`microsoft-fast-build` DESIGN.md](../../crates/microsoft-fast-build/DESIGN.md) for details). It normalizes `shadowrootmode` and legacy `shadowroot` for compatibility: when neither has a non-empty value, it emits `shadowrootmode="open" shadowroot="open"`; when exactly one has a non-empty value, that value is mirrored to the other; when both have explicit non-empty values, both are preserved as authored, even if they conflict.
 
 See the [`microsoft-fast-build` DESIGN.md](../../crates/microsoft-fast-build/DESIGN.md) for details on the Rust rendering pipeline.
 

--- a/packages/fast-build/bin/fast.js
+++ b/packages/fast-build/bin/fast.js
@@ -223,13 +223,13 @@ function staticPrefixDir(pattern) {
  * @param {string} html
  * @param {string} filePath - used in warning messages
  * @param {object} wasm - the loaded WASM module
- * @returns {{ name: string, content: string, shadowrootAttributes: { name: string, value: string | null }[] }[]}
+ * @returns {{ name: string, content: string, shadowrootAttributes: { name: string, value: string | null }[], hostAttributes: { name: string, value: string | null }[] }[]}
  */
 function parseFTemplates(html, filePath, wasm) {
-    /** @type {{ name: string | null, content: string, shadowrootAttributes?: { name: string, value: string | null }[] }[]} */
+    /** @type {{ name: string | null, content: string, shadowrootAttributes?: { name: string, value: string | null }[], hostAttributes?: { name: string, value: string | null }[] }[]} */
     const parsed = JSON.parse(wasm.parse_f_templates(html));
     const results = [];
-    for (const { name, content, shadowrootAttributes } of parsed) {
+    for (const { name, content, shadowrootAttributes, hostAttributes } of parsed) {
         if (name === null) {
             process.stderr.write(
                 `Warning: <f-template> without a 'name' attribute in '${filePath}': ${content.trim()}\n`
@@ -239,6 +239,7 @@ function parseFTemplates(html, filePath, wasm) {
                 name,
                 content,
                 shadowrootAttributes: shadowrootAttributes || [],
+                hostAttributes: hostAttributes || [],
             });
         }
     }
@@ -252,7 +253,7 @@ function parseFTemplates(html, filePath, wasm) {
  * Warns (but does not error) if the base directory does not exist.
  * @param {string} pattern
  * @param {object} wasm - the loaded WASM module
- * @returns {{ name: string, content: string, shadowrootAttributes: { name: string, value: string | null }[] }[]}
+ * @returns {{ name: string, content: string, shadowrootAttributes: { name: string, value: string | null }[], hostAttributes: { name: string, value: string | null }[] }[]}
  */
 function resolvePattern(pattern, wasm) {
     const baseDir = staticPrefixDir(pattern);
@@ -266,8 +267,8 @@ function resolvePattern(pattern, wasm) {
         if (globMatch(pattern, file)) {
             const html = fs.readFileSync(file, "utf8");
             const templates = parseFTemplates(html, file, wasm);
-            for (const { name, content, shadowrootAttributes } of templates) {
-                results.push({ name, content, shadowrootAttributes });
+            for (const { name, content, shadowrootAttributes, hostAttributes } of templates) {
+                results.push({ name, content, shadowrootAttributes, hostAttributes });
             }
         }
     }
@@ -313,13 +314,13 @@ async function runBuild(args) {
                     `Warning: No template files found for pattern "${pattern}".\n`
                 );
             }
-            for (const { name, content, shadowrootAttributes } of matches) {
+            for (const { name, content, shadowrootAttributes, hostAttributes } of matches) {
                 if (name in templatesMap) {
                     process.stderr.write(
                         `Warning: Duplicate template name "${name}" — later file overwrites earlier.\n`
                     );
                 }
-                templatesMap[name] = { content, shadowrootAttributes };
+                templatesMap[name] = { content, shadowrootAttributes, hostAttributes };
             }
         }
     }

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -461,6 +461,12 @@ When `templateOptions: "defer-and-hydrate"` is used, the server must render:
 2. A `<template shadowrootmode="open" shadowroot="open">` containing pre-rendered HTML annotated with FAST's hydration markers. Build-time renderers keep both attributes for Declarative Shadow DOM compatibility and may forward additional `shadowroot`-prefixed attributes from the source `<f-template>`.
 3. An `<f-template>` element somewhere in the page that carries the template definition.
 
+### Host attributes from the source `<f-template>`
+
+Build-time renderers (e.g. `@microsoft/fast-build`) forward attributes declared on the inner `<template>` element of an `<f-template>` onto the rendered host element opening tag. Static attributes are forwarded verbatim (HTML-escaped); `name="{{expr}}"` and `?name="{{expr}}"` are resolved against the element's initial child state (the root state with the host element's HTML attributes overlaid). Client-only attributes (`@event`, `:prop`, `f-ref`, `f-slotted`, `f-children`) are skipped — they have no meaning on a server-rendered host element.
+
+Author attributes on the host element always win on conflicts (case-insensitive name match; for `?name="{{expr}}"` template attrs, the dedupe key is the bare `name` without the leading `?`). The hydration marker formats described below are unchanged — no additional `data-fe-c` marker is allocated for these propagated attributes.
+
 ### Hydration marker formats
 
 **Content bindings** use HTML comments:

--- a/packages/fast-html/RENDERING.md
+++ b/packages/fast-html/RENDERING.md
@@ -375,6 +375,42 @@ Should result in:
 <!--fe-b$$end$$0$$t01oHhokPY$$fe-b-->
 ```
 
+### Host attributes from `<f-template>`
+
+Build-time renderers (e.g. `@microsoft/fast-build`) forward attributes declared on the inner `<template>` element of an `<f-template>` onto the rendered host element opening tag.
+
+Example template:
+```html
+<f-template name="my-button">
+    <template tabindex="0" ?disabled="{{isDisabled}}">
+        <button><slot></slot></button>
+    </template>
+</f-template>
+```
+
+Combined with author HTML `<my-button></my-button>` and state:
+```json
+{
+    "isDisabled": true
+}
+```
+
+Should result in:
+```html
+<my-button tabindex="0" disabled defer-hydration needs-hydration>
+    <template shadowrootmode="open" shadowroot="open">
+        <button><slot></slot></button>
+    </template>
+</my-button>
+```
+
+Rules:
+- Client-only attributes (`@event`, `:prop`, `f-ref`, `f-slotted`, `f-children`) are skipped — they have no meaning on a server-rendered host element.
+- Author attributes on the host element always win on conflicts (case-insensitive name match; the dedupe key for `?name="{{expr}}"` is the bare `name`).
+- Static `name="value"` is forwarded verbatim (HTML-escaped); static boolean `name` is emitted bare.
+- `name="{{expr}}"` is resolved against the element's initial child state; primitives are emitted as `name="value"`, `Array` / `Object` / `Null` and missing values are stripped.
+- `?name="{{expr}}"` is evaluated as a boolean against the same state; the bare `name` (without `?`) is emitted when truthy and skipped when falsy.
+
 ### Client Side Bindings
 
 Client side bindings are bindings which the client needs, but they are not necessary as part of an initial render. These must still be accounted for when creating hydration comments however, as the template needs to know which elements to attach these bindings to. There are two types of client side bindings, events and attribute directives. These do not require state as they are bound to class methods or properties.

--- a/packages/fast-html/test/fixtures/host-bindings/entry.html
+++ b/packages/fast-html/test/fixtures/host-bindings/entry.html
@@ -1,27 +1,28 @@
 <!DOCTYPE html>
+<!-- biome-ignore-all format: SSR-rendered output binding markers must survive byte-for-byte -->
 <html lang="en-US">
     <head>
         <meta charset="utf-8">
         <title>Host Bindings Test</title>
         <style>
         /* Ensure custom elements display as block to prevent overlap */
-        host-event-element,
-        host-multi-element,
-        host-static-element,
-        host-events-element,
-        host-multi-content-element,
-        host-text-binding-element,
-        host-property-element,
-        host-all-types-element,
-        host-perm-attr-first,
-        host-perm-bool-first,
-        host-perm-prop-first,
-        host-autofocus {
-            display: block;
-            margin: 10px 0;
-            padding: 10px;
-            border: 1px solid #ccc;
-        }
+host-event-element,
+host-multi-element,
+host-static-element,
+host-events-element,
+host-multi-content-element,
+host-text-binding-element,
+host-property-element,
+host-all-types-element,
+host-perm-attr-first,
+host-perm-bool-first,
+host-perm-prop-first,
+host-autofocus {
+    display: block;
+    margin: 10px 0;
+    padding: 10px;
+    border: 1px solid #ccc;
+}
         </style>
     </head>
     <body>

--- a/packages/fast-html/test/fixtures/host-bindings/entry.html
+++ b/packages/fast-html/test/fixtures/host-bindings/entry.html
@@ -4,23 +4,24 @@
         <meta charset="utf-8">
         <title>Host Bindings Test</title>
         <style>
-            /* Ensure custom elements display as block to prevent overlap */
-            host-event-element,
-            host-multi-element,
-            host-static-element,
-            host-events-element,
-            host-multi-content-element,
-            host-text-binding-element,
-            host-property-element,
-            host-all-types-element,
-            host-perm-attr-first,
-            host-perm-bool-first,
-            host-perm-prop-first {
-                display: block;
-                margin: 10px 0;
-                padding: 10px;
-                border: 1px solid #ccc;
-            }
+        /* Ensure custom elements display as block to prevent overlap */
+        host-event-element,
+        host-multi-element,
+        host-static-element,
+        host-events-element,
+        host-multi-content-element,
+        host-text-binding-element,
+        host-property-element,
+        host-all-types-element,
+        host-perm-attr-first,
+        host-perm-bool-first,
+        host-perm-prop-first,
+        host-autofocus {
+            display: block;
+            margin: 10px 0;
+            padding: 10px;
+            border: 1px solid #ccc;
+        }
         </style>
     </head>
     <body>
@@ -31,10 +32,28 @@
         <host-multi-content-element first="a" second="b"></host-multi-content-element>
         <host-text-binding-element text="text content"></host-text-binding-element>
         <host-property-element text="property test"></host-property-element>
-        <host-all-types-element text="all types" attr="value" disabled></host-all-types-element>
-        <host-perm-attr-first text="perm attr first" attr="value" disabled></host-perm-attr-first>
-        <host-perm-bool-first text="perm bool first" attr="value" disabled></host-perm-bool-first>
-        <host-perm-prop-first text="perm prop first" attr="value" disabled></host-perm-prop-first>
+        <host-all-types-element
+            text="all types"
+            attr="value"
+            disabled
+        ></host-all-types-element>
+        <host-perm-attr-first
+            text="perm attr first"
+            attr="value"
+            disabled
+        ></host-perm-attr-first>
+        <host-perm-bool-first
+            text="perm bool first"
+            attr="value"
+            disabled
+        ></host-perm-bool-first>
+        <host-perm-prop-first
+            text="perm prop first"
+            attr="value"
+            disabled
+        ></host-perm-prop-first>
+        <!-- biome-ignore lint/a11y/noAutofocus: deliberate fixture verifying author-provided host attribute propagation through SSR -->
+        <host-autofocus autofocus></host-autofocus>
         <script type="module" src="./main.ts"></script>
     </body>
 </html>

--- a/packages/fast-html/test/fixtures/host-bindings/host-bindings.spec.ts
+++ b/packages/fast-html/test/fixtures/host-bindings/host-bindings.spec.ts
@@ -374,4 +374,24 @@ test.describe("Host Bindings Hydration", async () => {
             }
         });
     });
+
+    test.describe("should propagate host attributes from the template's <template>", () => {
+        test("host-autofocus has author-provided autofocus and template-provided tabindex", async ({
+            page,
+        }) => {
+            const hydrationCompleted = page.waitForFunction(
+                () => (window as any).hydrationCompleted === true,
+            );
+            await page.goto("/fixtures/host-bindings/");
+            await hydrationCompleted;
+
+            const element = page.locator("host-autofocus");
+
+            // Author-provided attribute survives the SSR pipeline.
+            await expect(element).toHaveAttribute("autofocus", "");
+
+            // Template <template tabindex="0"> attribute is propagated to the host tag.
+            await expect(element).toHaveAttribute("tabindex", "0");
+        });
+    });
 });

--- a/packages/fast-html/test/fixtures/host-bindings/index.html
+++ b/packages/fast-html/test/fixtures/host-bindings/index.html
@@ -4,92 +4,162 @@
         <meta charset="utf-8">
         <title>Host Bindings Test</title>
         <style>
-            /* Ensure custom elements display as block to prevent overlap */
-            host-event-element,
-            host-multi-element,
-            host-static-element,
-            host-events-element,
-            host-multi-content-element,
-            host-text-binding-element,
-            host-property-element,
-            host-all-types-element,
-            host-perm-attr-first,
-            host-perm-bool-first,
-            host-perm-prop-first {
-                display: block;
-                margin: 10px 0;
-                padding: 10px;
-                border: 1px solid #ccc;
-            }
+        /* Ensure custom elements display as block to prevent overlap */
+        host-event-element,
+        host-multi-element,
+        host-static-element,
+        host-events-element,
+        host-multi-content-element,
+        host-text-binding-element,
+        host-property-element,
+        host-all-types-element,
+        host-perm-attr-first,
+        host-perm-bool-first,
+        host-perm-prop-first,
+        host-autofocus {
+            display: block;
+            margin: 10px 0;
+            padding: 10px;
+            border: 1px solid #ccc;
+        }
         </style>
     </head>
     <body>
-        <host-event-element><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$greeting-0$$fe-b-->Hello<!--fe-b$$end$$0$$greeting-0$$fe-b--></span></template></host-event-element>
-        <host-multi-element disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->World<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-multi-element>
-        <host-static-element id="static-host"><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$first-0$$fe-b-->first<!--fe-b$$end$$0$$first-0$$fe-b--> <!--fe-b$$start$$1$$second-1$$fe-b-->second<!--fe-b$$end$$1$$second-1$$fe-b--></span></template></host-static-element>
-        <host-events-element text="content text"><template shadowrootmode="open" shadowroot="open"><!--fe-b$$start$$0$$text-0$$fe-b-->content text<!--fe-b$$end$$0$$text-0$$fe-b--></template></host-events-element>
-        <host-multi-content-element first="a" second="b"><template shadowrootmode="open" shadowroot="open"><span first="a" second="b" data-fe-c-0-2></span></template></host-multi-content-element>
-        <host-text-binding-element text="text content"><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->text content<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-text-binding-element>
-        <host-property-element text="property test"><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->property test<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-property-element>
-        <host-all-types-element text="all types" attr="value" disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->all types<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-all-types-element>
-        <host-perm-attr-first text="perm attr first" attr="value" disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->perm attr first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-perm-attr-first>
-        <host-perm-bool-first text="perm bool first" attr="value" disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->perm bool first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-perm-bool-first>
-        <host-perm-prop-first text="perm prop first" attr="value" disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->perm prop first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-perm-prop-first>
-<f-template name="host-event-element">
-    <template @click="{handleClick()}">
-        <span>{{greeting}}</span>
-    </template>
-</f-template>
-<f-template name="host-multi-element">
-    <template @click="{handleClick()}" ?disabled="{{isDisabled}}">
-        <span>{{text}}</span>
-    </template>
-</f-template>
-<f-template name="host-static-element">
-    <template id="static-host" @click="{handleClick()}">
-        <span>{{first}} {{second}}</span>
-    </template>
-</f-template>
-<f-template name="host-events-element">
-    <template @click="{handleClick()}" @mouseenter="{handleMouseEnter()}">
-        {{text}}
-    </template>
-</f-template>
-<f-template name="host-multi-content-element">
-    <template @click="{handleClick()}">
-        <span first="{{first}}" second="{{second}}"></span>
-    </template>
-</f-template>
-<f-template name="host-text-binding-element">
-    <template @click="{handleClick()}">
-        <span>{{text}}</span>
-    </template>
-</f-template>
-<f-template name="host-property-element">
-    <template :title="{hostTitle}">
-        <span>{{text}}</span>
-    </template>
-</f-template>
-<f-template name="host-all-types-element">
-    <template @click="{handleClick()}" ?disabled="{{isDisabled}}" :title="{hostTitle}" attr="{{hostAttr}}">
-        <span>{{text}}</span>
-    </template>
-</f-template>
-<f-template name="host-perm-attr-first">
-    <template attr="{{hostAttr}}" :title="{hostTitle}" ?disabled="{{isDisabled}}" @click="{handleClick()}">
-        <span>{{text}}</span>
-    </template>
-</f-template>
-<f-template name="host-perm-bool-first">
-    <template ?disabled="{{isDisabled}}" @click="{handleClick()}" attr="{{hostAttr}}" :title="{hostTitle}">
-        <span>{{text}}</span>
-    </template>
-</f-template>
-<f-template name="host-perm-prop-first">
-    <template :title="{hostTitle}" attr="{{hostAttr}}" @click="{handleClick()}" ?disabled="{{isDisabled}}">
-        <span>{{text}}</span>
-    </template>
-</f-template>
+        <host-event-element
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span>Hello<!--fe-b$$end$$0$$greeting-0$$fe-b--></span></template
+            ></host-event-element
+        >
+        <host-multi-element disabled
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span>World<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
+            ></host-multi-element
+        >
+        <host-static-element id="static-host"
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span
+                    >first<!--fe-b$$end$$0$$first-0$$fe-b--> <!--fe-b$$start$$1$$second-1$$fe-b-->second<!--fe-b$$end$$1$$second-1$$fe-b--></span
+                ></template
+            ></host-static-element
+        >
+        <host-events-element text="content text"
+            ><template shadowrootmode="open" shadowroot="open"
+                >content text<!--fe-b$$end$$0$$text-0$$fe-b--></template
+            ></host-events-element
+        >
+        <host-multi-content-element first="a" second="b"
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span first="a" second="b" data-fe-c-0-2></span></template
+            ></host-multi-content-element
+        >
+        <host-text-binding-element text="text content"
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span>text content<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
+            ></host-text-binding-element
+        >
+        <host-property-element text="property test"
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span>property test<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
+            ></host-property-element
+        >
+        <host-all-types-element text="all types" attr="value" disabled
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span>all types<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
+            ></host-all-types-element
+        >
+        <host-perm-attr-first text="perm attr first" attr="value" disabled
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span>perm attr first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
+            ></host-perm-attr-first
+        >
+        <host-perm-bool-first text="perm bool first" attr="value" disabled
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span>perm bool first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
+            ></host-perm-bool-first
+        >
+        <host-perm-prop-first text="perm prop first" attr="value" disabled
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span>perm prop first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
+            ></host-perm-prop-first
+        >
+        <!-- biome-ignore lint/a11y/noAutofocus: deliberate fixture verifying author-provided host attribute propagation through SSR -->
+        <host-autofocus autofocus tabindex="0"
+            ><template shadowrootmode="open" shadowroot="open"
+                ><span>World<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
+            ></host-autofocus
+        >
+        <f-template name="host-event-element">
+            <template @click="{handleClick()}"> <span>{{ greeting }}</span> </template>
+        </f-template>
+        <f-template name="host-multi-element">
+            <template @click="{handleClick()}" ?disabled="{{isDisabled}}">
+                <span>{{ text }}</span>
+            </template>
+        </f-template>
+        <f-template name="host-static-element">
+            <template id="static-host" @click="{handleClick()}">
+                <span>{{ first }} {{ second }}</span>
+            </template>
+        </f-template>
+        <f-template name="host-events-element">
+            <template @click="{handleClick()}" @mouseenter="{handleMouseEnter()}">
+                {{ text }}
+            </template>
+        </f-template>
+        <f-template name="host-multi-content-element">
+            <template @click="{handleClick()}">
+                <span first="{{first}}" second="{{second}}"></span>
+            </template>
+        </f-template>
+        <f-template name="host-text-binding-element">
+            <template @click="{handleClick()}"> <span>{{ text }}</span> </template>
+        </f-template>
+        <f-template name="host-property-element">
+            <template :title="{hostTitle}"> <span>{{ text }}</span> </template>
+        </f-template>
+        <f-template name="host-all-types-element">
+            <template
+                @click="{handleClick()}"
+                ?disabled="{{isDisabled}}"
+                :title="{hostTitle}"
+                attr="{{hostAttr}}"
+            >
+                <span>{{ text }}</span>
+            </template>
+        </f-template>
+        <f-template name="host-perm-attr-first">
+            <template
+                attr="{{hostAttr}}"
+                :title="{hostTitle}"
+                ?disabled="{{isDisabled}}"
+                @click="{handleClick()}"
+            >
+                <span>{{ text }}</span>
+            </template>
+        </f-template>
+        <f-template name="host-perm-bool-first">
+            <template
+                ?disabled="{{isDisabled}}"
+                @click="{handleClick()}"
+                attr="{{hostAttr}}"
+                :title="{hostTitle}"
+            >
+                <span>{{ text }}</span>
+            </template>
+        </f-template>
+        <f-template name="host-perm-prop-first">
+            <template
+                :title="{hostTitle}"
+                attr="{{hostAttr}}"
+                @click="{handleClick()}"
+                ?disabled="{{isDisabled}}"
+            >
+                <span>{{ text }}</span>
+            </template>
+        </f-template>
+        <f-template name="host-autofocus">
+            <template tabindex="0"> <span>{{ text }}</span> </template>
+        </f-template>
 
         <script type="module" src="./main.ts"></script>
     </body>

--- a/packages/fast-html/test/fixtures/host-bindings/index.html
+++ b/packages/fast-html/test/fixtures/host-bindings/index.html
@@ -1,165 +1,105 @@
 <!DOCTYPE html>
+<!-- biome-ignore-all format: SSR-rendered output binding markers must survive byte-for-byte -->
 <html lang="en-US">
     <head>
         <meta charset="utf-8">
         <title>Host Bindings Test</title>
         <style>
         /* Ensure custom elements display as block to prevent overlap */
-        host-event-element,
-        host-multi-element,
-        host-static-element,
-        host-events-element,
-        host-multi-content-element,
-        host-text-binding-element,
-        host-property-element,
-        host-all-types-element,
-        host-perm-attr-first,
-        host-perm-bool-first,
-        host-perm-prop-first,
-        host-autofocus {
-            display: block;
-            margin: 10px 0;
-            padding: 10px;
-            border: 1px solid #ccc;
-        }
+host-event-element,
+host-multi-element,
+host-static-element,
+host-events-element,
+host-multi-content-element,
+host-text-binding-element,
+host-property-element,
+host-all-types-element,
+host-perm-attr-first,
+host-perm-bool-first,
+host-perm-prop-first,
+host-autofocus {
+    display: block;
+    margin: 10px 0;
+    padding: 10px;
+    border: 1px solid #ccc;
+}
         </style>
     </head>
     <body>
-        <host-event-element
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span>Hello<!--fe-b$$end$$0$$greeting-0$$fe-b--></span></template
-            ></host-event-element
-        >
-        <host-multi-element disabled
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span>World<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
-            ></host-multi-element
-        >
-        <host-static-element id="static-host"
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span
-                    >first<!--fe-b$$end$$0$$first-0$$fe-b--> <!--fe-b$$start$$1$$second-1$$fe-b-->second<!--fe-b$$end$$1$$second-1$$fe-b--></span
-                ></template
-            ></host-static-element
-        >
-        <host-events-element text="content text"
-            ><template shadowrootmode="open" shadowroot="open"
-                >content text<!--fe-b$$end$$0$$text-0$$fe-b--></template
-            ></host-events-element
-        >
-        <host-multi-content-element first="a" second="b"
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span first="a" second="b" data-fe-c-0-2></span></template
-            ></host-multi-content-element
-        >
-        <host-text-binding-element text="text content"
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span>text content<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
-            ></host-text-binding-element
-        >
-        <host-property-element text="property test"
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span>property test<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
-            ></host-property-element
-        >
-        <host-all-types-element text="all types" attr="value" disabled
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span>all types<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
-            ></host-all-types-element
-        >
-        <host-perm-attr-first text="perm attr first" attr="value" disabled
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span>perm attr first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
-            ></host-perm-attr-first
-        >
-        <host-perm-bool-first text="perm bool first" attr="value" disabled
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span>perm bool first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
-            ></host-perm-bool-first
-        >
-        <host-perm-prop-first text="perm prop first" attr="value" disabled
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span>perm prop first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
-            ></host-perm-prop-first
-        >
+        <host-event-element><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$greeting-0$$fe-b-->Hello<!--fe-b$$end$$0$$greeting-0$$fe-b--></span></template></host-event-element>
+        <host-multi-element disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->World<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-multi-element>
+        <host-static-element id="static-host"><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$first-0$$fe-b-->first<!--fe-b$$end$$0$$first-0$$fe-b--> <!--fe-b$$start$$1$$second-1$$fe-b-->second<!--fe-b$$end$$1$$second-1$$fe-b--></span></template></host-static-element>
+        <host-events-element text="content text"><template shadowrootmode="open" shadowroot="open"><!--fe-b$$start$$0$$text-0$$fe-b-->content text<!--fe-b$$end$$0$$text-0$$fe-b--></template></host-events-element>
+        <host-multi-content-element first="a" second="b"><template shadowrootmode="open" shadowroot="open"><span first="a" second="b" data-fe-c-0-2></span></template></host-multi-content-element>
+        <host-text-binding-element text="text content"><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->text content<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-text-binding-element>
+        <host-property-element text="property test"><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->property test<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-property-element>
+        <host-all-types-element text="all types" attr="value" disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->all types<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-all-types-element>
+        <host-perm-attr-first text="perm attr first" attr="value" disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->perm attr first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-perm-attr-first>
+        <host-perm-bool-first text="perm bool first" attr="value" disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->perm bool first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-perm-bool-first>
+        <host-perm-prop-first text="perm prop first" attr="value" disabled><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->perm prop first<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-perm-prop-first>
         <!-- biome-ignore lint/a11y/noAutofocus: deliberate fixture verifying author-provided host attribute propagation through SSR -->
-        <host-autofocus autofocus tabindex="0"
-            ><template shadowrootmode="open" shadowroot="open"
-                ><span>World<!--fe-b$$end$$0$$text-0$$fe-b--></span></template
-            ></host-autofocus
-        >
-        <f-template name="host-event-element">
-            <template @click="{handleClick()}"> <span>{{ greeting }}</span> </template>
-        </f-template>
-        <f-template name="host-multi-element">
-            <template @click="{handleClick()}" ?disabled="{{isDisabled}}">
-                <span>{{ text }}</span>
-            </template>
-        </f-template>
-        <f-template name="host-static-element">
-            <template id="static-host" @click="{handleClick()}">
-                <span>{{ first }} {{ second }}</span>
-            </template>
-        </f-template>
-        <f-template name="host-events-element">
-            <template @click="{handleClick()}" @mouseenter="{handleMouseEnter()}">
-                {{ text }}
-            </template>
-        </f-template>
-        <f-template name="host-multi-content-element">
-            <template @click="{handleClick()}">
-                <span first="{{first}}" second="{{second}}"></span>
-            </template>
-        </f-template>
-        <f-template name="host-text-binding-element">
-            <template @click="{handleClick()}"> <span>{{ text }}</span> </template>
-        </f-template>
-        <f-template name="host-property-element">
-            <template :title="{hostTitle}"> <span>{{ text }}</span> </template>
-        </f-template>
-        <f-template name="host-all-types-element">
-            <template
-                @click="{handleClick()}"
-                ?disabled="{{isDisabled}}"
-                :title="{hostTitle}"
-                attr="{{hostAttr}}"
-            >
-                <span>{{ text }}</span>
-            </template>
-        </f-template>
-        <f-template name="host-perm-attr-first">
-            <template
-                attr="{{hostAttr}}"
-                :title="{hostTitle}"
-                ?disabled="{{isDisabled}}"
-                @click="{handleClick()}"
-            >
-                <span>{{ text }}</span>
-            </template>
-        </f-template>
-        <f-template name="host-perm-bool-first">
-            <template
-                ?disabled="{{isDisabled}}"
-                @click="{handleClick()}"
-                attr="{{hostAttr}}"
-                :title="{hostTitle}"
-            >
-                <span>{{ text }}</span>
-            </template>
-        </f-template>
-        <f-template name="host-perm-prop-first">
-            <template
-                :title="{hostTitle}"
-                attr="{{hostAttr}}"
-                @click="{handleClick()}"
-                ?disabled="{{isDisabled}}"
-            >
-                <span>{{ text }}</span>
-            </template>
-        </f-template>
-        <f-template name="host-autofocus">
-            <template tabindex="0"> <span>{{ text }}</span> </template>
-        </f-template>
+        <host-autofocus autofocus tabindex="0"><template shadowrootmode="open" shadowroot="open"><span><!--fe-b$$start$$0$$text-0$$fe-b-->World<!--fe-b$$end$$0$$text-0$$fe-b--></span></template></host-autofocus>
+<!-- biome-ignore-all format: SSR renderer requires multi-line <template> layout for binding marker placement -->
+<f-template name="host-event-element">
+    <template @click="{handleClick()}">
+        <span>{{greeting}}</span>
+    </template>
+</f-template>
+<f-template name="host-multi-element">
+    <template @click="{handleClick()}" ?disabled="{{isDisabled}}">
+        <span>{{text}}</span>
+    </template>
+</f-template>
+<f-template name="host-static-element">
+    <template id="static-host" @click="{handleClick()}">
+        <span>{{first}} {{second}}</span>
+    </template>
+</f-template>
+<f-template name="host-events-element">
+    <template @click="{handleClick()}" @mouseenter="{handleMouseEnter()}">
+        {{text}}
+    </template>
+</f-template>
+<f-template name="host-multi-content-element">
+    <template @click="{handleClick()}">
+        <span first="{{first}}" second="{{second}}"></span>
+    </template>
+</f-template>
+<f-template name="host-text-binding-element">
+    <template @click="{handleClick()}">
+        <span>{{text}}</span>
+    </template>
+</f-template>
+<f-template name="host-property-element">
+    <template :title="{hostTitle}">
+        <span>{{text}}</span>
+    </template>
+</f-template>
+<f-template name="host-all-types-element">
+    <template @click="{handleClick()}" ?disabled="{{isDisabled}}" :title="{hostTitle}" attr="{{hostAttr}}">
+        <span>{{text}}</span>
+    </template>
+</f-template>
+<f-template name="host-perm-attr-first">
+    <template attr="{{hostAttr}}" :title="{hostTitle}" ?disabled="{{isDisabled}}" @click="{handleClick()}">
+        <span>{{text}}</span>
+    </template>
+</f-template>
+<f-template name="host-perm-bool-first">
+    <template ?disabled="{{isDisabled}}" @click="{handleClick()}" attr="{{hostAttr}}" :title="{hostTitle}">
+        <span>{{text}}</span>
+    </template>
+</f-template>
+<f-template name="host-perm-prop-first">
+    <template :title="{hostTitle}" attr="{{hostAttr}}" @click="{handleClick()}" ?disabled="{{isDisabled}}">
+        <span>{{text}}</span>
+    </template>
+</f-template>
+<f-template name="host-autofocus">
+    <template tabindex="0">
+        <span>{{text}}</span>
+    </template>
+</f-template>
 
         <script type="module" src="./main.ts"></script>
     </body>

--- a/packages/fast-html/test/fixtures/host-bindings/main.ts
+++ b/packages/fast-html/test/fixtures/host-bindings/main.ts
@@ -212,6 +212,16 @@ RenderableFASTElement(HostPermPropFirst).defineAsync({
     templateOptions: "defer-and-hydrate",
 });
 
+// Test 12: Autofocus
+class HostAutofocus extends FASTElement {
+    @attr
+    text: string = "autofocus";
+}
+RenderableFASTElement(HostAutofocus).defineAsync({
+    name: "host-autofocus",
+    templateOptions: "defer-and-hydrate",
+});
+
 TemplateElement.config({
     hydrationComplete() {
         (window as any).hydrationCompleted = true;

--- a/packages/fast-html/test/fixtures/host-bindings/templates.html
+++ b/packages/fast-html/test/fixtures/host-bindings/templates.html
@@ -1,21 +1,19 @@
 <f-template name="host-event-element">
-    <template @click="{handleClick()}">
-        <span>{{greeting}}</span>
-    </template>
+    <template @click="{handleClick()}"> <span>{{ greeting }}</span> </template>
 </f-template>
 <f-template name="host-multi-element">
     <template @click="{handleClick()}" ?disabled="{{isDisabled}}">
-        <span>{{text}}</span>
+        <span>{{ text }}</span>
     </template>
 </f-template>
 <f-template name="host-static-element">
     <template id="static-host" @click="{handleClick()}">
-        <span>{{first}} {{second}}</span>
+        <span>{{ first }} {{ second }}</span>
     </template>
 </f-template>
 <f-template name="host-events-element">
     <template @click="{handleClick()}" @mouseenter="{handleMouseEnter()}">
-        {{text}}
+        {{ text }}
     </template>
 </f-template>
 <f-template name="host-multi-content-element">
@@ -24,32 +22,51 @@
     </template>
 </f-template>
 <f-template name="host-text-binding-element">
-    <template @click="{handleClick()}">
-        <span>{{text}}</span>
-    </template>
+    <template @click="{handleClick()}"> <span>{{ text }}</span> </template>
 </f-template>
 <f-template name="host-property-element">
-    <template :title="{hostTitle}">
-        <span>{{text}}</span>
-    </template>
+    <template :title="{hostTitle}"> <span>{{ text }}</span> </template>
 </f-template>
 <f-template name="host-all-types-element">
-    <template @click="{handleClick()}" ?disabled="{{isDisabled}}" :title="{hostTitle}" attr="{{hostAttr}}">
-        <span>{{text}}</span>
+    <template
+        @click="{handleClick()}"
+        ?disabled="{{isDisabled}}"
+        :title="{hostTitle}"
+        attr="{{hostAttr}}"
+    >
+        <span>{{ text }}</span>
     </template>
 </f-template>
 <f-template name="host-perm-attr-first">
-    <template attr="{{hostAttr}}" :title="{hostTitle}" ?disabled="{{isDisabled}}" @click="{handleClick()}">
-        <span>{{text}}</span>
+    <template
+        attr="{{hostAttr}}"
+        :title="{hostTitle}"
+        ?disabled="{{isDisabled}}"
+        @click="{handleClick()}"
+    >
+        <span>{{ text }}</span>
     </template>
 </f-template>
 <f-template name="host-perm-bool-first">
-    <template ?disabled="{{isDisabled}}" @click="{handleClick()}" attr="{{hostAttr}}" :title="{hostTitle}">
-        <span>{{text}}</span>
+    <template
+        ?disabled="{{isDisabled}}"
+        @click="{handleClick()}"
+        attr="{{hostAttr}}"
+        :title="{hostTitle}"
+    >
+        <span>{{ text }}</span>
     </template>
 </f-template>
 <f-template name="host-perm-prop-first">
-    <template :title="{hostTitle}" attr="{{hostAttr}}" @click="{handleClick()}" ?disabled="{{isDisabled}}">
-        <span>{{text}}</span>
+    <template
+        :title="{hostTitle}"
+        attr="{{hostAttr}}"
+        @click="{handleClick()}"
+        ?disabled="{{isDisabled}}"
+    >
+        <span>{{ text }}</span>
     </template>
+</f-template>
+<f-template name="host-autofocus">
+    <template tabindex="0"> <span>{{ text }}</span> </template>
 </f-template>

--- a/packages/fast-html/test/fixtures/host-bindings/templates.html
+++ b/packages/fast-html/test/fixtures/host-bindings/templates.html
@@ -1,19 +1,22 @@
+<!-- biome-ignore-all format: SSR renderer requires multi-line <template> layout for binding marker placement -->
 <f-template name="host-event-element">
-    <template @click="{handleClick()}"> <span>{{ greeting }}</span> </template>
+    <template @click="{handleClick()}">
+        <span>{{greeting}}</span>
+    </template>
 </f-template>
 <f-template name="host-multi-element">
     <template @click="{handleClick()}" ?disabled="{{isDisabled}}">
-        <span>{{ text }}</span>
+        <span>{{text}}</span>
     </template>
 </f-template>
 <f-template name="host-static-element">
     <template id="static-host" @click="{handleClick()}">
-        <span>{{ first }} {{ second }}</span>
+        <span>{{first}} {{second}}</span>
     </template>
 </f-template>
 <f-template name="host-events-element">
     <template @click="{handleClick()}" @mouseenter="{handleMouseEnter()}">
-        {{ text }}
+        {{text}}
     </template>
 </f-template>
 <f-template name="host-multi-content-element">
@@ -22,51 +25,37 @@
     </template>
 </f-template>
 <f-template name="host-text-binding-element">
-    <template @click="{handleClick()}"> <span>{{ text }}</span> </template>
+    <template @click="{handleClick()}">
+        <span>{{text}}</span>
+    </template>
 </f-template>
 <f-template name="host-property-element">
-    <template :title="{hostTitle}"> <span>{{ text }}</span> </template>
+    <template :title="{hostTitle}">
+        <span>{{text}}</span>
+    </template>
 </f-template>
 <f-template name="host-all-types-element">
-    <template
-        @click="{handleClick()}"
-        ?disabled="{{isDisabled}}"
-        :title="{hostTitle}"
-        attr="{{hostAttr}}"
-    >
-        <span>{{ text }}</span>
+    <template @click="{handleClick()}" ?disabled="{{isDisabled}}" :title="{hostTitle}" attr="{{hostAttr}}">
+        <span>{{text}}</span>
     </template>
 </f-template>
 <f-template name="host-perm-attr-first">
-    <template
-        attr="{{hostAttr}}"
-        :title="{hostTitle}"
-        ?disabled="{{isDisabled}}"
-        @click="{handleClick()}"
-    >
-        <span>{{ text }}</span>
+    <template attr="{{hostAttr}}" :title="{hostTitle}" ?disabled="{{isDisabled}}" @click="{handleClick()}">
+        <span>{{text}}</span>
     </template>
 </f-template>
 <f-template name="host-perm-bool-first">
-    <template
-        ?disabled="{{isDisabled}}"
-        @click="{handleClick()}"
-        attr="{{hostAttr}}"
-        :title="{hostTitle}"
-    >
-        <span>{{ text }}</span>
+    <template ?disabled="{{isDisabled}}" @click="{handleClick()}" attr="{{hostAttr}}" :title="{hostTitle}">
+        <span>{{text}}</span>
     </template>
 </f-template>
 <f-template name="host-perm-prop-first">
-    <template
-        :title="{hostTitle}"
-        attr="{{hostAttr}}"
-        @click="{handleClick()}"
-        ?disabled="{{isDisabled}}"
-    >
-        <span>{{ text }}</span>
+    <template :title="{hostTitle}" attr="{{hostAttr}}" @click="{handleClick()}" ?disabled="{{isDisabled}}">
+        <span>{{text}}</span>
     </template>
 </f-template>
 <f-template name="host-autofocus">
-    <template tabindex="0"> <span>{{ text }}</span> </template>
+    <template tabindex="0">
+        <span>{{text}}</span>
+    </template>
 </f-template>


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds support for propagating host attributes declared on the inner `<template>` of an `<f-template>` definition onto the rendered host element opening tag during SSR.

Today the build-time renderer drops every attribute on the source `<template>`, so authors cannot pre-declare host attributes (e.g. `tabindex`, `role`, `aria-*`) on a component's declarative template. After this change, the following template:

```html
<f-template name="host-autofocus">
    <template tabindex="0">
        <span>{{text}}</span>
    </template>
</f-template>
```

Now renders as `<host-autofocus autofocus tabindex="0">…</host-autofocus>` when the author writes `<host-autofocus autofocus></host-autofocus>` — both the author-provided `autofocus` and the template-provided `tabindex="0"` survive SSR.

**Resolution rules:**

- Static `name="value"`, dynamic `name="{{expr}}"`, and boolean `?name="{{expr}}"` bindings on the template's `<template>` are propagated.
- Author-provided host attributes win on conflict (dedupe on lowercased name; `?name` dedupes against bare `name`).
- Client-only attribute prefixes are skipped: `@event`, `:property`, `f-ref`, `f-slotted`, `f-children`.
- `{{expr}}` resolves against the same state used to render the shadow root; non-primitive / null values are stripped.

**Breaking change (prerelease):** `Locator::add_template_with_shadowroot_attrs` was renamed and widened to `add_template_with_attrs(name, content, shadowroot_attrs, host_attrs)`. `Locator::from_template_definitions` is now `pub` and accepts a 3-tuple metadata value `(content, shadowroot_attrs, host_attrs)`. The WASM/JSON shape `templatesMap[name]` now includes a `hostAttributes` array. No external callers existed inside the monorepo.

## 👩‍💻 Reviewer Notes

- `crates/microsoft-fast-build/src/directive.rs` is where the actual splice happens. `merge_template_host_attrs` formats and joins filtered attrs before the rightmost `>` of the host opening tag.
- The skip list is intentionally hand-rolled (no shared constant with the existing client-side dispatch in `fast-html`); see the `is_client_only_attr` helper for the canonical list.
- The host-bindings fixture (`packages/fast-html/test/fixtures/host-bindings`) gained an intentional `autofocus` usage; a `biome-ignore lint/a11y/noAutofocus` HTML comment documents the rationale and survives `npm run build:fixtures` regeneration of `index.html`.

## 📑 Test Plan

- 16 new Rust unit/integration tests in `crates/microsoft-fast-build` (`tests/host_attributes.rs` + `locator.rs` unit tests + 2 WASM tests) — all 87 cargo tests pass.
- 1 new Playwright assertion in `packages/fast-html/test/fixtures/host-bindings/host-bindings.spec.ts` verifying both `autofocus` (author) and `tabindex="0"` (propagated) survive SSR + hydration.
- Full repo acceptance: `npm run build` ✓, `npm run test` ✓ (301/301 fast-html chromium, no regressions in other fixtures), `npm run biome:check` ✓, `npm run checkchange` ✓.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
