### PR TITLE
fix(fast-element): avoid mutating render template bindings

### DIFF
--- a/change/@microsoft-fast-element-2613f3cc-434d-4262-96ad-f1ab70e28a86.json
+++ b/change/@microsoft-fast-element-2613f3cc-434d-4262-96ad-f1ab70e28a86.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "Avoid mutating render template bindings",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/SIZES.md
+++ b/packages/fast-element/SIZES.md
@@ -4,22 +4,22 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 76.90 KB | 23.04 KB | 20.42 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.84 KB | 7.39 KB | 6.65 KB |
+| CDN Rollup Bundle | 76.61 KB | 23.01 KB | 20.39 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.73 KB | 7.36 KB | 6.63 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 288 B |
-| Observable (@microsoft/fast-element/observable.js) | 6.77 KB | 2.52 KB | 2.24 KB |
-| observable (@microsoft/fast-element/observable.js) | 6.80 KB | 2.54 KB | 2.25 KB |
+| Observable (@microsoft/fast-element/observable.js) | 6.70 KB | 2.50 KB | 2.22 KB |
+| observable (@microsoft/fast-element/observable.js) | 6.74 KB | 2.51 KB | 2.23 KB |
 | attr (@microsoft/fast-element/attr.js) | 477 B | 288 B | 244 B |
-| children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.65 KB |
-| ref (@microsoft/fast-element/ref.js) | 3.84 KB | 1.54 KB | 1.35 KB |
-| slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
-| volatile (@microsoft/fast-element/volatile.js) | 6.86 KB | 2.55 KB | 2.26 KB |
-| when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 584 B |
-| html (@microsoft/fast-element/html.js) | 25.62 KB | 8.38 KB | 7.52 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 29.65 KB | 9.43 KB | 8.52 KB |
+| children (@microsoft/fast-element/children.js) | 4.81 KB | 1.86 KB | 1.64 KB |
+| ref (@microsoft/fast-element/ref.js) | 3.78 KB | 1.52 KB | 1.34 KB |
+| slotted (@microsoft/fast-element/slotted.js) | 4.60 KB | 1.79 KB | 1.58 KB |
+| volatile (@microsoft/fast-element/volatile.js) | 6.79 KB | 2.53 KB | 2.25 KB |
+| when (@microsoft/fast-element/when.js) | 1.82 KB | 712 B | 565 B |
+| html (@microsoft/fast-element/html.js) | 25.92 KB | 8.50 KB | 7.61 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 29.57 KB | 9.41 KB | 8.48 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 43.43 KB | 13.26 KB | 11.92 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 60.71 KB | 19.16 KB | 17.13 KB |
-| ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.57 KB | 4.47 KB | 4.03 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 20.47 KB | 7.26 KB | 6.53 KB |
-| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.84 KB | 5.60 KB | 5.05 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 43.27 KB | 13.19 KB | 11.88 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 58.77 KB | 18.45 KB | 16.46 KB |
+| ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.51 KB | 4.45 KB | 4.01 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 20.41 KB | 7.24 KB | 6.52 KB |
+| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.78 KB | 5.58 KB | 5.04 KB |

--- a/packages/fast-element/SIZES.md
+++ b/packages/fast-element/SIZES.md
@@ -4,22 +4,22 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 76.61 KB | 23.01 KB | 20.39 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.73 KB | 7.36 KB | 6.63 KB |
+| CDN Rollup Bundle | 77.15 KB | 23.15 KB | 20.51 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.84 KB | 7.39 KB | 6.65 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 288 B |
-| Observable (@microsoft/fast-element/observable.js) | 6.70 KB | 2.50 KB | 2.22 KB |
-| observable (@microsoft/fast-element/observable.js) | 6.74 KB | 2.51 KB | 2.23 KB |
+| Observable (@microsoft/fast-element/observable.js) | 6.77 KB | 2.52 KB | 2.24 KB |
+| observable (@microsoft/fast-element/observable.js) | 6.80 KB | 2.54 KB | 2.25 KB |
 | attr (@microsoft/fast-element/attr.js) | 477 B | 288 B | 244 B |
