### PR TITLE
feat(fast-element): warn on duplicate render registrations

### DIFF
--- a/change/@microsoft-fast-element-4dbc9ebd-2055-4ad1-af2a-5f3dacb6decc.json
+++ b/change/@microsoft-fast-element-4dbc9ebd-2055-4ad1-af2a-5f3dacb6decc.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "feat: warn when duplicate render instruction registrations replace existing entries",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/DESIGN.md
+++ b/packages/fast-element/DESIGN.md
@@ -243,6 +243,12 @@ See [docs/architecture/html-tagged-template-literal.md](./docs/architecture/html
 
 `ViewBehaviorFactory` (created at template-authoring time) is the blueprint; `ViewBehavior` (created per `HTMLView` instance) is the live runtime object.
 
+The `render` directive in `src/templating/render.ts` uses `RenderInstruction`
+registrations to resolve templates for arbitrary model types. Registrations are
+keyed by model constructor and instruction name. Registering another instruction
+for the same type/name pair intentionally replaces the existing instruction and
+emits a debug warning through `FAST.warn`; production behavior remains unchanged.
+
 See [docs/template-bindings.md](./docs/template-bindings.md) for the full binding pipeline including `DOMAspect` routing and two-way binding.
 
 ---

--- a/packages/fast-element/SIZES.md
+++ b/packages/fast-element/SIZES.md
@@ -4,22 +4,22 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 76.36 KB | 22.91 KB | 20.33 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.73 KB | 7.36 KB | 6.63 KB |
+| CDN Rollup Bundle | 76.50 KB | 22.95 KB | 20.35 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.80 KB | 7.37 KB | 6.64 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 288 B |
-| Observable (@microsoft/fast-element/observable.js) | 6.70 KB | 2.50 KB | 2.22 KB |
-| observable (@microsoft/fast-element/observable.js) | 6.74 KB | 2.51 KB | 2.23 KB |
+| Observable (@microsoft/fast-element/observable.js) | 6.77 KB | 2.52 KB | 2.24 KB |
+| observable (@microsoft/fast-element/observable.js) | 6.80 KB | 2.54 KB | 2.25 KB |
 | attr (@microsoft/fast-element/attr.js) | 477 B | 288 B | 244 B |
-| children (@microsoft/fast-element/children.js) | 4.81 KB | 1.86 KB | 1.64 KB |
-| ref (@microsoft/fast-element/ref.js) | 3.78 KB | 1.52 KB | 1.34 KB |
-| slotted (@microsoft/fast-element/slotted.js) | 4.60 KB | 1.79 KB | 1.58 KB |
-| volatile (@microsoft/fast-element/volatile.js) | 6.79 KB | 2.53 KB | 2.25 KB |
-| when (@microsoft/fast-element/when.js) | 1.82 KB | 712 B | 565 B |
-| html (@microsoft/fast-element/html.js) | 25.92 KB | 8.50 KB | 7.61 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 29.57 KB | 9.41 KB | 8.48 KB |
+| children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.65 KB |
+| ref (@microsoft/fast-element/ref.js) | 3.84 KB | 1.54 KB | 1.35 KB |
+| slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
+| volatile (@microsoft/fast-element/volatile.js) | 6.86 KB | 2.55 KB | 2.26 KB |
+| when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 584 B |
+| html (@microsoft/fast-element/html.js) | 25.98 KB | 8.52 KB | 7.63 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 29.64 KB | 9.43 KB | 8.50 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 43.64 KB | 13.29 KB | 11.97 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 60.62 KB | 19.11 KB | 17.07 KB |
-| ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.51 KB | 4.45 KB | 4.01 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 20.41 KB | 7.24 KB | 6.52 KB |
-| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.78 KB | 5.58 KB | 5.04 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 43.70 KB | 13.31 KB | 11.99 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 60.69 KB | 19.13 KB | 17.07 KB |
+| ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.57 KB | 4.47 KB | 4.03 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 20.47 KB | 7.26 KB | 6.53 KB |
+| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.84 KB | 5.60 KB | 5.05 KB |

--- a/packages/fast-element/src/debug.ts
+++ b/packages/fast-element/src/debug.ts
@@ -22,6 +22,8 @@ const baseDebugMessages = {
         "'${aspectName}' on '${tagName}' is blocked by the current DOMPolicy.",
     [1210 /* invalidHydrationAttributeMarker */]:
         "Invalid data-fe attribute value '${value}'. Expected a positive integer.",
+    [1211 /* duplicateRenderInstruction */]:
+        "Replacing existing RenderInstruction for '${type}' with name '${name}'.",
     [1401 /* missingElementDefinition */]: "Missing FASTElement definition.",
     [1501 /* noRegistrationForContext */]:
         "No registration for Context/Interface '${name}'.",

--- a/packages/fast-element/src/interfaces.ts
+++ b/packages/fast-element/src/interfaces.ts
@@ -66,8 +66,6 @@ export type ParameterDecorator = (
     parameterIndex: number,
 ) => void;
 
-
-
 /**
  * Warning and error messages.
  * @internal
@@ -87,6 +85,7 @@ export const enum Message {
     cannotSetTemplatePolicyAfterCompilation = 1208,
     blockedByDOMPolicy = 1209,
     invalidHydrationAttributeMarker = 1210,
+    duplicateRenderInstruction = 1211,
     // 1301 - 1400 Styles
     // 1401 - 1500 Components
     missingElementDefinition = 1401,

--- a/packages/fast-element/src/templating/render-registration.pw.spec.ts
+++ b/packages/fast-element/src/templating/render-registration.pw.spec.ts
@@ -1,0 +1,97 @@
+import { expect, test } from "@playwright/test";
+
+const testServerUrl = process.env.FAST_TEST_SERVER_URL ?? "/";
+
+test.describe("RenderInstruction registration", () => {
+    test("warns when registering over an existing instruction", async ({ page }) => {
+        await page.goto(testServerUrl);
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FAST, RenderInstruction, html } = await import("/main.js");
+
+            const currentWarn = FAST.warn;
+            const warnings: { code: number; values?: Record<string, any> }[] = [];
+            class TestClass {}
+
+            try {
+                FAST.warn = function (code: number, values?: Record<string, any>) {
+                    warnings.push({ code, values });
+                };
+
+                const first = RenderInstruction.register({
+                    type: TestClass,
+                    template: html`
+                        <p>First Template</p>
+                    `,
+                    name: "test",
+                });
+                const second = RenderInstruction.register({
+                    type: TestClass,
+                    template: html`
+                        <p>Second Template</p>
+                    `,
+                    name: "test",
+                });
+                const found = RenderInstruction.getByType(TestClass, "test");
+
+                return {
+                    count: warnings.length,
+                    code: warnings[0]?.code,
+                    name: warnings[0]?.values?.name,
+                    type: warnings[0]?.values?.type,
+                    replaced: found === second && found !== first,
+                };
+            } finally {
+                FAST.warn = currentWarn;
+            }
+        });
+
+        expect(result.count).toBe(1);
+        expect(result.code).toBe(1211);
+        expect(result.name).toBe("test");
+        expect(result.type).toBe("TestClass");
+        expect(result.replaced).toBe(true);
+    });
+
+    test("does not warn when registering a different instruction name", async ({
+        page,
+    }) => {
+        await page.goto(testServerUrl);
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FAST, RenderInstruction, html } = await import("/main.js");
+
+            const currentWarn = FAST.warn;
+            const warnings: { code: number; values?: Record<string, any> }[] = [];
+            class TestClass {}
+
+            try {
+                FAST.warn = function (code: number, values?: Record<string, any>) {
+                    warnings.push({ code, values });
+                };
+
+                RenderInstruction.register({
+                    type: TestClass,
+                    template: html`
+                        <p>Default Template</p>
+                    `,
+                });
+                RenderInstruction.register({
+                    type: TestClass,
+                    template: html`
+                        <p>Named Template</p>
+                    `,
+                    name: "test",
+                });
+
+                return warnings.length;
+            } finally {
+                FAST.warn = currentWarn;
+            }
+        });
+
+        expect(result).toBe(0);
+    });
+});

--- a/packages/fast-element/src/templating/render.ts
+++ b/packages/fast-element/src/templating/render.ts
@@ -6,13 +6,14 @@ import { FASTElementDefinition } from "../components/fast-definitions.js";
 import type { FASTElement } from "../components/fast-element.js";
 import { isHydratable } from "../components/hydration.js";
 import type { DOMPolicy } from "../dom-policy.js";
-import { type Constructable, isFunction, isString } from "../interfaces.js";
+import { type Constructable, isFunction, isString, Message } from "../interfaces.js";
 import type { Subscriber } from "../observation/notifier.js";
 import type {
     ExecutionContext,
     Expression,
     ExpressionObserver,
 } from "../observation/observable.js";
+import { FAST } from "../platform.js";
 import type { ContentTemplate, ContentView } from "./html-binding-directive.js";
 import {
     type AddViewBehaviorFactory,
@@ -487,6 +488,15 @@ function register(optionsOrInstruction: any): RenderInstruction {
     const instruction = instanceOf(optionsOrInstruction)
         ? optionsOrInstruction
         : create(optionsOrInstruction);
+
+    if (lookup[instruction.name] !== void 0) {
+        const typeName = (instruction.type as Function).name || "(anonymous)";
+
+        FAST.warn(Message.duplicateRenderInstruction, {
+            type: typeName,
+            name: instruction.name,
+        });
+    }
 
     return (lookup[instruction.name] = instruction);
 }

--- a/sites/website/src/docs/3.x/resources/export-sizes.md
+++ b/sites/website/src/docs/3.x/resources/export-sizes.md
@@ -19,22 +19,22 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 76.36 KB | 22.91 KB | 20.33 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.73 KB | 7.36 KB | 6.63 KB |
+| CDN Rollup Bundle | 76.50 KB | 22.95 KB | 20.35 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.80 KB | 7.37 KB | 6.64 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 288 B |
-| Observable (@microsoft/fast-element/observable.js) | 6.70 KB | 2.50 KB | 2.22 KB |
-| observable (@microsoft/fast-element/observable.js) | 6.74 KB | 2.51 KB | 2.23 KB |
+| Observable (@microsoft/fast-element/observable.js) | 6.77 KB | 2.52 KB | 2.24 KB |
+| observable (@microsoft/fast-element/observable.js) | 6.80 KB | 2.54 KB | 2.25 KB |
 | attr (@microsoft/fast-element/attr.js) | 477 B | 288 B | 244 B |
-| children (@microsoft/fast-element/children.js) | 4.81 KB | 1.86 KB | 1.64 KB |
-| ref (@microsoft/fast-element/ref.js) | 3.78 KB | 1.52 KB | 1.34 KB |
-| slotted (@microsoft/fast-element/slotted.js) | 4.60 KB | 1.79 KB | 1.58 KB |
-| volatile (@microsoft/fast-element/volatile.js) | 6.79 KB | 2.53 KB | 2.25 KB |
-| when (@microsoft/fast-element/when.js) | 1.82 KB | 712 B | 565 B |
-| html (@microsoft/fast-element/html.js) | 25.92 KB | 8.50 KB | 7.61 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 29.57 KB | 9.41 KB | 8.48 KB |
+| children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.65 KB |
+| ref (@microsoft/fast-element/ref.js) | 3.84 KB | 1.54 KB | 1.35 KB |
+| slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
+| volatile (@microsoft/fast-element/volatile.js) | 6.86 KB | 2.55 KB | 2.26 KB |
+| when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 584 B |
+| html (@microsoft/fast-element/html.js) | 25.98 KB | 8.52 KB | 7.63 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 29.64 KB | 9.43 KB | 8.50 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 43.64 KB | 13.29 KB | 11.97 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 60.62 KB | 19.11 KB | 17.07 KB |
-| ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.51 KB | 4.45 KB | 4.01 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 20.41 KB | 7.24 KB | 6.52 KB |
-| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.78 KB | 5.58 KB | 5.04 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 43.70 KB | 13.31 KB | 11.99 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 60.69 KB | 19.13 KB | 17.07 KB |
+| ArrayObserver (@microsoft/fast-element/array-observer.js) | 12.57 KB | 4.47 KB | 4.03 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 20.47 KB | 7.26 KB | 6.53 KB |
+| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.84 KB | 5.60 KB | 5.05 KB |


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds a debug warning when `RenderInstruction.register()` replaces an existing instruction for the same model type and instruction name. The PR adds focused Playwright coverage for duplicate and distinct-name render registrations, documents replacement behavior in `packages/fast-element/DESIGN.md`, and includes a beachball change file.

## 📑 Test Plan

- `npm run build:tsc -w @microsoft/fast-element`
- `FAST_TEST_SERVER_URL=http://localhost:5273/ npx playwright test src/templating/render-registration.pw.spec.ts --project=chromium`
- `npx biome check packages/fast-element/src/debug.ts packages/fast-element/src/interfaces.ts packages/fast-element/src/templating/render.ts packages/fast-element/src/templating/render-registration.pw.spec.ts packages/fast-element/DESIGN.md change/@microsoft-fast-element-4dbc9ebd-2055-4ad1-af2a-5f3dacb6decc.json`
- `npm run checkchange`

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
