### PR TITLE
refactor(test-harness): remove parseDefaultValue and CEM-related logic from SSR renderer

### DIFF
--- a/change/@microsoft-fast-test-harness-1af13817-db82-424b-b0e2-1751827905de.json
+++ b/change/@microsoft-fast-test-harness-1af13817-db82-424b-b0e2-1751827905de.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "refactor: remove parseDefaultValue and CEM-related logic from SSR renderer",
+  "packageName": "@microsoft/fast-test-harness",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-test-harness/README.md
+++ b/packages/fast-test-harness/README.md
@@ -266,7 +266,7 @@ CLI flags take precedence over environment variables.
 | `@microsoft/fast-test-harness` | `test`, `expect`, `CSRFixture`, `SSRFixture`, `toHaveCustomState`, `installDomShim`, `createSSRRenderer` |
 | `@microsoft/fast-test-harness/build/*.js` | `installDomShim`, `generateStylesheets`, `generateFTemplates`, `generateWebuiTemplates`, `definitionAsyncResolver`, `shadowOptionsToAttributes`, `ShadowOptionsResolver` |
 | `@microsoft/fast-test-harness/fixtures/*.js` | `CSRFixture`, `SSRFixture`, `toHaveCustomState`, extended `test` and `expect` |
-| `@microsoft/fast-test-harness/ssr/render.js` | `createSSRRenderer`, `renderTemplate`, `buildEntryHtml`, `buildState`, `parseDefaultValue` |
+| `@microsoft/fast-test-harness/ssr/render.js` | `createSSRRenderer`, `renderTemplate`, `buildEntryHtml`, `buildState` |
 | `@microsoft/fast-test-harness/server.mjs` | `startServer` |
 | `@microsoft/fast-test-harness/playwright.config.mjs` | Shared Playwright configuration |
 | `@microsoft/fast-test-harness/vite.config.mjs` | Shared Vite configuration |

--- a/packages/fast-test-harness/src/ssr/render.test.ts
+++ b/packages/fast-test-harness/src/ssr/render.test.ts
@@ -4,67 +4,8 @@ import {
     buildEntryHtml,
     buildState,
     createSSRRenderer,
-    parseDefaultValue,
     renderTemplate,
 } from "@microsoft/fast-test-harness/ssr/render.js";
