### PR TITLE
fix: replace arrays during observerMap deepMerge

### DIFF
--- a/change/@microsoft-fast-html-4fbef46f-8bc2-4bd4-a785-599c7b2ed9ea.json
+++ b/change/@microsoft-fast-html-4fbef46f-8bc2-4bd4-a785-599c7b2ed9ea.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "breaking: replace arrays during observerMap deepMerge",
+  "packageName": "@microsoft/fast-html",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-html-4fbef46f-8bc2-4bd4-a785-599c7b2ed9ea.json
+++ b/change/@microsoft-fast-html-4fbef46f-8bc2-4bd4-a785-599c7b2ed9ea.json
@@ -1,5 +1,5 @@
 {
-  "type": "none",
+  "type": "prerelease",
   "comment": "breaking: replace arrays during observerMap deepMerge",
   "packageName": "@microsoft/fast-html",
   "email": "7559015+janechu@users.noreply.github.com",

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -122,7 +122,9 @@ When `properties` is omitted (`observerMap: {}` or `observerMap: "all"`), all ro
 Observer-map-managed array updates replace the array reference when `deepMerge`
 receives a new array. This avoids mutating an existing observed array while it
 may be notifying subscribers and lets repeat bindings observe the new array
-reference.
+reference. Replaced arrays are wrapped with the schema for the assigned
+property, and array observer subscriptions are installed once per array so
+reprocessing does not duplicate accessors or notification work.
 
 The resolution algorithm walks the schema and configuration tree in parallel:
 1. If `properties` is present and a root property is not listed, it is skipped.

--- a/packages/fast-html/DESIGN.md
+++ b/packages/fast-html/DESIGN.md
@@ -119,6 +119,11 @@ Each path entry can be:
 
 When `properties` is omitted (`observerMap: {}` or `observerMap: "all"`), all root properties are observed. When `properties` is present but empty (`{ properties: {} }`), no root properties are observed.
 
+Observer-map-managed array updates replace the array reference when `deepMerge`
+receives a new array. This avoids mutating an existing observed array while it
+may be notifying subscribers and lets repeat bindings observe the new array
+reference.
+
 The resolution algorithm walks the schema and configuration tree in parallel:
 1. If `properties` is present and a root property is not listed, it is skipped.
 2. `true`/`false` booleans apply to the entire subtree.

--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -268,7 +268,9 @@ When `properties` is omitted, all root properties are observed (backward compati
 
 When observer-map data is updated with `deepMerge`, array properties are replaced
 rather than updated in place. This avoids synchronous reentrant array work and
-allows repeat bindings to observe the new array reference.
+allows repeat bindings to observe the new array reference. Replacement arrays
+are processed through observerMap so nested item properties and subsequent array
+mutations remain observable.
 
 #### `attributeMap`
 

--- a/packages/fast-html/README.md
+++ b/packages/fast-html/README.md
@@ -266,6 +266,10 @@ observerMap: {
 
 When `properties` is omitted, all root properties are observed (backward compatible). When `properties` is present but empty (`{ properties: {} }`), no root properties are observed.
 
+When observer-map data is updated with `deepMerge`, array properties are replaced
+rather than updated in place. This avoids synchronous reentrant array work and
+allows repeat bindings to observe the new array reference.
+
 #### `attributeMap`
 
 When `attributeMap: "all"` (or `attributeMap: {}`) is configured for an element, `@microsoft/fast-html` automatically creates reactive `@attr` properties for every **leaf binding** in the template — simple expressions like `{{foo}}` or `id="{{fooBar}}"` that have no nested properties. Both `"all"` and `{}` are equivalent and use the default `"camelCase"` attribute name strategy.

--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -1938,18 +1938,11 @@ export function deepMerge(target: any, source: any): boolean {
         hasChanges = true;
 
         if (Array.isArray(sourceValue)) {
-            const isTargetArray = Array.isArray(targetValue);
             const clonedItems = sourceValue.map((item: unknown) =>
                 isPlainObject(item) ? { ...item } : item,
             );
 
-            if (isTargetArray) {
-                // Use splice to maintain observable array tracking
-                targetValue.splice(0, targetValue.length, ...clonedItems);
-            } else {
-                // Target isn't an array, replace it
-                target[key] = clonedItems;
-            }
+            target[key] = clonedItems;
             continue;
         }
 

--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -1,4 +1,4 @@
-import { Observable } from "@microsoft/fast-element/observable.js";
+import { type Accessor, Observable } from "@microsoft/fast-element/observable.js";
 import {
     defsPropertyName,
     fastContextMetaData,
@@ -181,7 +181,58 @@ const objectTargetsMap = new WeakMap<object, ObservedTargetsAndProperties[]>();
 /**
  * A map of arrays being observered
  */
-const observedArraysMap = new WeakMap<object, void>();
+const observedArraysMap = new WeakSet<object>();
+
+function defineObservableProperty(
+    targetObject: any,
+    key: string,
+    schema: JSONSchema | JSONSchemaDefinition,
+    rootSchema: JSONSchema,
+    target: any,
+    rootProperty: string,
+): void {
+    if (!Observable.getAccessors(targetObject).some(accessor => accessor.name === key)) {
+        const field = `_${key}`;
+        const callback = `${key}Changed`;
+        const accessor: Accessor = {
+            name: key,
+            getValue(source: any): any {
+                Observable.track(source, key);
+                return source[field];
+            },
+            setValue(source: any, value: any): void {
+                const oldValue = source[field];
+                const newValue = assignObservables(
+                    schema,
+                    rootSchema,
+                    value,
+                    target,
+                    rootProperty,
+                );
+
+                if (oldValue !== newValue) {
+                    source[field] = newValue;
+
+                    const changeCallback = source[callback];
+
+                    if (typeof changeCallback === "function") {
+                        changeCallback.call(source, oldValue, newValue);
+                    }
+
+                    Observable.notify(source, key);
+                }
+            },
+        };
+
+        Observable.defineProperty(targetObject, accessor);
+    }
+}
+
+function findArrayItemDef(schema: JSONSchema | JSONSchemaDefinition): string | null {
+    const items = (schema as JSONSchema).items;
+
+    return findDef(schema) ?? (items === undefined ? null : findDef(items));
+}
 
 /**
  * Get the index of the next matching tag
@@ -1228,38 +1279,51 @@ function assignObservablesToArray(
         ? proxiedData.map((item: any) => {
               const originalItem = Object.assign({}, item);
 
-              assignProxyToItemsInArray(item, originalItem, schema, rootSchema);
+              assignProxyToItemsInArray(
+                  item,
+                  originalItem,
+                  schema,
+                  rootSchema,
+                  target,
+                  rootProperty,
+              );
 
               return Object.assign(item, originalItem);
           })
         : proxiedData;
 
-    Observable.getNotifier(data).subscribe({
-        handleChange(subject, args) {
-            args.forEach((arg: any) => {
-                if (arg.addedCount > 0) {
-                    if (schemaProperties) {
-                        for (let i = arg.addedCount - 1; i >= 0; i--) {
-                            const item = subject[arg.index + i];
-                            const originalItem = Object.assign({}, item);
+    if (!observedArraysMap.has(data)) {
+        observedArraysMap.add(data);
 
-                            assignProxyToItemsInArray(
-                                item,
-                                originalItem,
-                                schema,
-                                rootSchema,
-                            );
+        Observable.getNotifier(data).subscribe({
+            handleChange(subject, args) {
+                args.forEach((arg: any) => {
+                    if (arg.addedCount > 0) {
+                        if (schemaProperties) {
+                            for (let i = arg.addedCount - 1; i >= 0; i--) {
+                                const item = subject[arg.index + i];
+                                const originalItem = Object.assign({}, item);
 
-                            Object.assign(item, originalItem);
+                                assignProxyToItemsInArray(
+                                    item,
+                                    originalItem,
+                                    schema,
+                                    rootSchema,
+                                    target,
+                                    rootProperty,
+                                );
+
+                                Object.assign(item, originalItem);
+                            }
                         }
-                    }
 
-                    // Notify observers of the target object's root property
-                    Observable.notify(target, rootProperty);
-                }
-            });
-        },
-    });
+                        // Notify observers of the target object's root property
+                        Observable.notify(target, rootProperty);
+                    }
+                });
+            },
+        });
+    }
 
     if (schemaProperties !== null) {
         return data;
@@ -1337,24 +1401,6 @@ export function findDef(schema: JSONSchema | JSONSchemaDefinition): string | nul
 }
 
 /**
- * Subscribe to a notifier on data that is an observed array
- * @param data - The array being observed
- * @param updateArrayObservables - The function to call to update the array item
- */
-function assignSubscribeToObservableArray(
-    data: any,
-    updateArrayObservables: () => void,
-): void {
-    Observable.getNotifier(data).subscribe({
-        handleChange(subject, args) {
-            args.forEach((arg: any) => {
-                updateArrayObservables();
-            });
-        },
-    });
-}
-
-/**
  * Assign observables to data
  * @param schema - The schema
  * @param rootSchema - The root schema mapping to the root property
@@ -1375,7 +1421,7 @@ export function assignObservables(
 
     switch (dataType) {
         case "array": {
-            const context = findDef(schema);
+            const context = findArrayItemDef(schema);
 
             if (context) {
                 proxiedData = assignObservablesToArray(
@@ -1387,23 +1433,6 @@ export function assignObservables(
                     target,
                     rootProperty,
                 );
-
-                if (!observedArraysMap.has(proxiedData)) {
-                    observedArraysMap.set(
-                        proxiedData,
-                        assignSubscribeToObservableArray(proxiedData, () =>
-                            assignObservablesToArray(
-                                proxiedData,
-                                (rootSchema as JSONSchema)[defsPropertyName]?.[
-                                    context
-                                ] as JSONSchemaDefinition,
-                                rootSchema,
-                                target,
-                                rootProperty,
-                            ),
-                        ),
-                    );
-                }
             } else {
                 // Primitive array (items have no schema $ref): wrap in a proxy so that
                 // direct index assignments (e.g. arr[0] = value) use FAST's splice-based
@@ -1446,6 +1475,8 @@ function assignProxyToItemsInArray(
     originalItem: any,
     schema: JSONSchema | JSONSchemaDefinition,
     rootSchema: JSONSchema,
+    target: any,
+    rootProperty: string,
 ): void {
     const schemaProperties = getSchemaProperties(schema);
 
@@ -1472,7 +1503,14 @@ function assignProxyToItemsInArray(
         );
 
         // Then make the property observable
-        Observable.defineProperty(proxiableItem, key);
+        defineObservableProperty(
+            proxiableItem,
+            key,
+            childSchema,
+            rootSchema,
+            target,
+            rootProperty,
+        );
     });
 }
 
@@ -1548,7 +1586,7 @@ function assignProxyToItemsInObject(
             addTargetToObject(proxiedData, target, rootProperty);
         }
     } else if (type === "array") {
-        const context = findDef((schema as JSONSchema).items);
+        const context = findArrayItemDef(schema);
 
         if (context) {
             const definition = (rootSchema as JSONSchema)[defsPropertyName]?.[context];
@@ -1561,19 +1599,6 @@ function assignProxyToItemsInObject(
                     target,
                     rootProperty,
                 );
-
-                if (!observedArraysMap.has(proxiedData)) {
-                    observedArraysMap.set(
-                        proxiedData,
-                        assignObservablesToArray(
-                            proxiedData,
-                            definition as JSONSchemaDefinition,
-                            rootSchema,
-                            target,
-                            rootProperty,
-                        ),
-                    );
-                }
             }
         }
     }
@@ -1657,7 +1682,7 @@ export function assignProxy(
                 }
 
                 obj[prop] = assignObservables(
-                    schema,
+                    childSchema ?? schema,
                     rootSchema,
                     value,
                     target,

--- a/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
@@ -269,7 +269,23 @@ test.describe("Deep Merge Test Fixture", () => {
         await expect(newUser).toContainText("No orders yet");
     });
 
-    test("should preserve object identity for observable arrays when using deepMerge", async ({
+    test("should replace observable arrays when using deepMerge", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.testArrayReplacement());
+
+        expect(result.sameOrders).toBe(false);
+        expect(result.orderCount).toBe(1);
+        await expect(page.locator(".user-card").first()).toContainText("Order #103");
+    });
+
+    test("should avoid reentrant observerMap deepMerge array changes during notification", async ({
         page,
     }) => {
         const hydrationCompleted = page.waitForFunction(
@@ -277,19 +293,15 @@ test.describe("Deep Merge Test Fixture", () => {
         );
         await page.goto("/fixtures/deep-merge/");
         await hydrationCompleted;
-        // This test verifies that splice is used internally by checking
-        // that updates work correctly multiple times (proving the array
-        // reference is maintained)
 
-        await page.click('button:has-text("Update Product Tags")');
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.testDeepMergeObserverMapReentry());
 
-        const firstItem = page.locator(".item").first();
-        await expect(firstItem).toContainText("Views: 300");
-
-        // Update again - if array identity wasn't preserved, this might fail
-        await page.click('button:has-text("Update Product Tags")');
-
-        // Should still work correctly
-        await expect(firstItem).toContainText("Views: 300");
+        expect(result.maxDepth).toBe(1);
+        expect(result.firstCalls).toBe(1);
+        expect(result.sameArray).toBe(false);
+        expect(result.currentItemCount).toBe(1);
+        expect(result.oldItemCount).toBe(3);
     });
 });

--- a/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
@@ -285,6 +285,73 @@ test.describe("Deep Merge Test Fixture", () => {
         await expect(page.locator(".user-card").first()).toContainText("Order #103");
     });
 
+    test("should observe nested object properties after replacing arrays with deepMerge", async ({
+        page,
+    }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.replaceOrdersAndMutateNestedData());
+
+        const firstOrder = page.locator(".order").first();
+        await expect(firstOrder).toContainText("Total: $123.45");
+        await expect(firstOrder.locator(".item").first()).toContainText("Views: 401");
+    });
+
+    test("should observe nested array mutations after replacing arrays with deepMerge", async ({
+        page,
+    }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.replaceOrdersAndPushNestedItem());
+
+        const firstOrder = page.locator(".order").first();
+        await expect(firstOrder.locator(".item")).toHaveCount(2);
+        await expect(firstOrder).toContainText("Stand");
+    });
+
+    test("should not duplicate observerMap array item accessors", async ({ page }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.countAccessorsForInitialOrdersPush());
+
+        expect(result.orderCount).toBe(3);
+        expect(result.duplicateAccessors).toEqual([]);
+    });
+
+    test("should not duplicate observerMap accessors for initial array items", async ({
+        page,
+    }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.countAccessorsForInitialOrder());
+
+        expect(result.duplicateAccessors).toEqual([]);
+    });
+
     test("should avoid reentrant observerMap deepMerge array changes during notification", async ({
         page,
     }) => {

--- a/packages/fast-html/test/fixtures/deep-merge/main.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/main.ts
@@ -358,6 +358,75 @@ class DeepMergeTestElement extends FASTElement {
         };
     }
 
+    public async replaceOrdersAndMutateNestedData() {
+        this.updateUserOrders();
+
+        await Updates.next();
+
+        this.users[0].orders[0].total = 123.45;
+        this.users[0].orders[0].items[0].metadata.views = 401;
+
+        await Updates.next();
+    }
+
+    public async replaceOrdersAndPushNestedItem() {
+        this.updateUserOrders();
+
+        await Updates.next();
+
+        this.users[0].orders[0].items.push({
+            id: 1005,
+            name: "Stand",
+            price: 25.0,
+            inStock: true,
+            tags: ["accessories"],
+            metadata: {
+                views: 50,
+                rating: 4.1,
+            },
+        });
+
+        await Updates.next();
+    }
+
+    public async countAccessorsForInitialOrdersPush() {
+        const newOrder = {
+            id: 104,
+            date: "2024-05-01",
+            total: 25.0,
+            items: [],
+        };
+
+        this.users[0].orders.push(newOrder);
+
+        await Updates.next();
+
+        const accessorNames = Observable.getAccessors(newOrder).map(
+            accessor => accessor.name,
+        );
+
+        return {
+            accessorCount: accessorNames.length,
+            duplicateAccessors: accessorNames.filter(
+                (name, index) => accessorNames.indexOf(name) !== index,
+            ),
+            orderCount: this.users[0].orders.length,
+        };
+    }
+
+    public countAccessorsForInitialOrder() {
+        const accessorNames = Observable.getAccessors(this.users[0].orders[0]).map(
+            accessor => accessor.name,
+        );
+
+        return {
+            accessorCount: accessorNames.length,
+            duplicateAccessors: accessorNames.filter(
+                (name, index) => accessorNames.indexOf(name) !== index,
+            ),
+        };
+    }
+
     public async testDeepMergeObserverMapReentry() {
         const items = this.users[0].orders[0].items;
         const observer = Observable.getNotifier(items);

--- a/packages/fast-html/test/fixtures/deep-merge/main.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/main.ts
@@ -1,4 +1,4 @@
-import { FASTElement, observable } from "@microsoft/fast-element";
+import { FASTElement, Observable, observable, Updates } from "@microsoft/fast-element";
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
 import { deepMerge } from "@microsoft/fast-html/utilities.js";
 
@@ -345,6 +345,81 @@ class DeepMergeTestElement extends FASTElement {
         };
 
         deepMerge(this.users[0], updates);
+    }
+
+    public testArrayReplacement() {
+        const previousOrders = this.users[0].orders;
+
+        this.updateUserOrders();
+
+        return {
+            sameOrders: previousOrders === this.users[0].orders,
+            orderCount: this.users[0].orders.length,
+        };
+    }
+
+    public async testDeepMergeObserverMapReentry() {
+        const items = this.users[0].orders[0].items;
+        const observer = Observable.getNotifier(items);
+        let firstCalls = 0;
+        let depth = 0;
+        let maxDepth = 0;
+
+        const nestedSubscriber = {
+            handleChange() {},
+        };
+
+        observer.subscribe({
+            handleChange: () => {
+                firstCalls++;
+                depth++;
+                maxDepth = Math.max(maxDepth, depth);
+
+                if (firstCalls === 1) {
+                    deepMerge(this.users[0].orders[0], {
+                        items: [
+                            {
+                                id: 3001,
+                                name: "Dock",
+                                price: 125.0,
+                                inStock: true,
+                                tags: ["accessories"],
+                                metadata: {
+                                    views: 40,
+                                    rating: 4.2,
+                                },
+                            },
+                        ],
+                    });
+                    observer.subscribe(nestedSubscriber);
+                }
+
+                depth--;
+            },
+        });
+
+        items.push({
+            id: 3000,
+            name: "Cable",
+            price: 10.0,
+            inStock: true,
+            tags: ["accessories"],
+            metadata: {
+                views: 10,
+                rating: 4.0,
+            },
+        });
+
+        await Updates.next();
+        await Updates.next();
+
+        return {
+            firstCalls,
+            maxDepth,
+            currentItemCount: this.users[0].orders[0].items.length,
+            oldItemCount: items.length,
+            sameArray: items === this.users[0].orders[0].items,
+        };
     }
 }
 

--- a/packages/fast-html/test/fixtures/observer-map/index.html
+++ b/packages/fast-html/test/fixtures/observer-map/index.html
@@ -13,8 +13,8 @@
                 <li class="simple-item"><!--fe-b$$start$$0$$item-0$$fe-b-->baz<!--fe-b$$end$$0$$item-0$$fe-b--></li>
             <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$0$$repeat-0$$fe-b-->
         </ul>
-        <button data-fe-c-1-1>Update First Item</button>
-        <button data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
+        <button type="button" data-fe-c-1-1>Update First Item</button>
+        <button type="button" data-fe-c-2-1>Update Second Item</button></template></observer-map-simple-array-test-element>
             <observer-map-test-element><template shadowrootmode="open" shadowroot="open"><observer-map-internal-test-element data-fe-c-0-3><template shadowrootmode="open" shadowroot="open">selected user: <!--fe-b$$start$$0$$selecteduserid-0$$fe-b-->1<!--fe-b$$end$$0$$selecteduserid-0$$fe-b--> <!-- because this is bound to an attribute property it must be lowercase -->
         <br>
         total users: <!--fe-b$$start$$1$$totalusers-1$$fe-b-->2<!--fe-b$$end$$1$$totalusers-1$$fe-b-->
@@ -30,12 +30,12 @@
         <!--fe-b$$start$$5$$when-5$$fe-b-->
             <span class="nested-define"><!--fe-b$$start$$0$$5-a.b.c-0$$fe-b--><!--fe-b$$end$$0$$5-a.b.c-0$$fe-b--></span>
         <!--fe-b$$end$$5$$when-5$$fe-b-->
-        <button data-fe-c-6-1>Define B</button>
-        <button data-fe-c-7-1>Update C</button>
+        <button type="button" data-fe-c-6-1>Define B</button>
+        <button type="button" data-fe-c-7-1>Update C</button>
         <br>
         <!--fe-b$$start$$8$$when-8$$fe-b--><!--fe-b$$end$$8$$when-8$$fe-b-->
-        <button data-fe-c-9-1>Define Y</button>
-        <button data-fe-c-10-1>Update Z</button>
+        <button type="button" data-fe-c-9-1>Define Y</button>
+        <button type="button" data-fe-c-10-1>Update Z</button>
         <div>
             <!--fe-b$$start$$11$$repeat-11$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
                 <!--fe-b$$start$$0$$repeat-0$$fe-b--><!--fe-repeat$$start$$0$$fe-repeat-->
@@ -48,12 +48,22 @@
                 <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$0$$repeat-0$$fe-b-->
             <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$11$$repeat-11$$fe-b-->
         </div>
-        <button data-fe-c-12-1>Remove all items</button>
-        <button data-fe-c-13-1>Add an item</button>
-        <button data-fe-c-14-1>Update an item</button>
-        <button data-fe-c-15-1>Remove groups</button>
-        <button data-fe-c-16-1>Add group</button>
-        <button data-fe-c-17-1>Update an action label</button></template></observer-map-internal-test-element>
+        <button type="button" data-fe-c-12-1>Remove all items</button>
+        <button type="button" data-fe-c-13-1>Add an item</button>
+        <button type="button" data-fe-c-14-1>Update an item</button>
+        <button type="button" data-fe-c-15-1>Remove groups</button>
+        <button type="button" data-fe-c-16-1>Add group</button>
+        <button type="button" data-fe-c-17-1>Update an action label</button>
+        <div class="complex-owner">
+            Owner: <!--fe-b$$start$$18$$complex.owner.profile.name-18$$fe-b--><!--fe-b$$end$$18$$complex.owner.profile.name-18$$fe-b--> |
+            Timezone: <!--fe-b$$start$$19$$complex.owner.profile.settings.timezone-19$$fe-b--><!--fe-b$$end$$19$$complex.owner.profile.settings.timezone-19$$fe-b-->
+        </div>
+        <div class="complex-tree">
+            <!--fe-b$$start$$20$$repeat-20$$fe-b--><!--fe-b$$end$$20$$repeat-20$$fe-b-->
+        </div>
+        <button type="button" data-fe-c-21-1>Update complex object fields</button>
+        <button type="button" data-fe-c-22-1>Add complex nested items</button>
+        <button type="button" data-fe-c-23-1>Add complex section</button></template></observer-map-internal-test-element>
         <div class="stats">
             <h2>Global Stats</h2>
             <div class="nested-info">
@@ -66,8 +76,8 @@
                 Render: <!--fe-b$$start$$6$$stats.metrics.performance.rendertime-6$$fe-b-->0.8<!--fe-b$$end$$6$$stats.metrics.performance.rendertime-6$$fe-b-->s
             </div>
             <div class="controls">
-                <button data-fe-c-7-1>Update Stats</button>
-                <button data-fe-c-8-1>Add New User</button>
+                <button type="button" data-fe-c-7-1>Update Stats</button>
+                <button type="button" data-fe-c-8-1>Add New User</button>
             </div>
         </div>
 
@@ -111,14 +121,14 @@
                     </div>
 
                     <div class="controls">
-                        <button data-fe-c-13-1>Select User</button>
-                        <button data-fe-c-14-1>Age +1</button>
-                        <button data-fe-c-15-1>Toggle Theme</button>
-                        <button data-fe-c-16-1>Change Location</button>
-                        <button data-fe-c-17-1>Update Notifications</button>
-                        <button data-fe-c-18-1>Add Category</button>
-                        <button data-fe-c-19-1>Remove Tech Category</button>
-                        <button data-fe-c-20-1>Remove User</button>
+                        <button type="button" data-fe-c-13-1>Select User</button>
+                        <button type="button" data-fe-c-14-1>Age +1</button>
+                        <button type="button" data-fe-c-15-1>Toggle Theme</button>
+                        <button type="button" data-fe-c-16-1>Change Location</button>
+                        <button type="button" data-fe-c-17-1>Update Notifications</button>
+                        <button type="button" data-fe-c-18-1>Add Category</button>
+                        <button type="button" data-fe-c-19-1>Remove Tech Category</button>
+                        <button type="button" data-fe-c-20-1>Remove User</button>
                     </div>
 
                     <div>
@@ -145,7 +155,7 @@
                                     <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$7$$repeat-7$$fe-b-->
                                 </div>
                                 <div class="controls">
-                                    <button data-fe-c-8-1>Like Post</button>
+                                    <button type="button" data-fe-c-8-1>Like Post</button>
                                 </div>
                             </div>
                         <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-repeat$$start$$1$$fe-repeat-->
@@ -170,12 +180,12 @@
                                     <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$7$$repeat-7$$fe-b-->
                                 </div>
                                 <div class="controls">
-                                    <button data-fe-c-8-1>Like Post</button>
+                                    <button type="button" data-fe-c-8-1>Like Post</button>
                                 </div>
                             </div>
                         <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$22$$repeat-22$$fe-b-->
                         <div class="controls">
-                            <button data-fe-c-23-1>Add New Post</button>
+                            <button type="button" data-fe-c-23-1>Add New Post</button>
                         </div>
                     </div>
                 </div>
@@ -215,14 +225,14 @@
                     </div>
 
                     <div class="controls">
-                        <button data-fe-c-13-1>Select User</button>
-                        <button data-fe-c-14-1>Age +1</button>
-                        <button data-fe-c-15-1>Toggle Theme</button>
-                        <button data-fe-c-16-1>Change Location</button>
-                        <button data-fe-c-17-1>Update Notifications</button>
-                        <button data-fe-c-18-1>Add Category</button>
-                        <button data-fe-c-19-1>Remove Tech Category</button>
-                        <button data-fe-c-20-1>Remove User</button>
+                        <button type="button" data-fe-c-13-1>Select User</button>
+                        <button type="button" data-fe-c-14-1>Age +1</button>
+                        <button type="button" data-fe-c-15-1>Toggle Theme</button>
+                        <button type="button" data-fe-c-16-1>Change Location</button>
+                        <button type="button" data-fe-c-17-1>Update Notifications</button>
+                        <button type="button" data-fe-c-18-1>Add Category</button>
+                        <button type="button" data-fe-c-19-1>Remove Tech Category</button>
+                        <button type="button" data-fe-c-20-1>Remove User</button>
                     </div>
 
                     <div>
@@ -247,22 +257,22 @@
                                     <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$7$$repeat-7$$fe-b-->
                                 </div>
                                 <div class="controls">
-                                    <button data-fe-c-8-1>Like Post</button>
+                                    <button type="button" data-fe-c-8-1>Like Post</button>
                                 </div>
                             </div>
                         <!--fe-repeat$$end$$0$$fe-repeat--><!--fe-b$$end$$22$$repeat-22$$fe-b-->
                         <div class="controls">
-                            <button data-fe-c-23-1>Add New Post</button>
+                            <button type="button" data-fe-c-23-1>Add New Post</button>
                         </div>
                     </div>
                 </div>
             <!--fe-repeat$$end$$1$$fe-repeat--><!--fe-b$$end$$9$$repeat-9$$fe-b-->
         </div></template></observer-map-test-element>
             <observer-map-with-observables-test-element><template shadowrootmode="open" shadowroot="open">Level 3 Value: <!--fe-b$$start$$0$$value1-0$$fe-b-->42<!--fe-b$$end$$0$$value1-0$$fe-b-->
-        <button data-fe-c-1-1>Update Value1</button>
+        <button type="button" data-fe-c-1-1>Update Value1</button>
         <br>
         Level 3 Value Observable: <!--fe-b$$start$$2$$value2-2$$fe-b-->42<!--fe-b$$end$$2$$value2-2$$fe-b-->
-        <button data-fe-c-3-1>Update Value2</button></template></observer-map-with-observables-test-element>
+        <button type="button" data-fe-c-3-1>Update Value2</button></template></observer-map-with-observables-test-element>
         </div>
 <f-template name="observer-map-test-element">
     <template>
@@ -283,8 +293,8 @@
                 Render: {{stats.metrics.performance.rendertime}}s
             </div>
             <div class="controls">
-                <button @click="{updateStats()}">Update Stats</button>
-                <button @click="{addNewUser()}">Add New User</button>
+                <button type="button" @click="{updateStats()}">Update Stats</button>
+                <button type="button" @click="{addNewUser()}">Add New User</button>
             </div>
         </div>
 
@@ -326,14 +336,14 @@
                     </div>
 
                     <div class="controls">
-                        <button @click="{selectUser(user.id)}">Select User</button>
-                        <button @click="{updateUserAge(user.id)}">Age +1</button>
-                        <button @click="{toggleUserTheme(user.id)}">Toggle Theme</button>
-                        <button @click="{updateUserLocation(user.id)}">Change Location</button>
-                        <button @click="{updateNotificationSettings(user.id)}">Update Notifications</button>
-                        <button @click="{addNotificationCategory(user.id)}">Add Category</button>
-                        <button @click="{removeNotificationCategory(user.id)}">Remove Tech Category</button>
-                        <button @click="{removeUser(user.id)}">Remove User</button>
+                        <button type="button" @click="{selectUser(user.id)}">Select User</button>
+                        <button type="button" @click="{updateUserAge(user.id)}">Age +1</button>
+                        <button type="button" @click="{toggleUserTheme(user.id)}">Toggle Theme</button>
+                        <button type="button" @click="{updateUserLocation(user.id)}">Change Location</button>
+                        <button type="button" @click="{updateNotificationSettings(user.id)}">Update Notifications</button>
+                        <button type="button" @click="{addNotificationCategory(user.id)}">Add Category</button>
+                        <button type="button" @click="{removeNotificationCategory(user.id)}">Remove Tech Category</button>
+                        <button type="button" @click="{removeUser(user.id)}">Remove User</button>
                     </div>
 
                     <div>
@@ -358,12 +368,12 @@
                                     </f-repeat>
                                 </div>
                                 <div class="controls">
-                                    <button @click="{incrementPostLikes(post.id)}">Like Post</button>
+                                    <button type="button" @click="{incrementPostLikes(post.id)}">Like Post</button>
                                 </div>
                             </div>
                         </f-repeat>
                         <div class="controls">
-                            <button @click="{addPostToUser(user.id)}">Add New Post</button>
+                            <button type="button" @click="{addPostToUser(user.id)}">Add New Post</button>
                         </div>
                     </div>
                 </div>
@@ -388,14 +398,14 @@
         <f-when value="{{a}}">
             <span class="nested-define">{{a.b.c}}</span>
         </f-when>
-        <button @click="{defineB()}">Define B</button>
-        <button @click="{updateC()}">Update C</button>
+        <button type="button" @click="{defineB()}">Define B</button>
+        <button type="button" @click="{updateC()}">Update C</button>
         <br>
         <f-when value="{{x}}">
             <span class="nested-define-2">{{x.y.z}}</span>
         </f-when>
-        <button @click="{defineY()}">Define Y</button>
-        <button @click="{updateZ()}">Update Z</button>
+        <button type="button" @click="{defineY()}">Define Y</button>
+        <button type="button" @click="{updateZ()}">Update Z</button>
         <div>
             <f-repeat value="{{group in groups}}">
                 <f-repeat value="{{item in group.items}}">
@@ -408,21 +418,55 @@
                 </f-repeat>
             </f-repeat>
         </div>
-        <button @click="{removeAllItems()}">Remove all items</button>
-        <button @click="{addAnItem()}">Add an item</button>
-        <button @click="{updateAnItem()}">Update an item</button>
-        <button @click="{removeGroup()}">Remove groups</button>
-        <button @click="{addGroup()}">Add group</button>
-        <button @click="{updateActionLabel()}">Update an action label</button>
+        <button type="button" @click="{removeAllItems()}">Remove all items</button>
+        <button type="button" @click="{addAnItem()}">Add an item</button>
+        <button type="button" @click="{updateAnItem()}">Update an item</button>
+        <button type="button" @click="{removeGroup()}">Remove groups</button>
+        <button type="button" @click="{addGroup()}">Add group</button>
+        <button type="button" @click="{updateActionLabel()}">Update an action label</button>
+        <div class="complex-owner">
+            Owner: {{complex.owner.profile.name}} |
+            Timezone: {{complex.owner.profile.settings.timezone}}
+        </div>
+        <div class="complex-tree">
+            <f-repeat value="{{suite in complex.suites}}">
+                <section class="complex-suite">
+                    <h4>{{suite.name}}</h4>
+                    <f-repeat value="{{section in suite.sections}}">
+                        <div class="complex-section">
+                            <h5>{{section.title}}</h5>
+                            <f-repeat value="{{row in section.rows}}">
+                                <div class="complex-row">
+                                    <strong>{{row.label}}</strong>
+                                    <f-repeat value="{{cell in row.cells}}">
+                                        <span class="complex-cell">
+                                            {{cell.value}}: {{cell.meta.status}}
+                                            <f-repeat value="{{history in cell.meta.history}}">
+                                                <em class="complex-history">
+                                                    {{history.note}}/{{history.flags.reviewed}}
+                                                </em>
+                                            </f-repeat>
+                                        </span>
+                                    </f-repeat>
+                                </div>
+                            </f-repeat>
+                        </div>
+                    </f-repeat>
+                </section>
+            </f-repeat>
+        </div>
+        <button type="button" @click="{updateComplexObjectFields()}">Update complex object fields</button>
+        <button type="button" @click="{addComplexNestedItems()}">Add complex nested items</button>
+        <button type="button" @click="{addComplexSectionAndMutate()}">Add complex section</button>
     </template>
 </f-template>
 <f-template name="observer-map-with-observables-test-element">
     <template>
         Level 3 Value: {{value1}}
-        <button @click="{updateValue1()}">Update Value1</button>
+        <button type="button" @click="{updateValue1()}">Update Value1</button>
         <br>
         Level 3 Value Observable: {{value2}}
-        <button @click="{updateValue2()}">Update Value2</button>
+        <button type="button" @click="{updateValue2()}">Update Value2</button>
     </template>
 </f-template>
 <f-template name="observer-map-simple-array-test-element">
@@ -432,8 +476,8 @@
                 <li class="simple-item">{{item}}</li>
             </f-repeat>
         </ul>
-        <button @click="{updateFirstItem()}">Update First Item</button>
-        <button @click="{updateSecondItem()}">Update Second Item</button>
+        <button type="button" @click="{updateFirstItem()}">Update First Item</button>
+        <button type="button" @click="{updateSecondItem()}">Update Second Item</button>
     </template>
 </f-template>
 

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -1,5 +1,12 @@
-import { attr, FASTElement, Observable, observable } from "@microsoft/fast-element";
+import {
+    attr,
+    FASTElement,
+    Observable,
+    observable,
+    Updates,
+} from "@microsoft/fast-element";
 import { RenderableFASTElement, TemplateElement } from "@microsoft/fast-html";
+import { deepMerge } from "@microsoft/fast-html/utilities.js";
 
 class ObserverMapTestElement extends FASTElement {
     public users: any[] = [
@@ -475,6 +482,41 @@ class ObserverMapInternalTestElement extends FASTElement {
 
         suite.sections[1].rows[0].cells[0].meta.history[0].flags.reviewed = true;
         suite.sections[1].rows[0].cells[0].meta.status = "approved";
+    }
+
+    public async replaceComplexRowsAndMutateNestedObject() {
+        const section = this.complex.suites[0].sections[0];
+
+        deepMerge(section, {
+            rows: [
+                {
+                    label: "Row Replacement",
+                    cells: [
+                        {
+                            value: "Cell Replacement",
+                            meta: {
+                                status: "replaced",
+                                history: [
+                                    {
+                                        note: "replacement",
+                                        flags: {
+                                            reviewed: false,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        await Updates.next();
+
+        section.rows[0].cells[0].meta.status = "mutated";
+        section.rows[0].cells[0].meta.history[0].flags.reviewed = true;
+
+        await Updates.next();
     }
 
     public defineB() {

--- a/packages/fast-html/test/fixtures/observer-map/main.ts
+++ b/packages/fast-html/test/fixtures/observer-map/main.ts
@@ -320,6 +320,48 @@ class ObserverMapInternalTestElement extends FASTElement {
         },
     ];
 
+    public complex = {
+        owner: {
+            profile: {
+                name: "Owner A",
+                settings: {
+                    timezone: "UTC",
+                },
+            },
+        },
+        suites: [
+            {
+                name: "Suite A",
+                sections: [
+                    {
+                        title: "Section A",
+                        rows: [
+                            {
+                                label: "Row A",
+                                cells: [
+                                    {
+                                        value: "Cell A",
+                                        meta: {
+                                            status: "ready",
+                                            history: [
+                                                {
+                                                    note: "created",
+                                                    flags: {
+                                                        reviewed: false,
+                                                    },
+                                                },
+                                            ],
+                                        },
+                                    },
+                                ],
+                            },
+                        ],
+                    },
+                ],
+            },
+        ],
+    };
+
     public removeAllItems() {
         this.groups[0].items.shift();
     }
@@ -366,6 +408,73 @@ class ObserverMapInternalTestElement extends FASTElement {
 
     public updateActionLabel() {
         this.groups[0].items[0].actions.trailing[0].label = "action label B";
+    }
+
+    public updateComplexObjectFields() {
+        const cell = this.complex.suites[0].sections[0].rows[0].cells[0];
+
+        this.complex.owner.profile.name = "Owner B";
+        this.complex.owner.profile.settings.timezone = "PST";
+        cell.meta.status = "done";
+        cell.meta.history[0].flags.reviewed = true;
+    }
+
+    public addComplexNestedItems() {
+        const row = this.complex.suites[0].sections[0].rows[0];
+
+        row.cells[0].meta.history.push({
+            note: "reviewed",
+            flags: {
+                reviewed: true,
+            },
+        });
+
+        row.cells.push({
+            value: "Cell B",
+            meta: {
+                status: "pending",
+                history: [
+                    {
+                        note: "queued",
+                        flags: {
+                            reviewed: false,
+                        },
+                    },
+                ],
+            },
+        });
+    }
+
+    public addComplexSectionAndMutate() {
+        const suite = this.complex.suites[0];
+
+        suite.sections.push({
+            title: "Section B",
+            rows: [
+                {
+                    label: "Row B",
+                    cells: [
+                        {
+                            value: "Cell C",
+                            meta: {
+                                status: "new",
+                                history: [
+                                    {
+                                        note: "draft",
+                                        flags: {
+                                            reviewed: false,
+                                        },
+                                    },
+                                ],
+                            },
+                        },
+                    ],
+                },
+            ],
+        });
+
+        suite.sections[1].rows[0].cells[0].meta.history[0].flags.reviewed = true;
+        suite.sections[1].rows[0].cells[0].meta.status = "approved";
     }
 
     public defineB() {

--- a/packages/fast-html/test/fixtures/observer-map/observer-map.spec.ts
+++ b/packages/fast-html/test/fixtures/observer-map/observer-map.spec.ts
@@ -256,6 +256,52 @@ test.describe("ObserverMap", async () => {
         await expect(page.locator(".action-label")).toHaveText("action label B");
     });
 
+    test("should render complex nested arrays and objects", async ({ page }) => {
+        await expect(page.locator(".complex-owner")).toContainText("Owner: Owner A");
+        await expect(page.locator(".complex-owner")).toContainText("Timezone: UTC");
+        await expect(page.locator(".complex-suite")).toHaveCount(1);
+        await expect(page.locator(".complex-section")).toHaveCount(1);
+        await expect(page.locator(".complex-row")).toHaveCount(1);
+        await expect(page.locator(".complex-cell")).toHaveCount(1);
+        await expect(page.locator(".complex-cell")).toContainText("Cell A: ready");
+        await expect(page.locator(".complex-history")).toHaveText("created/false");
+    });
+
+    test("should update deep object fields inside nested arrays", async ({ page }) => {
+        await page.locator("button:has-text('Update complex object fields')").click();
+
+        await expect(page.locator(".complex-owner")).toContainText("Owner: Owner B");
+        await expect(page.locator(".complex-owner")).toContainText("Timezone: PST");
+        await expect(page.locator(".complex-cell")).toContainText("Cell A: done");
+        await expect(page.locator(".complex-history")).toHaveText("created/true");
+    });
+
+    test("should observe additions at multiple nested array levels", async ({ page }) => {
+        await page.locator("button:has-text('Add complex nested items')").click();
+
+        await expect(page.locator(".complex-cell")).toHaveCount(2);
+        await expect(page.locator(".complex-history")).toHaveCount(3);
+        await expect(page.locator(".complex-cell").nth(1)).toContainText(
+            "Cell B: pending",
+        );
+        await expect(page.locator(".complex-history").nth(1)).toHaveText("reviewed/true");
+        await expect(page.locator(".complex-history").nth(2)).toHaveText("queued/false");
+    });
+
+    test("should observe new deeply nested objects created in added array branches", async ({
+        page,
+    }) => {
+        await page.locator("button:has-text('Add complex section')").click();
+
+        await expect(page.locator(".complex-section")).toHaveCount(2);
+        await expect(page.locator(".complex-section").nth(1)).toContainText("Section B");
+        await expect(page.locator(".complex-row").nth(1)).toContainText("Row B");
+        await expect(page.locator(".complex-cell").nth(1)).toContainText(
+            "Cell C: approved",
+        );
+        await expect(page.locator(".complex-history").nth(1)).toHaveText("draft/true");
+    });
+
     test("should update global stats with nested metrics", async ({ page }) => {
         // Check initial engagement stats
         const initialDaily = await page

--- a/packages/fast-html/test/fixtures/observer-map/observer-map.spec.ts
+++ b/packages/fast-html/test/fixtures/observer-map/observer-map.spec.ts
@@ -302,6 +302,26 @@ test.describe("ObserverMap", async () => {
         await expect(page.locator(".complex-history").nth(1)).toHaveText("draft/true");
     });
 
+    test("should observe deep mutations after replacing nested arrays", async ({
+        page,
+    }) => {
+        await page
+            .locator("observer-map-internal-test-element")
+            .evaluate((element: any) =>
+                element.replaceComplexRowsAndMutateNestedObject(),
+            );
+
+        await expect(page.locator(".complex-row").first()).toContainText(
+            "Row Replacement",
+        );
+        await expect(page.locator(".complex-cell").first()).toContainText(
+            "Cell Replacement: mutated",
+        );
+        await expect(page.locator(".complex-history").first()).toHaveText(
+            "replacement/true",
+        );
+    });
+
     test("should update global stats with nested metrics", async ({ page }) => {
         // Check initial engagement stats
         const initialDaily = await page

--- a/packages/fast-html/test/fixtures/observer-map/templates.html
+++ b/packages/fast-html/test/fixtures/observer-map/templates.html
@@ -17,8 +17,8 @@
                 Render: {{stats.metrics.performance.rendertime}}s
             </div>
             <div class="controls">
-                <button @click="{updateStats()}">Update Stats</button>
-                <button @click="{addNewUser()}">Add New User</button>
+                <button type="button" @click="{updateStats()}">Update Stats</button>
+                <button type="button" @click="{addNewUser()}">Add New User</button>
             </div>
         </div>
 
@@ -60,14 +60,14 @@
                     </div>
 
                     <div class="controls">
-                        <button @click="{selectUser(user.id)}">Select User</button>
-                        <button @click="{updateUserAge(user.id)}">Age +1</button>
-                        <button @click="{toggleUserTheme(user.id)}">Toggle Theme</button>
-                        <button @click="{updateUserLocation(user.id)}">Change Location</button>
-                        <button @click="{updateNotificationSettings(user.id)}">Update Notifications</button>
-                        <button @click="{addNotificationCategory(user.id)}">Add Category</button>
-                        <button @click="{removeNotificationCategory(user.id)}">Remove Tech Category</button>
-                        <button @click="{removeUser(user.id)}">Remove User</button>
+                        <button type="button" @click="{selectUser(user.id)}">Select User</button>
+                        <button type="button" @click="{updateUserAge(user.id)}">Age +1</button>
+                        <button type="button" @click="{toggleUserTheme(user.id)}">Toggle Theme</button>
+                        <button type="button" @click="{updateUserLocation(user.id)}">Change Location</button>
+                        <button type="button" @click="{updateNotificationSettings(user.id)}">Update Notifications</button>
+                        <button type="button" @click="{addNotificationCategory(user.id)}">Add Category</button>
+                        <button type="button" @click="{removeNotificationCategory(user.id)}">Remove Tech Category</button>
+                        <button type="button" @click="{removeUser(user.id)}">Remove User</button>
                     </div>
 
                     <div>
@@ -92,12 +92,12 @@
                                     </f-repeat>
                                 </div>
                                 <div class="controls">
-                                    <button @click="{incrementPostLikes(post.id)}">Like Post</button>
+                                    <button type="button" @click="{incrementPostLikes(post.id)}">Like Post</button>
                                 </div>
                             </div>
                         </f-repeat>
                         <div class="controls">
-                            <button @click="{addPostToUser(user.id)}">Add New Post</button>
+                            <button type="button" @click="{addPostToUser(user.id)}">Add New Post</button>
                         </div>
                     </div>
                 </div>
@@ -122,14 +122,14 @@
         <f-when value="{{a}}">
             <span class="nested-define">{{a.b.c}}</span>
         </f-when>
-        <button @click="{defineB()}">Define B</button>
-        <button @click="{updateC()}">Update C</button>
+        <button type="button" @click="{defineB()}">Define B</button>
+        <button type="button" @click="{updateC()}">Update C</button>
         <br>
         <f-when value="{{x}}">
             <span class="nested-define-2">{{x.y.z}}</span>
         </f-when>
-        <button @click="{defineY()}">Define Y</button>
-        <button @click="{updateZ()}">Update Z</button>
+        <button type="button" @click="{defineY()}">Define Y</button>
+        <button type="button" @click="{updateZ()}">Update Z</button>
         <div>
             <f-repeat value="{{group in groups}}">
                 <f-repeat value="{{item in group.items}}">
@@ -142,21 +142,55 @@
                 </f-repeat>
             </f-repeat>
         </div>
-        <button @click="{removeAllItems()}">Remove all items</button>
-        <button @click="{addAnItem()}">Add an item</button>
-        <button @click="{updateAnItem()}">Update an item</button>
-        <button @click="{removeGroup()}">Remove groups</button>
-        <button @click="{addGroup()}">Add group</button>
-        <button @click="{updateActionLabel()}">Update an action label</button>
+        <button type="button" @click="{removeAllItems()}">Remove all items</button>
+        <button type="button" @click="{addAnItem()}">Add an item</button>
+        <button type="button" @click="{updateAnItem()}">Update an item</button>
+        <button type="button" @click="{removeGroup()}">Remove groups</button>
+        <button type="button" @click="{addGroup()}">Add group</button>
+        <button type="button" @click="{updateActionLabel()}">Update an action label</button>
+        <div class="complex-owner">
+            Owner: {{complex.owner.profile.name}} |
+            Timezone: {{complex.owner.profile.settings.timezone}}
+        </div>
+        <div class="complex-tree">
+            <f-repeat value="{{suite in complex.suites}}">
+                <section class="complex-suite">
+                    <h4>{{suite.name}}</h4>
+                    <f-repeat value="{{section in suite.sections}}">
+                        <div class="complex-section">
+                            <h5>{{section.title}}</h5>
+                            <f-repeat value="{{row in section.rows}}">
+                                <div class="complex-row">
+                                    <strong>{{row.label}}</strong>
+                                    <f-repeat value="{{cell in row.cells}}">
+                                        <span class="complex-cell">
+                                            {{cell.value}}: {{cell.meta.status}}
+                                            <f-repeat value="{{history in cell.meta.history}}">
+                                                <em class="complex-history">
+                                                    {{history.note}}/{{history.flags.reviewed}}
+                                                </em>
+                                            </f-repeat>
+                                        </span>
+                                    </f-repeat>
+                                </div>
+                            </f-repeat>
+                        </div>
+                    </f-repeat>
+                </section>
+            </f-repeat>
+        </div>
+        <button type="button" @click="{updateComplexObjectFields()}">Update complex object fields</button>
+        <button type="button" @click="{addComplexNestedItems()}">Add complex nested items</button>
+        <button type="button" @click="{addComplexSectionAndMutate()}">Add complex section</button>
     </template>
 </f-template>
 <f-template name="observer-map-with-observables-test-element">
     <template>
         Level 3 Value: {{value1}}
-        <button @click="{updateValue1()}">Update Value1</button>
+        <button type="button" @click="{updateValue1()}">Update Value1</button>
         <br>
         Level 3 Value Observable: {{value2}}
-        <button @click="{updateValue2()}">Update Value2</button>
+        <button type="button" @click="{updateValue2()}">Update Value2</button>
     </template>
 </f-template>
 <f-template name="observer-map-simple-array-test-element">
@@ -166,7 +200,7 @@
                 <li class="simple-item">{{item}}</li>
             </f-repeat>
         </ul>
-        <button @click="{updateFirstItem()}">Update First Item</button>
-        <button @click="{updateSecondItem()}">Update Second Item</button>
+        <button type="button" @click="{updateFirstItem()}">Update First Item</button>
+        <button type="button" @click="{updateSecondItem()}">Update Second Item</button>
     </template>
 </f-template>


### PR DESCRIPTION
# Pull Request

## Description

Fix observer-map-managed array updates so `deepMerge` replaces arrays instead of
mutating existing observed arrays in place.

- Replace arrays during observerMap deep merges to avoid synchronous reentrant
  array notification work.
- Add a Playwright regression test for the observerMap + deepMerge reentrant
  notification path.
- Document the array replacement behavior and add a Beachball change file.

## Test Plan

- `npm run build -w @microsoft/fast-html`
- `npm run build:tsc -w @microsoft/fast-html`
- `npm run lint -w @microsoft/fast-html`
- `npm run test:chromium -w @microsoft/fast-html -- test/fixtures/deep-merge/deep-merge.spec.ts`
- `npm run checkchange`

## Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
