### PR TITLE
feat(checkchange): bypass on publish_<ts> branches for repo admins

### DIFF
--- a/.github/skills/shipping/SKILL.md
+++ b/.github/skills/shipping/SKILL.md
@@ -146,10 +146,10 @@ The Beachball config ([`beachball.config.js`](../../../beachball.config.js)) ign
 - `package-lock.json`
 - `.vscode/`, `.prettierrc`
 
-Additionally, [`build/scripts/checkchange.mjs`](../../../build/scripts/checkchange.mjs) (which wraps `beachball check` for the `checkchange` npm script) skips the check entirely on **manual version bump** branches authored by an allowlisted maintainer. Specifically, both of the following must be true for the current run:
+Additionally, [`build/scripts/checkchange.mjs`](../../../build/scripts/checkchange.mjs) (which wraps `beachball check` for the `checkchange` npm script) skips the check entirely on **manual version bump** branches authored by a repo admin. Specifically, both of the following must be true for the current run:
 
 1. Branch name matches `^publish_\d+$` (beachball's documented publish-branch convention).
-2. `$GITHUB_ACTOR` (or the local HEAD commit author email) is on the allowlist defined at the top of the wrapper.
+2. The actor (`$GITHUB_ACTOR` in CI; locally, the user from `gh api user`) has the `admin` role on `microsoft/fast`, verified via the GitHub REST API.
 
 If either condition fails, the change-file requirement applies as before. See [`CONTRIBUTING.md` > Manual version bumps](../../../CONTRIBUTING.md#manual-version-bumps) for the full rationale and reviewer expectations.
 

--- a/.github/skills/shipping/SKILL.md
+++ b/.github/skills/shipping/SKILL.md
@@ -146,6 +146,13 @@ The Beachball config ([`beachball.config.js`](../../../beachball.config.js)) ign
 - `package-lock.json`
 - `.vscode/`, `.prettierrc`
 
+Additionally, [`build/scripts/checkchange.mjs`](../../../build/scripts/checkchange.mjs) (which wraps `beachball check` for the `checkchange` npm script) skips the check entirely on **manual version bump** branches authored by an allowlisted maintainer. Specifically, both of the following must be true for the current run:
+
+1. Branch name matches `^publish_\d+$` (beachball's documented publish-branch convention).
+2. `$GITHUB_ACTOR` (or the local HEAD commit author email) is on the allowlist defined at the top of the wrapper.
+
+If either condition fails, the change-file requirement applies as before. See [`CONTRIBUTING.md` > Manual version bumps](../../../CONTRIBUTING.md#manual-version-bumps) for the full rationale and reviewer expectations.
+
 ## Cross-branch targeting
 
 When working across feature branches, target the branch explicitly:

--- a/.github/workflows/ci-validate-pr.yml
+++ b/.github/workflows/ci-validate-pr.yml
@@ -50,6 +50,8 @@ jobs:
 
     - name: Check for the presence of changed files inside ./change
       run: npm run checkchange
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
 
     - name: Biome CI check
       run: npm run biome:ci

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,10 +158,12 @@ Every PR that touches a publishable workspace should include a beachball [change
 
 #### 2. Create the bump branch
 
+The branch name must match beachball's `publish_<timestamp>` convention so that [`build/scripts/checkchange.mjs`](build/scripts/checkchange.mjs) recognizes the PR as a bump and skips the change-file requirement (see [Manual version bumps](#manual-version-bumps) below for the bypass details).
+
 ```bash
 git checkout main
 git pull origin main
-git checkout -b chore/bump-$(date +%Y-%m-%d)
+git checkout -b "publish_$(node -p 'Date.now()')"
 ```
 
 #### 3. Run `npm run bump`
@@ -201,14 +203,16 @@ A typical bump PR touches:
 ```bash
 git add -A
 git commit -m "chore: release packages"
-git push origin chore/bump-$(date +%Y-%m-%d)
+git push origin "$(git rev-parse --abbrev-ref HEAD)"
 gh pr create --fill --base main
 ```
 
-The bump PR goes through normal review. `npm run checkchange` will pass because the change files have all been consumed; the PR itself does **not** publish anything.
+The bump PR goes through normal review. `npm run checkchange` will pass because the branch name matches `publish_<timestamp>` and the commit author is on the [manual-bump allowlist](#manual-version-bumps); the PR itself does **not** publish anything.
 
 :::note
-Do not edit `package.json` or `Cargo.toml` versions by hand. Let `npm run bump` and the postbump hook do it. [`create-github-releases.mjs`](build/scripts/create-github-releases.mjs) refuses to release a workspace whose npm version and paired crate version disagree.
+Do not edit `package.json` or `Cargo.toml` versions by hand as part of a normal feature/fix PR. Let `npm run bump` and the postbump hook do it. [`create-github-releases.mjs`](build/scripts/create-github-releases.mjs) refuses to release a workspace whose npm version and paired crate version disagree.
+
+A narrow exception exists for the **manual version bump** flow described in [the next section](#manual-version-bumps) — hotfix overrides, paired Rust/npm sync recovery, or scripted version pins. Those edits are tolerated by `npm run checkchange` only on a `publish_<timestamp>` branch authored by an allowlisted maintainer.
 :::
 
 #### 6. After merge
@@ -222,6 +226,28 @@ The same flow works for a single-package release — just keep only the relevant
 ```bash
 npx beachball bump --package "@microsoft/fast-build"
 ```
+
+### Manual version bumps
+
+`npm run checkchange` normally requires a beachball [change file](#change-files) for any edit to `packages/*/package.json`, including a single `"version"` line. Three maintainer-driven flows produce legitimate `package.json` edits without a change file:
+
+- The full bump PR documented in [Publishing](#publishing) above (`npm run bump` consumes the change files, so by the time the PR is opened there is nothing left for `npm run change` to record).
+- **Hotfix overrides** where the entire change is `1.2.3` → `1.2.4` on one or two workspaces.
+- **Paired Rust crate ↔ npm package sync recovery** where the postbump hook missed an entry (the npm version is correct but `Cargo.toml` drifted, or vice versa) and a maintainer is forcing the two back into agreement.
+
+To accommodate these flows without weakening the check for the broad contributor population, [`build/scripts/checkchange.mjs`](build/scripts/checkchange.mjs) skips beachball entirely **only** when both of the following are true for the current run:
+
+1. **Branch name matches `^publish_\d+$`** — beachball's own convention for its temporary publish branch, generated as `'publish_' + String(new Date().getTime())` in [`beachball/lib/commands/publish.js`](https://github.com/microsoft/beachball/blob/master/src/commands/publish.ts). Recommended way to generate one:
+   ```bash
+   git checkout -b "publish_$(node -p 'Date.now()')"
+   ```
+2. **Actor is on the maintainer allowlist.** The wrapper reads `$GITHUB_ACTOR` in CI (the user who opened or synchronized the PR) and falls back to the HEAD commit author email locally. Allowlisted identities are listed inline at the top of [`checkchange.mjs`](build/scripts/checkchange.mjs).
+
+If either condition fails, beachball runs normally and the change-file requirement applies. Both conditions must be deliberately satisfied — naming a branch `publish_1234567890` is not enough on its own, nor is being a maintainer on a regular feature branch.
+
+Every bypass writes a multi-line banner to the CI log naming the branch, the actor, and the source of each (env var vs. local git). Reviewers should spot-check that banner on bump PRs and either close the PR or rename the branch (drop the `publish_` prefix) if the diff turns out to contain real source-code changes rather than a version bump.
+
+To extend the allowlist (e.g. a new maintainer takes ownership of releases), edit the `ALLOWED_LOGINS` and `ALLOWED_EMAILS` constants near the top of the wrapper and open a PR — the diff is auditable and the change is reverted by the next reviewer if unintended.
 
 ### Recommended Settings for Visual Studio Code
 

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -158,7 +158,7 @@ Every PR that touches a publishable workspace should include a beachball [change
 
 #### 2. Create the bump branch
 
-The branch name must match beachball's `publish_<timestamp>` convention so that [`build/scripts/checkchange.mjs`](build/scripts/checkchange.mjs) recognizes the PR as a bump and skips the change-file requirement (see [Manual version bumps](#manual-version-bumps) below for the bypass details).
+The branch name must match beachball's `publish_<timestamp>` convention so that [`build/scripts/checkchange.mjs`](build/scripts/checkchange.mjs) recognizes the PR as a bump and skips the change-file requirement, provided the actor has the `admin` role on the repo (see [Manual version bumps](#manual-version-bumps) below for the bypass details).
 
 ```bash
 git checkout main
@@ -207,12 +207,12 @@ git push origin "$(git rev-parse --abbrev-ref HEAD)"
 gh pr create --fill --base main
 ```
 
-The bump PR goes through normal review. `npm run checkchange` will pass because the branch name matches `publish_<timestamp>` and the commit author is on the [manual-bump allowlist](#manual-version-bumps); the PR itself does **not** publish anything.
+The bump PR goes through normal review. `npm run checkchange` will pass because the branch name matches `publish_<timestamp>` and the actor has admin on the repo (see [Manual version bumps](#manual-version-bumps)); the PR itself does **not** publish anything.
 
 :::note
 Do not edit `package.json` or `Cargo.toml` versions by hand as part of a normal feature/fix PR. Let `npm run bump` and the postbump hook do it. [`create-github-releases.mjs`](build/scripts/create-github-releases.mjs) refuses to release a workspace whose npm version and paired crate version disagree.
 
-A narrow exception exists for the **manual version bump** flow described in [the next section](#manual-version-bumps) — hotfix overrides, paired Rust/npm sync recovery, or scripted version pins. Those edits are tolerated by `npm run checkchange` only on a `publish_<timestamp>` branch authored by an allowlisted maintainer.
+A narrow exception exists for the **manual version bump** flow described in [the next section](#manual-version-bumps) — hotfix overrides, paired Rust/npm sync recovery, or scripted version pins. Those edits are tolerated by `npm run checkchange` only on a `publish_<timestamp>` branch whose actor has the `admin` role on `microsoft/fast`.
 :::
 
 #### 6. After merge
@@ -241,13 +241,13 @@ To accommodate these flows without weakening the check for the broad contributor
    ```bash
    git checkout -b "publish_$(node -p 'Date.now()')"
    ```
-2. **Actor is on the maintainer allowlist.** The wrapper reads `$GITHUB_ACTOR` in CI (the user who opened or synchronized the PR) and falls back to the HEAD commit author email locally. Allowlisted identities are listed inline at the top of [`checkchange.mjs`](build/scripts/checkchange.mjs).
+2. **Actor has the `admin` role on `microsoft/fast`,** verified live via the GitHub REST API (`GET /repos/microsoft/fast/collaborators/<login>/permission`). The wrapper reads the actor login from `$GITHUB_ACTOR` in CI and falls back to `gh api user --jq .login` locally; it reads the API token from `$GITHUB_TOKEN` → `$GH_TOKEN` → `gh auth token` in order. Maintainership lives in the GitHub repo settings, so adding or removing a maintainer requires no change to this script.
 
-If either condition fails, beachball runs normally and the change-file requirement applies. Both conditions must be deliberately satisfied — naming a branch `publish_1234567890` is not enough on its own, nor is being a maintainer on a regular feature branch.
+If either condition fails, beachball runs normally and the change-file requirement applies. The bypass is granted only when the GitHub API responds with `"admin"`; any short-circuit before that (missing token, missing login, network error, non-admin role) falls through to `beachball check` and the wrapper logs the reason.
 
-Every bypass writes a multi-line banner to the CI log naming the branch, the actor, and the source of each (env var vs. local git). Reviewers should spot-check that banner on bump PRs and either close the PR or rename the branch (drop the `publish_` prefix) if the diff turns out to contain real source-code changes rather than a version bump.
+Every bypass writes a multi-line banner to the CI log naming the branch, the actor, the resolved role, and the source of each (env var vs. local CLI). Reviewers should spot-check that banner on bump PRs and either close the PR or rename the branch (drop the `publish_` prefix) if the diff turns out to contain real source-code changes rather than a version bump.
 
-To extend the allowlist (e.g. a new maintainer takes ownership of releases), edit the `ALLOWED_LOGINS` and `ALLOWED_EMAILS` constants near the top of the wrapper and open a PR — the diff is auditable and the change is reverted by the next reviewer if unintended.
+To grant or revoke the bypass for someone, change their role on `microsoft/fast` (Settings → Collaborators and teams). The wrapper picks up the change on the next CI run.
 
 ### Recommended Settings for Visual Studio Code
 

--- a/beachball.config.js
+++ b/beachball.config.js
@@ -105,6 +105,10 @@ function syncPairedCrateVersion(packagePath, name, version) {
     }
 }
 
+// `npm run checkchange` is wrapped by `build/scripts/checkchange.mjs`,
+// which can skip `beachball check` for maintainer-authored manual bump
+// branches (see CONTRIBUTING.md > "Manual version bumps"). The
+// `ignorePatterns` and `hooks` below still apply when beachball runs.
 module.exports = {
     ignorePatterns: [
         ".ignore",

--- a/build/scripts/checkchange.mjs
+++ b/build/scripts/checkchange.mjs
@@ -55,7 +55,6 @@ const ALLOWED_LOGINS = new Set(["janechu", "chrisdholt"]);
 const ALLOWED_EMAILS = new Set([
     "7559015+janechu@users.noreply.github.com",
     "13071055+chrisdholt@users.noreply.github.com",
-    "chhol@microsoft.com",
 ]);
 
 const PUBLISH_BRANCH_RE = /^publish_\d+$/;

--- a/build/scripts/checkchange.mjs
+++ b/build/scripts/checkchange.mjs
@@ -1,0 +1,164 @@
+#!/usr/bin/env node
+/**
+ * Wrapper around `beachball check` for the `checkchange` npm script.
+ *
+ * Background
+ * ----------
+ * Beachball requires a [change file](https://microsoft.github.io/beachball/concepts/change-files.html)
+ * for ANY edit to a publishable workspace's `package.json` — including
+ * a hand-written `version` bump. That is the desired default for normal
+ * feature/fix PRs, but a small set of maintainer-driven flows
+ * legitimately produce package.json edits without a change file:
+ *
+ *   - Hotfix overrides where the bump is the entire change.
+ *   - Paired Rust-crate / npm-package version sync recovery.
+ *   - Renovate-style or scripted version pins on a dedicated branch.
+ *
+ * Authorizing the bypass
+ * ----------------------
+ * To avoid weakening the check for the broad contributor population,
+ * `checkchange` skips beachball entirely ONLY when BOTH of the
+ * following are true:
+ *
+ *   1. The current branch name matches beachball's documented publish
+ *      branch convention (`publish_<timestamp>`, generated as
+ *      `'publish_' + String(new Date().getTime())` in
+ *      `beachball/lib/commands/publish.js`). Matching pattern:
+ *      `/^publish_\d+$/`.
+ *
+ *   2. The workflow actor (`$GITHUB_ACTOR`) or, locally, the HEAD
+ *      commit author email, is on a short allowlist of maintainers
+ *      who routinely own the release / hotfix flow.
+ *
+ * Both conditions must hold. A contributor who renames their branch to
+ * `publish_1234567890` but is not on the allowlist gets the normal
+ * change-file requirement; an allowlisted maintainer working on a
+ * regular feature branch also gets the normal requirement. The bypass
+ * is a deliberate, opt-in convention — not an implicit perk of
+ * maintainer status.
+ *
+ * Every bypass writes a loud banner to stdout naming the branch,
+ * actor, and event source so a reviewer scanning CI logs can spot it.
+ *
+ * See `CONTRIBUTING.md` ("Manual version bumps") for the maintainer
+ * workflow and the rationale behind each guard.
+ */
+
+import { spawnSync } from "node:child_process";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+
+const ALLOWED_LOGINS = new Set(["janechu", "chrisdholt"]);
+
+const ALLOWED_EMAILS = new Set([
+    "7559015+janechu@users.noreply.github.com",
+    "13071055+chrisdholt@users.noreply.github.com",
+    "chhol@microsoft.com",
+]);
+
+const PUBLISH_BRANCH_RE = /^publish_\d+$/;
+
+function git(args) {
+    const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+    if (result.status !== 0) {
+        return "";
+    }
+    return result.stdout.trim();
+}
+
+function getBranchName() {
+    const headRef = process.env.GITHUB_HEAD_REF;
+    if (headRef && headRef.trim() !== "") {
+        return { value: headRef.trim(), source: "GITHUB_HEAD_REF" };
+    }
+    const refName = process.env.GITHUB_REF_NAME;
+    if (refName && refName.trim() !== "") {
+        return { value: refName.trim(), source: "GITHUB_REF_NAME" };
+    }
+    const local = git(["rev-parse", "--abbrev-ref", "HEAD"]);
+    return { value: local, source: "git" };
+}
+
+function getActorIdentity() {
+    const actor = process.env.GITHUB_ACTOR;
+    if (actor && actor.trim() !== "") {
+        return { value: actor.trim(), kind: "login", source: "GITHUB_ACTOR" };
+    }
+    const email = git(["log", "-1", "--format=%ae", "HEAD"]);
+    return { value: email, kind: "email", source: "git" };
+}
+
+function isAllowedActor(actor) {
+    if (!actor.value) return false;
+    if (actor.kind === "login") return ALLOWED_LOGINS.has(actor.value);
+    if (actor.kind === "email") return ALLOWED_EMAILS.has(actor.value);
+    return false;
+}
+
+function logBypassBanner({ branch, actor }) {
+    const lines = [
+        "",
+        "================================================================",
+        "[checkchange] BYPASS: skipping `beachball check` for this run.",
+        "----------------------------------------------------------------",
+        `  branch          : ${branch.value}    (source: ${branch.source})`,
+        `  actor (${actor.kind.padEnd(5)}) : ${actor.value}    (source: ${actor.source})`,
+        "",
+        "  Reason: branch matches beachball's `publish_<timestamp>`",
+        "  convention AND actor is on the manual-bump allowlist in",
+        "  build/scripts/checkchange.mjs.",
+        "",
+        "  No change file is required for this PR. If this bypass is",
+        "  unexpected (e.g. the branch contains real source changes",
+        "  rather than a version bump), close the PR or rename the",
+        "  branch to remove the `publish_` prefix and push again.",
+        "",
+        "  See CONTRIBUTING.md > 'Manual version bumps' for context.",
+        "================================================================",
+        "",
+    ];
+    for (const line of lines) {
+        console.log(line);
+    }
+}
+
+function runBeachballCheck(passThroughArgs) {
+    const args = [
+        "beachball",
+        "check",
+        "--scope",
+        "!sites/*",
+        "--changehint",
+        "Run 'npm run change' to generate a change file",
+        ...passThroughArgs,
+    ];
+    const result = spawnSync("npx", args, {
+        cwd: repoRoot,
+        stdio: "inherit",
+    });
+    if (result.error) {
+        console.error("[checkchange] Failed to execute beachball:", result.error.message);
+        process.exit(1);
+    }
+    process.exit(result.status ?? 1);
+}
+
+function main() {
+    const passThroughArgs = process.argv.slice(2);
+    const branch = getBranchName();
+    const actor = getActorIdentity();
+
+    const branchMatches = PUBLISH_BRANCH_RE.test(branch.value);
+    const actorAllowed = isAllowedActor(actor);
+
+    if (branchMatches && actorAllowed) {
+        logBypassBanner({ branch, actor });
+        process.exit(0);
+    }
+
+    runBeachballCheck(passThroughArgs);
+}
+
+main();

--- a/build/scripts/checkchange.mjs
+++ b/build/scripts/checkchange.mjs
@@ -6,9 +6,9 @@
  * ----------
  * Beachball requires a [change file](https://microsoft.github.io/beachball/concepts/change-files.html)
  * for ANY edit to a publishable workspace's `package.json` — including
- * a hand-written `version` bump. That is the desired default for normal
- * feature/fix PRs, but a small set of maintainer-driven flows
- * legitimately produce package.json edits without a change file:
+ * a hand-written `version` bump. That is the desired default for the
+ * broad contributor population, but a small set of maintainer-driven
+ * flows legitimately produce package.json edits without a change file:
  *
  *   - Hotfix overrides where the bump is the entire change.
  *   - Paired Rust-crate / npm-package version sync recovery.
@@ -26,19 +26,27 @@
  *      `beachball/lib/commands/publish.js`). Matching pattern:
  *      `/^publish_\d+$/`.
  *
- *   2. The workflow actor (`$GITHUB_ACTOR`) or, locally, the HEAD
- *      commit author email, is on a short allowlist of maintainers
- *      who routinely own the release / hotfix flow.
+ *   2. The actor has the `admin` role on `microsoft/fast`, verified
+ *      live via the GitHub REST API:
+ *      `GET /repos/microsoft/fast/collaborators/<login>/permission`.
+ *      The actor login is read from `$GITHUB_ACTOR` in CI and falls
+ *      back to `gh api user --jq .login` for local runs. The API
+ *      token is read from `$GITHUB_TOKEN` → `$GH_TOKEN` →
+ *      `gh auth token` in order.
  *
- * Both conditions must hold. A contributor who renames their branch to
- * `publish_1234567890` but is not on the allowlist gets the normal
- * change-file requirement; an allowlisted maintainer working on a
- * regular feature branch also gets the normal requirement. The bypass
- * is a deliberate, opt-in convention — not an implicit perk of
- * maintainer status.
+ * Both conditions must hold. Maintainership lives in the GitHub repo
+ * settings (no hardcoded login list to keep in sync), and a publishable
+ * branch alone — without admin role — gets the normal change-file
+ * requirement.
  *
- * Every bypass writes a loud banner to stdout naming the branch,
- * actor, and event source so a reviewer scanning CI logs can spot it.
+ * Fail-closed
+ * -----------
+ * Every short-circuit before the bypass (no token, no login, network
+ * error, non-admin role) falls through to `beachball check`. The
+ * bypass is only granted when the API responds with `"admin"`.
+ *
+ * Every bypass writes a loud banner to stdout naming the branch, the
+ * actor, and the role so a reviewer scanning CI logs can spot it.
  *
  * See `CONTRIBUTING.md` ("Manual version bumps") for the maintainer
  * workflow and the rationale behind each guard.
@@ -50,17 +58,21 @@ import { fileURLToPath } from "node:url";
 
 const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
 
-const ALLOWED_LOGINS = new Set(["janechu", "chrisdholt"]);
-
-const ALLOWED_EMAILS = new Set([
-    "7559015+janechu@users.noreply.github.com",
-    "13071055+chrisdholt@users.noreply.github.com",
-]);
-
+const REPO = "microsoft/fast";
+const REQUIRED_ROLE = "admin";
 const PUBLISH_BRANCH_RE = /^publish_\d+$/;
+const API_TIMEOUT_MS = 5000;
 
 function git(args) {
     const result = spawnSync("git", args, { cwd: repoRoot, encoding: "utf8" });
+    if (result.status !== 0) {
+        return "";
+    }
+    return result.stdout.trim();
+}
+
+function ghCli(args) {
+    const result = spawnSync("gh", args, { cwd: repoRoot, encoding: "utf8" });
     if (result.status !== 0) {
         return "";
     }
@@ -80,34 +92,70 @@ function getBranchName() {
     return { value: local, source: "git" };
 }
 
-function getActorIdentity() {
+function getActorLogin() {
     const actor = process.env.GITHUB_ACTOR;
     if (actor && actor.trim() !== "") {
-        return { value: actor.trim(), kind: "login", source: "GITHUB_ACTOR" };
+        return { value: actor.trim(), source: "GITHUB_ACTOR" };
     }
-    const email = git(["log", "-1", "--format=%ae", "HEAD"]);
-    return { value: email, kind: "email", source: "git" };
+    const login = ghCli(["api", "user", "--jq", ".login"]);
+    if (login) {
+        return { value: login, source: "gh api user" };
+    }
+    return { value: null, source: null };
 }
 
-function isAllowedActor(actor) {
-    if (!actor.value) return false;
-    if (actor.kind === "login") return ALLOWED_LOGINS.has(actor.value);
-    if (actor.kind === "email") return ALLOWED_EMAILS.has(actor.value);
-    return false;
+function getToken() {
+    if (process.env.GITHUB_TOKEN) {
+        return { value: process.env.GITHUB_TOKEN, source: "GITHUB_TOKEN" };
+    }
+    if (process.env.GH_TOKEN) {
+        return { value: process.env.GH_TOKEN, source: "GH_TOKEN" };
+    }
+    const token = ghCli(["auth", "token"]);
+    if (token) {
+        return { value: token, source: "gh auth token" };
+    }
+    return { value: null, source: null };
 }
 
-function logBypassBanner({ branch, actor }) {
+async function fetchPermission(login, token) {
+    const url = `https://api.github.com/repos/${REPO}/collaborators/${encodeURIComponent(login)}/permission`;
+    const controller = new AbortController();
+    const timeoutId = setTimeout(() => controller.abort(), API_TIMEOUT_MS);
+    try {
+        const res = await fetch(url, {
+            headers: {
+                Authorization: `Bearer ${token}`,
+                Accept: "application/vnd.github+json",
+                "X-GitHub-Api-Version": "2022-11-28",
+                "User-Agent": "fast-checkchange",
+            },
+            signal: controller.signal,
+        });
+        if (!res.ok) {
+            return { permission: null, error: `HTTP ${res.status} ${res.statusText}` };
+        }
+        const body = await res.json();
+        return { permission: body.permission ?? null, error: null };
+    } catch (err) {
+        return { permission: null, error: err.message || String(err) };
+    } finally {
+        clearTimeout(timeoutId);
+    }
+}
+
+function logBypassBanner({ branch, actor, permission }) {
     const lines = [
         "",
         "================================================================",
         "[checkchange] BYPASS: skipping `beachball check` for this run.",
         "----------------------------------------------------------------",
-        `  branch          : ${branch.value}    (source: ${branch.source})`,
-        `  actor (${actor.kind.padEnd(5)}) : ${actor.value}    (source: ${actor.source})`,
+        `  branch    : ${branch.value}    (source: ${branch.source})`,
+        `  actor     : ${actor.value}    (source: ${actor.source})`,
+        `  role      : ${permission}    (source: GitHub API ${REPO})`,
         "",
         "  Reason: branch matches beachball's `publish_<timestamp>`",
-        "  convention AND actor is on the manual-bump allowlist in",
-        "  build/scripts/checkchange.mjs.",
+        `  convention AND actor has the '${REQUIRED_ROLE}' role on ${REPO}.`,
         "",
         "  No change file is required for this PR. If this bypass is",
         "  unexpected (e.g. the branch contains real source changes",
@@ -144,20 +192,65 @@ function runBeachballCheck(passThroughArgs) {
     process.exit(result.status ?? 1);
 }
 
-function main() {
+async function main() {
     const passThroughArgs = process.argv.slice(2);
     const branch = getBranchName();
-    const actor = getActorIdentity();
 
-    const branchMatches = PUBLISH_BRANCH_RE.test(branch.value);
-    const actorAllowed = isAllowedActor(actor);
-
-    if (branchMatches && actorAllowed) {
-        logBypassBanner({ branch, actor });
-        process.exit(0);
+    if (!PUBLISH_BRANCH_RE.test(branch.value)) {
+        runBeachballCheck(passThroughArgs);
+        return;
     }
 
-    runBeachballCheck(passThroughArgs);
+    const actor = getActorLogin();
+    if (!actor.value) {
+        console.warn(
+            "[checkchange] Branch matches `publish_<timestamp>` but the " +
+                "actor login could not be determined (no $GITHUB_ACTOR and " +
+                "`gh api user` failed). Falling through to `beachball check`.",
+        );
+        runBeachballCheck(passThroughArgs);
+        return;
+    }
+
+    const token = getToken();
+    if (!token.value) {
+        console.warn(
+            "[checkchange] Branch matches `publish_<timestamp>` and actor " +
+                `is '${actor.value}', but no GitHub token is available ` +
+                "(set $GITHUB_TOKEN, $GH_TOKEN, or authenticate with " +
+                "`gh auth login`). Falling through to `beachball check`.",
+        );
+        runBeachballCheck(passThroughArgs);
+        return;
+    }
+
+    const { permission, error } = await fetchPermission(actor.value, token.value);
+    if (error) {
+        console.warn(
+            `[checkchange] Could not verify '${actor.value}' role on ` +
+                `${REPO} via GitHub API (${error}; token source: ` +
+                `${token.source}). Falling through to \`beachball check\`.`,
+        );
+        runBeachballCheck(passThroughArgs);
+        return;
+    }
+
+    if (permission !== REQUIRED_ROLE) {
+        console.log(
+            `[checkchange] Branch matches \`publish_<timestamp>\` but ` +
+                `actor '${actor.value}' has role '${permission ?? "none"}' ` +
+                `on ${REPO} (required: '${REQUIRED_ROLE}'). Falling ` +
+                "through to `beachball check`.",
+        );
+        runBeachballCheck(passThroughArgs);
+        return;
+    }
+
+    logBypassBanner({ branch, actor, permission });
+    process.exit(0);
 }
 
-main();
+main().catch(err => {
+    console.error("[checkchange] Unexpected error:", err);
+    process.exit(1);
+});

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bump": "beachball bump",
     "build": "lage build",
     "change": "beachball change --dependent-change-type none",
-    "checkchange": "beachball check  --scope \"!sites/*\" --changehint \"Run 'npm run change' to generate a change file\"",
+    "checkchange": "node build/scripts/checkchange.mjs",
     "check": "beachball check ",
     "build:gh-pages": "npm run build -w @microsoft/fast-site",
     "publish": "beachball publish",


### PR DESCRIPTION
## Description

Replaces the bare `beachball check` invocation in `npm run checkchange` with a thin Node wrapper (`build/scripts/checkchange.mjs`) that **skips the change-file requirement** only when **both** of these hold for the current run:

1. **Branch name matches `^publish_\d+$`** — beachball's own publish-branch convention, generated as `'publish_' + String(new Date().getTime())` in [`beachball/lib/commands/publish.js`](https://github.com/microsoft/beachball/blob/master/src/commands/publish.ts).
2. **Actor has the `admin` role on `microsoft/fast`** — verified live via the GitHub REST API: `GET /repos/microsoft/fast/collaborators/<login>/permission`. The wrapper resolves the actor login from `$GITHUB_ACTOR` in CI (falling back to `gh api user --jq .login` locally) and reads the API token from `$GITHUB_TOKEN` → `$GH_TOKEN` → `gh auth token`.

Maintainership lives in the GitHub repo settings — adding or revoking the bypass for someone happens by changing their role on `microsoft/fast`, not by editing this script.

When the bypass fires, the wrapper writes a multi-line banner to stdout naming the branch, the actor, the resolved role, and the source of each so reviewers can spot the bypass in CI logs and verify the diff really is a version bump.

This PR supersedes the now-closed #7536, which used diff-content inspection ("the only changed line is `"version"`") to auto-exclude packages. That approach was silently coupled to file contents and was abandoned in favor of the explicit, declarative branch + role check here.

## Reviewer notes

- **Why both conditions?** Either alone is too easy to trigger. Branch-name alone would let any contributor bypass by renaming their branch. Role-only would bypass every PR from a maintainer, including normal source-code changes. The AND is the safety net.
- **Why `^publish_\d+$` and not a broader pattern?** Matching beachball's exact convention keeps the bypass surface narrow. Maintainers create the branch explicitly with `git checkout -b "publish_$(node -p 'Date.now()')"`. Patterns like `^publish[_/]` would catch plausible feature branches by accident.
- **Why `admin` (and not `maintain`/`write`)?** The bypass disables one of the few automated guards on bump correctness; only people empowered to publish should be able to skip it.
- **Why GitHub API instead of a hardcoded allowlist?** A list of logins in the script drifts as the team changes. The API check sources the truth from the repo's collaborator settings, where it's auditable in GitHub and managed through normal access reviews.
- **Fail-closed everywhere.** Missing token, missing login, API error, non-admin response, network timeout — all paths fall through to `beachball check` and log why. The bypass is granted only when the API responds with `"admin"`.
- **Workflow change:** `.github/workflows/ci-validate-pr.yml` now exposes `GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}` to the `npm run checkchange` step. The `/collaborators/.../permission` endpoint requires push access to the repo, which the default workflow token has for same-repo PRs but not for fork PRs — fork PRs will silently fall through to beachball (and contributors don't have admin anyway, so behavior is identical).
- **What's NOT changed:** Beachball's `ignorePatterns`, the `postbump` Cargo-sync hook, Lefthook, and biome configs are all untouched.

## Manual verification

Run from a fresh clone of this branch with `npm ci`:

| # | Setup | Expected | Result |
|---|---|---|---|
| A | Clean tree, no env vars (branch != `publish_*`) | Short-circuit, beachball runs, exits 0 | ✅ |
| B | Edit `packages/fast-element/package.json` version + `GITHUB_HEAD_REF=publish_<n> GITHUB_ACTOR=janechu` (admin) | Bypass banner, exits 0 | ✅ |
| C | Same edit + `GITHUB_HEAD_REF=publish_<n> GITHUB_ACTOR=chrisdholt` (admin) | Bypass banner, exits 0 | ✅ |
| D | Same edit + `GITHUB_HEAD_REF=publish_<n> GITHUB_ACTOR=dependabot` (no role) | Wrapper logs "role 'none'", beachball runs, exits 1 | ✅ |
| E | Same edit + `publish_<n>` + admin actor + **no token** anywhere | Wrapper logs "no token available", beachball runs, exits 1 | ✅ |
| F | Same edit + `publish_<n>` + admin actor + invalid `$GITHUB_TOKEN` | Wrapper logs "HTTP 401", beachball runs, exits 1 | ✅ |
| G | Local fallback: branch = `publish_<n>` checked out, no env vars, `gh auth` authenticated as `janechu` | Wrapper resolves login + token via `gh`, API returns `admin`, bypass banner, exits 0 | ✅ |

Live API probe used during design (verifying expected roles):

```
gh api repos/microsoft/fast/collaborators/janechu/permission     -> admin
gh api repos/microsoft/fast/collaborators/chrisdholt/permission  -> admin
gh api repos/microsoft/fast/collaborators/dependabot/permission  -> none
```

## Documentation

- **`CONTRIBUTING.md`** — new `Manual version bumps` section spelling out the bypass conditions (branch pattern + admin role), the three use cases (full bump PR, hotfix override, paired Rust/npm sync recovery), the recommended branch-naming recipe, and reviewer expectations.
- **`CONTRIBUTING.md` (Publishing section)** — the bump-PR walkthrough now uses `publish_$(node -p 'Date.now()')` so the existing flow benefits from the bypass.
- **`.github/skills/shipping/SKILL.md`** — `When change files are NOT required` now references the admin-role check.
- **`.github/workflows/ci-validate-pr.yml`** — passes `GITHUB_TOKEN` to the `checkchange` step.

## Checklist

- [x] Code changes meet the [contributor guide](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md).
- [x] Changes are based on the [`main` branch](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md#getting-started).
- [x] Documentation has been added/updated.
- [ ] A `change/` file describing the changes has been added (N/A — this PR doesn't touch `packages/*` and is itself a tooling change; the wrapper script lives under `build/scripts/`).
