### PR TITLE
feat: auto-tolerate version-only package.json edits in checkchange

### DIFF
--- a/.github/skills/shipping/SKILL.md
+++ b/.github/skills/shipping/SKILL.md
@@ -146,6 +146,8 @@ The Beachball config ([`beachball.config.js`](../../../beachball.config.js)) ign
 - `package-lock.json`
 - `.vscode/`, `.prettierrc`
 
+In addition, the `npm run checkchange` wrapper ([`build/scripts/checkchange.mjs`](../../../build/scripts/checkchange.mjs)) auto-tolerates **version-only** hand edits to `packages/*/package.json`: a PR that only bumps a workspace's `version` field (no other files in that package directory, no other fields in `package.json`) is auto-excluded from beachball's check and does not need a change file. This is intended for hotfix overrides, paired Rust/npm sync recovery, and automation-driven version pins. Any other edit in the package directory re-enables the standard requirement. Remember to also update the paired `crates/<crate-name>/Cargo.toml` and `Cargo.lock` for any package that has one — the `postbump` hook only fires during `npm run bump`.
+
 ## Cross-branch targeting
 
 When working across feature branches, target the branch explicitly:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -208,7 +208,9 @@ gh pr create --fill --base main
 The bump PR goes through normal review. `npm run checkchange` will pass because the change files have all been consumed; the PR itself does **not** publish anything.
 
 :::note
-Do not edit `package.json` or `Cargo.toml` versions by hand. Let `npm run bump` and the postbump hook do it. [`create-github-releases.mjs`](build/scripts/create-github-releases.mjs) refuses to release a workspace whose npm version and paired crate version disagree.
+Avoid editing `package.json` or `Cargo.toml` versions by hand as part of a normal feature/fix PR — let `npm run bump` and the postbump hook do it during a release. [`create-github-releases.mjs`](build/scripts/create-github-releases.mjs) refuses to release a workspace whose npm version and paired crate version disagree.
+
+The exception is a deliberate version-only edit (e.g. a hotfix override, paired Rust/npm version sync recovery, or automation-driven version pin): `npm run checkchange` will auto-tolerate a hand-edited `version` field in `packages/*/package.json` as long as that is the only file touched in the package directory and the only line changed in `package.json`. In that case you do **not** need to author a change file. If you also need to bump the paired Rust crate, edit `crates/<crate-name>/Cargo.toml` and `crates/<crate-name>/Cargo.lock` to match — the `postbump` hook only fires during `npm run bump`, not on hand edits, so manual npm version edits must be paired with manual crate version edits. See [`build/scripts/checkchange.mjs`](build/scripts/checkchange.mjs) for the full auto-exclusion conditions.
 :::
 
 #### 6. After merge

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -122,3 +122,12 @@ module.exports = {
         postbump: syncPairedCrateVersion,
     },
 };
+
+// Note: `npm run checkchange` is wrapped by
+// `build/scripts/checkchange.mjs` so that hand-edited version-only
+// bumps in `packages/*/package.json` (hotfix overrides, paired
+// Rust/npm sync recovery, automation-driven version pins) don't
+// require a no-op change file. The wrapper adds dynamic
+// `--scope "!packages/<pkg>"` exclusions before invoking
+// `beachball check`. See that script's header for the full set of
+// auto-exclusion conditions.