-| children (@microsoft/fast-element/children.js) | 4.81 KB | 1.86 KB | 1.64 KB |
-| ref (@microsoft/fast-element/ref.js) | 3.78 KB | 1.52 KB | 1.34 KB |
-| slotted (@microsoft/fast-element/slotted.js) | 4.60 KB | 1.79 KB | 1.58 KB |
-| volatile (@microsoft/fast-element/volatile.js) | 6.79 KB | 2.53 KB | 2.25 KB |
-| when (@microsoft/fast-element/when.js) | 1.82 KB | 712 B | 565 B |
-| html (@microsoft/fast-element/html.js) | 25.92 KB | 8.50 KB | 7.61 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 29.57 KB | 9.41 KB | 8.48 KB |
+| children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.65 KB |
+| ref (@microsoft/fast-element/ref.js) | 3.84 KB | 1.54 KB | 1.35 KB |
+| slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
+| volatile (@microsoft/fast-element/volatile.js) | 6.86 KB | 2.55 KB | 2.26 KB |
+| when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 584 B |
+| html (@microsoft/fast-element/html.js) | 25.62 KB | 8.38 KB | 7.52 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 29.65 KB | 9.43 KB | 8.52 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 43.27 KB | 13.19 KB | 11.88 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 58.77 KB | 18.45 KB | 16.46 KB |
-| ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.51 KB | 4.45 KB | 4.01 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 20.41 KB | 7.24 KB | 6.52 KB |
-| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.78 KB | 5.58 KB | 5.04 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 43.43 KB | 13.26 KB | 11.92 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 60.71 KB | 19.16 KB | 17.13 KB |
+| ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.57 KB | 4.47 KB | 4.03 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 20.47 KB | 7.26 KB | 6.53 KB |
+| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.84 KB | 5.60 KB | 5.05 KB |

--- a/packages/fast-element/src/templating/render-binding.pw.spec.ts
+++ b/packages/fast-element/src/templating/render-binding.pw.spec.ts
@@ -1,0 +1,71 @@
+import { expect, test } from "@playwright/test";
+
+test.describe("The render template binding", () => {
+    test("does not mutate a provided template binding so it can be reused", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { render, RenderInstruction, html, oneWay, Fake } = await import(
+                "/main.js"
+            );
+
+            const childEditTemplate = html`
+                <p>Child Edit Template</p>
+            `;
+            const parentEditTemplate = html`
+                <p>Parent Edit Template</p>
+            `;
+
+            class TestChild {
+                name = "FAST";
+            }
+
+            class TestParent {
+                name = "FAST";
+            }
+
+            RenderInstruction.register({
+                type: TestChild,
+                template: childEditTemplate,
+                name: "edit",
+            });
+
+            RenderInstruction.register({
+                type: TestParent,
+                template: parentEditTemplate,
+                name: "edit",
+            });
+
+            const source = {
+                child: new TestChild(),
+                parent: new TestParent(),
+                viewName: "edit",
+            };
+            const context = Fake.executionContext();
+            const templateBinding = oneWay((x: any) => x.viewName);
+            const originalEvaluate = templateBinding.evaluate;
+            const childDirective = render((x: any) => x.child, templateBinding);
+            const parentDirective = render((x: any) => x.parent, templateBinding);
+
+            return {
+                bindingEvaluateUnchanged: templateBinding.evaluate === originalEvaluate,
+                bindingValueUnchanged:
+                    templateBinding.evaluate(source, context) === "edit",
+                childTemplate:
+                    childDirective.templateBinding.evaluate(source, context) ===
+                    childEditTemplate,
+                parentTemplate:
+                    parentDirective.templateBinding.evaluate(source, context) ===
+                    parentEditTemplate,
+            };
+        });
+
+        expect(result.bindingEvaluateUnchanged).toBe(true);
+        expect(result.bindingValueUnchanged).toBe(true);
+        expect(result.childTemplate).toBe(true);
+        expect(result.parentTemplate).toBe(true);
+    });
+});

--- a/packages/fast-element/src/templating/render.ts
+++ b/packages/fast-element/src/templating/render.ts
@@ -370,12 +370,70 @@ const nullTemplate = html`
     &nbsp;
 `;
 
