### PR TITLE
fix(docs): update example references in documentation and tests

### DIFF
--- a/change/@microsoft-fast-test-harness-bd9102c0-6436-40f7-887f-bda7586184cc.json
+++ b/change/@microsoft-fast-test-harness-bd9102c0-6436-40f7-887f-bda7586184cc.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "fix: update references to \"contoso\" in documentation and tests",
+  "packageName": "@microsoft/fast-test-harness",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-test-harness/DESIGN.md
+++ b/packages/fast-test-harness/DESIGN.md
@@ -264,7 +264,7 @@ The `src/ssr/render.ts` module exports `createSSRRenderer`, a factory that scans
 
 | Option | Type | Default | Description |
 |--------|------|---------|-------------|
-| `tagPrefix` | `string` | — | Tag name prefix for custom elements (e.g., `"fluent"`, `"mai"`) |
+| `tagPrefix` | `string` | — | Tag name prefix for custom elements (e.g., `"fluent"`, `"contoso"`) |
 | `packageName` | `string?` | — | Monolithic package name — scans subdirectories for component artifacts. Mutually exclusive with `components`. |
 | `components` | `ComponentRegistration[]?` | — | Explicit list of per-component packages. Mutually exclusive with `packageName`. |
 | `distDir` | `string?` | `"dist/esm"` | Artifact directory relative to the package root. Only used with `packageName`. |

--- a/packages/fast-test-harness/README.md
+++ b/packages/fast-test-harness/README.md
@@ -253,7 +253,7 @@ CLI flags take precedence over environment variables.
 
 | Option | Type | Description |
 |--------|------|-------------|
-| `tagPrefix` | `string` | Tag name prefix for custom elements (e.g., `"fluent"`, `"mai"`) |
+| `tagPrefix` | `string` | Tag name prefix for custom elements (e.g., `"fluent"`, `"contoso"`) |
 | `packageName` | `string?` | Monolithic package name — scans subdirectories for component artifacts. Mutually exclusive with `components`. |
 | `components` | `ComponentRegistration[]?` | Explicit list of per-component packages. Mutually exclusive with `packageName`. |
 | `distDir` | `string?` | Artifact directory relative to the package root (default: `"dist/esm"`). Only used with `packageName`. |

--- a/packages/fast-test-harness/src/build/generate-templates.test.ts
+++ b/packages/fast-test-harness/src/build/generate-templates.test.ts
@@ -158,10 +158,10 @@ test.describe("generateFTemplates", () => {
             };`,
         );
 
-        await generateFTemplates({ cwd: tempDir, tagPrefix: "mai" });
+        await generateFTemplates({ cwd: tempDir, tagPrefix: "contoso" });
 
         const html = await readFile(join(distDir, "badge.template.html"), "utf8");
-        assert.ok(html.includes('<f-template name="mai-badge"'));
+        assert.ok(html.includes('<f-template name="contoso-badge"'));
         assert.ok(html.includes("<slot></slot>"));
         assert.ok(html.includes("{{styles}}"));
     });
@@ -329,7 +329,7 @@ test.describe("generateWebuiTemplates", () => {
             };`,
         );
 
-        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "mai" });
+        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "contoso" });
 
         const html = await readFile(join(distDir, "badge.template-webui.html"), "utf8");
         assert.ok(html.includes('<template shadowrootmode="open">'));

--- a/packages/fast-test-harness/src/build/generate-templates.ts
+++ b/packages/fast-test-harness/src/build/generate-templates.ts
@@ -352,7 +352,7 @@ export function convertTemplate(
     // so the test harness can substitute it with a <link rel="stylesheet"> at
     // render time. Harness fallback auto-injects if the marker is missing, but
     // emitting it explicitly keeps generated output consistent with hand-authored
-    // f-templates (see MAI core components).
+    // f-templates.
     fInner = fInner.replace(/(<template[^>]*>)/, `$1${stylesMarker}`);
     return `<f-template name="${componentName}" shadowrootmode="open">\n${fInner}\n</f-template>\n`;
 }

--- a/packages/fast-test-harness/src/build/generate-webui-templates.test.ts
+++ b/packages/fast-test-harness/src/build/generate-webui-templates.test.ts
@@ -28,7 +28,7 @@ test.describe("generateWebuiTemplates", () => {
             };`,
         );
 
-        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "mai" });
+        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "contoso" });
 
         const html = await readFile(join(distDir, "badge.template-webui.html"), "utf8");
         assert.ok(html.includes('<template shadowrootmode="open">'));
@@ -167,7 +167,7 @@ test.describe("generateWebuiTemplates", () => {
             };`,
         );
 