-
-test.describe("parseDefaultValue", () => {
-    test("should return empty string for empty input", () => {
-        assert.strictEqual(parseDefaultValue(""), "");
-    });
-
-    test("should return empty string for 'undefined'", () => {
-        assert.strictEqual(parseDefaultValue("undefined"), "");
-    });
-
-    test("should return empty string for 'null'", () => {
-        assert.strictEqual(parseDefaultValue("null"), "");
-    });
-
-    test("should return true for 'true'", () => {
-        assert.strictEqual(parseDefaultValue("true"), true);
-    });
-
-    test("should return false for 'false'", () => {
-        assert.strictEqual(parseDefaultValue("false"), false);
-    });
-
-    test("should strip single quotes from strings", () => {
-        assert.strictEqual(parseDefaultValue("'img'"), "img");
-    });
-
-    test("should strip double quotes from strings", () => {
-        assert.strictEqual(parseDefaultValue('"hello"'), "hello");
-    });
-
-    test("should parse integers", () => {
-        assert.strictEqual(parseDefaultValue("42"), 42);
-    });
-
-    test("should parse floats", () => {
-        assert.strictEqual(parseDefaultValue("3.14"), 3.14);
-    });
-
-    test("should parse zero", () => {
-        assert.strictEqual(parseDefaultValue("0"), 0);
-    });
-
-    test("should parse JSON arrays", () => {
-        assert.deepStrictEqual(parseDefaultValue("[1,2,3]"), [1, 2, 3]);
-    });
-
-    test("should parse JSON objects", () => {
-        assert.deepStrictEqual(parseDefaultValue('{"a":1}'), { a: 1 });
-    });
-
-    test("should return empty string for unparseable values", () => {
-        assert.strictEqual(parseDefaultValue("some random text"), "");
-    });
-
-    test("should trim whitespace", () => {
-        assert.strictEqual(parseDefaultValue("  true  "), true);
-    });
-});
 
 test.describe("renderTemplate", () => {
     test("should replace {{styles}} with a link tag", () => {

--- a/packages/fast-test-harness/src/ssr/render.ts
+++ b/packages/fast-test-harness/src/ssr/render.ts
@@ -138,88 +138,6 @@ function toServerUrl(absolutePath: string, packageRoot: string): string {
     return `/${relative(packageRoot, absolutePath).replace(/\\/g, "/")}`;
 }
 
-/**
- * Parse a JavaScript default value string from CEM into a JSON-safe value.
- * @internal
- */
-export function parseDefaultValue(raw: string): unknown {
-    const trimmed = raw.trim();
-
-    if (trimmed === "" || trimmed === "undefined" || trimmed === "null") {
-        return "";
-    }
-
-    if (trimmed === "true") {
-        return true;
-    }
-
-    if (trimmed === "false") {
-        return false;
-    }
-
-    if (trimmed.startsWith("'") || trimmed.startsWith('"')) {
-        return trimmed.slice(1, -1);
-    }
-
-    const num = Number(trimmed);
-    if (!Number.isNaN(num)) {
-        return num;
-    }
-
-    try {
-        return JSON.parse(trimmed);
-    } catch {
-        return "";
-    }
-}
-
-/**
- * Load a Custom Elements Manifest and extract default state for
- * each custom element declaration. Returns a map of tag names to
- * their default property values.
- */
-function loadDefaultStateFromCEM(
-    packageName: string,
-    tagPrefix: string,
-): Map<string, Record<string, unknown>> {
-    const cemPath = resolveSpecifier(`${packageName}/custom-elements.json`);
-    if (!cemPath) {
-        return new Map();
-    }
-
-    try {
-        const cem = JSON.parse(readFileSync(cemPath, "utf8"));
-        const result = new Map<string, Record<string, unknown>>();
-
-        for (const mod of cem.modules ?? []) {
-            for (const decl of mod.declarations ?? []) {
-                if (!decl.customElement) {
-                    continue;
-                }
-                const tagName =
-                    decl.tagName ?? `${tagPrefix}-${decl.name?.toLowerCase()}`;
-                const state: Record<string, unknown> = {};
-                for (const member of decl.members ?? []) {
-                    if (member.kind !== "field" || member.privacy !== "public") {
-                        continue;
-                    }
-                    state[member.name] =
-                        member.default != null
-                            ? parseDefaultValue(String(member.default))
-                            : "";
-                }
-                if (Object.keys(state).length > 0) {
-                    result.set(tagName, state);
-                }
-            }
-        }
-
-        return result;
-    } catch {
-        return new Map();
-    }
-}
-
 interface ComponentArtifacts {
     componentName: string;
     fTemplate: string | null;
@@ -429,28 +347,12 @@ export function createSSRRenderer(options: SSRRendererOptions): {
         }
     }
 
-    // Populate maps and collect default state from CEM.
-    const defaultStateByTag = new Map<string, Record<string, unknown>>();
+    // Populate template and style maps from collected artifacts.
     for (const art of artifacts) {
         if (art.fTemplate) {
             fTemplatesByName.set(art.componentName, art.fTemplate);
         }
         styleUrlsByName.set(art.componentName, art.stylesUrl);
-    }
-
-    // Load CEM defaults per-package (each package may contain multiple elements).
-    if (options.components) {
-        for (const reg of options.components) {
-            const cemDefaults = loadDefaultStateFromCEM(reg.packageName, tagPrefix);
-            for (const [tag, state] of cemDefaults) {
-                defaultStateByTag.set(tag, state);
-            }
-        }
-    } else if (options.packageName) {
-        const cemDefaults = loadDefaultStateFromCEM(options.packageName, tagPrefix);
-        for (const [tag, state] of cemDefaults) {
-            defaultStateByTag.set(tag, state);
-        }
     }
 
     // Inject styles into f-templates, then parse into the WASM
@@ -510,12 +412,7 @@ export function createSSRRenderer(options: SSRRendererOptions): {
     return {
         render(queryObj: Record<string, string> = {}): RenderResult {
             const entryHtml = buildEntryHtml(queryObj);
-            const requestState = buildState(queryObj);
-
-            // Merge CEM default state (base) with request state (overrides).
-            const tagName = String(queryObj.tagName ?? "");
-            const defaults = defaultStateByTag.get(tagName) ?? {};
-            const state = { ...defaults, ...requestState };
+            const state = buildState(queryObj);
 
             let fixture = "";
             if (entryHtml) {
@@ -547,7 +444,7 @@ export function createSSRRenderer(options: SSRRendererOptions): {
                             const solo: string = wasm.render_with_templates(
                                 `${open}</${nestedTag}>`,
                                 templatesJson,
-                                JSON.stringify(defaultStateByTag.get(nestedTag) ?? {}),
+                                "{}",
                                 "camelCase",
                             );
                             // Extract the DSD that was injected.


### PR DESCRIPTION
# Pull Request

## 📖 Description

Remove the `parseDefaultValue` function and all Custom Elements Manifest (CEM) loading logic from the SSR renderer in `@microsoft/fast-test-harness`. This code was a workaround to populate default component state from CEM metadata during SSR test rendering, but it is no longer needed. State is now supplied directly through the test fixtures.

This is a refactor that reduces complexity and removes an implicit dependency on `custom-elements.json` files at render time.

## 📑 Test Plan

All existing tests pass. The `parseDefaultValue` test suite was removed along with the function itself. Remaining SSR renderer tests (`renderTemplate`, `buildEntryHtml`, `buildState`, `createSSRRenderer`) are unaffected.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.