### PR TITLE
feat: add streaming fast-build output

### DIFF
--- a/change/@microsoft-fast-build-2f1e5af3-c3bc-45bb-9abd-9d9bbd3d5c4b.json
+++ b/change/@microsoft-fast-build-2f1e5af3-c3bc-45bb-9abd-9d9bbd3d5c4b.json
@@ -1,5 +1,5 @@
 {
-  "type": "minor",
+  "type": "prerelease",
   "comment": "feat: add simulated streaming output for fast-build",
   "packageName": "@microsoft/fast-build",
   "email": "7559015+janechu@users.noreply.github.com",

--- a/change/@microsoft-fast-build-2f1e5af3-c3bc-45bb-9abd-9d9bbd3d5c4b.json
+++ b/change/@microsoft-fast-build-2f1e5af3-c3bc-45bb-9abd-9d9bbd3d5c4b.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "feat: add simulated streaming output for fast-build",
+  "packageName": "@microsoft/fast-build",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/crates/microsoft-fast-build/DESIGN.md
+++ b/crates/microsoft-fast-build/DESIGN.md
@@ -55,7 +55,7 @@ render_template(template, state_str)
 | `json.rs` | Hand-rolled JSON parser producing `JsonValue` |
 | `locator.rs` | `Locator` struct — maps element names to template strings; glob scanner; `<f-template>` parser |
 | `error.rs` | `RenderError` enum with `Display` impl and helpers |
-| `wasm.rs` | WASM bindings (`#[cfg(target_arch = "wasm32")]`) — exposes `render`, `render_with_templates`, `render_entry_with_templates`, `render_entry_stream_with_templates`, and `parse_f_templates` to JavaScript |
+| `wasm.rs` | WASM bindings (`#[cfg(target_arch = "wasm32")]`) — exposes `render`, `render_with_templates`, `render_entry_with_templates`, and `parse_f_templates` to JavaScript |
 
 ---
 
@@ -344,11 +344,10 @@ All render functions accept `config: Option<&RenderConfig>` as their last parame
 - `render_entry_template_stream_with_locator(template, state_str, locator, config)`
 - `render_entry_template_stream_with_locator_without_state(template, locator, config)`
 
-The streaming APIs return `Result<Vec<String>, RenderError>` and otherwise use the same configuration and state semantics as their non-streaming equivalents. The `*_without_state` APIs render with an empty object root state. In WASM, the state parameter is optional for `render`, `render_with_templates`, `render_entry_with_templates`, and `render_entry_stream_with_templates`; omitted state also uses an empty object. The template-rendering WASM exports accept an `attribute_name_strategy` string parameter (`""`, `"none"`, or `"camelCase"`):
+The streaming APIs return `Result<Vec<String>, RenderError>` and otherwise use the same configuration and state semantics as their non-streaming equivalents. The `*_without_state` APIs render with an empty object root state. In WASM, the state parameter is optional for `render`, `render_with_templates`, and `render_entry_with_templates`; omitted state also uses an empty object. The template-rendering WASM exports accept an `attribute_name_strategy` string parameter (`""`, `"none"`, or `"camelCase"`), and `render_entry_with_templates` accepts an optional fifth `stream` boolean:
 
 - `render_with_templates(entry, templates_json, state?, attribute_name_strategy?)`
-- `render_entry_with_templates(entry, templates_json, state?, attribute_name_strategy?)`
-- `render_entry_stream_with_templates(entry, templates_json, state?, attribute_name_strategy?)`
+- `render_entry_with_templates(entry, templates_json, state?, attribute_name_strategy?, stream?)`
 
 ---
 
@@ -506,14 +505,13 @@ Hand-rolled in `glob_match` → `match_segments` → `match_segment` → `match_
 
 ## WASM bindings — `wasm.rs`
 
-`wasm.rs` is compiled only for the `wasm32-unknown-unknown` target (`#[cfg(target_arch = "wasm32")]`). It exposes five functions to JavaScript via `wasm-bindgen`:
+`wasm.rs` is compiled only for the `wasm32-unknown-unknown` target (`#[cfg(target_arch = "wasm32")]`). It exposes four functions to JavaScript via `wasm-bindgen`:
 
 | Export | Signature | Description |
 |--------|-----------|-------------|
 | `render` | `(entry: &str, state?: string) → String` | Render a template with no custom elements; omitted state is `{}` |
 | `render_with_templates` | `(entry: &str, templates_json: &str, state?: string, attribute_name_strategy?: string) → String` | Render a template with a pre-built `{name: content}` templates map using non-entry semantics; omitted state is `{}` |
-| `render_entry_with_templates` | `(entry: &str, templates_json: &str, state?: string, attribute_name_strategy?: string) → String` | Render top-level entry HTML with a pre-built `{name: content}` templates map; omitted state is `{}` |
-| `render_entry_stream_with_templates` | `(entry: &str, templates_json: &str, state?: string, attribute_name_strategy?: string) → String` | Render top-level entry HTML into a JSON array string of stream chunks; omitted state is `{}` |
+| `render_entry_with_templates` | `(entry: &str, templates_json: &str, state?: string, attribute_name_strategy?: string, stream?: bool) → String` | Render top-level entry HTML with a pre-built `{name: content}` templates map; omitted state is `{}`. When `stream` is `true`, returns a JSON array string of stream chunks instead of HTML. |
 | `parse_f_templates` | `(html: &str) → String` | Parse `<f-template>` elements and return a JSON array |
 
 ### `parse_f_templates`
@@ -543,13 +541,14 @@ Accepts `templates_json` as a JSON object string mapping element names to raw te
 
 ### `render_entry_with_templates`
 
-Accepts the same arguments as `render_with_templates`, but calls `render_entry_template_with_locator` when state is provided, or the no-state equivalent when it is omitted. Root-level custom elements therefore receive entry opening-tag handling, matching CLI entry rendering.
-
-### `render_entry_stream_with_templates`
-
-Accepts the same arguments as `render_entry_with_templates`, but calls the entry
-streaming APIs and serializes the resulting `Vec<String>` as a JSON array
-string. JavaScript callers parse the array before writing the raw chunks.
+Accepts the same arguments as `render_with_templates`, plus an optional fifth
+`stream` boolean. With `stream` omitted or `false`, it calls
+`render_entry_template_with_locator` when state is provided, or the no-state
+equivalent when it is omitted. Root-level custom elements therefore receive
+entry opening-tag handling, matching CLI entry rendering. With `stream` set to
+`true`, it calls the entry streaming APIs and serializes the resulting
+`Vec<String>` as a JSON array string. JavaScript callers parse the array before
+writing the raw chunks.
 
 ---
 

--- a/crates/microsoft-fast-build/DESIGN.md
+++ b/crates/microsoft-fast-build/DESIGN.md
@@ -6,7 +6,7 @@ This document explains how the crate works internally: the data flow, the key da
 
 ## High-level overview
 
-The crate takes a **FAST declarative HTML template** (a string) and an optional **JSON state object** and produces static HTML. Public no-state entry points treat omitted state exactly like an empty object (`{}`). Rendering happens in a single recursive pass — no AST is built, no DOM is constructed. The template string is scanned byte-by-byte, literal regions are copied verbatim, and directives / bindings are resolved and replaced.
+The crate takes a **FAST declarative HTML template** (a string) and an optional **JSON state object** and produces static HTML or precomputed HTML stream chunks. Public no-state entry points treat omitted state exactly like an empty object (`{}`). Rendering happens in a single recursive pass — no AST is built, no DOM is constructed. The template string is scanned byte-by-byte, literal regions are copied verbatim, and directives / bindings are resolved and replaced.
 
 ```
 render_template(template, state_str)
@@ -41,8 +41,9 @@ render_template(template, state_str)
 | Module | Role |
 |--------|------|
 | `lib.rs` | Public API surface — render functions, `pub use` re-exports, and config types |
-| `renderer.rs` | Thin entry points converting the public API into `render_node` calls |
+| `renderer.rs` | Thin entry points converting the public API into `render_node` or `stream_node` calls |
 | `node.rs` | The main rendering loop — scans for directives, handles attribute bindings in hydration mode |
+| `streaming.rs` | Simulated streaming loop — mirrors `node.rs` and returns non-empty HTML chunks |
 | `directive.rs` | `Directive` enum, `next_directive` scanner, and all directive renderers |
 | `content.rs` | `{{expr}}` and `{{{expr}}}` binding renderers, `html_escape` |
 | `attribute.rs` | Low-level HTML/attribute string parsing utilities + hydration attribute helpers; `strip_client_only_attrs` (shadow-DOM tags and nested element opening tags) |
@@ -54,7 +55,7 @@ render_template(template, state_str)
 | `json.rs` | Hand-rolled JSON parser producing `JsonValue` |
 | `locator.rs` | `Locator` struct — maps element names to template strings; glob scanner; `<f-template>` parser |
 | `error.rs` | `RenderError` enum with `Display` impl and helpers |
-| `wasm.rs` | WASM bindings (`#[cfg(target_arch = "wasm32")]`) — exposes `render`, `render_with_templates`, `render_entry_with_templates`, and `parse_f_templates` to JavaScript |
+| `wasm.rs` | WASM bindings (`#[cfg(target_arch = "wasm32")]`) — exposes `render`, `render_with_templates`, `render_entry_with_templates`, `render_entry_stream_with_templates`, and `parse_f_templates` to JavaScript |
 
 ---
 
@@ -86,6 +87,33 @@ The loop works like a cursor:
 7. Repeat.
 
 All handlers return `Result<(String, usize), RenderError>`. The `usize` is the byte position in the original template that the handler consumed up to — the cursor's next position.
+
+---
+
+## Simulated streaming — `streaming.rs`
+
+`stream_node` mirrors the recursive rendering loop in `node.rs`, but returns
+`Vec<String>` instead of a single `String`. Streaming is simulated: every chunk
+is prepared in memory before the API returns. The invariant is that
+`chunks.join("")` matches the equivalent non-streamed render.
+
+The streaming loop flushes literal HTML before each content binding or custom
+element, omits empty chunks, and resolves attribute bindings while the complete
+opening tag is still in the current chunk. This prevents streamed consumers from
+receiving a partial tag.
+
+Custom elements are split conservatively:
+
+1. The opening tag is rendered with any attribute bindings resolved.
+2. The full Declarative Shadow DOM `<template>` is rendered into the same
+   opening chunk.
+3. Light DOM children are streamed recursively.
+4. The custom element closing tag is appended to the final light DOM chunk, or
+   to the opening chunk when the element has no children.
+
+The shadow template itself is not streamed independently. Keeping it with the
+opening tag ensures custom element constructors can discover Declarative Shadow
+DOM as soon as the element is parsed.
 
 ---
 
@@ -295,19 +323,32 @@ All render functions accept `config: Option<&RenderConfig>` as their last parame
 - `render_without_state(template, config)`
 - `render_template(template, state_str, config)`
 - `render_template_without_state(template, config)`
+- `render_template_stream(template, state_str, config)`
+- `render_template_stream_without_state(template, config)`
+- `render_stream(template, state, config)`
+- `render_stream_without_state(template, config)`
 - `render_with_locator(template, state, locator, config)`
 - `render_with_locator_without_state(template, locator, config)`
+- `render_stream_with_locator(template, state, locator, config)`
+- `render_stream_with_locator_without_state(template, locator, config)`
 - `render_template_with_locator(template, state_str, locator, config)`
 - `render_template_with_locator_without_state(template, locator, config)`
+- `render_template_stream_with_locator(template, state_str, locator, config)`
+- `render_template_stream_with_locator_without_state(template, locator, config)`
 - `render_entry_with_locator(template, state, locator, config)`
 - `render_entry_with_locator_without_state(template, locator, config)`
+- `render_entry_stream_with_locator(template, state, locator, config)`
+- `render_entry_stream_with_locator_without_state(template, locator, config)`
 - `render_entry_template_with_locator(template, state_str, locator, config)`
 - `render_entry_template_with_locator_without_state(template, locator, config)`
+- `render_entry_template_stream_with_locator(template, state_str, locator, config)`
+- `render_entry_template_stream_with_locator_without_state(template, locator, config)`
 
-The `*_without_state` APIs render with an empty object root state. In WASM, the state parameter is optional for `render`, `render_with_templates`, and `render_entry_with_templates`; omitted state also uses an empty object. The template-rendering WASM exports accept an `attribute_name_strategy` string parameter (`""`, `"none"`, or `"camelCase"`):
+The streaming APIs return `Result<Vec<String>, RenderError>` and otherwise use the same configuration and state semantics as their non-streaming equivalents. The `*_without_state` APIs render with an empty object root state. In WASM, the state parameter is optional for `render`, `render_with_templates`, `render_entry_with_templates`, and `render_entry_stream_with_templates`; omitted state also uses an empty object. The template-rendering WASM exports accept an `attribute_name_strategy` string parameter (`""`, `"none"`, or `"camelCase"`):
 
 - `render_with_templates(entry, templates_json, state?, attribute_name_strategy?)`
 - `render_entry_with_templates(entry, templates_json, state?, attribute_name_strategy?)`
+- `render_entry_stream_with_templates(entry, templates_json, state?, attribute_name_strategy?)`
 
 ---
 
@@ -465,13 +506,14 @@ Hand-rolled in `glob_match` → `match_segments` → `match_segment` → `match_
 
 ## WASM bindings — `wasm.rs`
 
-`wasm.rs` is compiled only for the `wasm32-unknown-unknown` target (`#[cfg(target_arch = "wasm32")]`). It exposes four functions to JavaScript via `wasm-bindgen`:
+`wasm.rs` is compiled only for the `wasm32-unknown-unknown` target (`#[cfg(target_arch = "wasm32")]`). It exposes five functions to JavaScript via `wasm-bindgen`:
 
 | Export | Signature | Description |
 |--------|-----------|-------------|
 | `render` | `(entry: &str, state?: string) → String` | Render a template with no custom elements; omitted state is `{}` |
 | `render_with_templates` | `(entry: &str, templates_json: &str, state?: string, attribute_name_strategy?: string) → String` | Render a template with a pre-built `{name: content}` templates map using non-entry semantics; omitted state is `{}` |
 | `render_entry_with_templates` | `(entry: &str, templates_json: &str, state?: string, attribute_name_strategy?: string) → String` | Render top-level entry HTML with a pre-built `{name: content}` templates map; omitted state is `{}` |
+| `render_entry_stream_with_templates` | `(entry: &str, templates_json: &str, state?: string, attribute_name_strategy?: string) → String` | Render top-level entry HTML into a JSON array string of stream chunks; omitted state is `{}` |
 | `parse_f_templates` | `(html: &str) → String` | Parse `<f-template>` elements and return a JSON array |
 
 ### `parse_f_templates`
@@ -502,6 +544,12 @@ Accepts `templates_json` as a JSON object string mapping element names to raw te
 ### `render_entry_with_templates`
 
 Accepts the same arguments as `render_with_templates`, but calls `render_entry_template_with_locator` when state is provided, or the no-state equivalent when it is omitted. Root-level custom elements therefore receive entry opening-tag handling, matching CLI entry rendering.
+
+### `render_entry_stream_with_templates`
+
+Accepts the same arguments as `render_entry_with_templates`, but calls the entry
+streaming APIs and serializes the resulting `Vec<String>` as a JSON array
+string. JavaScript callers parse the array before writing the raw chunks.
 
 ---
 

--- a/crates/microsoft-fast-build/README.md
+++ b/crates/microsoft-fast-build/README.md
@@ -548,11 +548,20 @@ const html = render_entry_with_templates(
     entry,
     templatesJson,
     stateJson,
-    "camelCase"  // or "none"
+    "camelCase", // or "none"
+    false        // optional stream flag
+);
+
+const chunksJson = render_entry_with_templates(
+    entry,
+    templatesJson,
+    stateJson,
+    "camelCase",
+    true
 );
 ```
 
-Use `render_with_templates` for the original non-entry template-rendering semantics; use `render_entry_with_templates` for top-level entry HTML rendering.
+Use `render_with_templates` for the original non-entry template-rendering semantics; use `render_entry_with_templates` for top-level entry HTML rendering. Passing `true` as the optional fifth argument switches `render_entry_with_templates` to stream mode and returns a JSON array string of HTML chunks; omitted or `false` returns normal HTML.
 
 Passing `"none"` or `""` as the strategy uses the default behaviour.
 

--- a/crates/microsoft-fast-build/README.md
+++ b/crates/microsoft-fast-build/README.md
@@ -49,6 +49,36 @@ let html = render("<p>{{name}}</p>", &state)?;
 
 Both functions return `Result<String, RenderError>`. See [Error Handling](#error-handling).
 
+### Render simulated stream chunks
+
+Streaming APIs return precomputed HTML chunks in memory. Joining the chunks
+matches the equivalent non-streamed render, while chunk boundaries are chosen
+around content bindings and custom elements.
+
+```rust
+use microsoft_fast_build::{render_template, render_template_stream};
+
+let chunks = render_template_stream(
+    "<p>{{message}}</p>",
+    r#"{"message": "Hello"}"#,
+    None,
+)?;
+
+let html = render_template(
+    "<p>{{message}}</p>",
+    r#"{"message": "Hello"}"#,
+    None,
+)?;
+
+assert_eq!(chunks, vec!["<p>", "Hello", "</p>"]);
+assert_eq!(chunks.join(""), html);
+```
+
+Custom element streaming uses the `*_stream_with_locator` and
+`render_entry_*_stream_with_locator` APIs. For entry HTML, a custom element's
+opening tag chunk includes the complete Declarative Shadow DOM template; light
+DOM content follows in later chunks.
+
 ---
 
 ## Template Syntax

--- a/crates/microsoft-fast-build/STREAMING_NOTES.md
+++ b/crates/microsoft-fast-build/STREAMING_NOTES.md
@@ -35,7 +35,10 @@ chunk directly to stdout.
   DOM immediately.
 - Chunk boundaries are an implementation detail except for the safety rules
   above. Consumers should not depend on a specific number of chunks.
-- False `<f-when>` branches, empty repeats, and missing or empty content
-  bindings can remove chunks entirely.
+- In non-hydrated stream scopes, false `<f-when>` branches, empty repeats,
+  and missing or empty content bindings can remove chunks entirely. When
+  hydration is active, the renderer still emits the same hydration marker
+  comments as the equivalent non-streamed render, even when the rendered value
+  or directive body is empty.
 - No additional template-render cache is introduced for streaming; the renderer
   reuses the locator/template map and renders each encountered custom element.

--- a/crates/microsoft-fast-build/STREAMING_NOTES.md
+++ b/crates/microsoft-fast-build/STREAMING_NOTES.md
@@ -2,9 +2,10 @@
 
 `microsoft-fast-build` currently implements **simulated streaming**. The renderer
 walks the template with the same semantics as normal rendering and returns a
-precomputed `Vec<String>` of HTML chunks. The WASM export serializes that vector
-as a JSON array string; the `@microsoft/fast-build` CLI parses the array and
-writes each chunk directly to stdout.
+precomputed `Vec<String>` of HTML chunks. The WASM `render_entry_with_templates`
+export serializes that vector as a JSON array string when called with
+`stream: true`; the `@microsoft/fast-build` CLI parses the array and writes each
+chunk directly to stdout.
 
 ## Guarantees
 
@@ -24,6 +25,8 @@ writes each chunk directly to stdout.
   result is returned to JavaScript.
 - The CLI `--stream` mode is stdout-only. It does not write `--output` and does
   not print the normal `Built: ...` message.
+- The CLI uses `render_entry_with_templates(..., true)` for `--stream`, passing
+  `{}` as `templates_json` when no templates were loaded.
 - The CLI writes raw HTML chunks, not a Node.js `ReadableStream`, so consumers
   should pipe stdout if they need process-level streaming.
 - Shadow templates for custom elements are rendered fully before the custom

--- a/crates/microsoft-fast-build/STREAMING_NOTES.md
+++ b/crates/microsoft-fast-build/STREAMING_NOTES.md
@@ -1,0 +1,38 @@
+# Streaming notes
+
+`microsoft-fast-build` currently implements **simulated streaming**. The renderer
+walks the template with the same semantics as normal rendering and returns a
+precomputed `Vec<String>` of HTML chunks. The WASM export serializes that vector
+as a JSON array string; the `@microsoft/fast-build` CLI parses the array and
+writes each chunk directly to stdout.
+
+## Guarantees
+
+- `chunks.join("")` matches the equivalent non-streamed render.
+- Empty chunks are omitted.
+- Content bindings may become their own chunks.
+- Attribute bindings are resolved inside a complete opening tag chunk, so a
+  streamed tag is never split before `>`.
+- A custom element chunk begins with the rendered opening tag and includes the
+  complete Declarative Shadow DOM `<template>`. Light DOM content follows in
+  later chunks when present.
+- Existing non-streamed rendering and CLI file output are unchanged.
+
+## Current limitations and gotchas
+
+- Streaming is not lazy: all chunks are prepared in memory before any WASM
+  result is returned to JavaScript.
+- The CLI `--stream` mode is stdout-only. It does not write `--output` and does
+  not print the normal `Built: ...` message.
+- The CLI writes raw HTML chunks, not a Node.js `ReadableStream`, so consumers
+  should pipe stdout if they need process-level streaming.
+- Shadow templates for custom elements are rendered fully before the custom
+  element opening chunk is emitted. This intentionally keeps the shadow template
+  with the opening tag so custom element constructors can see Declarative Shadow
+  DOM immediately.
+- Chunk boundaries are an implementation detail except for the safety rules
+  above. Consumers should not depend on a specific number of chunks.
+- False `<f-when>` branches, empty repeats, and missing or empty content
+  bindings can remove chunks entirely.
+- No additional template-render cache is introduced for streaming; the renderer
+  reuses the locator/template map and renders each encountered custom element.

--- a/crates/microsoft-fast-build/src/directive.rs
+++ b/crates/microsoft-fast-build/src/directive.rs
@@ -193,7 +193,7 @@ fn render_repeat_items(
     }
 }
 
-fn build_loop_vars(
+pub(crate) fn build_loop_vars(
     loop_vars: &[(String, JsonValue)],
     var_name: &str,
     item: &JsonValue,
@@ -206,7 +206,7 @@ fn build_loop_vars(
 }
 
 /// Parse `"item in list"` into `("item", "list")`.
-fn parse_repeat_expr(expr: &str) -> Option<(String, String)> {
+pub(crate) fn parse_repeat_expr(expr: &str) -> Option<(String, String)> {
     let parts: Vec<&str> = expr.trim().splitn(3, ' ').collect();
     if parts.len() == 3 && parts[1] == "in" && !parts[0].is_empty() && !parts[2].is_empty() {
         Some((parts[0].to_string(), parts[2].to_string()))
@@ -231,7 +231,7 @@ pub fn render_custom_element(
     root: &JsonValue,
     loop_vars: &[(String, JsonValue)],
     locator: &Locator,
-    parent_hydration: Option<&mut HydrationScope>,
+    mut parent_hydration: Option<&mut HydrationScope>,
     is_entry: bool,
     config: &RenderConfig,
 ) -> Result<(String, usize), RenderError> {
@@ -255,99 +255,18 @@ pub fn render_custom_element(
         open_tag_content[..open_tag_content.len() - 1].to_string()
     };
 
-    // Build the child state used to render this element's shadow template.
-    //
-    // The child state always starts with the current root state as a base so
-    // all unbound state keys (e.g. `text`, `error`, `showProgress`) propagate
-    // through to every descendant custom element automatically. Per-element
-    // attributes (e.g. `planet="earth"`, boolean `show`) are then overlaid on
-    // top, overriding root state for any overlapping key.
-    //
-    // When the element has no state-relevant attributes, we skip cloning the
-    // root state entirely and pass it through by reference.
-    //
-    // Attribute processing rules:
-    //   - `@event`, `?bool`, `f-ref`, `f-slotted`, `f-children` → skipped entirely
-    //   - `:prop="{{expr}}"` → resolved and added to state under `prop`; not rendered
-    //   - `data-kebab-name` → grouped under `dataset.camelName` (MDN dataset convention)
-    //   - `aria-*` → camelCase property name via lookup table (ARIA reflection)
-    //   - HTML attrs with mismatched property names → camelCase via lookup table
-    //   - Anything else → lowercased key (or camelCase when `attribute_name_strategy` is `CamelCase`)
-    fn build_attr_state(
-        attrs: &[(String, Option<String>)],
-        root: &JsonValue,
-        loop_vars: &[(String, JsonValue)],
-        base: std::collections::HashMap<String, JsonValue>,
-        strategy: AttributeNameStrategy,
-    ) -> JsonValue {
-        let mut state_map = base;
-        for (attr_name, value) in attrs {
-            if attr_name.starts_with('@')
-                || attr_name.starts_with('?')
-                || attr_name.eq_ignore_ascii_case("f-ref")
-                || attr_name.eq_ignore_ascii_case("f-slotted")
-                || attr_name.eq_ignore_ascii_case("f-children")
-            {
-                continue;
-            }
-            if let Some(prop_name) = attr_name.strip_prefix(':') {
-                let json_val = attribute_to_json_value(value.as_ref(), root, loop_vars);
-                let key = prop_name.to_lowercase();
-                state_map.insert(key, json_val);
-                continue;
-            }
-            let json_val = attribute_to_json_value(value.as_ref(), root, loop_vars);
-            let lowered = attr_name.to_lowercase();
-            if let Some(path) = data_attr_to_dataset_key(&lowered) {
-                if let Some((group, prop)) = path.split_once('.') {
-                    let group_val = state_map
-                        .entry(group.to_string())
-                        .or_insert_with(|| JsonValue::Object(std::collections::HashMap::new()));
-                    if let JsonValue::Object(ref mut map) = group_val {
-                        map.insert(prop.to_string(), json_val);
-                    }
-                }
-            } else if let Some(key) = aria_attr_to_property_key(&lowered) {
-                state_map.insert(key.to_string(), json_val);
-            } else if let Some(key) = html_attr_to_property_key(&lowered) {
-                state_map.insert(key.to_string(), json_val);
-            } else if strategy == AttributeNameStrategy::CamelCase && lowered.contains('-') {
-                state_map.insert(kebab_to_camel(&lowered), json_val);
-            } else {
-                state_map.insert(lowered, json_val);
-            }
-        }
-        JsonValue::Object(state_map)
-    }
-
-    /// Returns true if any parsed attribute would contribute to child state.
-    fn has_state_relevant_attrs(attrs: &[(String, Option<String>)]) -> bool {
-        attrs.iter().any(|(name, _)| {
-            !name.starts_with('@')
-                && !name.starts_with('?')
-                && !name.eq_ignore_ascii_case("f-ref")
-                && !name.eq_ignore_ascii_case("f-slotted")
-                && !name.eq_ignore_ascii_case("f-children")
-        })
-    }
-
     // Parse attributes once, then decide whether cloning is necessary.
     // When the element has no state-relevant attributes, skip the HashMap
     // clone and reuse `root` directly — avoids O(state-size) work per element
     // in deep custom-element trees.
     let attrs = parse_element_attributes(open_tag_content);
-    let child_root_owned;
-    let child_root: &JsonValue = if has_state_relevant_attrs(&attrs) {
-        let base = if let JsonValue::Object(ref root_map) = root {
-            root_map.clone()
-        } else {
-            std::collections::HashMap::new()
-        };
-        child_root_owned = build_attr_state(&attrs, root, loop_vars, base, config.attribute_name_strategy);
-        &child_root_owned
-    } else {
-        root
-    };
+    let child_root_owned = build_custom_element_child_root(
+        &attrs,
+        root,
+        loop_vars,
+        config.attribute_name_strategy,
+    );
+    let child_root = child_root_owned.as_ref().unwrap_or(root);
 
     // Render the shadow DOM template with a fresh hydration scope.
     let mut shadow_scope = HydrationScope::new();
@@ -356,7 +275,14 @@ pub fn render_custom_element(
     let shadowroot_attributes = build_shadowroot_template_attrs(locator.get_shadowroot_attributes(&tag_name));
 
     // Build the final opening tag, resolving {{expr}} attrs and injecting hydration attrs.
-    let element_open = build_element_open_tag(&open_tag_base, open_tag_content, root, loop_vars, parent_hydration, is_entry);
+    let element_open = build_element_open_tag(
+        &open_tag_base,
+        open_tag_content,
+        root,
+        loop_vars,
+        parent_hydration.as_mut().map(|h| &mut **h),
+        is_entry,
+    );
 
     // Extract the light DOM children (for non-self-closing elements).
     let (children, after) = if is_self_closing {
@@ -369,15 +295,118 @@ pub fn render_custom_element(
             })?
     };
 
+    let rendered_children = if children.is_empty() {
+        String::new()
+    } else {
+        render_node(
+            &children,
+            root,
+            loop_vars,
+            Some(locator),
+            parent_hydration.as_mut().map(|h| &mut **h),
+            false,
+            config,
+        )?
+    };
+
     let output = format!(
         "{}<template{}>{}</template>{}</{}>",
-        element_open, shadowroot_attributes, rendered, children, tag_name
+        element_open, shadowroot_attributes, rendered, rendered_children, tag_name
     );
 
     Ok((output, after))
 }
 
-fn build_shadowroot_template_attrs(attrs: &[(String, Option<String>)]) -> String {
+/// Build the child state used to render a custom element's shadow template.
+///
+/// The child state starts with the current root state as a base so unbound state
+/// keys propagate through descendant custom elements. Per-element attributes are
+/// then overlaid on top, overriding root state for matching keys.
+///
+/// Attribute processing rules:
+///   - `@event`, `?bool`, `f-ref`, `f-slotted`, `f-children` → skipped entirely
+///   - `:prop="{{expr}}"` → resolved and added to state under `prop`; not rendered
+///   - `data-kebab-name` → grouped under `dataset.camelName` (MDN dataset convention)
+///   - `aria-*` → camelCase property name via lookup table (ARIA reflection)
+///   - HTML attrs with mismatched property names → camelCase via lookup table
+///   - Anything else → lowercased key (or camelCase when `attribute_name_strategy` is `CamelCase`)
+pub(crate) fn build_custom_element_child_root(
+    attrs: &[(String, Option<String>)],
+    root: &JsonValue,
+    loop_vars: &[(String, JsonValue)],
+    strategy: AttributeNameStrategy,
+) -> Option<JsonValue> {
+    if !has_state_relevant_attrs(attrs) {
+        return None;
+    }
+
+    let base = if let JsonValue::Object(ref root_map) = root {
+        root_map.clone()
+    } else {
+        std::collections::HashMap::new()
+    };
+
+    Some(build_attr_state(attrs, root, loop_vars, base, strategy))
+}
+
+fn build_attr_state(
+    attrs: &[(String, Option<String>)],
+    root: &JsonValue,
+    loop_vars: &[(String, JsonValue)],
+    base: std::collections::HashMap<String, JsonValue>,
+    strategy: AttributeNameStrategy,
+) -> JsonValue {
+    let mut state_map = base;
+    for (attr_name, value) in attrs {
+        if attr_name.starts_with('@')
+            || attr_name.starts_with('?')
+            || attr_name.eq_ignore_ascii_case("f-ref")
+            || attr_name.eq_ignore_ascii_case("f-slotted")
+            || attr_name.eq_ignore_ascii_case("f-children")
+        {
+            continue;
+        }
+        if let Some(prop_name) = attr_name.strip_prefix(':') {
+            let json_val = attribute_to_json_value(value.as_ref(), root, loop_vars);
+            let key = prop_name.to_lowercase();
+            state_map.insert(key, json_val);
+            continue;
+        }
+        let json_val = attribute_to_json_value(value.as_ref(), root, loop_vars);
+        let lowered = attr_name.to_lowercase();
+        if let Some(path) = data_attr_to_dataset_key(&lowered) {
+            if let Some((group, prop)) = path.split_once('.') {
+                let group_val = state_map
+                    .entry(group.to_string())
+                    .or_insert_with(|| JsonValue::Object(std::collections::HashMap::new()));
+                if let JsonValue::Object(ref mut map) = group_val {
+                    map.insert(prop.to_string(), json_val);
+                }
+            }
+        } else if let Some(key) = aria_attr_to_property_key(&lowered) {
+            state_map.insert(key.to_string(), json_val);
+        } else if let Some(key) = html_attr_to_property_key(&lowered) {
+            state_map.insert(key.to_string(), json_val);
+        } else if strategy == AttributeNameStrategy::CamelCase && lowered.contains('-') {
+            state_map.insert(kebab_to_camel(&lowered), json_val);
+        } else {
+            state_map.insert(lowered, json_val);
+        }
+    }
+    JsonValue::Object(state_map)
+}
+
+fn has_state_relevant_attrs(attrs: &[(String, Option<String>)]) -> bool {
+    attrs.iter().any(|(name, _)| {
+        !name.starts_with('@')
+            && !name.starts_with('?')
+            && !name.eq_ignore_ascii_case("f-ref")
+            && !name.eq_ignore_ascii_case("f-slotted")
+            && !name.eq_ignore_ascii_case("f-children")
+    })
+}
+
+pub(crate) fn build_shadowroot_template_attrs(attrs: &[(String, Option<String>)]) -> String {
     let mut mode: Option<Option<String>> = None;
     let mut legacy_shadowroot: Option<Option<String>> = None;
     let mut forwarded: Vec<(String, Option<String>)> = Vec::new();
@@ -470,7 +499,7 @@ fn attribute_to_json_value(value: Option<&String>, root: &JsonValue, loop_vars: 
     JsonValue::String(v.clone())
 }
 
-fn build_element_open_tag(
+pub(crate) fn build_element_open_tag(
     open_tag_base: &str,
     open_tag_content: &str,
     root: &JsonValue,

--- a/crates/microsoft-fast-build/src/json.rs
+++ b/crates/microsoft-fast-build/src/json.rs
@@ -66,6 +66,34 @@ pub fn parse(input: &str) -> Result<JsonValue, JsonError> {
     Ok(value)
 }
 
+#[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn escape_json_str(s: &str) -> String {
+    let mut out = String::with_capacity(s.len());
+    for c in s.chars() {
+        match c {
+            '"' => out.push_str("\\\""),
+            '\\' => out.push_str("\\\\"),
+            '\n' => out.push_str("\\n"),
+            '\r' => out.push_str("\\r"),
+            '\t' => out.push_str("\\t"),
+            '\u{08}' => out.push_str("\\b"),
+            '\u{0c}' => out.push_str("\\f"),
+            c if c <= '\u{1f}' => out.push_str(&format!("\\u{:04x}", c as u32)),
+            c => out.push(c),
+        }
+    }
+    out
+}
+
+#[cfg(any(test, target_arch = "wasm32"))]
+pub(crate) fn json_string_array(items: &[String]) -> String {
+    let mut parts = Vec::with_capacity(items.len());
+    for item in items {
+        parts.push(format!("\"{}\"", escape_json_str(item)));
+    }
+    format!("[{}]", parts.join(","))
+}
+
 fn parse_value(input: &str) -> Result<(JsonValue, &str), JsonError> {
     let input = input.trim_start();
     if input.is_empty() {
@@ -292,6 +320,24 @@ mod tests {
         } else {
             panic!("Expected string");
         }
+    }
+
+    #[test]
+    fn test_escape_json_str_escapes_all_control_characters() {
+        let escaped = escape_json_str("a\"\n\r\t\\\u{0000}\u{0008}\u{000c}\u{001f}b");
+
+        assert_eq!(escaped, "a\\\"\\n\\r\\t\\\\\\u0000\\b\\f\\u001fb");
+    }
+
+    #[test]
+    fn test_json_string_array_escapes_control_characters() {
+        let json = json_string_array(&[
+            "first".to_string(),
+            "line\u{000b}separator".to_string(),
+        ]);
+
+        assert_eq!(json, "[\"first\",\"line\\u000bseparator\"]");
+        assert!(parse(&json).is_ok());
     }
 
     #[test]

--- a/crates/microsoft-fast-build/src/lib.rs
+++ b/crates/microsoft-fast-build/src/lib.rs
@@ -16,9 +16,11 @@
 //!         │
 //!         ▼
 //!   renderer::render(template, root) ─────────────────────────────────────┐
+//!   renderer::render_stream(template, root) ───────────────┐              │
 //!         │                                                                │
 //!         ▼                                                                │
 //!   node::render_node(template, root, loop_vars, locator, hydration?)     │
+//!   streaming::stream_node(...) → Vec<String> chunks                      │
 //!         │                                                                │
 //!         ├─ [hydration] scan literal HTML tags for attr bindings         │
 //!         │      └─ inject data-fe="N" count markers                    │
@@ -33,12 +35,17 @@
 //!         └─ append literal prefix + resolved chunk → output string
 //! ```
 //!
+//! Streaming entry points use the same scanner and rendering semantics, but
+//! return precomputed non-empty HTML chunks. Joining those chunks matches the
+//! equivalent non-streamed render.
+//!
 //! ## Module map
 //!
 //! | Module | Role |
 //! |--------|------|
-//! | `renderer` | Thin entry points mapping the public API into `render_node` calls |
+//! | `renderer` | Thin entry points mapping the public API into `render_node` or `stream_node` calls |
 //! | `node` | Main rendering loop — directive dispatch and hydration tag scan |
+//! | `streaming` | Simulated streaming loop — returns precomputed HTML chunks |
 //! | `directive` | `Directive` enum, `next_directive` scanner, directive renderers |
 //! | `content` | `{{expr}}` / `{{{expr}}}` binding renderers and `html_escape` |
 //! | `attribute` | Low-level HTML/attribute string parsing utilities |
@@ -66,6 +73,7 @@ mod directive;
 mod hydration;
 mod node;
 mod renderer;
+mod streaming;
 mod error;
 mod locator;
 #[cfg(target_arch = "wasm32")]
@@ -86,15 +94,32 @@ pub fn render_template(template: &str, state: &str, config: Option<&RenderConfig
     renderer::render(template, &state_value, config)
 }
 
+/// Render a FAST HTML template with a JSON state string into HTML stream chunks.
+pub fn render_template_stream(template: &str, state: &str, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let state_value = json::parse(state).map_err(|e| RenderError::JsonParse { message: e.message })?;
+    renderer::render_stream(template, &state_value, config)
+}
+
 /// Render a FAST HTML template with no state, using an empty object.
 pub fn render_template_without_state(template: &str, config: Option<&RenderConfig>) -> Result<String, RenderError> {
     let state_value = empty_state();
     renderer::render(template, &state_value, config)
 }
 
+/// Render a FAST HTML template with no state into HTML stream chunks.
+pub fn render_template_stream_without_state(template: &str, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let state_value = empty_state();
+    renderer::render_stream(template, &state_value, config)
+}
+
 /// Render a FAST HTML template with a parsed [`JsonValue`].
 pub fn render(template: &str, state: &JsonValue, config: Option<&RenderConfig>) -> Result<String, RenderError> {
     renderer::render(template, state, config)
+}
+
+/// Render a FAST HTML template with a parsed [`JsonValue`] into HTML stream chunks.
+pub fn render_stream(template: &str, state: &JsonValue, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    renderer::render_stream(template, state, config)
 }
 
 /// Render a FAST HTML template with no state, using an empty object.
@@ -103,9 +128,20 @@ pub fn render_without_state(template: &str, config: Option<&RenderConfig>) -> Re
     renderer::render(template, &state_value, config)
 }
 