+type TemplateBindingValue = ContentTemplate | string | Node;
+
 function instructionToTemplate(def: RenderInstruction | undefined) {
     if (def === void 0) {
         return nullTemplate;
     }
 
     return def.template;
+}
+
+function resolveTemplateBindingValue<TSource = any, TParent = any>(
+    result: TemplateBindingValue,
+    dataBinding: Binding<TSource>,
+    source: TSource,
+    context: ExecutionContext<TParent>,
+): ContentTemplate {
+    if (isString(result)) {
+        return instructionToTemplate(
+            getForInstance(dataBinding.evaluate(source, context), result),
+        );
+    }
+
+    if (result instanceof Node) {
+        return (result as any).$fastTemplate ?? new NodeTemplate(result);
+    }
+
+    return result;
+}
+
+function adaptTemplateBinding<TSource = any, TParent = any>(
+    binding: Binding<TSource, TemplateBindingValue, TParent>,
+    dataBinding: Binding<TSource>,
+): Binding<TSource, ContentTemplate, TParent> {
+    const evaluateTemplate = binding.evaluate;
+    const adapter = Object.create(Object.getPrototypeOf(binding)) as Binding<
+        TSource,
+        ContentTemplate,
+        TParent
+    >;
+
+    for (const propertyName of Object.getOwnPropertyNames(binding)) {
+        if (propertyName !== "evaluate") {
+            Object.defineProperty(
+                adapter,
+                propertyName,
+                Object.getOwnPropertyDescriptor(binding, propertyName)!,
+            );
+        }
+    }
+
+    Object.defineProperty(adapter, "evaluate", {
+        configurable: true,
+        enumerable: true,
+        value: (source: TSource, context: ExecutionContext<TParent>) =>
+            resolveTemplateBindingValue(
+                evaluateTemplate(source, context),
+                dataBinding,
+                source,
+                context,
+            ),
+        writable: true,
+    });
+
+    return adapter;
 }
 
 function createElementTemplate<TSource = any, TParent = any>(
@@ -742,23 +800,7 @@ export function render<TSource = any, TItem = any, TParent = any>(
             return instructionToTemplate(getForInstance(data, template));
         });
     } else if (template instanceof Binding) {
-        const evaluateTemplate = template.evaluate;
-
-        template.evaluate = (s: any, c: ExecutionContext) => {
-            let result = evaluateTemplate(s, c);
-
-            if (isString(result)) {
-                result = instructionToTemplate(
-                    getForInstance(dataBinding.evaluate(s, c), result),
-                );
-            } else if (result instanceof Node) {
-                result = (result as any).$fastTemplate ?? new NodeTemplate(result);
-            }
-
-            return result;
-        };
-
-        templateBinding = template as any;
+        templateBinding = adaptTemplateBinding(template, dataBinding);
     } else {
         templateBinding = oneTime((s: any, c: ExecutionContext) => template);
     }

--- a/sites/website/src/docs/3.x/resources/export-sizes.md
+++ b/sites/website/src/docs/3.x/resources/export-sizes.md
@@ -19,7 +19,7 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 76.90 KB | 23.04 KB | 20.42 KB |
+| CDN Rollup Bundle | 77.15 KB | 23.15 KB | 20.51 KB |
 | FASTElement (@microsoft/fast-element/fast-element.js) | 23.84 KB | 7.39 KB | 6.65 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 288 B |
 | Observable (@microsoft/fast-element/observable.js) | 6.77 KB | 2.52 KB | 2.24 KB |


### PR DESCRIPTION
# Pull Request

## 📖 Description

- Avoid mutating caller-owned template `Binding` instances passed to `render()`.
- Preserve string, node, and template resolution by adapting the binding used internally by the render directive.
- Add regression coverage for reusing the same template binding across different render data bindings.

## 👩‍💻 Reviewer Notes

Please focus review on the `render()` template binding adapter behavior.

## 📑 Test Plan

- `npx biome check packages\fast-element\src\templating\render.ts packages\fast-element\src\templating\render-binding.pw.spec.ts change\@microsoft-fast-element-2613f3cc-434d-4262-96ad-f1ab70e28a86.json`
- `npm run build:tsc -w @microsoft/fast-element && npm run build:rollup -w @microsoft/fast-element && npm run build:sizes -w @microsoft/fast-element`
- `npx playwright test --project=chromium -g "does not mutate a provided template binding"` from `packages\fast-element`
- `npx playwright test --project=chromium -g "The render"` from `packages\fast-element`
- `npx beachball check --branch origin/releases/fast-element-v3 --scope "!sites/*" --changehint "Run 'npm run change' to generate a change file"`

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Examples of the issue

This fixes cases where a single `Binding` instance is reused with multiple `render()` directives. For example:

```ts
const viewBinding = oneWay(x => x.viewName);

const childView = render(x => x.child, viewBinding);
const parentView = render(x => x.parent, viewBinding);
```

Before this change, `render()` mutated `viewBinding.evaluate` while creating the first directive. Reusing the same binding for `parentView` could then resolve the parent template using the child data binding instead. The shared binding itself could also be left mutated, so evaluating `viewBinding` later could return a template instead of the original view name.

This can show up in components that share module-level view-selection bindings across related parent/child templates or reusable render helpers.