### PR TITLE
docs(3.x): document <f-template> host attribute propagation in SSR page

### DIFF
--- a/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
+++ b/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
@@ -116,6 +116,78 @@ The renderer applies special rules for certain HTML attributes:
 | `aria-*` | camelCase ARIA property | `aria-label` → `ariaLabel` |
 | Boolean (`?attr`) | Truthy/falsy evaluation | `?disabled="{{isOff}}"` → present or absent |
 
+## Host Attribute Propagation
+
+Attributes declared on the inner `<template>` element of an `<f-template>` definition are propagated onto the rendered host element's opening tag. This lets a component's declarative template pre-declare host-level attributes — such as `tabindex`, `role`, `aria-*`, or `class` — without requiring the page author to repeat them on every usage.
+
+```html
+<f-template name="primary-button">
+    <template tabindex="0" role="button" class="primary">
+        <slot></slot>
+    </template>
+</f-template>
+```
+
+```html
+<!-- Author writes: -->
+<primary-button>Click me</primary-button>
+```
+
+```html
+<!-- Server renders: -->
+<primary-button tabindex="0" role="button" class="primary">
+    <template shadowrootmode="open">
+        <slot></slot>
+    </template>
+</primary-button>
+```
+
+### Supported binding forms
+
+Three forms on the source `<template>` are propagated to the host:
+
+| Form | Behavior on host |
+|---|---|
+| `name="value"` (static) | Emitted verbatim. |
+| `name="{{expression}}"` (dynamic) | Resolved against the same state used to render the shadow root. Primitive values are emitted as-is; `null`, `undefined`, arrays, and objects are stripped. |
+| `?name="{{expression}}"` (boolean) | Evaluated as a boolean. The bare `name` is emitted when truthy and omitted when falsy. |
+
+### Client-only attributes are skipped
+
+Attributes intended for the client-side runtime never appear on the rendered host element:
+
+- `@event` — event listener bindings
+- `:property` — property bindings
+- `f-ref` — element references
+- `f-slotted` — slotted content directives
+- `f-children` — child node directives
+
+These continue to be handled exclusively by the hydration runtime.
+
+### Author attributes win on conflict
+
+When the page author already supplies an attribute on the host element, that value is preserved and the template's value is ignored. Dedupe is performed on the lowercased attribute name, and `?name="{{expression}}"` is deduped against the bare `name`.
+
+```html
+<f-template name="primary-button">
+    <template tabindex="0" class="primary">
+        <slot></slot>
+    </template>
+</f-template>
+
+<!-- Author overrides tabindex; class is propagated. -->
+<primary-button tabindex="-1">Click me</primary-button>
+```
+
+```html
+<!-- Server renders: -->
+<primary-button tabindex="-1" class="primary">…</primary-button>
+```
+
+### Available in `@microsoft/fast-build`
+
+The propagation is implemented by the build-time renderer in `@microsoft/fast-build`. Author-provided host attributes always win, so existing templates that did not previously rely on template-level host attributes continue to render unchanged.
+
 ## Using `@microsoft/fast-build`
 
 The `@microsoft/fast-build` package is a build-time renderer for declarative templates, powered by a WebAssembly core. It implements the rendering contract described above and is primarily used in testing and development workflows.


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds a new **"Host Attribute Propagation"** section to the 3.x declarative server-rendering documentation page (`sites/website/src/docs/3.x/declarative-templates/server-rendering.md`) describing how attributes declared on the inner `<template>` of an `<f-template>` propagate onto the rendered host element opening tag during SSR.

The new section covers:

- The concept and a worked example (a `primary-button` component with `tabindex`, `role`, and `class` declared on its template).
- The three supported binding forms: static `name="value"`, dynamic `name="{{expression}}"`, and boolean `?name="{{expression}}"`, including which values get stripped.
- The client-only attribute skip list (`@event`, `:property`, `f-ref`, `f-slotted`, `f-children`).
- The "author wins on conflict" dedupe rule (including how `?name` dedupes against the bare `name`).

### 🎫 Issues

This documents the build-time renderer behavior implemented on `main` in [microsoft/fast#7521](https://github.com/microsoft/fast/pull/7521). The feature will be picked up by the next `main` → `releases/fast-element-v3` sync; this docs PR can land independently so that the website reflects the upcoming behavior.

## 👩‍💻 Reviewer Notes

- Docs-only change — no source, test, or build configuration is touched.
- The new section is placed between **State Propagation** and **Using `@microsoft/fast-build`**, keeping the conceptual flow (rendering contract → hydration flow → state in → host attrs out → tooling).
- Markdown is wrapped inside the existing `{% raw %}` Nunjucks block so that `{{ }}` examples render literally on the site.

## 📑 Test Plan

- No test changes are required. Verified the markdown edits render correctly by inspection (no broken table syntax, no unescaped Nunjucks/Liquid braces outside `{% raw %}`).
- Suggested smoke test for reviewer: `npm run build -w @microsoft/fast-site` (or the website's local dev preview) and open the rendered `server-rendering` page to confirm the new section displays as expected.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

## ⏭ Next Steps

When the next `main` → `releases/fast-element-v3` sync lands, this docs page will accurately describe the behavior shipping in the v3 build pipeline. No further docs work is anticipated for this feature on the v3 track.