--- a/build/scripts/checkchange.mjs
+++ b/build/scripts/checkchange.mjs
@@ -1,0 +1,276 @@
+#!/usr/bin/env node
+/**
+ * Wrapper around `beachball check` that auto-tolerates version-only
+ * `package.json` edits.
+ *
+ * Background
+ * ----------
+ * Beachball requires a [change file](https://microsoft.github.io/beachball/concepts/change-files.html)
+ * for ANY edit to a publishable workspace's `package.json` — including
+ * a single-line `version` bump. FAST does enough hand-bumping
+ * (hotfix overrides, paired Rust/npm sync recovery, automation-driven
+ * version pins) that requiring a no-op change file by hand each time
+ * is friction. This wrapper inspects the branch + staged diff and, for
+ * each `packages/<pkg>/package.json` whose ONLY diff is the `version`
+ * field, adds `--scope "!packages/<pkg>"` to the `beachball check`
+ * invocation. Beachball then treats those packages as out of scope and
+ * does not demand a change file for them.
+ *
+ * The intent is intentionally narrow: any package edit that goes
+ * beyond a pure version-line bump (other source files in the package,
+ * extra `package.json` fields touched, CHANGELOG.md modified, etc.)
+ * keeps the existing requirement.
+ *
+ * Auto-exclusion conditions (ALL must hold)
+ * -----------------------------------------
+ * 1. The package directory has exactly one changed file in the
+ *    branch+staged diff: `package.json`.
+ * 2. The `package.json` diff is exactly one removed line and one added
+ *    line, both matching the `"version": "..."` field, with the old
+ *    and new versions differing.
+ * 3. The package's current `package.json` is NOT `"private": true`
+ *    (private workspaces are never published, so beachball already
+ *    ignores them — defensive double-check).
+ * 4. No change file for this package already exists in `change/`
+ *    (respect explicit intent: if the maintainer wrote a change file,
+ *    let beachball evaluate it normally).
+ *
+ * If any condition fails, the package is left in scope and beachball
+ * fails as before with its standard hint message.
+ *
+ * Why scope exclusion instead of auto-generating change files?
+ * -----------------------------------------------------------
+ * Beachball's "package already has a change file" lookup is a
+ * `git diff --diff-filter=A` against the target branch, so a generated
+ * `change/*.json` only counts if it is *committed*. A check wrapper
+ * mutating git state on every invocation is unacceptable. Scope
+ * exclusion is purely in-process, leaves no artifacts, and is
+ * auditable through the verbose log this script prints before exec'ing
+ * beachball.
+ */
+
+import { spawnSync } from "node:child_process";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const changeDir = join(repoRoot, "change");
+
+const targetBranch = process.env.BEACHBALL_BRANCH || "origin/main";
+
+/**
+ * Run a git command capturing stdout. Returns "" on non-zero exit
+ * (mirroring beachball's tolerant style for diff-against-merge-base).
+ */
+function git(args) {
+    const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+    if (result.status !== 0) {
+        return "";
+    }
+    return result.stdout;
+}
+
+/**
+ * Get the merge-base of `targetBranch` and HEAD so a single diff
+ * covers committed + staged changes against the branch fork point.
+ * Falls back to `targetBranch` itself when no merge-base is available
+ * (e.g. shallow clone with no shared history yet).
+ */
+function getMergeBase() {
+    const mergeBase = git(["merge-base", targetBranch, "HEAD"]).trim();
+    return mergeBase || targetBranch;
+}
+
+/**
+ * Return the set of changed files (committed-in-branch + staged) as
+ * paths relative to the repo root, with forward slashes.
+ */
+function getChangedFiles(base) {
+    const committed = git(["diff", "--name-only", `${base}..HEAD`])
+        .split("\n")
+        .map(f => f.trim())
+        .filter(Boolean);
+    const staged = git(["diff", "--name-only", "--cached"])
+        .split("\n")
+        .map(f => f.trim())
+        .filter(Boolean);
+    return new Set([...committed, ...staged].map(f => f.split("\\").join("/")));
+}
+
+/**
+ * Return the unified diff of a single file from `base` to the index
+ * (which collapses committed + staged changes into one view).
+ * Diff is configured with zero context so the auto-exclude check sees
+ * only the actual changed lines.
+ */
+function getFileDiff(base, file) {
+    const result = spawnSync(
+        "git",
+        ["diff", "--cached", "--unified=0", "--no-color", base, "--", file],
+        { cwd: repoRoot, encoding: "utf8" },
+    );
+    if (result.status !== 0) {
+        return "";
+    }
+    return result.stdout;
+}
+
+const versionLineRe = /^[+-]\s*"version"\s*:\s*"([^"]+)"\s*,?\s*$/;
+
+/**
+ * Return true iff the file diff body consists of exactly one removed
+ * `"version": "X"` line and one added `"version": "Y"` line, with
+ * X !== Y. Diff headers, hunk headers, and "no newline" markers are
+ * ignored.
+ */
+function isVersionOnlyDiff(diff) {
+    let removed = null;
+    let added = null;
+    for (const line of diff.split("\n")) {
+        if (
+            line === "" ||
+            line.startsWith("diff ") ||
+            line.startsWith("index ") ||
+            line.startsWith("--- ") ||
+            line.startsWith("+++ ") ||
+            line.startsWith("@@") ||
+            line.startsWith("\\ ")
+        ) {
+            continue;
+        }
+        if (line.startsWith("-")) {
+            if (removed !== null) return false;
+            const match = versionLineRe.exec(line);
+            if (!match) return false;
+            removed = match[1];
+            continue;
+        }
+        if (line.startsWith("+")) {
+            if (added !== null) return false;
+            const match = versionLineRe.exec(line);
+            if (!match) return false;
+            added = match[1];
+            continue;
+        }
+        return false;
+    }
+    return removed !== null && added !== null && removed !== added;
+}
+
+/**
+ * Read the names listed in existing change files in `change/` so we
+ * never override an explicit maintainer-written change file.
+ */
+function getPackagesWithChangeFiles() {
+    const names = new Set();
+    if (!existsSync(changeDir)) return names;
+    for (const file of readdirSync(changeDir)) {
+        if (!file.endsWith(".json")) continue;
+        try {
+            const parsed = JSON.parse(readFileSync(join(changeDir, file), "utf8"));
+            const entries = Array.isArray(parsed.changes) ? parsed.changes : [parsed];
+            for (const entry of entries) {
+                if (entry && typeof entry.packageName === "string") {
+                    names.add(entry.packageName);
+                }
+            }
+        } catch {
+            // ignore unparseable change files; beachball's own validator will surface them
+        }
+    }
+    return names;
+}
+
+/**
+ * Read the package name and `private` flag from a workspace's
+ * package.json, returning `null` if the file is missing or unparseable
+ * (in which case we conservatively decline to auto-exclude).
+ */
+function readPackageMeta(packageJsonPath) {
+    if (!existsSync(packageJsonPath)) return null;
+    try {
+        const parsed = JSON.parse(readFileSync(packageJsonPath, "utf8"));
+        if (typeof parsed.name !== "string") return null;
+        return { name: parsed.name, private: parsed.private === true };
+    } catch {
+        return null;
+    }
+}
+
+function findAutoExcludablePackages() {
+    const base = getMergeBase();
+    const changedFiles = getChangedFiles(base);
+    if (changedFiles.size === 0) return [];
+
+    const packagesWithChangeFiles = getPackagesWithChangeFiles();
+
+    const candidates = new Map();
+    for (const file of changedFiles) {
+        const match = /^packages\/([^/]+)\/(.+)$/.exec(file);
+        if (!match) continue;
+        const [, pkgDir, rest] = match;
+        if (!candidates.has(pkgDir)) {
+            candidates.set(pkgDir, new Set());
+        }
+        candidates.get(pkgDir).add(rest);
+    }
+
+    const excludable = [];
+    for (const [pkgDir, files] of candidates) {
+        if (files.size !== 1 || !files.has("package.json")) continue;
+
+        const packageJsonPath = join(repoRoot, "packages", pkgDir, "package.json");
+        const meta = readPackageMeta(packageJsonPath);
+        if (!meta || meta.private) continue;
+        if (packagesWithChangeFiles.has(meta.name)) continue;
+
+        const diff = getFileDiff(base, `packages/${pkgDir}/package.json`);
+        if (!isVersionOnlyDiff(diff)) continue;
+
+        excludable.push({ pkgDir, name: meta.name });
+    }
+    return excludable;
+}
+
+function main() {
+    const passThroughArgs = process.argv.slice(2);
+    const extraScopes = [];
+
+    const excludable = findAutoExcludablePackages();
+    if (excludable.length > 0) {
+        console.log(
+            "[checkchange] Auto-excluding the following packages " +
+                "because their only branch diff is a version-line bump in " +
+                "package.json (no source changes, no existing change file):",
+        );
+        for (const { pkgDir, name } of excludable) {
+            console.log(`[checkchange]   - ${name} (packages/${pkgDir})`);
+            extraScopes.push("--scope", `!packages/${pkgDir}`);
+        }
+        console.log(
+            "[checkchange] If a change file IS desired for one of the " +
+                "above (e.g. to emit a changelog entry), run `npm run change` " +
+                "and beachball will re-include the package automatically.",
+        );
+    }
+
+    const beachballArgs = [
+        "beachball",
+        "check",
+        "--scope",
+        "!sites/*",
+        ...extraScopes,
+        "--changehint",
+        "Run 'npm run change' to generate a change file",
+        ...passThroughArgs,
+    ];
+
+    const result = spawnSync("npx", beachballArgs, {
+        cwd: repoRoot,
+        stdio: "inherit",
+    });
+    process.exit(result.status ?? 1);
+}
+
+main();

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bump": "beachball bump",
     "build": "lage build",
     "change": "beachball change --dependent-change-type none",