-        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "mai" });
+        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "contoso" });
 
         const html = await readFile(join(distDir, "label.template-webui.html"), "utf8");
         assert.ok(
@@ -220,7 +220,7 @@ test.describe("generateWebuiTemplates", () => {
             };`,
         );
 
-        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "mai" });
+        await generateWebuiTemplates({ cwd: tempDir, tagPrefix: "contoso" });
 
         const buttonHtml = await readFile(
             join(distDir, "button.template-webui.html"),

--- a/packages/fast-test-harness/src/build/generate-webui-templates.ts
+++ b/packages/fast-test-harness/src/build/generate-webui-templates.ts
@@ -14,7 +14,7 @@
  * ```ts
  * import { generateWebuiTemplates } from "@microsoft/fast-test-harness/build/generate-webui-templates.js";
  *
- * await generateWebuiTemplates({ cwd: process.cwd(), tagPrefix: "mai" });
+ * await generateWebuiTemplates({ cwd: process.cwd(), tagPrefix: "contoso" });
  * ```
  */
 

--- a/packages/fast-test-harness/src/ssr/render.ts
+++ b/packages/fast-test-harness/src/ssr/render.ts
@@ -21,10 +21,10 @@
  * flat exports.
  * ```ts
  * const { render } = createSSRRenderer({
- *     tagPrefix: "mai",
+ *     tagPrefix: "contoso",
  *     components: [
- *         { name: "button", packageName: "@mai-ui/button" },
- *         { name: "checkbox", packageName: "@mai-ui/checkbox" },
+ *         { name: "button", packageName: "@contoso/button" },
+ *         { name: "checkbox", packageName: "@contoso/checkbox" },
  *     ],
  * });
  * ```
@@ -44,28 +44,28 @@ export interface ComponentRegistration {
 
     /**
      * The npm package name for this component
-     * (e.g., "@mai-ui/button").
+     * (e.g., "@contoso/button").
      */
     packageName: string;
 }
 
 export interface SSRRendererOptions {
     /**
-     * Tag name prefix for custom elements (e.g., "fluent", "mai").
+     * Tag name prefix for custom elements (e.g., "fluent", "contoso").
      */
     tagPrefix: string;
 
     /**
      * The npm package name used to resolve component build artifacts
      * when all components live in subdirectories of a single package
-     * (Fluent-style). Mutually exclusive with `components`.
+     * (monolithic layout). Mutually exclusive with `components`.
      */
     packageName?: string;
 
     /**
-     * Explicit list of per-component packages (MAI-style). Each entry
-     * maps a component name to its npm package. Mutually exclusive
-     * with `packageName`.
+     * Explicit list of per-component packages. Each entry maps a
+     * component name to its npm package. Mutually exclusive with
+     * `packageName`.
      */
     components?: ComponentRegistration[];
 
@@ -249,7 +249,7 @@ function loadMonolithicComponent(
 
 /**
  * Load artifacts for a component from a per-component package
- * (e.g., `@mai-ui/button/template.html`).
+ * (e.g., `@contoso/button/template.html`).
  */
 function loadPerPackageComponent(reg: ComponentRegistration): ComponentArtifacts {
     const fTemplatePath = resolveSpecifier(`${reg.packageName}/template.html`);
@@ -369,9 +369,9 @@ export function buildState(queryObj: Record<string, string>): Record<string, unk
  *
  * Supports two modes:
  * - **`packageName`**: Scans a monolithic package's dist directory for
- *   components in subdirectories (Fluent-style).
+ *   components in subdirectories (monolithic layout).
  * - **`components`**: Uses an explicit list of per-component packages
- *   with flat exports (MAI-style).
+ *   with flat exports.
  */
 export function createSSRRenderer(options: SSRRendererOptions): {
     render: (queryObj: Record<string, string>) => RenderResult;
@@ -402,12 +402,12 @@ export function createSSRRenderer(options: SSRRendererOptions): {
     const artifacts: ComponentArtifacts[] = [];
 
     if (options.components) {
-        // Per-component packages (MAI-style).
+        // Per-component packages
         for (const reg of options.components) {
             artifacts.push(loadPerPackageComponent(reg));
         }
     } else if (options.packageName) {
-        // Monolithic package (Fluent-style).
+        // Monolithic package
         const packageRoot = resolvePackageRoot(options.packageName);
         const distDir = join(packageRoot, options.distDir ?? "dist/esm");
         const pattern = "**/*.template.html";


### PR DESCRIPTION
# Pull Request

## 📖 Description

Replace scoped references in `fast-test-harness` documentation, comments, and tests with generic equivalents.

- Swap example package scopes with `@contoso`
- Replace layout-specific labels (`Fluent-style`, etc.) with descriptive terms (`monolithic layout`, `per-component packages`)

No behavioral changes — only doc comments, inline comments, and test fixture strings.

## 📑 Test Plan

All existing tests pass. No runtime code was modified.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.