### PR TITLE
Use GitHub markdown styles and customize overrides for documentation

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -80,10 +80,7 @@
     "examples/ssr": {
       "name": "@microsoft/fast-ssr-example",
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@microsoft/fast-element": "^2.10.3",
         "@microsoft/fast-ssr": "^1.0.0-beta.40",
@@ -4486,6 +4483,18 @@
         "git-up": "^8.1.0"
       }
     },
+    "node_modules/github-markdown-css": {
+      "version": "5.9.0",
+      "resolved": "https://registry.npmjs.org/github-markdown-css/-/github-markdown-css-5.9.0.tgz",
+      "integrity": "sha512-tmT5sY+zvg2302XLYEfH2mtkViIM1SWf2nvYoF5N1ZsO0V6B2qZTiw3GOzw4vpjLygK/KG35qRlPFweHqfzz5w==",
+      "license": "MIT",
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/sindresorhus"
+      }
+    },
     "node_modules/glob-hasher": {
       "version": "1.4.2",
       "resolved": "https://registry.npmjs.org/glob-hasher/-/glob-hasher-1.4.2.tgz",
@@ -7078,7 +7087,8 @@
         "@11ty/eleventy": "^3.1.2",
         "@11ty/eleventy-navigation": "^1.0.5",
         "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
-        "@microsoft/api-documenter": "7.29.7"
+        "@microsoft/api-documenter": "7.29.7",
+        "github-markdown-css": "5.9.0"
       },
       "devDependencies": {
         "@microsoft/fast-build": "^0.7.0",

--- a/sites/website/eleventy.config.js
+++ b/sites/website/eleventy.config.js
@@ -1,53 +1,60 @@
+import { createRequire } from "node:module";
+import path from "node:path";
+import { IdAttributePlugin } from "@11ty/eleventy";
 import eleventyNavigationPlugin from "@11ty/eleventy-navigation";
 import syntaxHighlight from "@11ty/eleventy-plugin-syntaxhighlight";
-import { IdAttributePlugin } from "@11ty/eleventy";
 import { admonitionPlugin } from "./plugins/admonitions.js";
 
-export default function(eleventyConfig) {
-  /**
-   * Styles
-   */
-  eleventyConfig.addPassthroughCopy("src/css/main.css");
-  eleventyConfig.addPassthroughCopy("src/css/prism-vsc-dark-plus.css");
-  eleventyConfig.addPassthroughCopy("src/css/variables.css");
+const require = createRequire(import.meta.url);
+const githubMarkdownCssDir = path.dirname(
+    require.resolve("github-markdown-css/package.json"),
+);
 
-  /**
-   * Scripts
-   */
-  eleventyConfig.addPassthroughCopy("src/js/sidebar-navigation.js");
-  eleventyConfig.addPassthroughCopy("src/js/navbar-toggle.js");
+export default function (eleventyConfig) {
+    /**
+     * Styles
+     */
+    eleventyConfig.addPassthroughCopy("src/css");
+    eleventyConfig.addPassthroughCopy({
+        [path.join(githubMarkdownCssDir, "github-markdown-dark.css")]:
+            "css/github-markdown-dark.css",
+    });
 
-  /**
-   * Assets
-   */
-  eleventyConfig.addPassthroughCopy("src/static/favicon.ico");
-  eleventyConfig.addPassthroughCopy("src/static/fast-inline-logo.svg");
+    /**
+     * Scripts
+     */
+    eleventyConfig.addPassthroughCopy("src/js");
 
-  /**
-   * Plugins
-   */
-  eleventyConfig.addPlugin(eleventyNavigationPlugin);
-  eleventyConfig.addPlugin(syntaxHighlight);
-  eleventyConfig.addPlugin(IdAttributePlugin);
+    /**
+     * Assets
+     */
+    eleventyConfig.addPassthroughCopy("src/static");
 
-  /**
-   * Markdown
-   */
-  eleventyConfig.amendLibrary("md", (md) => {
-    md.use(admonitionPlugin);
-  });
+    /**
+     * Plugins
+     */
+    eleventyConfig.addPlugin(eleventyNavigationPlugin);
+    eleventyConfig.addPlugin(syntaxHighlight);
+    eleventyConfig.addPlugin(IdAttributePlugin);
 
-  /**
-   * Filters
-   */
-  eleventyConfig.addFilter("version", function(value) {
-    const version = "2.x";
+    /**
+     * Markdown
+     */
+    eleventyConfig.amendLibrary("md", md => {
+        md.use(admonitionPlugin);
+    });
 
-    if (typeof value === "string") {
-        const splitUrl = value.split("/");
-        return splitUrl[2] ?? version;
-    }
+    /**
+     * Filters
+     */
+    eleventyConfig.addFilter("version", function (value) {
+        const version = "2.x";
 
-    return version;
-  });
-};
+        if (typeof value === "string") {
+            const splitUrl = value.split("/");
+            return splitUrl[2] ?? version;
+        }
+
+        return version;
+    });
+}

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -26,7 +26,8 @@
     "@11ty/eleventy": "^3.1.2",
     "@11ty/eleventy-navigation": "^1.0.5",
     "@11ty/eleventy-plugin-syntaxhighlight": "^5.0.2",
-    "@microsoft/api-documenter": "7.29.7"
+    "@microsoft/api-documenter": "7.29.7",
+    "github-markdown-css": "5.9.0"
   },
   "devDependencies": {
     "@microsoft/fast-build": "^0.7.0",

--- a/sites/website/src/_includes/1x-container.njk
+++ b/sites/website/src/_includes/1x-container.njk
@@ -24,7 +24,7 @@ navigationOptions:
 
 <main>
   <div class="container padding-top--md padding-bottom--lg">
-    <div class="col doc-item">
+    <div class="col doc-item markdown-body">
         {{ content | safe }}
     </div>
   </div>

--- a/sites/website/src/_includes/2x-container.njk
+++ b/sites/website/src/_includes/2x-container.njk
@@ -24,7 +24,7 @@ navigationOptions:
 
 <main class="docs-main">
     <div class="container padding-top--md padding-bottom--lg">
-        <div class="col doc-item">
+        <div class="col doc-item markdown-body">
             {{ content | safe }}
         </div>
     </div>

--- a/sites/website/src/_includes/root.njk
+++ b/sites/website/src/_includes/root.njk
@@ -15,6 +15,8 @@
     <link data-rh="true" rel="alternate" href="https://www.fast.design/" hreflang="en">
     <link data-rh="true" rel="alternate" href="https://www.fast.design/" hreflang="x-default">
     <link rel="stylesheet" href="/css/main.css">
+    <link rel="stylesheet" href="/css/github-markdown-dark.css">
+    <link rel="stylesheet" href="/css/github-markdown-overrides.css">
     <link rel="stylesheet" href="/css/prism-vsc-dark-plus.css">
     <link rel="stylesheet" href="/css/variables.css">
     <meta name="viewport" content="width=device-width, initial-scale=1.0" data-rh="true">

--- a/sites/website/src/css/github-markdown-overrides.css
+++ b/sites/website/src/css/github-markdown-overrides.css
@@ -1,0 +1,95 @@
+/**
+ * Neutralize the blue-gray surfaces in github-markdown-dark.css so the docs
+ * body blends with the site's neutral `#1b1b1d` background.
+ *
+ * GitHub palette → site-neutral mapping:
+ *   #0d1117 (page bg)               → transparent (inherit site bg)
+ *   #151b23 (raised surfaces)       → #242426
+ *   #3d444d / #3d444db3 (borders)   → #3a3a3d / #3a3a3db3
+ *   #9198a1 (muted text)            → #9a9a9d
+ */
+
+.markdown-body {
+    background-color: transparent;
+    font-family: var(--ifm-font-family-base);
+}
+
+/* Links — follow the site's link color (Infima `--ifm-link-color`) */
+.markdown-body a {
+    color: var(--ifm-link-color);
+    text-decoration: var(--ifm-link-decoration);
+}
+
+.markdown-body a:hover {
+    color: var(--ifm-link-hover-color);
+    text-decoration: var(--ifm-link-hover-decoration);
+}
+
+/* Headings — bottom rule under h1/h2 */
+.markdown-body h1,
+.markdown-body h2 {
+    border-bottom-color: #3a3a3db3;
+}
+
+/* Inline <code>, <samp>, <kbd>-adjacent surfaces */
+.markdown-body code,
+.markdown-body tt {
+    background-color: #2e2e30;
+}
+
+/* <kbd> */
+.markdown-body kbd {
+    background-color: #242426;
+    border-color: #3a3a3d;
+    border-bottom-color: #3a3a3d;
+    box-shadow: inset 0 -1px 0 #3a3a3d;
+}
+
+/* Code blocks (<pre>) and highlight wrappers */
+.markdown-body pre,
+.markdown-body .highlight pre {
+    background-color: #242426;
+}
+
+/* Blockquotes */
+.markdown-body blockquote {
+    color: #9a9a9d;
+    border-left-color: #3a3a3d;
+}
+
+/* Horizontal rules */
+.markdown-body hr {
+    background-color: #3a3a3d;
+}
+
+/* Tables */
+.markdown-body table tr {
+    background-color: transparent;
+    border-top-color: #3a3a3db3;
+}
+
+.markdown-body table tr:nth-child(2n) {
+    background-color: #1f1f21;
+}
+
+.markdown-body table th,
+.markdown-body table td {
+    border-color: #3a3a3d;
+}
+
+/* Details / summary */
+.markdown-body summary {
+    color: inherit;
+}
+
+/* Muted text used in things like footnote labels */
+.markdown-body .color-fg-muted,
+.markdown-body .pl-c {
+    color: #9a9a9d;
+}
+
+/* Diff backgrounds (kept tinted, just slightly desaturated) */
+.markdown-body .highlight .mark,
+.markdown-body .highlight .mh {
+    background-color: transparent;
+}

--- a/sites/website/src/css/main.css
+++ b/sites/website/src/css/main.css
@@ -1244,10 +1244,18 @@ hr {
     text-decoration-thickness: 2px;
 }
 
-.navbar__logo img,
+.navbar__logo img {
+    height: inherit;
+}
+
 body,
 html {
-    height: inherit;
+    min-height: 100vh;
+}
+
+body {
+    display: flex;
+    flex-direction: column;
 }
 
 .badge,


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR adds the [github-markdown-css](https://github.com/sindresorhus/github-markdown-css) stylesheet, along with an override stylesheet to adapt the new styles to more closely match the look and feel of the FAST site. The new styles are additive, and meant to fill gaps in styling present in the existing styles.

## 👩‍💻 Reviewer Notes

In the future we will want to re-do the entire site's styles, since they're currently adapted from our old static site generator.

## ✅ Checklist

### General

- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.