-    "checkchange": "beachball check  --scope \"!sites/*\" --changehint \"Run 'npm run change' to generate a change file\"",
+    "checkchange": "node build/scripts/checkchange.mjs",
     "check": "beachball check ",
     "build:gh-pages": "npm run build -w @microsoft/fast-site",
     "publish": "beachball publish",


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add `build/scripts/checkchange.mjs`, a thin wrapper around `beachball check` that auto-tolerates **version-only** hand edits to `packages/*/package.json`.

Today `npm run checkchange` fails for any `package.json` edit in a publishable workspace — including a single-line `version` bump — because beachball requires a corresponding change file. FAST does enough hand-bumping (hotfix overrides, paired Rust/npm sync recovery, automation-driven version pins) that requiring a no-op change file by hand each time is friction, and instructing maintainers to never edit `package.json` versions by hand (the previous `CONTRIBUTING.md` guidance) is brittle.

The wrapper inspects the branch + staged diff and, for each `packages/<pkg>/package.json` whose **only** branch diff is a single-line `"version"` field bump (no other files in the package directory, no other fields in `package.json`, no existing change file for the package), adds `--scope "!packages/<pkg>"` to the `beachball check` invocation. Beachball then treats that package as out of scope and does not demand a change file. Any other edit in the package directory re-enables the standard requirement.