+/// Render a FAST HTML template with no state into HTML stream chunks.
+pub fn render_stream_without_state(template: &str, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let state_value = empty_state();
+    renderer::render_stream(template, &state_value, config)
+}
+
 /// Render a FAST HTML template with a parsed [`JsonValue`] and a [`Locator`] for custom elements.
 pub fn render_with_locator(template: &str, state: &JsonValue, locator: &Locator, config: Option<&RenderConfig>) -> Result<String, RenderError> {
     renderer::render_with_locator(template, state, locator, config)
+}
+
+/// Render a FAST HTML template with a parsed [`JsonValue`] and a [`Locator`] into HTML stream chunks.
+pub fn render_stream_with_locator(template: &str, state: &JsonValue, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    renderer::render_stream_with_locator(template, state, locator, config)
 }
 
 /// Render a FAST HTML template with a [`Locator`] for custom elements and no state.
@@ -114,15 +150,32 @@ pub fn render_with_locator_without_state(template: &str, locator: &Locator, conf
     renderer::render_with_locator(template, &state_value, locator, config)
 }
 
+/// Render a FAST HTML template with a [`Locator`] and no state into HTML stream chunks.
+pub fn render_stream_with_locator_without_state(template: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let state_value = empty_state();
+    renderer::render_stream_with_locator(template, &state_value, locator, config)
+}
+
 /// Render a FAST HTML template with a [`Locator`] for custom elements and no state.
 pub fn render_template_with_locator_without_state(template: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<String, RenderError> {
     render_with_locator_without_state(template, locator, config)
+}
+
+/// Render a FAST HTML template with a [`Locator`] and no state into HTML stream chunks.
+pub fn render_template_stream_with_locator_without_state(template: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    render_stream_with_locator_without_state(template, locator, config)
 }
 
 /// Render a FAST HTML template with a JSON state string and a [`Locator`] for custom elements.
 pub fn render_template_with_locator(template: &str, state: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<String, RenderError> {
     let state_value = json::parse(state).map_err(|e| RenderError::JsonParse { message: e.message })?;
     renderer::render_with_locator(template, &state_value, locator, config)
+}
+
+/// Render a FAST HTML template with a JSON state string and a [`Locator`] into HTML stream chunks.
+pub fn render_template_stream_with_locator(template: &str, state: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let state_value = json::parse(state).map_err(|e| RenderError::JsonParse { message: e.message })?;
+    renderer::render_stream_with_locator(template, &state_value, locator, config)
 }
 
 /// Render the top-level **entry HTML** with a parsed [`JsonValue`] and a [`Locator`].
@@ -132,15 +185,31 @@ pub fn render_entry_with_locator(template: &str, state: &JsonValue, locator: &Lo
     renderer::render_entry_with_locator(template, state, locator, config)
 }
 
+/// Render the top-level **entry HTML** into stream chunks with a parsed [`JsonValue`] and a [`Locator`].
+pub fn render_entry_stream_with_locator(template: &str, state: &JsonValue, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    renderer::render_entry_stream_with_locator(template, state, locator, config)
+}
+
 /// Render the top-level **entry HTML** with a [`Locator`] and no state.
 pub fn render_entry_with_locator_without_state(template: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<String, RenderError> {
     let state_value = empty_state();
     renderer::render_entry_with_locator(template, &state_value, locator, config)
 }
 
+/// Render the top-level **entry HTML** with a [`Locator`] and no state into stream chunks.
+pub fn render_entry_stream_with_locator_without_state(template: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let state_value = empty_state();
+    renderer::render_entry_stream_with_locator(template, &state_value, locator, config)
+}
+
 /// Render the top-level **entry HTML** with a [`Locator`] and no state.
 pub fn render_entry_template_with_locator_without_state(template: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<String, RenderError> {
     render_entry_with_locator_without_state(template, locator, config)
+}
+
+/// Render the top-level **entry HTML** with a [`Locator`] and no state into stream chunks.
+pub fn render_entry_template_stream_with_locator_without_state(template: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    render_entry_stream_with_locator_without_state(template, locator, config)
 }
 
 /// Render the top-level **entry HTML** with a JSON state string and a [`Locator`].
@@ -149,4 +218,10 @@ pub fn render_entry_template_with_locator_without_state(template: &str, locator:
 pub fn render_entry_template_with_locator(template: &str, state: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<String, RenderError> {
     let state_value = json::parse(state).map_err(|e| RenderError::JsonParse { message: e.message })?;
     renderer::render_entry_with_locator(template, &state_value, locator, config)
+}
+
+/// Render the top-level **entry HTML** with a JSON state string and a [`Locator`] into stream chunks.
+pub fn render_entry_template_stream_with_locator(template: &str, state: &str, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let state_value = json::parse(state).map_err(|e| RenderError::JsonParse { message: e.message })?;
+    renderer::render_entry_stream_with_locator(template, &state_value, locator, config)
 }

--- a/crates/microsoft-fast-build/src/renderer.rs
+++ b/crates/microsoft-fast-build/src/renderer.rs
@@ -2,6 +2,7 @@ use crate::json::JsonValue;
 use crate::error::RenderError;
 use crate::config::RenderConfig;
 use crate::node::render_node;
+use crate::streaming::stream_node;
 use crate::locator::Locator;
 
 pub fn render(template: &str, root: &JsonValue, config: Option<&RenderConfig>) -> Result<String, RenderError> {
@@ -10,10 +11,22 @@ pub fn render(template: &str, root: &JsonValue, config: Option<&RenderConfig>) -
     render_node(template, root, &[], None, None, false, config)
 }
 
+pub fn render_stream(template: &str, root: &JsonValue, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let default = RenderConfig::default();
+    let config = config.unwrap_or(&default);
+    stream_node(template, root, &[], None, None, false, config)
+}
+
 pub fn render_with_locator(template: &str, root: &JsonValue, locator: &Locator, config: Option<&RenderConfig>) -> Result<String, RenderError> {
     let default = RenderConfig::default();
     let config = config.unwrap_or(&default);
     render_node(template, root, &[], Some(locator), None, false, config)
+}
+
+pub fn render_stream_with_locator(template: &str, root: &JsonValue, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let default = RenderConfig::default();
+    let config = config.unwrap_or(&default);
+    stream_node(template, root, &[], Some(locator), None, false, config)
 }
 
 /// Render the top-level **entry HTML** — custom elements found at this level use
@@ -23,4 +36,10 @@ pub fn render_entry_with_locator(template: &str, root: &JsonValue, locator: &Loc
     let default = RenderConfig::default();
     let config = config.unwrap_or(&default);
     render_node(template, root, &[], Some(locator), None, true, config)
+}
+
+pub fn render_entry_stream_with_locator(template: &str, root: &JsonValue, locator: &Locator, config: Option<&RenderConfig>) -> Result<Vec<String>, RenderError> {
+    let default = RenderConfig::default();
+    let config = config.unwrap_or(&default);
+    stream_node(template, root, &[], Some(locator), None, true, config)
 }

--- a/crates/microsoft-fast-build/src/streaming.rs
+++ b/crates/microsoft-fast-build/src/streaming.rs
@@ -1,0 +1,472 @@
+use crate::attribute::{
+    count_tag_attribute_bindings, extract_directive_content, extract_directive_expr,
+    find_next_plain_html_tag, find_tag_end, inject_count_marker, parse_element_attributes,
+    read_tag_name, resolve_attribute_bindings_in_tag, strip_client_only_attrs,
+};
+use crate::config::RenderConfig;
+use crate::content::{render_double_brace, render_triple_brace};
+use crate::context::resolve_value;
+use crate::directive::{
+    build_custom_element_child_root, build_element_open_tag, build_loop_vars,
+    build_shadowroot_template_attrs, next_directive, parse_repeat_expr, Directive,
+};
+use crate::error::{template_context, RenderError};
+use crate::expression::evaluate;
+use crate::hydration::HydrationScope;
+use crate::json::JsonValue;
+use crate::locator::Locator;
+use crate::node::render_node;
+
+pub(crate) fn stream_node(
+    template: &str,
+    root: &JsonValue,
+    loop_vars: &[(String, JsonValue)],
+    locator: Option<&Locator>,
+    mut hydration: Option<&mut HydrationScope>,
+    is_entry: bool,
+    config: &RenderConfig,
+) -> Result<Vec<String>, RenderError> {
+    let mut chunks = Vec::new();
+    let mut current = String::new();
+    let mut pos = 0;
+
+    loop {
+        pos = process_plain_html_tags(
+            template,
+            pos,
+            root,
+            loop_vars,
+            locator,
+            hydration.as_mut().map(|h| &mut **h),
+            &mut current,
+        );
+
+        let dir_chunk = match next_directive(template, pos, locator) {
+            None => {
+                current.push_str(&template[pos..]);
+                push_non_empty(&mut chunks, current);
+                break;
+            }
+            Some(d) => d,
+        };
+
+        current.push_str(&template[pos..dir_chunk.position()]);
+        push_non_empty(&mut chunks, std::mem::take(&mut current));
+
+        let (dir_chunks, next_pos) = stream_directive(
+            dir_chunk,
+            template,
+            root,
+            loop_vars,
+            locator,
+            hydration.as_mut().map(|h| &mut **h),
+            is_entry,
+            config,
+        )?;
+        extend_non_empty(&mut chunks, dir_chunks);
+        pos = next_pos;
+    }
+
+    Ok(chunks)
+}
+
+fn process_plain_html_tags(
+    template: &str,
+    mut pos: usize,
+    root: &JsonValue,
+    loop_vars: &[(String, JsonValue)],
+    locator: Option<&Locator>,
+    mut hydration: Option<&mut HydrationScope>,
+    result: &mut String,
+) -> usize {
+    loop {
+        let dir_pos = next_directive(template, pos, locator)
+            .map(|d| d.position())
+            .unwrap_or(template.len());
+
+        let tag_pos = match find_next_plain_html_tag(template, pos, locator) {
+            Some(p) if p < dir_pos => p,
+            _ => break,
+        };
+
+        result.push_str(&template[pos..tag_pos]);
+
+        let tag_end = match find_tag_end(template, tag_pos) {
+            Some(e) => e,
+            None => {
+                result.push_str(&template[tag_pos..]);
+                return template.len();
+            }
+        };
+        let tag_str = &template[tag_pos..tag_end];
+        let (db, sb) = count_tag_attribute_bindings(tag_str);
+        let total = db + sb;
+
+        match hydration.as_mut() {
+            Some(hy) => {
+                if total > 0 {
+                    hy.binding_idx += total;
+                    let resolved = resolve_attribute_bindings_in_tag(tag_str, root, loop_vars);
+                    let stripped = strip_client_only_attrs(&resolved);
+                    result.push_str(&inject_count_marker(&stripped, total));
+                } else {
+                    result.push_str(&strip_client_only_attrs(tag_str));
+                }
+            }
+            None => {
+                if db > 0 {
+                    result.push_str(&resolve_attribute_bindings_in_tag(tag_str, root, loop_vars));
+                } else {
+                    result.push_str(tag_str);
+                }
+            }
+        }
+
+        pos = tag_end;
+    }
+
+    pos
+}
+
+fn stream_directive(
+    dir_chunk: Directive,
+    template: &str,
+    root: &JsonValue,
+    loop_vars: &[(String, JsonValue)],
+    locator: Option<&Locator>,
+    hydration: Option<&mut HydrationScope>,
+    is_entry: bool,
+    config: &RenderConfig,
+) -> Result<(Vec<String>, usize), RenderError> {
+    match dir_chunk {
+        Directive::TripleBrace(p) => {
+            let (out, end) = render_triple_brace(template, p, root, loop_vars)?;
+            Ok((chunk_vec(wrap_content_binding(out, hydration)), end))
+        }
+        Directive::DoubleBrace(p) => {
+            let (out, end) = render_double_brace(template, p, root, loop_vars)?;
+            Ok((chunk_vec(wrap_content_binding(out, hydration)), end))
+        }
+        Directive::When(p) => stream_when(template, p, root, loop_vars, locator, hydration, config),
+        Directive::Repeat(p) => {
+            stream_repeat(template, p, root, loop_vars, locator, hydration, config)
+        }
+        Directive::CustomElement(p) => stream_custom_element(
+            template,
+            p,
+            root,
+            loop_vars,
+            locator.expect("locator is required to render a CustomElement directive"),
+            hydration,
+            is_entry,
+            config,
+        ),
+    }
+}
+
+fn stream_when(
+    template: &str,
+    at: usize,
+    root: &JsonValue,
+    loop_vars: &[(String, JsonValue)],
+    locator: Option<&Locator>,
+    hydration: Option<&mut HydrationScope>,
+    config: &RenderConfig,
+) -> Result<(Vec<String>, usize), RenderError> {
+    let (inner, after) = extract_directive_content(template, at, "f-when").ok_or_else(|| {
+        RenderError::UnclosedDirective {
+            tag: "f-when".to_string(),
+            context: template_context(template, at),
+        }
+    })?;
+    let expr =
+        extract_directive_expr(template, at).ok_or_else(|| RenderError::MissingValueAttribute {
+            tag: "f-when".to_string(),
+            context: template_context(template, at),
+        })?;
+
+    let chunks = if let Some(hy) = hydration {
+        hy.next_binding();
+        let inner_chunks = if evaluate(&expr, root, loop_vars) {
+            let mut child_scope = HydrationScope::new();
+            stream_node(
+                &inner,
+                root,
+                loop_vars,
+                locator,
+                Some(&mut child_scope),
+                false,
+                config,
+            )?
+        } else {
+            Vec::new()
+        };
+        wrap_chunks_with_markers(
+            inner_chunks,
+            hy.content_start_marker(),
+            hy.content_end_marker(),
+        )
+    } else if evaluate(&expr, root, loop_vars) {
+        stream_node(&inner, root, loop_vars, locator, None, false, config)?
+    } else {
+        Vec::new()
+    };
+
+    Ok((chunks, after))
+}
+
+fn stream_repeat(
+    template: &str,
+    at: usize,
+    root: &JsonValue,
+    loop_vars: &[(String, JsonValue)],
+    locator: Option<&Locator>,
+    hydration: Option<&mut HydrationScope>,
+    config: &RenderConfig,
+) -> Result<(Vec<String>, usize), RenderError> {
+    let (inner, after) = extract_directive_content(template, at, "f-repeat").ok_or_else(|| {
+        RenderError::UnclosedDirective {
+            tag: "f-repeat".to_string(),
+            context: template_context(template, at),
+        }
+    })?;
+    let expr =
+        extract_directive_expr(template, at).ok_or_else(|| RenderError::MissingValueAttribute {
+            tag: "f-repeat".to_string(),
+            context: template_context(template, at),
+        })?;
+    let (var_name, list_expr) =
+        parse_repeat_expr(&expr).ok_or_else(|| RenderError::InvalidRepeatExpression {
+            expr: expr.clone(),
+            context: template_context(template, at),
+        })?;
+
+    let chunks = match resolve_value(&list_expr, root, loop_vars) {
+        None => stream_repeat_items(
+            &inner,
+            &[],
+            &var_name,
+            root,
+            loop_vars,
+            locator,
+            hydration,
+            config,
+        )?,
+        Some(JsonValue::Array(items)) => stream_repeat_items(
+            &inner, &items, &var_name, root, loop_vars, locator, hydration, config,
+        )?,
+        Some(_) => {
+            return Err(RenderError::NotAnArray {
+                binding: list_expr,
+                context: template_context(template, at),
+            });
+        }
+    };
+
+    Ok((chunks, after))
+}
+
+fn stream_repeat_items(
+    inner: &str,
+    items: &[JsonValue],
+    var_name: &str,
+    root: &JsonValue,
+    loop_vars: &[(String, JsonValue)],
+    locator: Option<&Locator>,
+    hydration: Option<&mut HydrationScope>,
+    config: &RenderConfig,
+) -> Result<Vec<String>, RenderError> {
+    match hydration {
+        Some(hy) => {
+            hy.next_binding();
+            let mut chunks = Vec::new();
+            let repeat_start = hy.repeat_start_marker();
+            let repeat_end = hy.repeat_end_marker();
+
+            for (i, item) in items.iter().enumerate() {
+                let new_vars = build_loop_vars(loop_vars, var_name, item, i);
+                let mut item_scope = HydrationScope::new();
+                let item_chunks = stream_node(
+                    inner,
+                    root,
+                    &new_vars,
+                    locator,
+                    Some(&mut item_scope),
+                    false,
+                    config,
+                )?;
+                extend_non_empty(
+                    &mut chunks,
+                    wrap_chunks_with_markers(item_chunks, repeat_start, repeat_end),
+                );
+            }
+
+            Ok(wrap_chunks_with_markers(
+                chunks,
+                hy.content_start_marker(),
+                hy.content_end_marker(),
+            ))
+        }
+        None => {
+            let mut chunks = Vec::new();
+            for (i, item) in items.iter().enumerate() {
+                let new_vars = build_loop_vars(loop_vars, var_name, item, i);
+                extend_non_empty(
+                    &mut chunks,
+                    stream_node(inner, root, &new_vars, locator, None, false, config)?,
+                );
+            }
+            Ok(chunks)
+        }
+    }
+}
+
+fn stream_custom_element(
+    template: &str,
+    at: usize,
+    root: &JsonValue,
+    loop_vars: &[(String, JsonValue)],
+    locator: &Locator,
+    mut parent_hydration: Option<&mut HydrationScope>,
+    is_entry: bool,
+    config: &RenderConfig,
+) -> Result<(Vec<String>, usize), RenderError> {
+    let tag_end = find_tag_end(template, at).ok_or_else(|| RenderError::UnclosedDirective {
+        tag: "custom element".to_string(),
+        context: template_context(template, at),
+    })?;
+
+    let tag_name = read_tag_name(template, at).unwrap_or_default();
+    let open_tag_content = &template[at..tag_end];
+    let before_gt = open_tag_content[..open_tag_content.len() - 1].trim_end();
+    let is_self_closing = before_gt.ends_with('/');
+    let open_tag_base = if is_self_closing {
+        before_gt[..before_gt.len() - 1].trim_end().to_string()
+    } else {
+        open_tag_content[..open_tag_content.len() - 1].to_string()
+    };
+
+    let attrs = parse_element_attributes(open_tag_content);
+    let child_root_owned =
+        build_custom_element_child_root(&attrs, root, loop_vars, config.attribute_name_strategy);
+    let child_root = child_root_owned.as_ref().unwrap_or(root);
+
+    let mut shadow_scope = HydrationScope::new();
+    let element_template = locator.get_template(&tag_name).unwrap_or_default();
+    let rendered_shadow = render_node(
+        element_template,
+        child_root,
+        &[],
+        Some(locator),
+        Some(&mut shadow_scope),
+        false,
+        config,
+    )?;
+    let shadowroot_attributes =
+        build_shadowroot_template_attrs(locator.get_shadowroot_attributes(&tag_name));
+
+    let element_open = build_element_open_tag(
+        &open_tag_base,
+        open_tag_content,
+        root,
+        loop_vars,
+        parent_hydration.as_mut().map(|h| &mut **h),
+        is_entry,
+    );
+
+    let (children, after) = if is_self_closing {
+        (String::new(), tag_end)
+    } else {
+        extract_directive_content(template, at, &tag_name).ok_or_else(|| {
+            RenderError::UnclosedDirective {
+                tag: tag_name.clone(),
+                context: template_context(template, at),
+            }
+        })?
+    };
+
+    let mut chunks = Vec::new();
+    let mut opening_chunk = format!(
+        "{}<template{}>{}</template>",
+        element_open, shadowroot_attributes, rendered_shadow
+    );
+    let close_tag = format!("</{}>", tag_name);
+
+    if is_self_closing || children.is_empty() {
+        opening_chunk.push_str(&close_tag);
+        push_non_empty(&mut chunks, opening_chunk);
+        return Ok((chunks, after));
+    }
+
+    push_non_empty(&mut chunks, opening_chunk);
+    let mut light_chunks = stream_node(
+        &children,
+        root,
+        loop_vars,
+        Some(locator),
+        parent_hydration.as_mut().map(|h| &mut **h),
+        false,
+        config,
+    )?;
+
+    if let Some(last) = light_chunks.last_mut() {
+        last.push_str(&close_tag);
+        extend_non_empty(&mut chunks, light_chunks);
+    } else if let Some(last) = chunks.last_mut() {
+        last.push_str(&close_tag);
+    }
+
+    Ok((chunks, after))
+}
+
+fn wrap_content_binding(out: String, hydration: Option<&mut HydrationScope>) -> String {
+    match hydration {
+        None => out,
+        Some(hy) => {
+            hy.next_binding();
+            format!(
+                "{}{}{}",
+                hy.content_start_marker(),
+                out,
+                hy.content_end_marker()
+            )
+        }
+    }
+}
+
+fn wrap_chunks_with_markers(
+    mut chunks: Vec<String>,
+    start_marker: &str,
+    end_marker: &str,
+) -> Vec<String> {
+    if chunks.is_empty() {
+        return chunk_vec(format!("{}{}", start_marker, end_marker));
+    }
+
+    chunks[0].insert_str(0, start_marker);
+    let last = chunks
+        .last_mut()
+        .expect("non-empty chunks should have a last item");
+    last.push_str(end_marker);
+    chunks
+}
+
+fn chunk_vec(chunk: String) -> Vec<String> {
+    if chunk.is_empty() {
+        Vec::new()
+    } else {
+        vec![chunk]
+    }
+}
+
+fn extend_non_empty(chunks: &mut Vec<String>, new_chunks: Vec<String>) {
+    for chunk in new_chunks {
+        push_non_empty(chunks, chunk);
+    }
+}
+
+fn push_non_empty(chunks: &mut Vec<String>, chunk: String) {
+    if !chunk.is_empty() {
+        chunks.push(chunk);
+    }
+}

--- a/crates/microsoft-fast-build/src/wasm.rs
+++ b/crates/microsoft-fast-build/src/wasm.rs
@@ -1,8 +1,9 @@
 use crate::config::{AttributeNameStrategy, RenderConfig};
 use crate::{
-    json, render_entry_template_with_locator, render_entry_template_with_locator_without_state,
-    render_entry_template_stream_with_locator, render_entry_template_stream_with_locator_without_state,
-    render_template, render_template_with_locator, render_template_with_locator_without_state,
+    json, render_entry_template_stream_with_locator,
+    render_entry_template_stream_with_locator_without_state, render_entry_template_with_locator,
+    render_entry_template_with_locator_without_state, render_template,
+    render_template_with_locator, render_template_with_locator_without_state,
     render_template_without_state, Locator,
 };
 use std::collections::HashMap;
@@ -59,43 +60,46 @@ pub fn render_with_templates(
 /// e.g. `{"my-button": "<template>...</template>"}`, or template metadata objects.
 /// `attribute_name_strategy` controls attribute-to-property mapping: `"camelCase"` (default)
 /// or `"none"`. Pass an empty string for the default.
-/// Returns the rendered HTML or throws a JavaScript error.
+/// Pass `stream: true` to return a JSON array string of stream chunks; in
+/// stream mode, `templates_json` may be `{}`. Omitted or `false` stream
+/// preserves the rendered HTML behavior.
 #[wasm_bindgen]
 pub fn render_entry_with_templates(
     entry: &str,
     templates_json: &str,
     state: Option<String>,
     attribute_name_strategy: Option<String>,
+    stream: Option<bool>,
 ) -> Result<String, JsValue> {
     let templates = parse_templates_map(templates_json)?;
     let locator = Locator::from_template_definitions(templates);
     let config = build_config(attribute_name_strategy.as_deref())?;
-    match state {
-        Some(state) => render_entry_template_with_locator(entry, &state, &locator, config.as_ref()),
-        None => render_entry_template_with_locator_without_state(entry, &locator, config.as_ref()),
-    }
-    .map_err(|e| JsValue::from_str(&e.to_string()))
-}
 
-/// Render the top-level **entry HTML** as a JSON array string of stream chunks.
-/// Omitted state is treated as an empty object. `templates_json` may be `{}`.
-#[wasm_bindgen]
-pub fn render_entry_stream_with_templates(
-    entry: &str,
-    templates_json: &str,
-    state: Option<String>,
-    attribute_name_strategy: Option<String>,
-) -> Result<String, JsValue> {
-    let templates = parse_templates_map(templates_json)?;
-    let locator = Locator::from_template_definitions(templates);
-    let config = build_config(attribute_name_strategy.as_deref())?;
-    let chunks = match state {
-        Some(state) => render_entry_template_stream_with_locator(entry, &state, &locator, config.as_ref()),
-        None => render_entry_template_stream_with_locator_without_state(entry, &locator, config.as_ref()),
-    }
-    .map_err(|e| JsValue::from_str(&e.to_string()))?;
+    if stream.unwrap_or(false) {
+        let chunks = match state {
+            Some(state) => {
+                render_entry_template_stream_with_locator(entry, &state, &locator, config.as_ref())
+            }
+            None => render_entry_template_stream_with_locator_without_state(
+                entry,
+                &locator,
+                config.as_ref(),
+            ),
+        }
+        .map_err(|e| JsValue::from_str(&e.to_string()))?;
 
-    Ok(json_string_array(&chunks))
+        Ok(json_string_array(&chunks))
+    } else {
+        match state {
+            Some(state) => {
+                render_entry_template_with_locator(entry, &state, &locator, config.as_ref())
+            }
+            None => {
+                render_entry_template_with_locator_without_state(entry, &locator, config.as_ref())
+            }
+        }
+        .map_err(|e| JsValue::from_str(&e.to_string()))
+    }
 }
 
 /// Parse all `<f-template>` elements from an HTML string.

--- a/crates/microsoft-fast-build/src/wasm.rs
+++ b/crates/microsoft-fast-build/src/wasm.rs
@@ -1,6 +1,7 @@
 use crate::config::{AttributeNameStrategy, RenderConfig};
 use crate::{
     json, render_entry_template_with_locator, render_entry_template_with_locator_without_state,
+    render_entry_template_stream_with_locator, render_entry_template_stream_with_locator_without_state,
     render_template, render_template_with_locator, render_template_with_locator_without_state,
     render_template_without_state, Locator,
 };
@@ -76,6 +77,27 @@ pub fn render_entry_with_templates(
     .map_err(|e| JsValue::from_str(&e.to_string()))
 }
 
+/// Render the top-level **entry HTML** as a JSON array string of stream chunks.
+/// Omitted state is treated as an empty object. `templates_json` may be `{}`.
+#[wasm_bindgen]
+pub fn render_entry_stream_with_templates(
+    entry: &str,
+    templates_json: &str,
+    state: Option<String>,
+    attribute_name_strategy: Option<String>,
+) -> Result<String, JsValue> {
+    let templates = parse_templates_map(templates_json)?;
+    let locator = Locator::from_template_definitions(templates);
+    let config = build_config(attribute_name_strategy.as_deref())?;
+    let chunks = match state {
+        Some(state) => render_entry_template_stream_with_locator(entry, &state, &locator, config.as_ref()),
+        None => render_entry_template_stream_with_locator_without_state(entry, &locator, config.as_ref()),
+    }
+    .map_err(|e| JsValue::from_str(&e.to_string()))?;
+
+    Ok(json_string_array(&chunks))
+}
+
 /// Parse all `<f-template>` elements from an HTML string.
 /// Returns a JSON array of template metadata objects,
 /// one per `<f-template>` element found. `name` is `null` when the element has
@@ -128,6 +150,14 @@ fn escape_json_str(s: &str) -> String {
         }
     }
     out
+}
+
+fn json_string_array(items: &[String]) -> String {
+    let mut parts = Vec::with_capacity(items.len());
+    for item in items {
+        parts.push(format!("\"{}\"", escape_json_str(item)));
+    }
+    format!("[{}]", parts.join(","))
 }
 
 fn parse_templates_map(

--- a/crates/microsoft-fast-build/src/wasm.rs
+++ b/crates/microsoft-fast-build/src/wasm.rs
@@ -1,6 +1,7 @@
 use crate::config::{AttributeNameStrategy, RenderConfig};
+use crate::json::{self, escape_json_str, json_string_array};
 use crate::{
-    json, render_entry_template_stream_with_locator,
+    render_entry_template_stream_with_locator,
     render_entry_template_stream_with_locator_without_state, render_entry_template_with_locator,
     render_entry_template_with_locator_without_state, render_template,
     render_template_with_locator, render_template_with_locator_without_state,
@@ -137,29 +138,6 @@ fn shadowroot_attributes_json(attrs: &[(String, Option<String>)]) -> String {
             escape_json_str(name),
             value_json
         ));
-    }
-    format!("[{}]", parts.join(","))
-}
-
-fn escape_json_str(s: &str) -> String {
-    let mut out = String::with_capacity(s.len());
-    for c in s.chars() {
-        match c {
-            '"' => out.push_str("\\\""),
-            '\\' => out.push_str("\\\\"),
-            '\n' => out.push_str("\\n"),
-            '\r' => out.push_str("\\r"),
-            '\t' => out.push_str("\\t"),
-            c => out.push(c),
-        }
-    }
-    out
-}
-
-fn json_string_array(items: &[String]) -> String {
-    let mut parts = Vec::with_capacity(items.len());
-    for item in items {
-        parts.push(format!("\"{}\"", escape_json_str(item)));
     }
     format!("[{}]", parts.join(","))
 }

--- a/crates/microsoft-fast-build/tests/streaming.rs
+++ b/crates/microsoft-fast-build/tests/streaming.rs
@@ -1,0 +1,210 @@
+mod common;
+
+use common::make_locator;
+use microsoft_fast_build::{
+    render_entry_template_stream_with_locator, render_entry_template_with_locator, render_template,
+    render_template_stream,
+};
+
+fn strings(items: &[&str]) -> Vec<String> {
+    items.iter().map(|item| (*item).to_string()).collect()
+}
+
+fn assert_no_empty(chunks: &[String]) {
+    assert!(
+        chunks.iter().all(|chunk| !chunk.is_empty()),
+        "stream should not contain empty chunks: {chunks:?}"
+    );
+}
+
+#[test]
+fn prompt_example_streams_in_sensible_chunks() {
+    let locator = make_locator(&[("custom-subheading", "{{text}}<slot></slot>")]);
+    let entry = r#"<h1 id="{{id}}">Hello world</h1><custom-subheading text="{{subheadingText}}"> <span>and friends</span></custom-subheading><p>{{paragraphText}}</p>"#;
+    let state = r#"{"id":"title","subheadingText":"from Mars","paragraphText":"A letter from one planet to another"}"#;
+
+    let chunks = render_entry_template_stream_with_locator(entry, state, &locator, None).unwrap();
+
+    assert_eq!(
+        chunks,
+        strings(&[
+            r#"<h1 id="title">Hello world</h1>"#,
+            r#"<custom-subheading text="from Mars"><template shadowrootmode="open" shadowroot="open"><!--fe:b-->from Mars<!--fe:/b--><slot></slot></template>"#,
+            r#" <span>and friends</span></custom-subheading>"#,
+            "<p>",
+            "A letter from one planet to another",
+            "</p>",
+        ])
+    );
+    assert_eq!(
+        chunks.join(""),
+        render_entry_template_with_locator(entry, state, &locator, None).unwrap()
+    );
+    assert_no_empty(&chunks);
+}
+
+#[test]
+fn no_templates_no_custom_elements_streams_content_bindings() {
+    let chunks =
+        render_template_stream("<p>{{greeting}}</p>", r#"{"greeting":"Hello"}"#, None).unwrap();
+
+    assert_eq!(chunks, strings(&["<p>", "Hello", "</p>"]));
+    assert_eq!(
+        chunks.join(""),
+        render_template("<p>{{greeting}}</p>", r#"{"greeting":"Hello"}"#, None).unwrap()
+    );
+}
+
+#[test]
+fn attribute_bindings_stay_in_their_tag_chunk() {
+    let chunks = render_template_stream(
+        r#"<h1 id="{{id}}" class="title">Hello</h1><p>{{text}}</p>"#,
+        r#"{"id":"heading","text":"Body"}"#,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        chunks,
+        strings(&[
+            r#"<h1 id="heading" class="title">Hello</h1><p>"#,
+            "Body",
+            "</p>",
+        ])
+    );
+}
+
+#[test]
+fn custom_element_opening_chunk_contains_complete_shadow_template() {
+    let locator = make_locator(&[("my-el", "<span>{{text}}</span>")]);
+    let entry = r#"<my-el text="{{text}}">light</my-el>"#;
+    let chunks =
+        render_entry_template_stream_with_locator(entry, r#"{"text":"Hello"}"#, &locator, None)
+            .unwrap();
+
+    assert_eq!(
+        chunks[0],
+        r#"<my-el text="Hello"><template shadowrootmode="open" shadowroot="open"><span><!--fe:b-->Hello<!--fe:/b--></span></template>"#
+    );
+    assert!(
+        chunks[0].contains("</template>"),
+        "shadow template must be complete"
+    );
+    assert!(
+        !chunks[0].contains("</my-el>"),
+        "closing tag belongs with light DOM"
+    );
+    assert_eq!(
+        chunks.join(""),
+        render_entry_template_with_locator(entry, r#"{"text":"Hello"}"#, &locator, None).unwrap()
+    );
+}
+
+#[test]
+fn custom_element_light_dom_streams_nested_bindings_and_custom_elements() {
+    let locator = make_locator(&[
+        ("outer-el", "<slot></slot>"),
+        ("inner-el", "<strong>{{label}}</strong>"),
+    ]);
+    let entry =
+        r#"<outer-el><span>{{light}}</span><inner-el label="{{inner}}"></inner-el></outer-el>"#;
+    let chunks = render_entry_template_stream_with_locator(
+        entry,
+        r#"{"light":"Light","inner":"Nested"}"#,
+        &locator,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(
+        chunks,
+        strings(&[
+            r#"<outer-el><template shadowrootmode="open" shadowroot="open"><slot></slot></template>"#,
+            "<span>",
+            "Light",
+            "</span>",
+            r#"<inner-el label="Nested"><template shadowrootmode="open" shadowroot="open"><strong><!--fe:b-->Nested<!--fe:/b--></strong></template></inner-el></outer-el>"#,
+        ])
+    );
+    assert_eq!(
+        chunks.join(""),
+        render_entry_template_with_locator(
+            entry,
+            r#"{"light":"Light","inner":"Nested"}"#,
+            &locator,
+            None,
+        )
+        .unwrap()
+    );
+    assert_no_empty(&chunks);
+}
+
+#[test]
+fn f_when_streams_nested_content_with_normal_render_parity() {
+    let locator = make_locator(&[("my-badge", "<span>{{label}}</span>")]);
+    let entry = r#"<f-when value="{{show}}"><p>{{text}}</p><my-badge label="{{text}}"></my-badge></f-when>"#;
+    let state = r#"{"show":true,"text":"Visible"}"#;
+    let chunks = render_entry_template_stream_with_locator(entry, state, &locator, None).unwrap();
+
+    assert!(
+        chunks.contains(&"<p>".to_string()),
+        "content binding should split"
+    );
+    assert!(
+        chunks.iter().any(|chunk| chunk.starts_with("<my-badge")),
+        "custom element should split into its own chunk: {chunks:?}"
+    );
+    assert_eq!(
+        chunks.join(""),
+        render_entry_template_with_locator(entry, state, &locator, None).unwrap()
+    );
+    assert_no_empty(&chunks);
+}
+
+#[test]
+fn f_repeat_streams_nested_content_and_custom_elements_with_normal_render_parity() {
+    let locator = make_locator(&[("my-badge", "<span>{{count}}</span>")]);
+    let entry = r#"<ul><f-repeat value="{{item in items}}"><li>{{item.name}}</li><my-badge count="{{item.count}}"></my-badge></f-repeat></ul>"#;
+    let state = r#"{"items":[{"name":"One","count":1},{"name":"Two","count":2}]}"#;
+    let chunks = render_entry_template_stream_with_locator(entry, state, &locator, None).unwrap();
+
+    assert_eq!(
+        chunks.join(""),
+        render_entry_template_with_locator(entry, state, &locator, None).unwrap()
+    );
+    assert!(chunks.iter().any(|chunk| chunk == "One"));
+    assert!(chunks
+        .iter()
+        .any(|chunk| chunk.starts_with("<my-badge count=\"1\"")));
+    assert_no_empty(&chunks);
+}
+
+#[test]
+fn false_when_and_empty_bindings_do_not_emit_empty_chunks() {
+    let chunks = render_template_stream(
+        r#"<f-when value="{{show}}"><span>{{hidden}}</span></f-when><div>{{missing}}</div><p>{{text}}</p>"#,
+        r#"{"show":false,"text":"Shown"}"#,
+        None,
+    )
+    .unwrap();
+
+    assert_eq!(chunks, strings(&["<div>", "</div><p>", "Shown", "</p>"]));
+    assert_no_empty(&chunks);
+}
+
+#[test]
+fn missing_bindings_and_triple_braces_preserve_normal_render_parity() {
+    let template = "<div>{{missing}}</div><section>{{{html}}}</section>";
+    let state = r#"{"html":"<em>ok</em>"}"#;
+    let chunks = render_template_stream(template, state, None).unwrap();
+
+    assert_eq!(
+        chunks.join(""),
+        render_template(template, state, None).unwrap()
+    );
+    assert_eq!(
+        chunks,
+        strings(&["<div>", "</div><section>", "<em>ok</em>", "</section>"])
+    );
+    assert_no_empty(&chunks);
+}

--- a/packages/fast-build/DESIGN.md
+++ b/packages/fast-build/DESIGN.md
@@ -11,7 +11,7 @@ This document describes the internal architecture of the `@microsoft/fast-build`
 1. Parsing CLI arguments and loading configuration
 2. Locating and parsing template HTML files (glob scanning + `<f-template>` extraction)
 3. Loading the entry HTML file and optional state JSON file
-4. Calling the WASM renderer or streaming renderer
+4. Calling the WASM renderer in HTML or stream mode
 5. Writing the rendered output file or raw stream chunks to stdout
 
 ```
@@ -49,7 +49,7 @@ fast build [options]
      │    └─ no templates     → wasm.render(entry, state?)
      │              ▼
      │        fs.writeFileSync(output, rendered)
-     └─ true  → wasm.render_entry_stream_with_templates(entry, JSON.stringify(templatesMap), state?, strategy)
+     └─ true  → wasm.render_entry_with_templates(entry, JSON.stringify(templatesMap), state?, strategy, true)
                     ▼
               JSON.parse(chunksJson) → process.stdout.write(chunk)
 ```
@@ -151,14 +151,13 @@ This means exact file paths like `"./components/my-button.html"` are fully suppo
 
 ## WASM integration
 
-Five WASM functions are available; the CLI uses the entry renderer when templates are loaded or streaming is requested:
+Four WASM functions are available; the CLI uses the entry renderer when templates are loaded or streaming is requested:
 
 | Function | Used when |
 |----------|-----------|
 | `wasm.render(entry, state?)` | No custom element templates. Omitted state renders as `{}`. |
 | `wasm.render_with_templates(entry, templatesJson, state?, strategy)` | JS consumers that need non-entry template rendering with custom elements. Omitted state renders as `{}`. `strategy` is `"camelCase"` or `"none"`. |
-| `wasm.render_entry_with_templates(entry, templatesJson, state?, strategy)` | CLI entry HTML rendering when at least one template was loaded. Omitted state renders as `{}`. `strategy` is `"camelCase"` or `"none"`. |
-| `wasm.render_entry_stream_with_templates(entry, templatesJson, state?, strategy)` | CLI `--stream` rendering. Returns a JSON array string of raw HTML chunks. Omitted state renders as `{}`. `strategy` is `"camelCase"` or `"none"`. |
+| `wasm.render_entry_with_templates(entry, templatesJson, state?, strategy, stream?)` | CLI entry HTML rendering when at least one template was loaded, and CLI `--stream` rendering when `stream` is `true`. Omitted state renders as `{}`. `strategy` is `"camelCase"` or `"none"`. With `stream: true`, returns a JSON array string of raw HTML chunks. |
 | `wasm.parse_f_templates(html)` | Parsing `<f-template>` elements from each matched HTML file |
 
 `templatesJson` is a JSON-stringified object mapping element names to template metadata objects. Each object contains the raw inner template string extracted from `<template>` inside `<f-template>` and any forwarded `shadowrootAttributes`. The WASM renderer uses this map to resolve custom element tags and inject Declarative Shadow DOM, copying `shadowroot*` attributes to the emitted `<template>`. It normalizes `shadowrootmode` and legacy `shadowroot` for compatibility: when neither has a non-empty value, it emits `shadowrootmode="open" shadowroot="open"`; when exactly one has a non-empty value, that value is mirrored to the other; when both have explicit non-empty values, both are preserved as authored, even if they conflict.
@@ -173,10 +172,10 @@ See the [`microsoft-fast-build` DESIGN.md](../../crates/microsoft-fast-build/DES
 forms. The option is not accepted in `fast-build.config.json`.
 
 When streaming is enabled, the CLI always calls
-`wasm.render_entry_stream_with_templates`, passing `{}` for `templatesJson` when
-no templates were loaded. The WASM export returns a JSON array string. The CLI
-validates that the parsed value is an array of strings and writes each chunk to
-stdout without separators.
+`wasm.render_entry_with_templates(..., true)`, passing `{}` for `templatesJson`
+when no templates were loaded. With `stream` set to `true`, the WASM export
+returns a JSON array string. The CLI validates that the parsed value is an array
+of strings and writes each chunk to stdout without separators.
 
 Streaming mode does not write `--output`, does not print `Built: ...`, and does
 not warn when `--templates` is omitted. Non-streaming output remains unchanged.

--- a/packages/fast-build/DESIGN.md
+++ b/packages/fast-build/DESIGN.md
@@ -11,14 +11,14 @@ This document describes the internal architecture of the `@microsoft/fast-build`
 1. Parsing CLI arguments and loading configuration
 2. Locating and parsing template HTML files (glob scanning + `<f-template>` extraction)
 3. Loading the entry HTML file and optional state JSON file
-4. Calling the WASM renderer
-5. Writing the rendered output
+4. Calling the WASM renderer or streaming renderer
+5. Writing the rendered output file or raw stream chunks to stdout
 
 ```
 fast build [options]
         │
         ▼
-  parseArgs(argv)        ← --entry, --state, --output, --templates, --attribute-name-strategy, --config
+  parseArgs(argv)        ← --entry, --state, --output, --templates, --attribute-name-strategy, --config, --stream
         │
         ├─ loadConfig(configPath)             ← load fast-build.config.json
         │       │
@@ -43,9 +43,15 @@ fast build [options]
         │       └─ omitted state → WASM receives no state and renders with {}
         │
         ▼
-  wasm.render_entry_with_templates(entry, JSON.stringify(templatesMap), state?, strategy)
-        ▼
-  fs.writeFileSync(output, rendered)
+  stream?
+     ├─ false
+     │    ├─ templates loaded → wasm.render_entry_with_templates(entry, JSON.stringify(templatesMap), state?, strategy)
+     │    └─ no templates     → wasm.render(entry, state?)
+     │              ▼
+     │        fs.writeFileSync(output, rendered)
+     └─ true  → wasm.render_entry_stream_with_templates(entry, JSON.stringify(templatesMap), state?, strategy)
+                    ▼
+              JSON.parse(chunksJson) → process.stdout.write(chunk)
 ```
 
 ---
@@ -83,7 +89,7 @@ CLI-provided paths are resolved relative to the current working directory (the d
 
 ### Validation
 
-The config file must be a JSON object. Each key must be one of the allowed option names (`entry`, `state`, `output`, `templates`, `attribute-name-strategy`) and each value must be a string. Unknown keys and non-string values produce an error referencing the config file path.
+The config file must be a JSON object. Each key must be one of the allowed option names (`entry`, `state`, `output`, `templates`, `attribute-name-strategy`) and each value must be a string. Unknown keys and non-string values produce an error referencing the config file path. `stream` is intentionally CLI-only and is rejected in config files.
 
 ### Helpers
 
@@ -145,18 +151,37 @@ This means exact file paths like `"./components/my-button.html"` are fully suppo
 
 ## WASM integration
 
-Four WASM functions are available; the CLI uses the entry renderer when templates are loaded:
+Five WASM functions are available; the CLI uses the entry renderer when templates are loaded or streaming is requested:
 
 | Function | Used when |
 |----------|-----------|
 | `wasm.render(entry, state?)` | No custom element templates. Omitted state renders as `{}`. |
 | `wasm.render_with_templates(entry, templatesJson, state?, strategy)` | JS consumers that need non-entry template rendering with custom elements. Omitted state renders as `{}`. `strategy` is `"camelCase"` or `"none"`. |
 | `wasm.render_entry_with_templates(entry, templatesJson, state?, strategy)` | CLI entry HTML rendering when at least one template was loaded. Omitted state renders as `{}`. `strategy` is `"camelCase"` or `"none"`. |
+| `wasm.render_entry_stream_with_templates(entry, templatesJson, state?, strategy)` | CLI `--stream` rendering. Returns a JSON array string of raw HTML chunks. Omitted state renders as `{}`. `strategy` is `"camelCase"` or `"none"`. |
 | `wasm.parse_f_templates(html)` | Parsing `<f-template>` elements from each matched HTML file |
 
 `templatesJson` is a JSON-stringified object mapping element names to template metadata objects. Each object contains the raw inner template string extracted from `<template>` inside `<f-template>` and any forwarded `shadowrootAttributes`. The WASM renderer uses this map to resolve custom element tags and inject Declarative Shadow DOM, copying `shadowroot*` attributes to the emitted `<template>`. It normalizes `shadowrootmode` and legacy `shadowroot` for compatibility: when neither has a non-empty value, it emits `shadowrootmode="open" shadowroot="open"`; when exactly one has a non-empty value, that value is mirrored to the other; when both have explicit non-empty values, both are preserved as authored, even if they conflict.
 
 See the [`microsoft-fast-build` DESIGN.md](../../crates/microsoft-fast-build/DESIGN.md) for details on the Rust rendering pipeline.
+
+---
+
+## Stream output
+
+`--stream`, `--stream=true`, and `--stream=false` are parsed as CLI-only boolean
+forms. The option is not accepted in `fast-build.config.json`.
+
+When streaming is enabled, the CLI always calls
+`wasm.render_entry_stream_with_templates`, passing `{}` for `templatesJson` when
+no templates were loaded. The WASM export returns a JSON array string. The CLI
+validates that the parsed value is an array of strings and writes each chunk to
+stdout without separators.
+
+Streaming mode does not write `--output`, does not print `Built: ...`, and does
+not warn when `--templates` is omitted. Non-streaming output remains unchanged.
+Chunk construction happens in Rust before the WASM call returns, so this is
+simulated streaming rather than a lazy Node.js `ReadableStream`.
 
 ---
 
@@ -173,9 +198,12 @@ See the [`microsoft-fast-build` DESIGN.md](../../crates/microsoft-fast-build/DES
 | `--entry` file not found | Print error to stderr; exit code 1 |
 | Explicit `--state` or config `state` file not found | Print error to stderr; exit code 1 |
 | State omitted | Do not check `state.json`; render with an empty state object (`{}`); breaking change from earlier implicit `state.json` loading |
-| `--templates` not provided | Warning to stderr; rendering continues without custom elements |
+| `--templates` not provided | Warning to stderr in non-streaming mode; rendering continues without custom elements |
 | `--attribute-name-strategy` invalid value | Print error to stderr; exit code 1 |
+| `--stream` value is not `true`, `false`, or empty | Print error to stderr; exit code 1 |
 | Pattern matches no files | Warning to stderr; pattern is skipped |
 | `<f-template>` without `name` | Warning to stderr; template is skipped |
 | Duplicate template name across files | Warning to stderr; later entry overwrites earlier |
+| Streaming WASM export missing | Print error to stderr; exit code 1 |
+| Streaming WASM return is not a JSON string array | Print error to stderr; exit code 1 |
 | WASM render error | Print error to stderr; exit code 1 |

--- a/packages/fast-build/DESIGN.md
+++ b/packages/fast-build/DESIGN.md
@@ -26,6 +26,7 @@ fast build [options]
         │       └─ default CWD lookup         ← silent fallback if missing
         │
         ├─ resolveOption(args, config, …)     ← CLI args override config values
+        ├─ resolveBooleanOption(args, config, "stream")
         │
         ├─ wasm = require(WASM_MODULE)         ← load WASM first
         │
@@ -89,7 +90,7 @@ CLI-provided paths are resolved relative to the current working directory (the d
 
 ### Validation
 
-The config file must be a JSON object. Each key must be one of the allowed option names (`entry`, `state`, `output`, `templates`, `attribute-name-strategy`) and each value must be a string. Unknown keys and non-string values produce an error referencing the config file path. `stream` is intentionally CLI-only and is rejected in config files.
+The config file must be a JSON object. Each key must be one of the allowed option names (`entry`, `state`, `output`, `templates`, `attribute-name-strategy`, `stream`). Unknown keys and invalid value types produce an error referencing the config file path. Path and string options must be strings; `stream` must be a JSON boolean (`true` or `false`).
 
 ### Helpers
 
@@ -97,6 +98,7 @@ The config file must be a JSON object. Each key must be one of the allowed optio
 |----------|------|
 | `loadConfig(configPath)` | Reads, parses, and validates the config file. Returns `{ config, configDir }`. |
 | `resolveOption(args, config, configDir, key, defaultValue)` | Returns the CLI arg if present, otherwise the config value (with path resolution), otherwise the default. The caller separately tracks whether `state` was explicitly provided so an explicit missing state file errors while omitted state is passed through to WASM as `{}`. |
+| `resolveBooleanOption(args, config, key)` | Resolves boolean options such as `stream`, with CLI values taking precedence over config booleans. |
 
 ---
 
@@ -168,8 +170,10 @@ See the [`microsoft-fast-build` DESIGN.md](../../crates/microsoft-fast-build/DES
 
 ## Stream output
 
-`--stream`, `--stream=true`, and `--stream=false` are parsed as CLI-only boolean
-forms. The option is not accepted in `fast-build.config.json`.
+`--stream`, `--stream=true`, and `--stream=false` are parsed as CLI boolean
+forms. `fast-build.config.json` also accepts `"stream": true` or
+`"stream": false`. CLI arguments take precedence, so `--stream=false` disables
+streaming even when the config enables it.
 
 When streaming is enabled, the CLI always calls
 `wasm.render_entry_with_templates(..., true)`, passing `{}` for `templatesJson`

--- a/packages/fast-build/README.md
+++ b/packages/fast-build/README.md
@@ -84,10 +84,11 @@ Produces `output.html`:
 
 ### Streaming output
 
-Pass `--stream`, `--stream=true`, or `--stream=false` to control stdout
-streaming. When streaming is enabled, the CLI writes raw rendered HTML chunks to
-stdout, does not write the `--output` file, and does not print the normal
-`Built: ...` message.
+Pass `--stream`, `--stream=true`, or `--stream=false`, or set
+`"stream": true` in `fast-build.config.json`, to control stdout streaming. When
+streaming is enabled, the CLI writes raw rendered HTML chunks to stdout, does
+not write the `--output` file, and does not print the normal `Built: ...`
+message.
 
 ```shell
 fast build --entry=index.html --state=state.json --stream
@@ -191,7 +192,7 @@ fast build --config=configs/my-build.json
 
 **Path resolution:** File paths in the config file (`entry`, `state`, `output`, `templates`) are resolved relative to the config file's directory, not the current working directory. This ensures the config works correctly regardless of where the CLI is invoked.
 
-All keys are optional. Only the following keys are allowed: `entry`, `state`, `output`, `templates`, `attribute-name-strategy`. Unknown keys or non-string values produce an error. If `state` is omitted, rendering uses `{}`; if `state` is present, the referenced file must exist. `stream` is intentionally CLI-only and is not accepted in config files.
+All keys are optional. Only the following keys are allowed: `entry`, `state`, `output`, `templates`, `attribute-name-strategy`, and `stream`. Unknown keys produce an error. Values must be strings except `stream`, which must be a JSON boolean (`true` or `false`). If `state` is omitted, rendering uses `{}`; if `state` is present, the referenced file must exist. CLI arguments always override config values, including `--stream=false` overriding `"stream": true`.
 
 ## Template syntax
 

--- a/packages/fast-build/README.md
+++ b/packages/fast-build/README.md
@@ -95,7 +95,9 @@ fast build --entry=index.html --state=state.json --stream
 
 Streaming is simulated by the WebAssembly renderer: chunks are prepared in
 memory, returned to JavaScript as a JSON array, parsed by the CLI, and then
-written to stdout. Chunk boundaries are safe for HTML parsing:
+written to stdout. `--stream` uses the same entry renderer with its stream flag
+enabled and passes an empty templates map when no `--templates` glob is
+provided. Chunk boundaries are safe for HTML parsing:
 
 - Attribute bindings stay within complete opening tag chunks.
 - Custom element opening chunks include the complete Declarative Shadow DOM

--- a/packages/fast-build/README.md
+++ b/packages/fast-build/README.md
@@ -38,9 +38,10 @@ fast build [options]
 | `--entry="<path>"` | `index.html` | Entry HTML template to render |
 | `--state="<path>"` | `{}` when omitted | JSON file containing the template state. If omitted, no state file is loaded and rendering uses an empty state object. If `--state` is provided, the file must exist. |
 | `--output="<path>"` | `output.html` | Where to write the rendered HTML |
-| `--templates="<glob>"` | _(none)_ | Glob pattern(s) for custom element template HTML files. Separate multiple patterns with commas. A warning is printed if not provided or if no files match a pattern. |
+| `--templates="<glob>"` | _(none)_ | Glob pattern(s) for custom element template HTML files. Separate multiple patterns with commas. A warning is printed if not provided in non-streaming mode or if no files match a pattern. |
 | `--attribute-name-strategy="<strategy>"` | `camelCase` | Strategy for mapping HTML attribute names to state property names on custom elements. `"camelCase"` converts dashes to camelCase (e.g. `foo-bar` → `fooBar`). `"none"` preserves dashes (e.g. `foo-bar` → `foo-bar`). See [Attribute name strategy](#attribute-name-strategy). |
 | `--config="<path>"` | `fast-build.config.json` | Path to a JSON configuration file. If omitted, `fast-build.config.json` in the current directory is used when present. CLI arguments take precedence over config values. See [Configuration file](#configuration-file). |
+| `--stream[=true/false]` | `false` | Write rendered HTML chunks directly to stdout instead of writing `--output`. Valueless `--stream` is treated as `true`. |
 
 ### Example
 
@@ -80,6 +81,27 @@ Produces `output.html`:
   </body>
 </html>
 ```
+
+### Streaming output
+
+Pass `--stream`, `--stream=true`, or `--stream=false` to control stdout
+streaming. When streaming is enabled, the CLI writes raw rendered HTML chunks to
+stdout, does not write the `--output` file, and does not print the normal
+`Built: ...` message.
+
+```shell
+fast build --entry=index.html --state=state.json --stream
+```
+
+Streaming is simulated by the WebAssembly renderer: chunks are prepared in
+memory, returned to JavaScript as a JSON array, parsed by the CLI, and then
+written to stdout. Chunk boundaries are safe for HTML parsing:
+
+- Attribute bindings stay within complete opening tag chunks.
+- Custom element opening chunks include the complete Declarative Shadow DOM
+  template.
+- Empty chunks are omitted.
+- Concatenating all chunks matches the normal non-streamed render.
 
 ### Missing or omitted state
 
@@ -167,7 +189,7 @@ fast build --config=configs/my-build.json
 
 **Path resolution:** File paths in the config file (`entry`, `state`, `output`, `templates`) are resolved relative to the config file's directory, not the current working directory. This ensures the config works correctly regardless of where the CLI is invoked.
 
-All keys are optional. Only the following keys are allowed: `entry`, `state`, `output`, `templates`, `attribute-name-strategy`. Unknown keys or non-string values produce an error. If `state` is omitted, rendering uses `{}`; if `state` is present, the referenced file must exist.
+All keys are optional. Only the following keys are allowed: `entry`, `state`, `output`, `templates`, `attribute-name-strategy`. Unknown keys or non-string values produce an error. If `state` is omitted, rendering uses `{}`; if `state` is present, the referenced file must exist. `stream` is intentionally CLI-only and is not accepted in config files.
 
 ## Template syntax
 

--- a/packages/fast-build/bin/fast.js
+++ b/packages/fast-build/bin/fast.js
@@ -7,6 +7,7 @@ const path = require("path");
 
 const WASM_MODULE = path.join(__dirname, "../wasm/microsoft_fast_build.js");
 const DEFAULT_CONFIG_FILENAME = "fast-build.config.json";
+const VALUELESS_CLI_FLAGS = new Set(["stream"]);
 const ALLOWED_CONFIG_KEYS = new Set([
     "entry",
     "state",
@@ -16,7 +17,8 @@ const ALLOWED_CONFIG_KEYS = new Set([
 ]);
 
 /**
- * Parse CLI arguments of the form --key="value" or --key=value.
+ * Parse CLI arguments of the form --key="value", --key=value, or supported
+ * valueless flags like --stream.
  * @param {string[]} argv
  * @returns {Record<string, string>}
  */
@@ -26,9 +28,40 @@ function parseArgs(argv) {
         const match = arg.match(/^--([^=]+)=(.*)$/s);
         if (match) {
             args[match[1]] = match[2].replace(/^"|"$/g, "");
+            continue;
+        }
+
+        const flag = arg.match(/^--([^=]+)$/s);
+        if (flag && VALUELESS_CLI_FLAGS.has(flag[1])) {
+            args[flag[1]] = "true";
         }
     }
     return args;
+}
+
+/**
+ * Resolve a CLI-only boolean flag.
+ * @param {Record<string, string>} args - Parsed CLI arguments.
+ * @param {string} key - The option key.
+ * @returns {boolean}
+ */
+function resolveBooleanFlag(args, key) {
+    if (!Object.prototype.hasOwnProperty.call(args, key)) {
+        return false;
+    }
+
+    const value = args[key].trim().toLowerCase();
+    if (value === "true" || value === "") {
+        return true;
+    }
+    if (value === "false") {
+        return false;
+    }
+
+    process.stderr.write(
+        `Error: Invalid --${key} value "${args[key]}". Expected "true" or "false".\n`
+    );
+    process.exit(1);
 }
 
 /**
@@ -287,6 +320,7 @@ async function runBuild(args) {
         Object.prototype.hasOwnProperty.call(args, "state") ||
         Object.prototype.hasOwnProperty.call(config, "state");
     const attributeNameStrategy = resolveOption(args, config, configDir, "attribute-name-strategy");
+    const stream = resolveBooleanFlag(args, "stream");
 
     if (attributeNameStrategy && attributeNameStrategy !== "none" && attributeNameStrategy !== "camelCase") {
         process.stderr.write(
@@ -301,9 +335,11 @@ async function runBuild(args) {
     // Resolve template files
     const templatesMap = {};
     if (!templatesArg) {
-        process.stderr.write(
-            "Warning: --templates was not provided. No custom element templates will be loaded.\n"
-        );
+        if (!stream) {
+            process.stderr.write(
+                "Warning: --templates was not provided. No custom element templates will be loaded.\n"
+            );
+        }
     } else {
         const patterns = templatesArg.split(",").map((p) => p.trim());
         for (const pattern of patterns) {
@@ -346,6 +382,48 @@ async function runBuild(args) {
     }
 
     // Render
+    if (stream) {
+        if (typeof wasm.render_entry_stream_with_templates !== "function") {
+            process.stderr.write(
+                "Error: Streaming requires render_entry_stream_with_templates to be exported by the WASM module.\n"
+            );
+            process.exit(1);
+        }
+
+        const renderedChunks = wasm.render_entry_stream_with_templates(
+            entryContent,
+            JSON.stringify(templatesMap),
+            stateContent,
+            attributeNameStrategy || "",
+        );
+
+        /** @type {unknown} */
+        let chunks;
+        try {
+            chunks = JSON.parse(renderedChunks);
+        } catch (e) {
+            process.stderr.write(
+                `Error: Streaming renderer returned invalid JSON: ${e.message}\n`
+            );
+            process.exit(1);
+        }
+
+        if (
+            !Array.isArray(chunks) ||
+            chunks.some((chunk) => typeof chunk !== "string")
+        ) {
+            process.stderr.write(
+                "Error: Streaming renderer must return a JSON array of strings.\n"
+            );
+            process.exit(1);
+        }
+
+        for (const chunk of chunks) {
+            process.stdout.write(chunk);
+        }
+        return;
+    }
+
     let rendered;
     if (Object.keys(templatesMap).length > 0) {
         rendered = wasm.render_entry_with_templates(
@@ -375,6 +453,8 @@ async function main() {
             '  --entry="index.html"   Entry HTML template file (default: index.html)\n' +
             '  --state="state.json"   State JSON file. If omitted, rendering uses\n' +
             '                         an empty state object.\n' +
+            '  --stream[=true|false]  Write rendered HTML chunks to stdout instead\n' +
+            '                         of writing an output file.\n' +
             '  --attribute-name-strategy="camelCase"\n' +
             '                         Strategy for mapping attribute names to property names.\n' +
             '                         "camelCase" (default) or "none".\n' +

--- a/packages/fast-build/bin/fast.js
+++ b/packages/fast-build/bin/fast.js
@@ -383,18 +383,19 @@ async function runBuild(args) {
 
     // Render
     if (stream) {
-        if (typeof wasm.render_entry_stream_with_templates !== "function") {
+        if (typeof wasm.render_entry_with_templates !== "function") {
             process.stderr.write(
-                "Error: Streaming requires render_entry_stream_with_templates to be exported by the WASM module.\n"
+                "Error: Streaming requires render_entry_with_templates to be exported by the WASM module.\n"
             );
             process.exit(1);
         }
 
-        const renderedChunks = wasm.render_entry_stream_with_templates(
+        const renderedChunks = wasm.render_entry_with_templates(
             entryContent,
             JSON.stringify(templatesMap),
             stateContent,
             attributeNameStrategy || "",
+            true,
         );
 
         /** @type {unknown} */

--- a/packages/fast-build/bin/fast.js
+++ b/packages/fast-build/bin/fast.js
@@ -14,7 +14,10 @@ const ALLOWED_CONFIG_KEYS = new Set([
     "output",
     "templates",
     "attribute-name-strategy",
+    "stream",
 ]);
+
+/** @typedef {Record<string, string | boolean>} FastBuildConfig */
 
 /**
  * Parse CLI arguments of the form --key="value", --key=value, or supported
@@ -40,28 +43,34 @@ function parseArgs(argv) {
 }
 
 /**
- * Resolve a CLI-only boolean flag.
+ * Resolve a boolean option, preferring CLI args over config values.
+ * CLI values accept true, false, or an empty valueless flag.
  * @param {Record<string, string>} args - Parsed CLI arguments.
+ * @param {FastBuildConfig} config - Parsed config file values.
  * @param {string} key - The option key.
  * @returns {boolean}
  */
-function resolveBooleanFlag(args, key) {
-    if (!Object.prototype.hasOwnProperty.call(args, key)) {
-        return false;
+function resolveBooleanOption(args, config, key) {
+    if (Object.prototype.hasOwnProperty.call(args, key)) {
+        const value = args[key].trim().toLowerCase();
+        if (value === "true" || value === "") {
+            return true;
+        }
+        if (value === "false") {
+            return false;
+        }
+
+        process.stderr.write(
+            `Error: Invalid --${key} value "${args[key]}". Expected "true" or "false".\n`
+        );
+        process.exit(1);
     }
 
-    const value = args[key].trim().toLowerCase();
-    if (value === "true" || value === "") {
-        return true;
-    }
-    if (value === "false") {
-        return false;
+    if (Object.prototype.hasOwnProperty.call(config, key)) {
+        return config[key] === true;
     }
 
-    process.stderr.write(
-        `Error: Invalid --${key} value "${args[key]}". Expected "true" or "false".\n`
-    );
-    process.exit(1);
+    return false;
 }
 
 /**
@@ -75,7 +84,7 @@ function resolveBooleanFlag(args, key) {
  * file's directory so that the caller can use them directly.
  *
  * @param {string | undefined} configPath - Explicit path from --config, if any.
- * @returns {{ config: Record<string, string>, configDir: string | null }}
+ * @returns {{ config: FastBuildConfig, configDir: string | null }}
  */
 function loadConfig(configPath) {
     /** @type {string} */
@@ -125,6 +134,16 @@ function loadConfig(configPath) {
             );
             process.exit(1);
         }
+        if (key === "stream") {
+            if (typeof raw[key] !== "boolean") {
+                process.stderr.write(
+                    `Error: Value for "${key}" in config file "${resolvedPath}" must be a boolean.\n`
+                );
+                process.exit(1);
+            }
+            continue;
+        }
+
         if (typeof raw[key] !== "string") {
             process.stderr.write(
                 `Error: Value for "${key}" in config file "${resolvedPath}" must be a string.\n`
@@ -143,7 +162,7 @@ function loadConfig(configPath) {
  * CLI-derived paths are resolved relative to CWD (the default behaviour).
  *
  * @param {Record<string, string>} args - Parsed CLI arguments.
- * @param {Record<string, string>} config - Parsed config file values.
+ * @param {FastBuildConfig} config - Parsed config file values.
  * @param {string | null} configDir - Directory of the config file, or null.
  * @param {string} key - The option key.
  * @param {string} [defaultValue] - Fallback when neither source provides a value.
@@ -155,6 +174,9 @@ function resolveOption(args, config, configDir, key, defaultValue) {
     }
     if (Object.prototype.hasOwnProperty.call(config, key)) {
         const value = config[key];
+        if (typeof value !== "string") {
+            return defaultValue;
+        }
         const isFilePath = key === "entry" || key === "state" || key === "output" || key === "templates";
         if (isFilePath && configDir !== null) {
             return path.resolve(configDir, value);
@@ -320,7 +342,7 @@ async function runBuild(args) {
         Object.prototype.hasOwnProperty.call(args, "state") ||
         Object.prototype.hasOwnProperty.call(config, "state");
     const attributeNameStrategy = resolveOption(args, config, configDir, "attribute-name-strategy");
-    const stream = resolveBooleanFlag(args, "stream");
+    const stream = resolveBooleanOption(args, config, "stream");
 
     if (attributeNameStrategy && attributeNameStrategy !== "none" && attributeNameStrategy !== "camelCase") {
         process.stderr.write(

--- a/packages/fast-build/test/config.test.js
+++ b/packages/fast-build/test/config.test.js
@@ -72,29 +72,18 @@ const stub = {
         calls.push({ name: "render", entry, state });
         return "<h1>Non-stream</h1>";
     },
-    render_entry_with_templates(entry, templatesJson, state, attributeNameStrategy) {
+    render_entry_with_templates(entry, templatesJson, state, attributeNameStrategy, stream) {
         calls.push({
             name: "render_entry_with_templates",
             entry,
             templatesJson,
             state,
             attributeNameStrategy,
+            stream,
         });
-        return "<my-el>Non-stream</my-el>";
-    },
-    render_entry_stream_with_templates(
-        entry,
-        templatesJson,
-        state,
-        attributeNameStrategy,
-    ) {
-        calls.push({
-            name: "render_entry_stream_with_templates",
-            entry,
-            templatesJson,
-            state,
-            attributeNameStrategy,
-        });
+        if (!stream) {
+            return "<my-el>Non-stream</my-el>";
+        }
         let title = "";
         try {
             title = JSON.parse(state || "{}").title || "";
@@ -351,7 +340,7 @@ describe("stream output", () => {
             dir,
         );
         const renderCall = calls.find(
-            call => call.name === "render_entry_stream_with_templates",
+            call => call.name === "render_entry_with_templates",
         );
 
         assert.equal(stdout, "<h1>Hello</h1>");
@@ -359,11 +348,11 @@ describe("stream output", () => {
         assert.ok(!fs.existsSync(path.join(dir, "out.html")));
         assert.ok(renderCall);
         assert.equal(renderCall.templatesJson, "{}");
+        assert.equal(renderCall.stream, true);
         assert.ok(!calls.some(call => call.name === "render"));
-        assert.ok(!calls.some(call => call.name === "render_entry_with_templates"));
     });
 
-    it("streams with templates through render_entry_stream_with_templates", () => {
+    it("streams with templates through render_entry_with_templates stream flag", () => {
         fs.writeFileSync(
             path.join(dir, "entry.html"),
             '<my-el text="{{title}}"></my-el>',
@@ -385,7 +374,7 @@ describe("stream output", () => {
             dir,
         );
         const renderCall = calls.find(
-            call => call.name === "render_entry_stream_with_templates",
+            call => call.name === "render_entry_with_templates",
         );
         assert.ok(renderCall);
         const templates = JSON.parse(renderCall.templatesJson);
@@ -396,8 +385,8 @@ describe("stream output", () => {
             { name: "shadowrootmode", value: "open" },
         ]);
         assert.equal(renderCall.attributeNameStrategy, "none");
+        assert.equal(renderCall.stream, true);
         assert.ok(calls.some(call => call.name === "parse_f_templates"));
-        assert.ok(!calls.some(call => call.name === "render_entry_with_templates"));
     });
 });
 

--- a/packages/fast-build/test/config.test.js
+++ b/packages/fast-build/test/config.test.js
@@ -365,7 +365,7 @@ describe("stream output", () => {
 
         const { stdout, calls } = runWithStubbedWasm(
             [
-                "--stream=true",
+                "--stream",
                 "--entry=entry.html",
                 "--state=state.json",
                 "--templates=templates.html",

--- a/packages/fast-build/test/config.test.js
+++ b/packages/fast-build/test/config.test.js
@@ -207,7 +207,7 @@ describe("config validation", () => {
         assert.ok(result.stderr.includes("Failed to parse"));
     });
 
-    it("keeps stream CLI-only by rejecting stream in config", () => {
+    it("rejects non-boolean stream config values", () => {
         writeFixture(dir, {
             config: {
                 entry: "entry.html",
@@ -218,7 +218,8 @@ describe("config validation", () => {
         });
         const result = runWithStderr([], dir);
         assert.equal(result.exitCode, 1);
-        assert.ok(result.stderr.includes('Unknown key "stream"'));
+        assert.ok(result.stderr.includes('Value for "stream"'));
+        assert.ok(result.stderr.includes("must be a boolean"));
     });
 });
 
@@ -265,6 +266,81 @@ describe("backward compatibility", () => {
 
         assert.equal(stdout, "Built: out.html\n");
         assert.ok(output.includes("Hello"));
+    });
+});
+
+describe("stream config", () => {
+    /** @type {string} */
+    let dir;
+
+    beforeEach(() => {
+        dir = tmpDir();
+    });
+
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("streams when stream is true in config", () => {
+        writeFixture(dir, {
+            config: {
+                entry: "entry.html",
+                state: "state.json",
+                output: "out.html",
+                stream: true,
+            },
+        });
+
+        const { stdout, calls } = runWithStubbedWasm([], dir);
+        const renderCall = calls.find(
+            call => call.name === "render_entry_with_templates",
+        );
+
+        assert.equal(stdout, "<h1>Hello</h1>");
+        assert.ok(!stdout.includes("Built:"));
+        assert.ok(!fs.existsSync(path.join(dir, "out.html")));
+        assert.ok(renderCall);
+        assert.equal(renderCall.stream, true);
+    });
+
+    it("lets --stream override stream false in config", () => {
+        writeFixture(dir, {
+            config: {
+                entry: "entry.html",
+                state: "state.json",
+                output: "out.html",
+                stream: false,
+            },
+        });
+
+        const { stdout, calls } = runWithStubbedWasm(["--stream"], dir);
+        const renderCall = calls.find(
+            call => call.name === "render_entry_with_templates",
+        );
+
+        assert.equal(stdout, "<h1>Hello</h1>");
+        assert.ok(!fs.existsSync(path.join(dir, "out.html")));
+        assert.ok(renderCall);
+        assert.equal(renderCall.stream, true);
+    });
+
+    it("lets --stream=false override stream true in config", () => {
+        writeFixture(dir, {
+            config: {
+                entry: "entry.html",
+                state: "state.json",
+                output: "out.html",
+                stream: true,
+            },
+        });
+
+        const { stdout, calls } = runWithStubbedWasm(["--stream=false"], dir);
+        const output = fs.readFileSync(path.join(dir, "out.html"), "utf8");
+
+        assert.equal(stdout, `Built: ${path.join(dir, "out.html")}\n`);
+        assert.equal(output, "<h1>Non-stream</h1>");
+        assert.ok(calls.some(call => call.name === "render"));
+        assert.ok(!calls.some(call => call.stream === true));
     });
 });
 

--- a/packages/fast-build/test/config.test.js
+++ b/packages/fast-build/test/config.test.js
@@ -10,6 +10,7 @@ const os = require("node:os");
 const FAST_BIN = path.resolve(__dirname, "../bin/fast.js");
 const WASM = require("../wasm/microsoft_fast_build.js");
 const WASM_MODULE = path.resolve(__dirname, "../wasm/microsoft_fast_build.js");
+const WASM_STUB = path.resolve(__dirname, "wasm-stub.cjs");
 
 function tmpDir() {
     return fs.mkdtempSync(path.join(os.tmpdir(), "fast-build-test-"));
@@ -19,10 +20,11 @@ function run(args, cwd) {
     return runNode(args, cwd);
 }
 
-function runNode(args, cwd, nodeArgs = []) {
+function runNode(args, cwd, nodeArgs = [], env = process.env) {
     return execFileSync(process.execPath, [...nodeArgs, FAST_BIN, "build", ...args], {
         cwd,
         encoding: "utf8",
+        env,
         stdio: ["pipe", "pipe", "pipe"],
     });
 }
@@ -45,77 +47,22 @@ function runWithStderr(args, cwd) {
 }
 
 function writeWasmStub(dir) {
-    const preload = path.join(dir, "wasm-stub.cjs");
     const record = path.join(dir, "wasm-calls.json");
 
-    fs.writeFileSync(
-        preload,
-        `
-const fs = require("node:fs");
-const Module = require("node:module");
-const wasmPath = ${JSON.stringify(WASM_MODULE)};
-const recordPath = ${JSON.stringify(record)};
-const calls = [];
-
-const stub = {
-    parse_f_templates(html) {
-        calls.push({ name: "parse_f_templates", html });
-        return JSON.stringify([
-            {
-                name: "my-el",
-                content: "<span>{{text}}</span>",
-                shadowrootAttributes: [{ name: "shadowrootmode", value: "open" }],
-            },
-        ]);
-    },
-    render(entry, state) {
-        calls.push({ name: "render", entry, state });
-        return "<h1>Non-stream</h1>";
-    },
-    render_entry_with_templates(entry, templatesJson, state, attributeNameStrategy, stream) {
-        calls.push({
-            name: "render_entry_with_templates",
-            entry,
-            templatesJson,
-            state,
-            attributeNameStrategy,
-            stream,
-        });
-        if (!stream) {
-            return "<my-el>Non-stream</my-el>";
-        }
-        let title = "";
-        try {
-            title = JSON.parse(state || "{}").title || "";
-        } catch {}
-        if (entry.includes("my-el")) {
-            return JSON.stringify(["<my-el>", title, "</my-el>"]);
-        }
-        return JSON.stringify(["<h1>", title, "</h1>"]);
-    },
-};
-
-process.on("exit", () => {
-    fs.writeFileSync(recordPath, JSON.stringify(calls));
-});
-
-const originalLoad = Module._load;
-Module._load = function (request, parent, isMain) {
-    const resolved = Module._resolveFilename(request, parent, isMain);
-    if (resolved === wasmPath) {
-        return stub;
-    }
-    return originalLoad.apply(this, arguments);
-};
-`,
-    );
-
-    return { preload, record };
+    return {
+        preload: WASM_STUB,
+        record,
+        env: {
+            ...process.env,
+            FAST_BUILD_WASM_STUB_MODULE: WASM_MODULE,
+            FAST_BUILD_WASM_STUB_RECORD: record,
+        },
+    };
 }
 
 function runWithStubbedWasm(args, cwd) {
-    const { preload, record } = writeWasmStub(cwd);
-    const stdout = runNode(args, cwd, ["--require", preload]);
+    const { preload, record, env } = writeWasmStub(cwd);
+    const stdout = runNode(args, cwd, ["--require", preload], env);
     const calls = JSON.parse(fs.readFileSync(record, "utf8"));
 
     return { stdout, calls };

--- a/packages/fast-build/test/config.test.js
+++ b/packages/fast-build/test/config.test.js
@@ -9,13 +9,18 @@ const os = require("node:os");
 
 const FAST_BIN = path.resolve(__dirname, "../bin/fast.js");
 const WASM = require("../wasm/microsoft_fast_build.js");
+const WASM_MODULE = path.resolve(__dirname, "../wasm/microsoft_fast_build.js");
 
 function tmpDir() {
     return fs.mkdtempSync(path.join(os.tmpdir(), "fast-build-test-"));
 }
 
 function run(args, cwd) {
-    return execFileSync(process.execPath, [FAST_BIN, "build", ...args], {
+    return runNode(args, cwd);
+}
+
+function runNode(args, cwd, nodeArgs = []) {
+    return execFileSync(process.execPath, [...nodeArgs, FAST_BIN, "build", ...args], {
         cwd,
         encoding: "utf8",
         stdio: ["pipe", "pipe", "pipe"],
@@ -37,6 +42,94 @@ function runWithStderr(args, cwd) {
             exitCode: e.status,
         };
     }
+}
+
+function writeWasmStub(dir) {
+    const preload = path.join(dir, "wasm-stub.cjs");
+    const record = path.join(dir, "wasm-calls.json");
+
+    fs.writeFileSync(
+        preload,
+        `
+const fs = require("node:fs");
+const Module = require("node:module");
+const wasmPath = ${JSON.stringify(WASM_MODULE)};
+const recordPath = ${JSON.stringify(record)};
+const calls = [];
+
+const stub = {
+    parse_f_templates(html) {
+        calls.push({ name: "parse_f_templates", html });
+        return JSON.stringify([
+            {
+                name: "my-el",
+                content: "<span>{{text}}</span>",
+                shadowrootAttributes: [{ name: "shadowrootmode", value: "open" }],
+            },
+        ]);
+    },
+    render(entry, state) {
+        calls.push({ name: "render", entry, state });
+        return "<h1>Non-stream</h1>";
+    },
+    render_entry_with_templates(entry, templatesJson, state, attributeNameStrategy) {
+        calls.push({
+            name: "render_entry_with_templates",
+            entry,
+            templatesJson,
+            state,
+            attributeNameStrategy,
+        });
+        return "<my-el>Non-stream</my-el>";
+    },
+    render_entry_stream_with_templates(
+        entry,
+        templatesJson,
+        state,
+        attributeNameStrategy,
+    ) {
+        calls.push({
+            name: "render_entry_stream_with_templates",
+            entry,
+            templatesJson,
+            state,
+            attributeNameStrategy,
+        });
+        let title = "";
+        try {
+            title = JSON.parse(state || "{}").title || "";
+        } catch {}
+        if (entry.includes("my-el")) {
+            return JSON.stringify(["<my-el>", title, "</my-el>"]);
+        }
+        return JSON.stringify(["<h1>", title, "</h1>"]);
+    },
+};
+
+process.on("exit", () => {
+    fs.writeFileSync(recordPath, JSON.stringify(calls));
+});
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+    const resolved = Module._resolveFilename(request, parent, isMain);
+    if (resolved === wasmPath) {
+        return stub;
+    }
+    return originalLoad.apply(this, arguments);
+};
+`,
+    );
+
+    return { preload, record };
+}
+
+function runWithStubbedWasm(args, cwd) {
+    const { preload, record } = writeWasmStub(cwd);
+    const stdout = runNode(args, cwd, ["--require", preload]);
+    const calls = JSON.parse(fs.readFileSync(record, "utf8"));
+
+    return { stdout, calls };
 }
 
 function writeFixture(dir, { entry, state, output, config, configName }) {
@@ -177,6 +270,20 @@ describe("config validation", () => {
         assert.equal(result.exitCode, 1);
         assert.ok(result.stderr.includes("Failed to parse"));
     });
+
+    it("keeps stream CLI-only by rejecting stream in config", () => {
+        writeFixture(dir, {
+            config: {
+                entry: "entry.html",
+                state: "state.json",
+                output: "out.html",
+                stream: "true",
+            },
+        });
+        const result = runWithStderr([], dir);
+        assert.equal(result.exitCode, 1);
+        assert.ok(result.stderr.includes('Unknown key "stream"'));
+    });
 });
 
 describe("backward compatibility", () => {
@@ -205,6 +312,92 @@ describe("backward compatibility", () => {
         run(["--state=state.json", "--output=out.html"], dir);
         const output = fs.readFileSync(path.join(dir, "out.html"), "utf8");
         assert.ok(output.includes("Hello"));
+    });
+
+    it("writes output and prints Built when --stream=false", () => {
+        writeFixture(dir, {});
+        const stdout = run(
+            [
+                "--entry=entry.html",
+                "--state=state.json",
+                "--output=out.html",
+                "--stream=false",
+            ],
+            dir,
+        );
+        const output = fs.readFileSync(path.join(dir, "out.html"), "utf8");
+
+        assert.equal(stdout, "Built: out.html\n");
+        assert.ok(output.includes("Hello"));
+    });
+});
+
+describe("stream output", () => {
+    /** @type {string} */
+    let dir;
+
+    beforeEach(() => {
+        dir = tmpDir();
+    });
+
+    afterEach(() => {
+        fs.rmSync(dir, { recursive: true, force: true });
+    });
+
+    it("treats valueless --stream as true and streams without templates", () => {
+        writeFixture(dir, {});
+        const { stdout, calls } = runWithStubbedWasm(
+            ["--stream", "--entry=entry.html", "--state=state.json", "--output=out.html"],
+            dir,
+        );
+        const renderCall = calls.find(
+            call => call.name === "render_entry_stream_with_templates",
+        );
+
+        assert.equal(stdout, "<h1>Hello</h1>");
+        assert.ok(!stdout.includes("Built:"));
+        assert.ok(!fs.existsSync(path.join(dir, "out.html")));
+        assert.ok(renderCall);
+        assert.equal(renderCall.templatesJson, "{}");
+        assert.ok(!calls.some(call => call.name === "render"));
+        assert.ok(!calls.some(call => call.name === "render_entry_with_templates"));
+    });
+
+    it("streams with templates through render_entry_stream_with_templates", () => {
+        fs.writeFileSync(
+            path.join(dir, "entry.html"),
+            '<my-el text="{{title}}"></my-el>',
+        );
+        fs.writeFileSync(path.join(dir, "state.json"), '{"title":"Hello"}');
+        fs.writeFileSync(
+            path.join(dir, "templates.html"),
+            '<f-template name="my-el"><span>{{text}}</span></f-template>',
+        );
+
+        const { stdout, calls } = runWithStubbedWasm(
+            [
+                "--stream=true",
+                "--entry=entry.html",
+                "--state=state.json",
+                "--templates=templates.html",
+                "--attribute-name-strategy=none",
+            ],
+            dir,
+        );
+        const renderCall = calls.find(
+            call => call.name === "render_entry_stream_with_templates",
+        );
+        assert.ok(renderCall);
+        const templates = JSON.parse(renderCall.templatesJson);
+
+        assert.equal(stdout, "<my-el>Hello</my-el>");
+        assert.equal(templates["my-el"].content, "<span>{{text}}</span>");
+        assert.deepEqual(templates["my-el"].shadowrootAttributes, [
+            { name: "shadowrootmode", value: "open" },
+        ]);
+        assert.equal(renderCall.attributeNameStrategy, "none");
+        assert.ok(calls.some(call => call.name === "parse_f_templates"));
+        assert.ok(!calls.some(call => call.name === "render_entry_with_templates"));
     });
 });
 

--- a/packages/fast-build/test/wasm-stub.cjs
+++ b/packages/fast-build/test/wasm-stub.cjs
@@ -1,0 +1,71 @@
+// @ts-check
+"use strict";
+
+const fs = require("node:fs");
+const Module = require("node:module");
+
+const wasmPath = process.env.FAST_BUILD_WASM_STUB_MODULE;
+const recordPath = process.env.FAST_BUILD_WASM_STUB_RECORD;
+
+if (!wasmPath || !recordPath) {
+    throw new Error("WASM stub requires module and record paths.");
+}
+
+const calls = [];
+
+const stub = {
+    parse_f_templates(html) {
+        calls.push({ name: "parse_f_templates", html });
+        return JSON.stringify([
+            {
+                name: "my-el",
+                content: "<span>{{text}}</span>",
+                shadowrootAttributes: [{ name: "shadowrootmode", value: "open" }],
+            },
+        ]);
+    },
+    render(entry, state) {
+        calls.push({ name: "render", entry, state });
+        return "<h1>Non-stream</h1>";
+    },
+    render_entry_with_templates(
+        entry,
+        templatesJson,
+        state,
+        attributeNameStrategy,
+        stream,
+    ) {
+        calls.push({
+            name: "render_entry_with_templates",
+            entry,
+            templatesJson,
+            state,
+            attributeNameStrategy,
+            stream,
+        });
+        if (!stream) {
+            return "<my-el>Non-stream</my-el>";
+        }
+        let title = "";
+        try {
+            title = JSON.parse(state || "{}").title || "";
+        } catch {}
+        if (entry.includes("my-el")) {
+            return JSON.stringify(["<my-el>", title, "</my-el>"]);
+        }
+        return JSON.stringify(["<h1>", title, "</h1>"]);
+    },
+};
+
+process.on("exit", () => {
+    fs.writeFileSync(recordPath, JSON.stringify(calls));
+});
+
+const originalLoad = Module._load;
+Module._load = function (request, parent, isMain) {
+    const resolved = Module._resolveFilename(request, parent, isMain);
+    if (resolved === wasmPath) {
+        return stub;
+    }
+    return originalLoad.call(this, request, parent, isMain);
+};


### PR DESCRIPTION
# Pull Request

## 📖 Description

- Adds simulated streaming HTML chunk rendering in `microsoft-fast-build`, including custom element shadow template chunks, content binding splits, and stream/non-stream parity tests.
- Exposes streaming through WASM and `fast build --stream`, writing raw HTML chunks to stdout without file output or the normal `Built:` message.
- Documents streaming behavior, gotchas, and usage in crate/package docs, with a minor change file for `@microsoft/fast-build`.

## 👩‍💻 Reviewer Notes

Please focus on chunk boundaries around content bindings, custom elements, and entry-level custom element light DOM parity.

## 📑 Test Plan

- `npm run build` ✅
- `cargo test --manifest-path crates\microsoft-fast-build\Cargo.toml --quiet` ✅
- `npm run test:node -w @microsoft/fast-build` ✅
- `npm run checkchange` ✅
- WASM export verified locally: `packages\fast-build\wasm\microsoft_fast_build.js` and `.d.ts` include `render_entry_stream_with_templates` ✅
- `npm run test` was attempted; it failed in unrelated `@microsoft/fast-test-harness` Firefox Playwright tests with timeouts and `NS_ERROR_SOCKET_ADDRESS_IN_USE` while the focused fast-build validations passed.
- `npm run biome:check` was attempted; on this Windows checkout, `biome-changed` exits 1 without diagnostics due the Windows `.bin\biome` shim resolution/local Git EOL warning. Manual equivalent `node_modules\.bin\biome.cmd check <changed files>` passed.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.