Documentation in `CONTRIBUTING.md` and `.github/skills/shipping/SKILL.md` is updated to describe the carve-out, including the reminder that hand edits to a paired Rust crate's `Cargo.toml`/`Cargo.lock` still have to be done manually (the `postbump` hook only fires during `npm run bump`).

## 👩‍💻 Reviewer Notes

- **Why scope exclusion, not auto-generated change files?** Beachball's "package already has a change file" lookup is a `git diff --diff-filter=A` against the target branch, so a generated `change/*.json` only counts if it's *committed*. A check wrapper mutating git state on every invocation would be unacceptable. Scope exclusion is purely in-process, leaves no artifacts, and is auditable through the verbose log the script prints before exec'ing beachball.
- **Auto-exclusion conditions** (all must hold, see the script header for the full rationale):
  1. The package directory has exactly one changed file: `package.json`.
  2. The `package.json` diff is exactly one removed line and one added line, both matching the `"version": "..."` field, old != new.
  3. The package is not `"private": true`.
  4. No change file for the package already exists in `change/`.
- **Bump-PR behaviour is intentionally unchanged.** Bump PRs touch `CHANGELOG.md` and frequently dependency versions in `package.json`, so they fail conditions 1 and 2 and are not auto-excluded by this wrapper. That keeps this PR's scope narrow.
- The wrapper honours the existing `--scope "!sites/*"` and `--changehint` exactly as the old script did, and forwards extra args via `process.argv.slice(2)`.

## 📑 Test Plan

Verified locally against a fresh `npm ci`:

- `npm run checkchange` on a clean tree → no-op, exits 0.
- Hand-edit `packages/fast-element/package.json` version only (staged) → wrapper logs `[checkchange] Auto-excluding @microsoft/fast-element …`, beachball check exits 0.
- Hand-edit version + a source file in the same package (`packages/fast-element/src/index.ts`) → wrapper does NOT exclude, beachball check fails with `Change files are needed!` and the original hint.
- Hand-edit a non-version field in `package.json` (with or without a version bump in the same diff) → wrapper does NOT exclude, beachball check fails as before.
- Staged change file already present for the bumped package → wrapper does NOT exclude (lets beachball evaluate the change file normally).
- `npx biome check build/scripts/checkchange.mjs beachball.config.js` → no issues.
- `npm run format:check` → passes.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [ ] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

> Note on the change-file box: this PR's changes live entirely in `.github/` (skill), root `package.json` (script wiring), `beachball.config.js`, `build/` (script), and `CONTRIBUTING.md`. None of those paths are publishable workspaces, so beachball does not require a change file for this PR (and the wrapper introduced here is itself the mechanism that confirms that).

> Note on the tests box: the changes are exercised end-to-end through `npm run checkchange` against synthetic manual-bump diffs (see Test Plan). The wrapper has no separately published surface, so dedicated unit tests are not introduced.

## ⏭ Next Steps

A natural follow-up is to extend the wrapper (or write a sibling helper) to handle the bump-PR scenario itself — today the bump PR fails `npm run checkchange` because `git diff --diff-filter=A` does not surface the deleted, just-consumed change files (despite the current note in `CONTRIBUTING.md` step 5 claiming the bump PR passes). That fix is out of scope for this PR but should be tracked separately.
