### PR TITLE
Rewrite v3 Getting Started docs

### DIFF
--- a/sites/website/eleventy.config.js
+++ b/sites/website/eleventy.config.js
@@ -57,4 +57,35 @@ export default function (eleventyConfig) {
 
         return version;
     });
+
+    /**
+     * Flatten an eleventy-navigation tree depth-first and return the entries
+     * immediately before and after the current page URL. Used to derive
+     * prev/next pagination from the sidebar order.
+     */
+    eleventyConfig.addFilter("prevNext", function (navTree, currentUrl) {
+        const flat = [];
+
+        (function walk(nodes) {
+            if (!Array.isArray(nodes)) return;
+            for (const node of nodes) {
+                if (node?.url) {
+                    flat.push({ url: node.url, title: node.title });
+                }
+                if (node?.children?.length) {
+                    walk(node.children);
+                }
+            }
+        })(navTree);
+
+        const idx = flat.findIndex(entry => entry.url === currentUrl);
+        if (idx === -1) {
+            return { prev: null, next: null };
+        }
+
+        return {
+            prev: idx > 0 ? flat[idx - 1] : null,
+            next: idx < flat.length - 1 ? flat[idx + 1] : null,
+        };
+    });
 }

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -7,7 +7,7 @@
     "clean": "clean build tmp",
     "prebuild": "npm run clean && node scripts/generate-docs.cjs 3",
     "build": "npm run prebuild && npx @11ty/eleventy --output=build --input=src",
-    "start": "npm run prebuild && npx @11ty/eleventy --output=build --input=src --serve",
+    "start": "npm run prebuild && npx @11ty/eleventy --output=build --input=src --serve --incremental",
     "help": "npx @11ty/eleventy --help"
   },
   "browserslist": {

--- a/sites/website/src/_includes/3x-container.njk
+++ b/sites/website/src/_includes/3x-container.njk
@@ -26,6 +26,8 @@ navigationOptions:
     <div class="container padding-top--md padding-bottom--lg">
         <div class="col doc-item">
             {{ content | safe }}
+            {% set paginationCollection = collections.3x %}
+            {% include "pagination-nav.njk" %}
         </div>
     </div>
 </main>

--- a/sites/website/src/_includes/pagination-nav.njk
+++ b/sites/website/src/_includes/pagination-nav.njk
@@ -1,0 +1,25 @@
+{# Derives prev/next from the eleventy-navigation tree for the current
+   collection. Requires `paginationCollection` to be set. #}
+{% set siblings = paginationCollection | eleventyNavigation | prevNext(page.url) %}
+{% set prevPage = siblings.prev %}
+{% set nextPage = siblings.next %}
+{% if prevPage or nextPage %}
+<nav class="pagination-nav" aria-label="Docs pages navigation">
+    {% if prevPage %}
+    <a class="pagination-nav__link pagination-nav__link--previous" href="{{ prevPage.url }}">
+        <div class="pagination-nav__sublabel">Previous</div>
+        <div class="pagination-nav__label">«&nbsp;{{ prevPage.title }}</div>
+    </a>
+    {% else %}
+    <div></div>
+    {% endif %}
+    {% if nextPage %}
+    <a class="pagination-nav__link pagination-nav__link--next" href="{{ nextPage.url }}">
+        <div class="pagination-nav__sublabel">Next</div>
+        <div class="pagination-nav__label">{{ nextPage.title }}&nbsp;»</div>
+    </a>
+    {% else %}
+    <div></div>
+    {% endif %}
+</nav>
+{% endif %}

--- a/sites/website/src/_includes/pagination-nav.njk
+++ b/sites/website/src/_includes/pagination-nav.njk
@@ -4,7 +4,7 @@
 {% set prevPage = siblings.prev %}
 {% set nextPage = siblings.next %}
 {% if prevPage or nextPage %}
-<nav class="pagination-nav" aria-label="Docs pages navigation">
+<nav class="pagination-nav" aria-label="Documentation page navigation">
     {% if prevPage %}
     <a class="pagination-nav__link pagination-nav__link--previous" href="{{ prevPage.url }}">
         <div class="pagination-nav__sublabel">Previous</div>

--- a/sites/website/src/css/main.css
+++ b/sites/website/src/css/main.css
@@ -2696,6 +2696,47 @@ body:not(.navigation-with-keyboard) :not(input):focus {
     }
 }
 
+.pagination-nav {
+    display: grid;
+    grid-template-columns: repeat(2, 1fr);
+    gap: 1rem;
+    margin-top: 3rem;
+}
+
+.pagination-nav__link {
+    border: 1px solid var(--ifm-color-emphasis-300);
+    border-radius: var(--ifm-global-radius);
+    display: flex;
+    flex-direction: column;
+    line-height: var(--ifm-heading-line-height);
+    padding: 1rem;
+    transition: border-color var(--ifm-transition-fast)
+        var(--ifm-transition-timing-default);
+}
+
+.pagination-nav__link:hover {
+    border-color: var(--ifm-color-primary);
+    text-decoration: none;
+}
+
+.pagination-nav__link--next {
+    grid-column: 2 / 3;
+    text-align: right;
+}
+
+.pagination-nav__sublabel {
+    color: var(--ifm-color-content-secondary);
+    font-size: var(--ifm-h6-font-size);
+    font-weight: var(--ifm-font-weight-semibold);
+    margin-bottom: 0.25rem;
+}
+
+.pagination-nav__label {
+    color: var(--ifm-link-color);
+    font-weight: var(--ifm-font-weight-bold);
+    word-break: break-word;
+}
+
 @media print {
     .footer,
     .menu,

--- a/sites/website/src/docs/3.x/getting-started/css-templates.md
+++ b/sites/website/src/docs/3.x/getting-started/css-templates.md
@@ -16,115 +16,221 @@ keywords:
 
 # CSS Templates
 
-The `@microsoft/fast-element` module offers a named export `css` which is a [tag template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals). It can be used to create CSS snippets which will become your web components CSS. These styles are [adoptedStylesheets](https://developer.mozilla.org/en-US/docs/Web/API/Document/adoptedStyleSheets) and associated with the `ShadowRoot`, they therefore do not affect styling in the rest of the document. To share styles between a document and web components, we suggest using [CSS properties](https://developer.mozilla.org/en-US/docs/Web/CSS/--*).
+Custom elements are typically styled by attaching a `<style>` element to their shadow root or by adopting a constructable stylesheet. FAST provides a tagged template function called `css`, which lets you author a component's styles in JavaScript and associate them with its definition.
 
-**Example:**
+Styles created with `css` produce an `ElementStyles` object that FAST applies to the component's shadow root. Because the Shadow DOM encapsulates style scope, selectors authored there match only elements within the component's shadow tree, so the styles do not affect the rest of the document. When the same styles are used across many instances of a component, FAST reuses a single underlying constructable stylesheet rather than duplicating it. Unlike HTML templates, `css` templates are static and do not support binding expressions.
+
+This document describes how to author styles with the `css` function, including composing styles, partial CSS fragments, CSS directives, and changing styles at runtime.
+
+## Defining Styles
+
+The `css` function is a tagged template that turns CSS into an `ElementStyles` object. The following example defines basic styles for a component:
+
 ```ts
-import { attr, css, FASTElement, html } from '@microsoft/fast-element';
+import { css, FASTElement, html } from "@microsoft/fast-element";
 
-const template = html`
-  <span>${x => x.greeting.toUpperCase()}</span>
+class HelloWorld extends FASTElement {}
+
+const template = html<HelloWorld>`
+  <template>
+    <span>Hello World!</span>
+  </template>
 `;
 
-export const styles = css`
+const styles = css`
   :host {
-    color: red;
-    background: var(--background-color, green);
+    border: 1px solid blue;
+  }
+
+  span {
+    color: green;
   }
 `;
 
-export class NameTag extends FASTElement {
-  @attr
-  greeting: string = 'hello';
-}
-
-NameTag.define({
-  name: 'name-tag',
+HelloWorld.define({
+  name: "hello-world",
   template,
-  styles
+  styles,
 });
 ```
 
-HTML file:
-```html
-<style>
-  body {
-    --background-color: orange;
-  }
-</style>
-<name-tag></name-tag>
-```
+The example above defines a `HelloWorld` component with a `span` element that displays a greeting. The component's stylesheet is provided via the `styles` property in the `define()` call. When a `<hello-world>` element is added to the page, it will have a blue border and the text inside the `span` will be green.
 
-Using the `css` helper, we're able to create `ElementStyles`. We configure this with the element through the `styles` option of the decorator. Internally, `FASTElement` will leverage [Constructable Stylesheet Objects](https://wicg.github.io/construct-stylesheets/) and `ShadowRoot#adoptedStyleSheets` to efficiently re-use CSS across components. This means that even if we have 1k instances of our `name-tag` component, they will all share a single instance of the associated styles, allowing for reduced memory allocation and improved performance. Because the styles are associated with the `ShadowRoot`, they will also be encapsulated. This ensures that your styles don't affect other elements and other element styles don't affect your element.
+## Composing Styles
 
-## Composing styles
-
-One of the nice features of `ElementStyles` is that it can be composed with other styles. Imagine that we had a CSS normalize that we wanted to use in our `name-tag` component. We could compose that into our styles like this:
-
-**Example: Composing CSS Registries**
+`ElementStyles` objects created with `css` can be composed into other styles. When you interpolate one `ElementStyles` object into another `css` template, FAST includes it as a complete, reusable stylesheet rather than copying its text. This lets you share common styles across components. For example:
 
 ```ts
-import { normalize } from './normalize';
-
-const styles = css`
-  ${normalize}
+const baseStyles = css`
   :host {
-    display: inline-block;
-    contain: content;
-    color: white;
-    background: var(--fill-color);
-    border-radius: var(--border-radius);
-    min-width: 325px;
-    text-align: center;
-    box-shadow: 0 0 calc(var(--depth) * 1px) rgba(0,0,0,.5);
+    display: block;
+    padding: 10px;
+  }
+`;
+
+const helloStyles = css`
+  ${baseStyles}
+
+  :host {
+    border: 1px solid blue;
   }
 
-  ...
+  span {
+    color: green;
+  }
 `;
 ```
 
-Rather than simply concatenating CSS strings, the `css` helper understands that `normalize` is `ElementStyles` and is able to re-use the same Constructable StyleSheet instance as any other component that uses `normalize`. 
+This example defines a `baseStyles` fragment that sets common styles for the host element. `helloStyles` interpolates `baseStyles` and adds rules of its own, so a component styled with `helloStyles` receives both sets of styles.
 
-:::note
-You can also pass a CSS `string` or a [CSSStyleSheet](https://developer.mozilla.org/en-US/docs/Web/API/CSSStyleSheet) instance directly to the element definition, or even a mixed array of `string`, `CSSStyleSheet`, or `ElementStyles`.
-:::
+### Mixing Style Sources
 
-:::tip
-For runtime style changes, keep the `ElementStyles` in your component and call
-`$fastController.addStyles()` / `$fastController.removeStyles()` from element
-change handlers or lifecycle callbacks. Check out the
-[advanced documentation](/docs/advanced/working-with-custom-elements.md) for
-details. `css` templates are static and do not support runtime binding
-expressions.
-:::
+The `styles` property of the `define()` method accepts an array of `ElementStyles` objects, `CSSStyleSheet` instances, and raw CSS strings, letting you combine styles from different sources in a single component. For example:
 
-## Adding external styles
-
-Styles can be added as an array, this can be useful for sharing styles between components and for bringing in styles as a string.
-
-**Example:**
 ```ts
-const sharedStyles = `
-  h2 {
-    font-family: sans-serif;
-  }
-`;
+const resetSheet = new CSSStyleSheet();
+resetSheet.replaceSync(`:host { box-sizing: border-box; }`);
 
-NameTag.define({
-  name: 'name-tag',
+const sharedText = `span { font-family: sans-serif; }`;
+
+HelloWorld.define({
+  name: "hello-world",
   template,
   styles: [
-    css`
-      :host {
-        color: red;
-        background: var(--background-color, green);
-      }
-    `,
-    sharedStyles
-  ]
-})
+    resetSheet,                     // a CSSStyleSheet, adopted as-is
+    sharedText,                     // a raw CSS string, parsed into its own stylesheet
+    css`:host { color: green; }`,   // ElementStyles via the css function
+  ],
+});
 ```
 
-:::tip
-You may notice that we have used [`:host`](https://developer.mozilla.org/en-US/docs/Web/CSS/:host), this is part of standard CSS pseudo classes. Pseudo elements that may be useful for styling your custom web components include [`::slotted`](https://developer.mozilla.org/en-US/docs/Web/CSS/::slotted) and [`::part`](https://developer.mozilla.org/en-US/docs/Web/CSS/::part).
+The example above combines three kinds of styles. `resetSheet` is a `CSSStyleSheet` that is adopted directly, `sharedText` is a raw CSS string that FAST parses into its own stylesheet, and the `css` function produces an `ElementStyles` object. Each is applied to the component's shadow root as a separate stylesheet.
+
+### Partial CSS
+
+The `css.partial` function creates a reusable fragment of CSS. Unlike a full `ElementStyles` object, which composes as a separate stylesheet, a partial is inlined into the `css` template that interpolates it. This means a partial can appear anywhere in a template, including inside a selector, which lets you share rules, declarations, or selector fragments across components.
+
+```ts
+import { css } from "@microsoft/fast-element";
+
+// A partial CSS fragment that matches checked states
+const checkedState = css.partial`:is([state--checked], :state(checked))`;
+
+const checkboxStyles = css`
+  :host(${checkedState}) {
+    font-weight: bold;
+  }
+`;
+```
+
+In this example, `checkedState` is a partial CSS fragment that matches elements with a `state--checked` attribute or a `checked` state. The `checkboxStyles` stylesheet includes this fragment in its selector, allowing it to apply styles to the host element when it is in the checked state.
+
+### CSS Directives
+
+A CSS directive is the general mechanism for contributing computed styles to a `css` template. The `css.partial` function described above is one built-in example. A directive is any object with a `createCSS()` method, registered with `CSSDirective.define()`. When the directive is interpolated into a `css` template, FAST calls `createCSS()` and incorporates the returned value into the stylesheet.
+
+```ts
+import { css, CSSDirective } from "@microsoft/fast-element";
+
+class Elevation implements CSSDirective {
+  constructor(private level: number) {}
+
+  createCSS(): string {
+    const blur = this.level * 2;
+    return `box-shadow: 0 ${this.level}px ${blur}px rgba(0, 0, 0, 0.2);`;
+  }
+}
+
+CSSDirective.define(Elevation);
+
+const cardStyles = css`
+  :host {
+    ${new Elevation(4)}
+  }
+`;
+```
+
+The `Elevation` directive in the example above returns a `box-shadow` declaration derived from its `level`. Calling `CSSDirective.define()` registers the class so FAST recognizes its instances during composition; without registration, the interpolated object would be stringified. When `cardStyles` is composed, FAST calls `createCSS()` and concatenates the result into the `:host` rule.
+
+:::note
+A `cssDirective()` decorator is also available and is equivalent to `CSSDirective.define()`. Annotating the class with `@cssDirective()` registers it the same way.
 :::
+
+The value returned from `createCSS()` follows the same composition rules as any interpolated value. A string is concatenated inline into the surrounding CSS, while an `ElementStyles` or `CSSStyleSheet` is composed as a separate stylesheet.
+
+A directive runs once, when the template is composed, and its output is fixed in the resulting `ElementStyles`. Because `css` templates are static, a directive cannot respond to component state or produce different styles per instance. Use one to encapsulate reusable style logic that is computed a single time, such as mapping a value to a set of declarations.
+
+## Changing Styles at Runtime
+
+Because `css` templates are static, you do not change a component's styles by re-evaluating its template. Instead, you add, remove, or replace `ElementStyles` through the component's controller, available as `this.$fastController`.
+
+This is most useful when a style depends on a value that can only be computed at runtime. In the following example, a component derives a custom property from a numeric attribute, then builds an `ElementStyles` object and applies it through the controller:
+
+```ts
+import { attr, css, ElementStyles, FASTElement } from "@microsoft/fast-element";
+
+class MyElement extends FASTElement {
+  @attr
+  ratio = 0;
+
+  private ratioStyles?: ElementStyles;
+
+  ratioChanged() {
+    if (this.ratioStyles) {
+      this.$fastController.removeStyles(this.ratioStyles);
+    }
+
+    this.ratioStyles = css`
+      :host {
+        --fill: ${this.ratio * 100}%;
+      }
+    `;
+
+    this.$fastController.addStyles(this.ratioStyles);
+  }
+}
+```
+
+Each time `ratio` changes, the component removes the previous stylesheet, builds a new one with the updated value, and adds it. The current stylesheet is held on a private field so it can be removed before the next one is applied. Because the styles are recomputed from a runtime value, a new `ElementStyles` object is created each time rather than reused.
+
+Applying the value as a stylesheet, rather than writing it to the host's inline `style` attribute, keeps the computed value encapsulated in the component's own styles and leaves the host element's `style` attribute free for consumers.
+
+To replace the component's primary stylesheet rather than layer on top of it, assign a new `ElementStyles` object to the controller's `mainStyles` property. This removes the previous main styles and applies the new set.
+
+For styling that can be expressed declaratively, prefer CSS custom properties and state selectors over runtime changes. Use the controller when a style depends on a value the static template cannot express. See the [working with custom elements](../../advanced/working-with-custom-elements/) guide for more on the element controller.
+
+## Selectors and Custom Properties
+
+Styling a component's shadow DOM uses standard CSS, but a few selectors are specific to custom elements and shadow trees:
+
+- [`:host`](https://developer.mozilla.org/en-US/docs/Web/CSS/:host) targets the component's host element. Its functional form, `:host(selector)`, targets the host only when it matches a selector, such as `:host([disabled])` or `:host(${checkedState})`.
+- [`::slotted(selector)`](https://developer.mozilla.org/en-US/docs/Web/CSS/::slotted) targets light DOM content projected through a `<slot>`. It matches only the top-level slotted nodes, not their descendants.
+- [`::part(name)`](https://developer.mozilla.org/en-US/docs/Web/CSS/::part) targets an element the component exposes through the `part` attribute, allowing consumers to style it from outside the shadow boundary.
+
+Although selectors are scoped to the shadow tree, CSS custom properties inherit through the shadow boundary. This makes them the primary mechanism for customizing a component from the outside. A component reads a custom property with `var()`, supplying a fallback for when it is not set, and a consumer sets the property from the surrounding document.
+
+```ts
+const styles = css`
+  :host {
+    color: var(--accent-color, blue);
+  }
+
+  :host([disabled]) {
+    opacity: 0.5;
+  }
+
+  ::slotted(strong) {
+    color: var(--accent-color, blue);
+  }
+`;
+```
+
+A consumer customizes the component by setting the custom property outside the shadow boundary:
+
+```css
+my-element {
+  --accent-color: rebeccapurple;
+}
+```
+
+Because the property inherits into the shadow tree, the component picks up the consumer's value wherever it reads `var(--accent-color)`. Design token systems build on this behavior, exposing a component's customizable values as custom properties.

--- a/sites/website/src/docs/3.x/getting-started/css-templates.md
+++ b/sites/website/src/docs/3.x/getting-started/css-templates.md
@@ -24,7 +24,7 @@ This document describes how to author styles with the `css` function, including 
 
 ## Defining Styles
 
-The `css` function is a tagged template that turns CSS into an `ElementStyles` object. The following example defines basic styles for a component:
+The `css` function is a tagged template that turns CSS into an `ElementStyles` object. The following example defines basic styles for a component:
 
 ```ts
 import { css, FASTElement, html } from "@microsoft/fast-element";
@@ -167,18 +167,38 @@ Because `css` templates are static, you do not change a component's styles by re
 This is most useful when a style depends on a value that can only be computed at runtime. In the following example, a component derives a custom property from a numeric attribute, then builds an `ElementStyles` object and applies it through the controller:
 
 ```ts
-import { attr, css, ElementStyles, FASTElement } from "@microsoft/fast-element";
+import {
+  attr,
+  css,
+  type ElementStyles,
+  FASTElement,
+  nullableNumberConverter,
+} from "@microsoft/fast-element";
 
 class MyElement extends FASTElement {
-  @attr
-  ratio = 0;
+  @attr({ converter: nullableNumberConverter })
+  ratio?: number | null;
 
   private ratioStyles?: ElementStyles;
 
-  ratioChanged() {
-    if (this.ratioStyles) {
-      this.$fastController.removeStyles(this.ratioStyles);
+  connectedCallback() {
+    super.connectedCallback();
+    this.updateRatioStyles();
+  }
+
+  ratioChanged(prev?: number | null, next?: number | null) {
+    if (typeof next !== "number") {
+      this.ratio = 0;
+      return;
     }
+
+    if (this.$fastController.isConnected) {
+      this.updateRatioStyles();
+    }
+  }
+
+  protected updateRatioStyles() {
+    this.$fastController.removeStyles(this.ratioStyles);
 
     this.ratioStyles = css`
       :host {
@@ -191,7 +211,9 @@ class MyElement extends FASTElement {
 }
 ```
 
-Each time `ratio` changes, the component removes the previous stylesheet, builds a new one with the updated value, and adds it. The current stylesheet is held on a private field so it can be removed before the next one is applied. Because the styles are recomputed from a runtime value, a new `ElementStyles` object is created each time rather than reused.
+`updateRatioStyles()` removes the previous stylesheet, builds a new one from the current value, and adds it. The stylesheet is held on a private field so it can be removed before the new one is applied. Because the styles are recomputed from a runtime value, a new `ElementStyles` object is created each time rather than reused.
+
+`addStyles()` and `removeStyles()` act on the component's shadow root, which FAST creates during connection, so the update has to wait for the controller to connect. `ratioChanged()` guards on `this.$fastController.isConnected` and skips the update until then, while `connectedCallback()` runs it once after `super.connectedCallback()` to apply the initial value.
 
 Applying the value as a stylesheet, rather than writing it to the host's inline `style` attribute, keeps the computed value encapsulated in the component's own styles and leaves the host element's `style` attribute free for consumers.
 

--- a/sites/website/src/docs/3.x/getting-started/css-templates.md
+++ b/sites/website/src/docs/3.x/getting-started/css-templates.md
@@ -186,12 +186,7 @@ class MyElement extends FASTElement {
     this.updateRatioStyles();
   }
 
-  ratioChanged(prev?: number | null, next?: number | null) {
-    if (typeof next !== "number") {
-      this.ratio = 0;
-      return;
-    }
-
+  ratioChanged() {
     if (this.$fastController.isConnected) {
       this.updateRatioStyles();
     }
@@ -202,7 +197,7 @@ class MyElement extends FASTElement {
 
     this.ratioStyles = css`
       :host {
-        --fill: ${this.ratio * 100}%;
+        --fill: ${(this.ratio ?? 0) * 100}%;
       }
     `;
 

--- a/sites/website/src/docs/3.x/getting-started/fast-element.md
+++ b/sites/website/src/docs/3.x/getting-started/fast-element.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   key: fast-element3x
   parent: getting-started3x
   title: FASTElement
+  order: 2
 navigationOptions:
   activeKey: fast-element3x
 keywords:
@@ -13,276 +14,213 @@ keywords:
   - web components
 ---
 
-# FASTElement
+# The `FASTElement` Base Class
 
-The `FASTElement` class can be extended from for your custom component logic.
+Custom elements in the browser start by extending the `HTMLElement` class. FAST provides a base class called `FASTElement`, which itself extends `HTMLElement`, and adds reactive property observation, automatic change callbacks, and lifecycle management for building web components. By extending `FASTElement`, you can take advantage of these features while still having access to all the standard Web Component APIs.
 
-## Attribute Bindings
+To create a custom FAST element, define a class that extends `FASTElement`. This class will contain the properties, methods, and lifecycle callbacks that define the behavior of your custom element:
 
-Attributes are defined using the `@attr` decorator.
-
-**Example:**
 ```ts
-import { attr, FASTElement } from '@microsoft/fast-element';
+import { FASTElement } from "@microsoft/fast-element";
+
+export class MyElement extends FASTElement {
+  // component logic goes here
+}
+```
+
+## Declaring Attributes with the `@attr` Decorator
+
+Native custom elements can define attributes by implementing the `observedAttributes` static getter and handling changes in the `attributeChangedCallback`. FAST simplifies this process with the `@attr` decorator, which allows you to declare attributes directly on class properties.
+
+```ts
+import { attr, FASTElement } from "@microsoft/fast-element";
 
 export class MyElement extends FASTElement {
   @attr
-  foo: string;
+  appearance?: string;
 }
 ```
 
-HTML file:
-```html
-<my-element foo="Hello"></my-element>
+In this example, the `@attr` decorator tells `FASTElement` to treat `appearance` as an observed attribute. This means that when you use `<my-element appearance="value">`, the `appearance` property on the class will be automatically updated to reflect the value of the attribute. You can also set the property in JavaScript, and it will update the corresponding attribute in the DOM.
+
+### Attribute Options
+
+The `@attr` decorator accepts an optional configuration object that allows you to customize how the attribute is bound to the property. For example, you can specify a different attribute name, a converter for type coercion, or whether the attribute should reflect back to the DOM.
+
+By default, decorated attribute properties use `mode: "reflect"`, which keeps the attribute and property in sync in both directions.
+
+#### Different Attribute Name
+
+Attributes in HTML are always case-insensitive, so FAST maps camelCase property names to lowercase attribute names by default. For example, a property named `myAttribute` would correspond to an attribute named `myattribute` in HTML.
+
+A common convention is to use kebab-case for attribute names, so you can specify a different attribute name using the `attribute` option:
+
+```ts
+@attr({ attribute: "my-attribute" })
+myAttribute?: string;
 ```
 
-An `@attr` can take a configuration with the following options:
+#### Boolean Attributes
 
-| Property | Description | Values | Default |
-|-|-|-|-|
-| attribute | The attribute name that is reflected in the DOM, this can be specified in cases where a different string is preferred. | `string` | The class property converted to lowercase |
-| mode | If the attribute is a boolean and the mode is set to "boolean" this allows `FASTElement` to add/remove the attribute from the element in the same way that [native boolean attributes on elements work](https://developer.mozilla.org/en-US/docs/Glossary/Boolean/HTML). The "fromView" behavior only updates the property value based on changes in the DOM, but does not reflect property changes back. | `"reflect" \| "boolean" \| "fromView"` | "reflect" |
-| converter | This allows the value of the attribute to be converted when moving to and from the HTML template. | [See ValueConverter Interface](#converters) | |
+The `mode` property allows for specifying boolean attributes, which are considered `true` if the attribute is present on the element, regardless of its value, and `false` if the attribute is absent:
 
-Example with a custom attribute name and boolean mode:
 ```ts
-import { attr, FASTElement } from '@microsoft/fast-element';
+@attr({ mode: "boolean" })
+enabled?: boolean;
+```
+
+#### One-way Binding
+
+By default, attributes and properties are kept in sync in both directions. However, if you want to create a one-way binding where changes to the property do not reflect back to the DOM, you can set the `mode` to `"fromView"`:
+
+```ts
+@attr({ attribute: "initial-value", mode: "fromView" })
+initialValue?: string;
+```
+
+#### Value Converters
+
+If your property expects a type other than `string`, you can provide a converter object to specify how to convert between the attribute value and the property value. The most common use case for a custom converter is to handle attributes that represent numbers, so FAST provides a built-in `nullableNumberConverter` for this purpose:
+
+```ts
+import { attr, FASTElement, nullableNumberConverter } from "@microsoft/fast-element";
 
 export class MyElement extends FASTElement {
-  @attr({
-    attribute: "foo-bar",
-    mode: "boolean"
-  })
-  foo: boolean;
+  @attr({ converter: nullableNumberConverter })
+  count?: number;
 }
 ```
 
-HTML file:
-```html
-<my-element foo-bar></my-element>
-```
+This converter will convert the attribute value to a number when reading from the DOM, and convert the value back to a string when writing to the DOM. If the attribute is not present or cannot be converted to a number, the property will be set to `undefined`. Likewise, if the property is set to `undefined`, `null`, or `NaN`, the attribute will be removed from the DOM.
 
 :::tip
-As a handy feature, attribute names are automatically converted to a lower-case version in HTML, so declaring `fooBar` as an `@attr` in `FASTElement` will in HTML convert to `foobar`. We include the configuration option of `attribute` to allow re-naming, and one of the most common use cases is adding dashes, so you can have `foo-bar` as in the example above.
+Properties decorated with `@attr({ mode: "boolean" })` automatically utilize the `booleanConverter` converter, which treats the presence of the attribute as `true` and its absence as `false`.
 :::
 
-:::important
-When the `mode` is set to `boolean`, a built-in `booleanConverter` is automatically used to ensure type correctness so that the manual configuration of the converter is not needed in this common scenario.
-:::
+## Property and Attribute Observation
 
-### Converters
+When declaring attributes via the platform's native `observedAttributes` API, you must also implement the `attributeChangedCallback` to respond to changes in those attributes. Similarly, if you want to observe changes to properties, you would need to implement getters and setters for those properties. FAST's `@attr` and `@observable` decorators enable observability callbacks without requiring you to implement these patterns directly.
 
-In addition to setting the `mode`, you can also supply a custom `ValueConverter` by setting the `converter` property of the attribute configuration. The converter must implement the following interface:
+For example, with `@attr`, you can define a callback method that will be called whenever an attribute-bound property changes:
 
 ```ts
-interface ValueConverter {
-    toView(value: any): string;
-    fromView(value: string): any;
-}
-```
+import { attr, FASTElement } from "@microsoft/fast-element";
 
-Here's how it works:
+export class MyElement extends FASTElement {
+  @attr
+  name?: string;
 
-* When the DOM attribute value changes, the converter's `fromView` method will be called, allowing custom code to coerce the value to the proper type expected by the property.
-* When the property value changes, the converter's `fromView` method will also be called, ensuring that the type is correct. After this, the `mode` will be determined. If the mode is set to `reflect` then the converter's `toView` method will be called to allow the type to be formatted before writing to the attribute using `setAttribute`.
-
-**Example: An Attribute in Reflect Mode with Custom Conversion**
-
-```ts
-import { attr, FASTElement, type ValueConverter } from '@microsoft/fast-element';
-
-const numberConverter: ValueConverter = {
-  toView(value: any): string {
-    // convert numbers to strings
-  },
-
-  fromView(value: string): any {
-    // convert strings to numbers
-  }
-};
-
-export class MyCounter extends FASTElement {
-  @attr({ converter: numberConverter }) count: number = 0;
-}
-
-MyCounter.define({
-  name: 'my-counter'
-});
-```
-
-A few commonly used converters are available as well:
-
-- [booleanConverter](/docs/3.x/api/fast-element/attr/fast-element.booleanconverter/)
-- [nullableBooleanConverter](/docs/3.x/api/fast-element/attr/fast-element.nullablebooleanconverter/)
-- [nullableNumberConverter](/docs/3.x/api/fast-element/attr/fast-element.nullablenumberconverter/)
-
-## Observables
-
-While `@attr` is used for primitive properties (string, boolean, and number), the `@observable` decorator is for all other properties. In addition to observing properties, the templating system can also observe arrays.
-
-These decorators are a means of meta-programming the properties on your class, such that they include all the implementation needed to support state tracking, observation, and reactivity. You can access any property within your template, but if it hasn't been decorated with one of these two decorators, its value will not update after the initial render.
-
-:::important
-Properties with only a getter, that function as a computed property over other observables, should not be decorated with `@attr` or `@observable`. However, they may need to be decorated with `@volatile`, depending on the internal logic.
-:::
-
-```ts
-import { FASTElement, observable } from '@microsoft/fast-element';
-
-export class MyComponent extends FASTElement {
-  @observable
-  someBoolean = false;
-
-  @observable
-  valueA = 0;
-
-  @observable
-  valueB = 42;
-}
-```
-
-A common use case for `@observable` is with slotted elements.
-
-**Example: Track changes to elements being added/removed to a slot**
-
-```ts
-import { FASTElement, observable } from '@microsoft/fast-element';
-
-class MyComponent extends FASTElement {
-  @observable
-  public slottedItems: HTMLElement[];
-
-  protected itemCount: number;
-
-  public slottedItemsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]): void {
-    if (this.$fastController.isConnected) {
-      this.itemCount = newValue.length;
-    }
+  nameChanged(oldValue?: string, newValue?: string) {
+    console.log(`Name changed from ${oldValue} to ${newValue}`);
   }
 }
 ```
 
-### Manually tracking observables
+Whenever the `name` property changes, whether through an attribute update in the DOM or by setting the property on an element instance in JavaScript, the `nameChanged` method will be called with the previous and new values. This allows you to react to changes in a declarative way without needing to manually implement attribute observation or property getters/setters.
 
-When `@attr` and `@observable` decorated properties are accessed during template rendering, they are tracked, allowing the engine to deeply understand the relationship between your model and view. These decorators serves to meta-program the property for you, injecting code to enable the observation system. However, if you do not like this approach, for `@observable`, you can always implement notification manually. This is especially useful if you need to do some additional logic inside a `getter` and `setter`. Here's what that would look like:
+### Property Observation with the `@observable` Decorator
 
-**Example: Manual Observer Implementation**
+The `@observable` decorator provides similar functionality for properties that are not necessarily tied to attributes. This is useful for internal state management within your component that doesn't need to be reflected in the DOM:
 
 ```ts
-import { Observable } from '@microsoft/fast-element';
+import { observable, FASTElement } from "@microsoft/fast-element";
+
+export class MyElement extends FASTElement {
+  @observable
+  count: number = 0;
+
+  countChanged(oldValue: number, newValue: number) {
+    console.log(`Count changed from ${oldValue} to ${newValue}`);
+  }
+}
+```
+
+In this example, the `count` property is decorated with `@observable`, which means that any changes to `count` will trigger the `countChanged` callback, allowing you to respond to changes in the internal state of your component.
+
+:::tip
+FAST's `Observable` API can be used independently of custom elements, so you can create observable objects and properties in any JavaScript class, not just those that extend `FASTElement`. Read the [Reactivity](../../advanced/reactivity/) section for more details on using observables in FAST.
+:::
+
+### Manually Tracking Observables
+
+The `@attr` and `@observable` decorators rewrite the decorated property into a getter/setter pair that calls into FAST's observation system. When a decorated property is accessed during template rendering, the engine tracks the access and establishes the relationship between the model and the view. The same notification behavior can be implemented manually, which is useful when a property requires additional logic in its getter or setter. The following example shows what that looks like:
+
+```ts
+import { Observable } from "@microsoft/fast-element";
 
 export class Person {
   private _name: string;
 
   get name() {
+    // Manually track the property access for reactivity
     Observable.track(this, 'name');
     return this._name;
   }
 
   set name(value: string) {
     this._name = value;
+    // Manually notify that the property has changed
     Observable.notify(this, 'name');
   }
 }
 ```
 
-## Emitting Events
+## Lifecycle Callbacks
 
-In various scenarios, it may be appropriate for a custom element to publish its own element-specific events. To do this, you can use the `$emit` helper on `FASTElement`. It's a convenience method that creates an instance of `CustomEvent` and uses the `dispatchEvent` API on `FASTElement` with the `bubbles: true` and `composed: true` options. It also ensures that the event is only emitted if the custom element is fully connected to the DOM.
-
-**Example: Custom Event Dispatch**
+Extending `HTMLElement` gives you access to the standard custom element lifecycle callbacks. `FASTElement` supports these callbacks and also provides additional lifecycle management features through its internal controller. When you override lifecycle methods like `connectedCallback` or `disconnectedCallback`, make sure to call `super` to ensure that the base class can perform necessary setup and teardown work.
 
 ```ts
-const template = html`
-  <input @change="${x => x.valueChanged()}" />
-`;
+import { FASTElement } from "@microsoft/fast-element";
 
-export class MyInput extends FASTElement {
-  @attr
-  value: string = '';
+export class MyElement extends FASTElement {
+  connectedCallback() {
+    super.connectedCallback();
+    console.log("Element connected to the DOM");
+  }
 
-  valueChanged() {
-    this.$emit('change', this.value);
+  disconnectedCallback() {
+    console.log("Element disconnected from the DOM");
+    super.disconnectedCallback();
+  }
+
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+    console.log(`Attribute ${name} changed from ${oldValue} to ${newValue}`);
+    super.attributeChangedCallback(name, oldValue, newValue);
   }
 }
 ```
 
-:::tip
-When emitting custom events, ensure that your event name is always lower-case, so that your Web Components stay compatible with various front-end frameworks that attach events through DOM binding patterns (the DOM is case insensitive).
+:::note
+Overriding `connectedCallback` can affect the timing of when your template is bound and when behaviors run, so it's generally recommended to call `super.connectedCallback()` at the beginning of your override. Conversely, for `disconnectedCallback` and `attributeChangedCallback`, it's usually best to call the super method at the end of your override to ensure that your custom logic runs while the element is still in a consistent state.
 :::
 
-## Defining
+## Defining the Element
 
-`FASTElement` has a `define` method, this is the means by which a custom web component is registered with the browser.
+### `define()`
 
-**Example:**
+Autonomous custom elements must be registered with the browser using `customElements.define()`. FAST provides a static `define()` method on `FASTElement`-derived classes that wraps this registration process and also allows you to specify additional configuration such as observed attributes, styles, and templates.
+
 ```ts
-import { FASTElement } from '@microsoft/fast-element';
+import { FASTElement, html, css } from "@microsoft/fast-element";
 
-export class MyElement extends FASTElement {}
-
-MyElement.define({
-  name: 'my-element'
-});
-```
-
-:::important
-Defining a web component creates [side effects](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Statements/import#import_a_module_for_its_side_effects_only). This is important to note as [tree shaking](https://developer.mozilla.org/en-US/docs/Glossary/Tree_shaking) may cause web components to be removed during transpile even if they are imported. Ensure that your build system accounts for this and does not tree shake out your web components.
-:::
-
-This configuration can take various options:
-
-| Property | Description | Values | Default | Required |
-|-|-|-|-|-|
-| name | The [name of the custom element](https://developer.mozilla.org/en-US/docs/Web/API/Web_Components/Using_custom_elements#name). | | | Yes |
-| template | The template to render for the custom element. Use the `html` tag template literal to create this template. | | | |
-| styles | The styles to associate with the custom element. Use the `css` tag template literal to create this template. | | | |
-| shadowOptions | Options controlling the creation of the custom element's shadow DOM. Provide null to render to the associated template to the light DOM instead. Example: `{ delegatesFocus: true }`, see the [ShadowRoot API](https://developer.mozilla.org/en-US/docs/Web/API/ShadowRoot) for details. | | Defaults to an open shadow root. | |
-| elementOptions | [Options](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define#options) controlling how the custom element is defined with the platform. | | | |
-| registry | The registry to register this component in by default. | | If not provided, defaults to the global registry. | |
-
-A typical configuration will at least include `name`, `template`, and `styles`.
-
-**Example:**
-```ts
-import { attr, css, FASTElement, html } from "@microsoft/fast-element";
-
-const template = html`<span>Hello ${x => x.name}!</span>`
-
-const styles = css`
-    :host {
-      border: 1px solid blue;
-    }
-`;
-
-class HelloWorld extends FASTElement {
-  @attr
-  name: string;
+export class MyElement extends FASTElement {
+  // component logic
 }
 
-HelloWorld.define({
-  name: "hello-world",
-  template,
-  styles,
+MyElement.define({
+  name: "my-element",
+  template: html`<div>Hello, World!</div>`,
+  styles: css`
+    div {
+      color: blue;
+    }
+  `,
 });
 ```
 
-**Example: Defining with a custom registry**
-```ts
-export const FooRegistry = Object.freeze({
-  prefix: 'foo',
-  registry: customElements,
-});
+In this example, `MyElement.define()` registers the custom element with the name `my-element`, and provides a template and styles for the element. The template defines the structure of the element's Shadow DOM, while the styles are scoped to that Shadow DOM, ensuring that they do not affect other elements on the page.
 
-HelloWorld.define({
-  name: `${FooRegistry.prefix}-tab`,
-  template,
-  styles,
-  registry: FooRegistry.registry,
-});
-```
-
-### Define Extensions
+#### Definition Extensions
 
 `define()` accepts an optional second argument — an array of extension callbacks. Each extension is a function that receives the resolved `FASTElementDefinition` and is called **before** the element is registered with `customElements.define()`. This enables a plugin pattern for hooking into element registration.
 
@@ -290,9 +228,9 @@ HelloWorld.define({
 import type { FASTElementExtension } from "@microsoft/fast-element";
 
 function myPlugin(): FASTElementExtension {
-    return definition => {
-        console.log(`Defining: ${definition.name}`);
-    };
+  return definition => {
+    console.log(`Defining: ${definition.name}`);
+  };
 }
 
 MyComponent.define({
@@ -302,36 +240,49 @@ MyComponent.define({
 }, [myPlugin()]);
 ```
 
-## Lifecycle
-
-All Web Components support a series of lifecycle events that you can tap into to execute custom code at specific points in time. `FASTElement` implements several of these callbacks automatically in order to enable features of its templating engine. However, you can override them to provide your own code. Here's an example of how you would execute custom code when your element is inserted into the DOM.
-
-**Example: Tapping into the Custom Element Lifecycle**
+Extensions can also be used with the static call style:
 
 ```ts
-import { attr, FASTElement } from '@microsoft/fast-element';
+FASTElement.define(MyComponent, { name: "my-component" }, [myPlugin()]);
+```
 
-export class NameTag extends FASTElement {
-  @attr
-  greeting: string = 'Hello';
+For the full set of configuration options accepted by `define()`, see the [`PartialFASTElementDefinition`](/docs/3.x/api/fast-element.partialfastelementdefinition/) API reference.
 
-  greetingChanged() {
-    this.shadowRoot!.innerHTML = this.greeting;
+## Utilities, Helpers, and Additional Features
+
+In addition to the features described above, `FASTElement` provides a number of utilities and helpers for working with custom elements, such as methods for adding and removing styles, accessing the element's internal controller, working with the processing queue, and more.
+
+### Using the Element Controller via `$fastController`
+
+Every `FASTElement` instance exposes a `$fastController` property that references the internal `ElementController` driving the element's lifecycle and reactivity. Most components do not need to access it directly, but one member is commonly used inside `*Changed` callbacks: `isConnected`.
+
+The `isConnected` property on the controller reports `true` after FAST has connected the element, which happens during `super.connectedCallback()`. It is distinct from the platform's `Node.isConnected`, which reports only whether the element is attached to a document. During the parse-time window when attributes are being assigned to a freshly upgraded element, the platform property is already `true`, but FAST has not yet bound the template or wired up the reactivity system. Reading from `this.elementInternals` or dispatching events during that window can produce inconsistent results.
+
+For this reason, `*Changed` callbacks that touch the DOM typically guard against running before the controller has connected:
+
+```ts
+protected disabledChanged() {
+  if (!this.$fastController.isConnected) {
+    return;
   }
+  this.elementInternals.ariaDisabled = `${this.disabled}`;
+}
+```
 
-  connectedCallback() {
-    super.connectedCallback();
-    console.log('name-tag is now connected to the DOM');
+For other uses of the controller, such as dynamically swapping stylesheets at runtime, see [Working with Custom Elements](/docs/advanced/working-with-custom-elements/).
+
+### Custom events with `$emit()`
+
+`FASTElement` provides a helper method called `$emit()` for dispatching custom events from your component. This method simplifies the process of creating and dispatching events by providing a convenient API for specifying event details such as the event name, detail data, and options.
+
+```ts
+import { FASTElement } from "@microsoft/fast-element";
+
+export class MyElement extends FASTElement {
+  handleClick() {
+    this.$emit("my-event", { some: "data" }, { bubbles: true, composed: true });
   }
 }
 ```
 
-The full list of available lifecycle callbacks is:
-
-| Callback | Description |
-| ------------- |-------------|
-| constructor | Runs when the element is created or upgraded. `FASTElement` will attach the shadow DOM at this time. |
-| connectedCallback | Runs when the element is inserted into the DOM. On first connect, `FASTElement` hydrates the HTML template, connects template bindings, and adds the styles. |
-| disconnectedCallback | Runs when the element is removed from the DOM. `FASTElement` will remove template bindings and clean up resources at this time. |
-| `<attribute>Changed(oldVal, newVal)` | Runs any time one of the element's custom attributes changes. `FASTElement` uses this to sync the attribute with its property. When the property updates, a render update is also queued, if there was a template dependency. The naming convention is to add "Changed" to the end of the attribute name, and that is the method that will get called. |
-| adoptedCallback | Runs if the element was moved from its current `document` into a new `document` via a call to the `adoptNode(...)` API. |
+In this example, the `handleClick` method dispatches a custom event named `my-event` with a detail object containing some data. The event is configured to bubble up through the DOM and to cross the shadow DOM boundary (if applicable) by setting `bubbles: true` and `composed: true` in the options.

--- a/sites/website/src/docs/3.x/getting-started/fast-element.md
+++ b/sites/website/src/docs/3.x/getting-started/fast-element.md
@@ -87,7 +87,7 @@ import { attr, FASTElement, nullableNumberConverter } from "@microsoft/fast-elem
 
 export class MyElement extends FASTElement {
   @attr({ converter: nullableNumberConverter })
-  count?: number;
+  count?: number | null;
 }
 ```
 
@@ -222,7 +222,7 @@ In this example, `MyElement.define()` registers the custom element with the name
 
 #### Definition Extensions
 
-`define()` accepts an optional second argument — an array of extension callbacks. Each extension is a function that receives the resolved `FASTElementDefinition` and is called **before** the element is registered with `customElements.define()`. This enables a plugin pattern for hooking into element registration.
+`define()` accepts an array of extension callbacks as an optional second argument. Each extension is a function that receives the resolved `FASTElementDefinition` and is called **before** the element is registered with `customElements.define()`. This enables a plugin pattern for hooking into element registration.
 
 ```ts
 import type { FASTElementExtension } from "@microsoft/fast-element";
@@ -286,3 +286,7 @@ export class MyElement extends FASTElement {
 ```
 
 In this example, the `handleClick` method dispatches a custom event named `my-event` with a detail object containing some data. The event is configured to bubble up through the DOM and to cross the shadow DOM boundary (if applicable) by setting `bubbles: true` and `composed: true` in the options.
+
+:::note
+`$emit()` only dispatches when the element is connected. Like the pre-connect lifecycle guidance above, this means a `$emit()` call during the parse-time window before the controller has connected is a no-op. If you need to emit an event in response to an early property change, guard on `this.$fastController.isConnected` and defer the dispatch until after the element has connected.
+:::

--- a/sites/website/src/docs/3.x/getting-started/fast-element.md
+++ b/sites/website/src/docs/3.x/getting-started/fast-element.md
@@ -91,7 +91,7 @@ export class MyElement extends FASTElement {
 }
 ```
 
-This converter will convert the attribute value to a number when reading from the DOM, and convert the value back to a string when writing to the DOM. If the attribute is not present or cannot be converted to a number, the property will be set to `undefined`. Likewise, if the property is set to `undefined`, `null`, or `NaN`, the attribute will be removed from the DOM.
+This converter will convert the attribute value to a number when reading from the DOM, and convert the value back to a string when writing to the DOM. If the attribute is not present or cannot be converted to a number, the property will be set to `null`. Likewise, if the property is set to `undefined`, `null`, or `NaN`, the attribute will be removed from the DOM.
 
 :::tip
 Properties decorated with `@attr({ mode: "boolean" })` automatically utilize the `booleanConverter` converter, which treats the presence of the attribute as `true` and its absence as `false`.
@@ -269,7 +269,7 @@ protected disabledChanged() {
 }
 ```
 
-For other uses of the controller, such as dynamically swapping stylesheets at runtime, see [Working with Custom Elements](/docs/advanced/working-with-custom-elements/).
+For other uses of the controller, such as dynamically swapping stylesheets at runtime, see [Working with Custom Elements](../../advanced/working-with-custom-elements/).
 
 ### Custom events with `$emit()`
 

--- a/sites/website/src/docs/3.x/getting-started/html-directives.md
+++ b/sites/website/src/docs/3.x/getting-started/html-directives.md
@@ -28,7 +28,7 @@ Rendering directives control what renders based on conditions or data. FAST Elem
 
 ### The `repeat` Directive
 
-The `repeat()` directive renders a list of items from an array, using a template to render each one. It accepts the array and an item template, plus an optional configuration object.
+The `repeat()` directive renders a list of items from an array, using a template to render each one. It accepts an expression which returns an array, an item template, and an optional configuration object.
 
 For a simple array, the item template renders each entry directly. Within the item template, the source (`x`) is the current item rather than the host component, so typing the template with `html<string>` makes `x` a `string`:
 
@@ -213,24 +213,12 @@ In the following example, the `ref()` directive maps the `<video>` element to th
 import { attr, FASTElement, html, observable, ref } from '@microsoft/fast-element';
 
 class MP4Player extends FASTElement {
-  /**
-   * The `src` attribute on the `<mp4-player>` element is
-   * mapped to this property using the `@attr` decorator.
-   */
   @attr
   src?: string;
 
-  /**
-   * The `<video>` element in the template is mapped to
-   * this property using the `ref()` directive.
-   */
   @observable
   video?: HTMLVideoElement;
 
-  /**
-   * The `videoChanged()` method is called whenever the `video` property changes.
-   * In this case, we want to play the video when it is assigned.
-   */
   videoChanged(_prev?: HTMLVideoElement, next?: HTMLVideoElement) {
     next?.play();
   }
@@ -258,15 +246,9 @@ The `slotted()` directive references the elements assigned to a `<slot>` in your
 import { FASTElement, html, observable, slotted } from '@microsoft/fast-element';
 
 class SlottedExample extends FASTElement {
-  /**
-   * The `slottedElements` property is an array of elements that are assigned to the `<slot>` in the template. The `@observable` decorator allows us to react to changes in this property.
-   */
   @observable
   slottedElements!: HTMLElement[];
 
-  /**
-   * The `slottedElementsChanged()` method is called whenever the collection assigned to the `slottedElements` property changes. In this case, we log the old and new values to the console.
-   */
   slottedElementsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]) {
     console.log("The collection of slotted elements has changed:", oldValue, newValue);
   }
@@ -288,7 +270,7 @@ In the example above, the `slotted("slottedElements")` directive creates a refer
 
 #### Filtering Slotted Elements
 
-The `slotted()` directive also accepts an optional configuration object to filter the assigned elements by tag name or CSS selector, so only matching element types reach the property:
+The `slotted()` directive also accepts an optional configuration object to filter the assigned elements by tag name or CSS selector, so only matching assigned nodes reach the property:
 
 ```ts
 import { elements, html, slotted } from "@microsoft/fast-element";

--- a/sites/website/src/docs/3.x/getting-started/html-directives.md
+++ b/sites/website/src/docs/3.x/getting-started/html-directives.md
@@ -228,7 +228,7 @@ class MP4Player extends FASTElement {
   video?: HTMLVideoElement;
 
   /**
-   * The `videoChanged()` method is called whenever the `video` property changes.\
+   * The `videoChanged()` method is called whenever the `video` property changes.
    * In this case, we want to play the video when it is assigned.
    */
   videoChanged(_prev?: HTMLVideoElement, next?: HTMLVideoElement) {

--- a/sites/website/src/docs/3.x/getting-started/html-directives.md
+++ b/sites/website/src/docs/3.x/getting-started/html-directives.md
@@ -322,7 +322,7 @@ const template = html<SlottedExample>`
 
 ### The `children` Directive
 
-The `children()` directive references the child elements of an element in your component's shadow DOM, so you can work with them from the component class.
+The `children()` directive references the child nodes of an element in your component's shadow DOM, so you can work with them from the component class.
 
 ```ts
 import { children, FASTElement, html, observable } from '@microsoft/fast-element';
@@ -337,10 +337,10 @@ const template = html<ChildrenExample>`
 
 class ChildrenExample extends FASTElement {
   @observable
-  listItems!: HTMLLIElement[];
+  listItems!: Node[];
 
-  listItemsChanged(oldValue: HTMLLIElement[], newValue: HTMLLIElement[]) {
-    console.log("The collection of child <li> elements has changed:", oldValue, newValue);
+  listItemsChanged(oldValue: Node[], newValue: Node[]) {
+    console.log("The collection of child nodes has changed:", oldValue, newValue);
   }
 
   connectedCallback() {
@@ -356,7 +356,7 @@ ChildrenExample.define({
 });
 ```
 
-In the example above, the `children("listItems")` directive creates a reference to the child `<li>` elements of the `<ul>` and maps them to the `listItems` property on the `ChildrenExample` class. The `listItemsChanged` method is called whenever the collection of child elements changes.
+In the example above, the `children("listItems")` directive creates a reference to the child nodes of the `<ul>` and maps them to the `listItems` property on the `ChildrenExample` class. The `listItemsChanged` method is called whenever the collection of child nodes changes.
 
 The `children()` directive works well with `repeat()` for dynamic lists: render the children with `repeat()`, then reference them through `children()`:
 
@@ -384,10 +384,10 @@ class TaskList extends FASTElement {
   ];
 
   @observable
-  listItems!: HTMLLIElement[];
+  listItems!: Node[];
 
   listItemsChanged() {
-    console.log(`The list now renders ${this.listItems.length} items.`);
+    console.log(`The list now renders ${this.listItems.length} nodes.`);
   }
 }
 
@@ -401,7 +401,7 @@ Here `repeat()` owns the rendering: it creates and updates the `<li>` elements a
 
 #### Filtering Child Elements
 
-Like `slotted()`, the `children()` directive accepts a configuration object in place of a property name. By default it observes every child node, including the text and comment nodes between elements. Add a `filter` to narrow the collection. The `elements()` filter keeps only element nodes, or only the elements that match a selector when you pass one:
+Like `slotted()`, the `children()` directive accepts a configuration object in place of a property name. By default, the directive observes every child node, including the text and comment nodes between elements. Add a `filter` to narrow the collection. The `elements()` filter keeps only element nodes, or only the elements that match a selector when you pass one:
 
 ```ts
 import { children, elements, html } from "@microsoft/fast-element";

--- a/sites/website/src/docs/3.x/getting-started/html-directives.md
+++ b/sites/website/src/docs/3.x/getting-started/html-directives.md
@@ -20,34 +20,229 @@ keywords:
 
 # HTML Directives
 
-FAST provides directives to aide in solving some common scenarios.
+When working with a custom element's shadow DOM, you often need references to structural pieces within the template. FAST Element provides directives that reference and manipulate elements in the template and control rendering based on conditions or data.
 
-## ref
+## Rendering Directives
 
-Sometimes you need a direct reference to a single DOM node from your template. This might be because you need the rendered dimensions of the node, you want to control the playback of a `video` element, use the drawing context of a `canvas` element, or pass an element to a 3rd party library. Whatever the reason, you can get a reference to the DOM node by using the `ref` directive.
+Rendering directives control what renders based on conditions or data. FAST Element provides two: `repeat` and `when`.
 
-**Example: Referencing an Element**
+### The `repeat` Directive
+
+The `repeat()` directive renders a list of items from an array, using a template to render each one. It accepts the array and an item template, plus an optional configuration object.
+
+For a simple array, the item template renders each entry directly. Within the item template, the source (`x`) is the current item rather than the host component, so typing the template with `html<string>` makes `x` a `string`:
 
 ```ts
-import { attr, FASTElement, html, ref } from '@microsoft/fast-element';
+import { FASTElement, html, observable, repeat } from '@microsoft/fast-element';
 
-const template = html<MP4Player>`
-  <video ${ref('video')}>
-    <source src=${x => x.src} type="video/mp4">
-  </video>
+const template = html<TagList>`
+  <ul>
+    ${repeat(x => x.tags, html<string>`
+      <li>${x => x}</li>
+    `)}
+  </ul>
 `;
 
-export class MP4Player extends FASTElement {
-  @attr
-  src: string;
+class TagList extends FASTElement {
+  @observable
+  tags: string[] = ["new", "featured", "sale"];
+}
 
-  video: HTMLVideoElement;
+TagList.define({
+  name: "tag-list",
+  template,
+});
+```
 
-  connectedCallback() {
-    super.connectedCallback();
-    this.video.play();
+The same pattern works for arrays of objects. Typing the item template with the item's type gives type-checked access to its properties:
+
+```ts
+import { FASTElement, html, observable, repeat } from '@microsoft/fast-element';
+
+interface Friend {
+  name: string;
+  age: number;
+}
+
+const template = html<FriendList>`
+  <ul>
+    ${repeat(x => x.friends, html<Friend>`
+      <li>${x => x.name} is ${x => x.age} years old.</li>
+    `)}
+  </ul>
+`;
+
+class FriendList extends FASTElement {
+  @observable
+  friends: Friend[] = [
+    { name: "Alice", age: 30 },
+    { name: "Bob", age: 25 },
+  ];
+}
+
+FriendList.define({
+  name: "friend-list",
+  template,
+});
+```
+
+Here `html<Friend>` makes `x` a `Friend`, so references like `x.name` and `x.age` are type-checked.
+
+#### Accessing the Parent Scope
+
+Within an item template's expressions, the source (`x`) is the current item, so it has no direct reference to the component the `repeat()` is declared in. The execution context (`c`) provides that reference: `c.parent` is the source the directive is bound to, and `c.parentContext` is that source's execution context. For a top-level `repeat()`, `c.parent` is the host component, so an item template can access the host's properties and methods.
+
+Typing the item template with `html<Friend, FriendList>` gives `c.parent` the host's type, so member access like `c.parent.removeFriend(x)` is type-checked:
+
+```ts
+import { FASTElement, html, observable, repeat } from '@microsoft/fast-element';
+
+interface Friend {
+  name: string;
+}
+
+const template = html<FriendList>`
+  <ul>
+    ${repeat(x => x.friends, html<Friend, FriendList>`
+      <li>
+        ${x => x.name}
+        <button @click=${(x, c) => c.parent.removeFriend(x)}>Remove</button>
+      </li>
+    `)}
+  </ul>
+`;
+
+class FriendList extends FASTElement {
+  @observable
+  friends: Friend[] = [{ name: "Alice" }, { name: "Bob" }];
+
+  removeFriend(friend: Friend) {
+    this.friends = this.friends.filter(f => f !== friend);
   }
 }
+
+FriendList.define({
+  name: "friend-list",
+  template,
+});
+```
+
+Here `c.parent` is the `FriendList` instance, so each item's button can call the `removeFriend()` method. When `repeat()` directives are nested, `c.parent` is the item from the enclosing `repeat()` and `c.parentContext` is its execution context, so an item template can reach the scopes that surround it.
+
+#### Positioning
+
+By default, an item template has access to its item but not its position in the list. To use position-dependent values, pass a configuration object as the third argument with the `positioning` property set to `true`. This adds `index` and `length` to the execution context, along with the derived `isFirst`, `isLast`, `isEven`, `isOdd`, and `isInMiddle` properties.
+
+```ts
+const template = html<FriendList>`
+  <ol>
+    ${repeat(
+      x => x.friends,
+      html<Friend>`
+        <li>${(x, c) => c.index + 1}. ${x => x.name}</li>
+      `,
+      { positioning: true }
+    )}
+  </ol>
+`;
+```
+
+Positioning is opt-in because it has a cost: when the list changes, FAST must update the context of the affected items to keep `index` and `length` current. Enable it only when an item template uses position-dependent values.
+
+#### Recycling Views
+
+When the list changes, `repeat()` reuses existing item views by default rather than creating new ones, which avoids unnecessary allocation. A reused view keeps the DOM from the item it previously displayed, then re-binds it to the new item. Any transient state that a binding does not control, such as scroll position or focus, can carry over.
+
+To give each item a fresh view instead, set `recycle: false`:
+
+```ts
+const template = html<FriendList>`
+  <ol>
+    ${repeat(
+      x => x.friends,
+      html<Friend>`
+        <li>${x => x.name}</li>
+      `,
+      { recycle: false }
+    )}
+  </ol>
+`;
+```
+
+Disabling recycling avoids stale state at the cost of recreating views, so reserve it for cases where reused DOM causes problems.
+
+### The `when` Directive
+
+The `when()` directive conditionally renders elements. It accepts a predicate function, a template to render when the predicate is true, and an optional template to render when it is false.
+
+```ts
+import { FASTElement, html, observable, when } from '@microsoft/fast-element';
+
+class WhenExample extends FASTElement {
+  @observable
+  showContent: boolean = true;
+}
+
+const template = html<WhenExample>`
+  <template>
+    ${when(
+      x => x.showContent,
+      html<WhenExample>`<span>This nested template is rendered when showContent is true.</span>`,
+      html<WhenExample>`<span>This nested template is rendered when showContent is false.</span>`,
+    )}
+  </template>
+`;
+
+WhenExample.define({
+  name: "when-example",
+  template,
+});
+```
+
+## Reference Directives
+
+Reference directives create references to elements in your template so you can manipulate them from your component's class. FAST Element provides three: `ref`, `slotted`, and `children`.
+
+### The `ref` Directive
+
+The `ref()` directive maps an element in the template to an observed property on the component class, so you can reach the element through the component instance.
+
+In the following example, the `ref()` directive maps the `<video>` element to the `video` property on the `MP4Player` class.
+
+```ts
+import { attr, FASTElement, html, observable, ref } from '@microsoft/fast-element';
+
+class MP4Player extends FASTElement {
+  /**
+   * The `src` attribute on the `<mp4-player>` element is
+   * mapped to this property using the `@attr` decorator.
+   */
+  @attr
+  src?: string;
+
+  /**
+   * The `<video>` element in the template is mapped to
+   * this property using the `ref()` directive.
+   */
+  @observable
+  video?: HTMLVideoElement;
+
+  /**
+   * The `videoChanged()` method is called whenever the `video` property changes.\
+   * In this case, we want to play the video when it is assigned.
+   */
+  videoChanged(_prev?: HTMLVideoElement, next?: HTMLVideoElement) {
+    next?.play();
+  }
+}
+
+const template = html<MP4Player>`
+  <template>
+    <video ${ref("video")}>
+      <source src="${x => x.src}" type="video/mp4">
+    </video>
+  </template>
+`;
 
 MP4Player.define({
   name: "mp4-player",
@@ -55,307 +250,195 @@ MP4Player.define({
 });
 ```
 
-Place the `ref` directive on the element you want to reference and provide it with a property name to assign the reference to. Once the `connectedCallback` lifecycle event runs, your property will be set to the reference, ready for use.
+### The `slotted` Directive
 
-:::tip
-If you provide a type for your HTML template, TypeScript will type check the property name you provide to ensure that it actually exists on your element.
-:::
-
-## slotted
-
-Sometimes you may want references to all nodes that are assigned to a particular slot. To accomplish this, use the `slotted` directive. (For more on slots, see [Working with Shadow DOM](/docs/advanced/working-with-custom-elements.md).)
+The `slotted()` directive references the elements assigned to a `<slot>` in your component's shadow DOM, so you can work with slotted content from the component class.
 
 ```ts
-import { FASTElement, html, slotted } from '@microsoft/fast-element';
+import { FASTElement, html, observable, slotted } from '@microsoft/fast-element';
 
-const template = html<MyElement>`
-  <div>
-    <slot ${slotted('slottedNodes')}></slot>
-  </div>
-`;
-
-export class MyElement extends FASTElement {
+class SlottedExample extends FASTElement {
+  /**
+   * The `slottedElements` property is an array of elements that are assigned to the `<slot>` in the template. The `@observable` decorator allows us to react to changes in this property.
+   */
   @observable
-  slottedNodes: Node[];
+  slottedElements!: HTMLElement[];
 
-  slottedNodesChanged() {
-    // respond to changes in slotted node
+  /**
+   * The `slottedElementsChanged()` method is called whenever the collection assigned to the `slottedElements` property changes. In this case, we log the old and new values to the console.
+   */
+  slottedElementsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]) {
+    console.log("The collection of slotted elements has changed:", oldValue, newValue);
   }
 }
-MyElement.define({
-  name: 'my-element',
+
+const template = html<SlottedExample>`
+  <template>
+    <slot ${slotted("slottedElements")}></slot>
+  </template>
+`;
+
+SlottedExample.define({
+  name: "slotted-example",
   template
 });
 ```
 
-Similar to the `children` directive, the `slotted` directive will populate the `slottedNodes` property with nodes assigned to the slot. If `slottedNodes` is decorated with `@observable` then it will be updated dynamically as the assigned nodes change. Like any observable, you can optionally implement a *propertyName*Changed method to be notified when the nodes change. Additionally, you can provide an `options` object to the `slotted` directive to specify a customized configuration for the underlying [assignedNodes() API call](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes) or specify a `filter`.
+In the example above, the `slotted("slottedElements")` directive creates a reference to the elements assigned to the `<slot>` and maps them to the `slottedElements` property on the `SlottedExample` class. The `slottedElementsChanged` method is called whenever the collection of slotted elements changes.
 
-:::tip
-It's best to leverage a change handler for slotted nodes rather than assuming that the nodes will be present in the `connectedCallback`.
-:::
+#### Filtering Slotted Elements
 
-## children
-
-Besides using `ref` to reference a single DOM node, you can use `children` to get references to all child nodes of a particular element.
-
-**Example: Referencing Child Nodes**
+The `slotted()` directive also accepts an optional configuration object to filter the assigned elements by tag name or CSS selector, so only matching element types reach the property:
 
 ```ts
-import { children, FASTElement, html, repeat } from '@microsoft/fast-element';
+import { elements, html, slotted } from "@microsoft/fast-element";
 
-const template = html<FriendList>`
-  <ul ${children('listItems')}>
-    ${repeat(x => x.friends, html<string>`
-      <li>${x => x}</li>
-    `)}
-  </ul>
-`;
-
-export class FriendList extends FASTElement {
-  @observable
-  listItems: Node[];
-
-  @observable
-  friends: string[] = [];
-
-  connectedCallback() {
-    super.connectedCallback();
-    console.log(this.listItems);
-  }
-}
-
-FriendList.define({
-  name: 'friend-list',
-  template
-});
-```
-
-In the example above, the `listItems` property will be populated with all child nodes of the `ul` element. If `listItems` is decorated with `@observable` then it will be updated dynamically as the child nodes change. Like any observable, you can optionally implement a *propertyName*Changed method to be notified when the nodes change. Additionally, you can provide an `options` object to the `children` directive to specify a customized configuration for the underlying [MutationObserver](https://developer.mozilla.org/en-US/docs/Web/API/MutationObserver).
-
-:::important
-Like `ref`, the child nodes are not available until the `connectedCallback` lifecycle event.
-:::
-
-:::tip
-Using the `children` directive on the `template` element will provide you with references to all Light DOM child nodes of your custom element, regardless of if or where they are slotted.
-:::
-
-You can also provide a `filter` function to control which child nodes are synchronized to your property. As a convenience, we provide an `elements` filter that lets you optionally specify a selector. Taking the above example, if we wanted to ensure that our `listItems` array only included `li` elements (and not any text nodes or other potential child nodes), we could author our template like this:
-
-**Example: HTML Template with Filtering Child Nodes**
-
-```ts
-const template = html<FriendList>`
-  <ul ${children({ property: 'listItems', filter: elements('li') })}>
-    ${repeat(x => x.friends, html<string>`
-      <li>${x => x}</li>
-    `)}
-  </ul>
-`;
-```
-
-If using the `subtree` option for `children` then a `selector` is *required* in place of a `filter`. This enables more efficient collection of the desired nodes in the presence of a potential large node quantity throughout the subtree.
-
-## when
-
-:::warning
-Use sparingly, this will have impacts on performance. If you find yourself using this directive a lot in a single component, consider creating multiple components instead.
-:::
-
-The `when` directive enables you to conditionally render blocks of HTML. When you provide an expression to `when` it will render the child template into the DOM when the expression evaluates to `true` and remove the child template when it evaluates to `false` (or if it is never `true`, the rendering will be skipped entirely).
-
-**Example: Conditional Rendering**
-
-```ts
-import { FASTElement, html, observable, when } from '@microsoft/fast-element';
-
-const template = html<MyApp>`
-  <h1>My App</h1>
-
-  ${when(x => !x.ready, html<MyApp>`
-    Loading...
-  `)}
-`;
-
-export class MyApp extends FASTElement {
-  @observable
-  ready: boolean = false;
-
-  @observable
-  data: any = null;
-
-  connectedCallback() {
-    super.connectedCallback();
-    this.loadData();
-  }
-
-  async loadData() {
-    const response = await fetch('some/resource');
-    const data = await response.json();
-    
-    this.data = data;
-    this.ready = true;
-  }
-}
-
-MyApp.define({
-  name: 'my-app',
-  template
-});
-```
-
-:::note
-The `@observable` decorator creates a property that the template system can watch for changes. It is similar to `@attr`, but the property is not surfaced as an HTML attribute on the element itself.
-:::
-
-In addition to providing a template to conditionally render, you can also provide an expression that evaluates to a template. This enables you to dynamically change what you are conditionally rendering.
-
-**Example: HTML Template with Conditional Rendering and Dynamic Template**
-
-```ts
-const template = html<MyApp>`
-  <h1>My App</h1>
-
-  ${when(x => x.ready, x => x.dataTemplate)}
-`;
-```
-
-## repeat
-
-:::warning
-Use sparingly, this will have impacts on performance. Instead, use slots and compose your component using multiple nested elements, slotted elements may provide more performant and more maintainable solutions. See the [FASTElement documentation](./fast-element.md) for details.
-:::
-
-To render a list of data, use the `repeat` directive, providing the list to render and a template to use in rendering each item.
-
-**Example: List Rendering**
-
-```ts
-import { FASTElement, html, observable, repeat } from '@microsoft/fast-element';
-
-const template = html<FriendList>`
-  <h1>Friends</h1>
-
-  <form @submit="${x => x.addFriend()}>"
-    <input type="text" :value="${x => x.name}" @input="${(x, c) => x.handleNameInput(c.event)}">
-    <button type="submit">Add Friend</button>
-  </form>
-  <ul>
-    ${repeat(x => x.friends, html<string>`
-      <li>${x => x}</li>
-    `)}
-  </ul>
-`;
-
-export class FriendList extends FASTElement {
-  @observable
-  friends: string[] = [];
-
-  @observable
-  name: string = '';
-
-  addFriend() {
-    if (!this.name) {
-      return;
-    }
-
-    this.friends.push(this.name);
-    this.name = '';
-  }
-
-  handleNameInput(event: Event) {
-    this.name = (event.target! as HTMLInputElement).value;
-  }
-}
-
-FriendList.define({
-  name: 'friend-list',
-  template
-})
-```
-
-Similar to event handlers, within a `repeat` block you have access to a special context object. Here is a list of the properties that are available on the context:
-
-* `event` - The event object when inside an event handler.
-* `parent` - The parent view-model when inside a `repeat` block.
-* `parentContext` - The parent `ExecutionContext` when inside a `repeat` block. This is useful when repeats are nested and the inner-most repeat needs access to the root view-model.
-* `index` - The index of the current item when inside a `repeat` block (opt-in).
-* `length` - The length of the array when inside a `repeat` block (opt-in).
-* `isEven` - True if the index of the current item is even when inside a `repeat` block (opt-in).
-* `isOdd` - True if the index of the current item is odd when inside a `repeat` block (opt-in).
-* `isFirst` - True if the current item is first in the array inside a `repeat` block (opt-in).
-* `isInMiddle` - True if the current item is somewhere in the middle of the array inside a `repeat` block (opt-in).
-* `isLast` - True if the current item is last in the array inside a `repeat` block (opt-in).
-
-Some context properties are opt-in because they are more costly to update. So, for performance reasons, they are not available by default. To opt into the positioning properties, pass options to the repeat directive, with the setting `positioning: true`. For example, here's how we would use the `index` in our friends template from above:
-
-**Example: HTMLTemplate with List Rendering and Item Index**
-
-```ts
-const template = html<FriendList>`
-  <ul>
-    ${repeat(x => x.friends, html<string>`
-      <li>${(x, c) => c.index} ${x => x}</li>
-    `, { positioning: true })}
-  </ul>
-`;
-```
-
-Whether or not a repeat directive re-uses item views can be controlled with the `recycle` option setting. When `recycle: true`, which is the default value, the repeat directive may reuse views rather than create new ones from the template.  When `recycle: false` 
-previously used views are always discarded and each item will always be assigned a new view. Recyling previously used views may improve performance in some situations but may also be "dirty" from the previously displayed item.
-
-**Example: HTML Template with List Rendering and without view recycling**
-
-```ts
-const template = html<FriendList>`
-  <ul>
-    ${repeat(
-      x => x.friends,
-      html<string>`<li>${(x, c) => c.index} ${x => x}</li>`,
-      { positioning: true, recycle: false }
-    )}
-  </ul>
-`;
-```
-
-In addition to providing a template to render the items with, you can also provide an expression that evaluates to a template. This enables you to dynamically change what you are using to render the items.
-
-## Host directives
-
-So far, our bindings and directives have only affected elements within the Shadow DOM of the component. However, sometimes you want to affect the host element itself, based on property state. For example, a progress component might want to write various `aria` attributes to the host, based on the progress state. In order to facilitate scenarios like this, you can use a `template` element as the root of your template, and it will represent the host element. Any attribute or directive you place on the `template` element will be applied to the host itself.
-
-**Example: Host Directive Template**
-
-```ts
-const template = html<MyProgress>`
-  <template (Represents my-progress element)
-      role="progressbar"
-      aria-valuenow=${x => x.value}
-      aria-valuemin=${x => x.min}
-      aria-valuemax=${x => x.max}>
-    (template targeted at Shadow DOM here)
+const template = html<SlottedExample>`
+  <template>
+    <slot ${slotted({
+      property: "slottedElements",
+      filter: elements("div")
+    })}></slot>
   </template>
 `;
 ```
 
-**Example: DOM with Host Directive Output**
+#### Flattening
 
-```html
-<my-progress
-    min="0"              (from user)
-    max="100"            (from user)
-    value="50"           (from user)
-    role="progressbar"   (from host directive)
-    aria-valuenow="50"   (from host directive)
-    aria-valuemin="0"    (from host directive)
-    aria-valuemax="100"  (from host directive)>
-</my-progress>
+The configuration object also accepts a `flatten` option. By default, `slotted()` references the nodes directly assigned to the slot. Setting `flatten: true` references the slot's flattened assigned nodes instead, resolving any nested slots to their distributed content and falling back to the slot's default content when nothing is assigned. The option is passed through to the underlying [`assignedNodes()`](https://developer.mozilla.org/en-US/docs/Web/API/HTMLSlotElement/assignedNodes) call.
+
+```ts
+import { html, slotted } from "@microsoft/fast-element";
+
+const template = html<SlottedExample>`
+  <template>
+    <slot ${slotted({
+      property: "slottedElements",
+      flatten: true
+    })}></slot>
+  </template>
+`;
 ```
 
-:::tip
-Using the `children` directive on the `template` element will provide you with references to all Light DOM child nodes of your custom element, regardless of if or where they are slotted.
-:::
+### The `children` Directive
 
-:::note
-If the same attributes are defined by the host directive and the user (in the above example role="progressbar"), then the attribute set by the user will take precedence.
-:::
+The `children()` directive references the child elements of an element in your component's shadow DOM, so you can work with them from the component class.
+
+```ts
+import { children, FASTElement, html, observable } from '@microsoft/fast-element';
+
+const template = html<ChildrenExample>`
+  <ul ${children("listItems")}>
+    <li>Item 1</li>
+    <li>Item 2</li>
+    <li>Item 3</li>
+  </ul>
+`;
+
+class ChildrenExample extends FASTElement {
+  @observable
+  listItems!: HTMLLIElement[];
+
+  listItemsChanged(oldValue: HTMLLIElement[], newValue: HTMLLIElement[]) {
+    console.log("The collection of child <li> elements has changed:", oldValue, newValue);
+  }
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    console.log(this.listItems);
+  }
+}
+
+ChildrenExample.define({
+  name: "children-example",
+  template
+});
+```
+
+In the example above, the `children("listItems")` directive creates a reference to the child `<li>` elements of the `<ul>` and maps them to the `listItems` property on the `ChildrenExample` class. The `listItemsChanged` method is called whenever the collection of child elements changes.
+
+The `children()` directive works well with `repeat()` for dynamic lists: render the children with `repeat()`, then reference them through `children()`:
+
+```ts
+import { children, FASTElement, html, observable, repeat } from '@microsoft/fast-element';
+
+interface Task {
+  id: number;
+  label: string;
+}
+
+const template = html<TaskList>`
+  <ul ${children("listItems")}>
+    ${repeat(x => x.tasks, html<Task>`
+      <li>${x => x.label}</li>
+    `)}
+  </ul>
+`;
+
+class TaskList extends FASTElement {
+  @observable
+  tasks: Task[] = [
+    { id: 1, label: "Write docs" },
+    { id: 2, label: "Review PR" },
+  ];
+
+  @observable
+  listItems!: HTMLLIElement[];
+
+  listItemsChanged() {
+    console.log(`The list now renders ${this.listItems.length} items.`);
+  }
+}
+
+TaskList.define({
+  name: "task-list",
+  template,
+});
+```
+
+Here `repeat()` owns the rendering: it creates and updates the `<li>` elements as the `tasks` array changes. The `children("listItems")` directive observes the same `<ul>` and keeps `listItems` in sync with whatever `repeat()` produces. Each time the rendered set of children changes, `listItemsChanged` runs with the current collection. This lets one directive drive the DOM while the other gives the component a live reference to the result.
+
+#### Filtering Child Elements
+
+Like `slotted()`, the `children()` directive accepts a configuration object in place of a property name. By default it observes every child node, including the text and comment nodes between elements. Add a `filter` to narrow the collection. The `elements()` filter keeps only element nodes, or only the elements that match a selector when you pass one:
+
+```ts
+import { children, elements, html } from "@microsoft/fast-element";
+
+const template = html<Menu>`
+  <div role="menu" ${children({
+    property: "menuItems",
+    filter: elements("[role=menuitem]")
+  })}>
+    <div role="menuitem">New</div>
+    <div role="menuitem">Open</div>
+    <div role="separator"></div>
+  </div>
+`;
+```
+
+In this example, `menuItems` is populated only with the children that match `[role=menuitem]`, and the separator is ignored.
+
+#### Observing the Subtree
+
+By default, `children()` observes only the direct children of the element it is placed on. To observe deeper descendants as well, set `subtree: true`. In subtree mode a `selector` is required, because a subtree can contain many unrelated nodes and the selector indicates which of them to assign to the property.
+
+```ts
+import { children, html } from "@microsoft/fast-element";
+
+const template = html<TreeView>`
+  <div role="tree" ${children({
+    property: "treeItems",
+    subtree: true,
+    selector: "[role=treeitem]"
+  })}>
+    <div role="group">
+      <div role="treeitem">Item 1</div>
+      <div role="treeitem">Item 2</div>
+    </div>
+  </div>
+`;
+```
+
+With `subtree: true` and a `selector` in place, `treeItems` is populated with every matching `[role=treeitem]` descendant at any depth, and updated whenever the matching set changes. In direct-child mode the `filter` option decides which children to keep; in subtree mode the `selector` takes over that role and matches descendants throughout the tree.

--- a/sites/website/src/docs/3.x/getting-started/html-directives.md
+++ b/sites/website/src/docs/3.x/getting-started/html-directives.md
@@ -205,7 +205,11 @@ Reference directives create references to elements in your template so you can m
 
 ### The `ref` Directive
 
-The `ref()` directive maps an element in the template to an observed property on the component class, so you can reach the element through the component instance.
+The `ref()` directive assigns a template element to a property on the component class, so you can reach it through the component instance.
+
+:::tip
+FAST populates the property while binding the view, which the `FASTElement` base class does as part of connecting the element. The property is assigned synchronously during the `super.connectedCallback()` call, and may not be available until after the binding has run. Decorating the property with `@observable` and responding in its change callback is a reliable way to act on the element the moment it becomes available. Without the decorator, the property will still hold the reference once binding has run, but you won't be notified when that happens.
+:::
 
 In the following example, the `ref()` directive maps the `<video>` element to the `video` property on the `MP4Player` class.
 
@@ -247,16 +251,16 @@ import { FASTElement, html, observable, slotted } from '@microsoft/fast-element'
 
 class SlottedExample extends FASTElement {
   @observable
-  slottedElements!: HTMLElement[];
+  slottedNodes!: Node[];
 
-  slottedElementsChanged(oldValue: HTMLElement[], newValue: HTMLElement[]) {
+  slottedNodesChanged(oldValue: Node[], newValue: Node[]) {
     console.log("The collection of slotted elements has changed:", oldValue, newValue);
   }
 }
 
 const template = html<SlottedExample>`
   <template>
-    <slot ${slotted("slottedElements")}></slot>
+    <slot ${slotted("slottedNodes")}></slot>
   </template>
 `;
 
@@ -266,7 +270,7 @@ SlottedExample.define({
 });
 ```
 
-In the example above, the `slotted("slottedElements")` directive creates a reference to the elements assigned to the `<slot>` and maps them to the `slottedElements` property on the `SlottedExample` class. The `slottedElementsChanged` method is called whenever the collection of slotted elements changes.
+In the example above, the `slotted("slottedNodes")` directive creates a reference to the elements assigned to the `<slot>` and maps them to the `slottedNodes` property on the `SlottedExample` class. The `slottedNodesChanged` method is called whenever the collection of slotted elements changes.
 
 #### Filtering Slotted Elements
 

--- a/sites/website/src/docs/3.x/getting-started/html-templates.md
+++ b/sites/website/src/docs/3.x/getting-started/html-templates.md
@@ -232,20 +232,24 @@ When rendered, the host element receives the `role` attribute:
 
 FAST applies this attribute to the host as a one-time binding when the template binds, during the element's connection. If the host already carries the attribute, for example because the consumer set it in markup, the template value overwrites it. The binding runs once, so attribute changes the consumer makes after connection are left in place.
 
-All of the bindings described in [Template Bindings](#template-bindings) (content, attribute, boolean attribute, property, and event) work on the `<template>` root. For example, a progress bar can mirror its state to ARIA attributes on the host:
+Static attributes, attribute value bindings, property bindings, and event bindings can all be applied to the host through the `<template>` root:
 
 ```ts
 const template = html<ProgressBar>`
   <template
     role="progressbar"
-    aria-valuenow="${x => x.value}"
     aria-valuemin="${x => x.min}"
     aria-valuemax="${x => x.max}"
+    aria-valuenow="${x => x.value}"
   >
     ...
   </template>
 `;
 ```
+
+:::note
+While technically supported, property bindings (`:property="${x => x.prop}"`) on the `<template>` root are rarely meaningful. The `<template>` root is the host, which is the component instance itself, so a property binding would write back to the component's own property. Deriving host properties with `@attr` or a computed `@observable` is a more common pattern than binding directly to the host property via the template.
+:::
 
 ### Event Bindings on the Host
 

--- a/sites/website/src/docs/3.x/getting-started/html-templates.md
+++ b/sites/website/src/docs/3.x/getting-started/html-templates.md
@@ -79,7 +79,7 @@ Dynamic content is set via the `textContent` HTML property for security reasons.
 
 ### Content Bindings
 
-Content bindings are used to insert dynamic text or HTML content into the template. They are denoted by `${...}` interpolation, with an arrow function as the expression. FAST invokes the function with the current source (typically the component instance) and uses its return value as the bound content. Because the binding is a function, FAST can re-invoke it whenever an observable property it reads from changes.
+Content bindings are used to insert dynamic content into the template. They are denoted by `${...}` interpolation, with an arrow function as the expression. FAST invokes the function with the current source (typically the component instance) and uses its return value as the bound content. Because the binding is a function, FAST can re-invoke it whenever an observable property it reads from changes.
 
 ```ts
 import { FASTElement, html, observable } from "@microsoft/fast-element";

--- a/sites/website/src/docs/3.x/getting-started/html-templates.md
+++ b/sites/website/src/docs/3.x/getting-started/html-templates.md
@@ -230,7 +230,7 @@ When rendered, the host element receives the `role` attribute:
 </my-element>
 ```
 
-If the consumer of the component sets the same attribute on the host directly, the consumer's value takes precedence over the value defined in the template.
+FAST applies this attribute to the host as a one-time binding when the template binds, during the element's connection. If the host already carries the attribute, for example because the consumer set it in markup, the template value overwrites it. The binding runs once, so attribute changes the consumer makes after connection are left in place.
 
 All of the bindings described in [Template Bindings](#template-bindings) (content, attribute, boolean attribute, property, and event) work on the `<template>` root. For example, a progress bar can mirror its state to ARIA attributes on the host:
 

--- a/sites/website/src/docs/3.x/getting-started/html-templates.md
+++ b/sites/website/src/docs/3.x/getting-started/html-templates.md
@@ -74,7 +74,7 @@ A non-function value passed to `${...}` is treated as a one-time static value an
 :::
 
 :::important
-Dynamic content is set via the `textContent` HTML property for security reasons. You *cannot* set HTML content this way. See the [Property bindings](#property-bindings) section for the explicit, opt-in mechanism for setting HTML via `:innerHTML`, which is blocked by the default DOMPolicy unless you configure an `innerHTML` guard. Follow the [DOMPolicy and Trusted Types guide](../advanced/dom-policy-and-trusted-types/) before rendering sanitized HTML.
+Dynamic content is set via the `textContent` HTML property for security reasons. You *cannot* set HTML content this way. See the [Property bindings](#property-bindings) section for the explicit, opt-in mechanism for setting HTML via `:innerHTML`, which is blocked by the default DOMPolicy unless you configure an `innerHTML` guard. Follow the [DOMPolicy and Trusted Types guide](../../advanced/dom-policy-and-trusted-types/) before rendering sanitized HTML.
 :::
 
 ### Content Bindings

--- a/sites/website/src/docs/3.x/getting-started/html-templates.md
+++ b/sites/website/src/docs/3.x/getting-started/html-templates.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   key: html-templates3x
   parent: getting-started3x
   title: HTML Templates
+  order: 3
 navigationOptions:
   activeKey: html-templates3x
 keywords:
@@ -16,134 +17,263 @@ keywords:
 
 # HTML Templates
 
-The `@microsoft/fast-element` module offers a named export `html` which is a [tag template literal](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Template_literals). It can be used to create HTML snippets which will become your web components shadow DOM.
+Custom elements typically build their shadow DOM either imperatively, by calling DOM APIs such as `appendChild()`, or by cloning a `<template>` element. FAST provides a tagged template function called `html`, which lets you describe the structure of a component's view declaratively in JavaScript and bind it to the component's state.
 
-**Example:**
-```typescript
-import { html } from "@microsoft/fast-element";
+Templates created with `html` are reactive. When an expression interpolated into the template reads from an observable property, FAST's observation system subscribes to that property and updates the corresponding part of the DOM whenever the value changes. Properties become observable through `@attr`, `@observable`, or the lower-level [`Observable`](../../getting-started/fast-element/#manually-tracking-observables) APIs. A template is associated with a component through the `template` option passed to [`define()`](../../getting-started/fast-element/#defining-the-element).
 
-export const template = html`
-  <template>Hello world</template>
-`;
-```
+This document describes how to author templates with the `html` function, including bindings for content, attributes, properties, and events, and how to type templates for use with TypeScript.
 
-## Binding
+:::tip
+For server-side rendering, see the [declarative templates](../../declarative-templates/overview/) documentation, which describes an alternate authoring format and the [`observerMap()`](../../declarative-templates/defining-elements/#observermap) extension for making schema-derived properties observable.
+:::
 
-When working with the `html` template, bindings allow more complex behavior than simply passing attributes. These bindings are dynamic and are denoted by the [arrow function](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Functions/Arrow_functions). By default attributes are assumed to be strings. We typically denote `x` for the element, and `c` for the context.
+## Template Basics
 
-**Example:**
+The `html` function is a tagged template literal that takes a template string and returns a `ViewTemplate` object that can be used as the `template` option when defining a component. The template string can contain any valid HTML.
+
 ```ts
-import { attr, FASTElement, html } from '@microsoft/fast-element';
+import { FASTElement, html } from "@microsoft/fast-element";
 
-const template = html<NameTag>`
-  <h3>${x => x.greeting.toUpperCase()}</h3>
+class HelloWorld extends FASTElement {}
+
+const template = html<HelloWorld>`
+  <span>Hello World!</span>
 `;
 
-export class NameTag extends FASTElement {
-  @attr
-  greeting: string = 'hello';
-}
-
-NameTag.define({
-  name: 'name-tag',
-  template
+HelloWorld.define({
+  name: "hello-world",
+  template,
 });
 ```
 
-When the greeting attribute is updated, so will the template.
-
-### Content
-
-To bind the content of an element, simply provide the expression within the start and end tags of the element. It can be the sole content of the element or interwoven with other elements and text.
-
-**Example: Basic Text Content**
+The example above creates a basic template that renders a `<span>` with the text "Hello World!" into the component's shadow DOM. When a `<hello-world>` element is used in HTML, the browser produces the following structure:
 
 ```html
-<h3>${x => x.greeting.toUpperCase()}</h3>
+<hello-world>
+  #shadow-root
+    <span>Hello World!</span>
+</hello-world>
 ```
 
-**Example: Interpolated Text Content**
+## Template Bindings
 
-```html
-<h3>${x => x.greeting}, my name is ${x => x.name}.</h3>
-```
+The `html` function supports several types of bindings for interpolating dynamic content from the component class into the template. These include content bindings, attribute bindings, property bindings, and event bindings. Each type of binding has a specific syntax for indicating how the value should be applied to the DOM.
 
-**Example: Heterogeneous Content**
+### Binding Expressions
 
-```html
-<h3>
-  ${x => x.greeting}, my name is
-  <span class="name">${x => x.name}</span>.
-</h3>
+Binding expressions are arrow functions of the form `(source, context) => value`. The `source` argument is the data source the template is bound to, which for component templates is the component instance. The `context` argument is an `ExecutionContext` object, whose contents vary depending on where the binding appears in the template. By convention, these arguments are named `x` and `c` respectively, but any names may be used, and the `context` argument can be omitted when it is not needed.
+
+```ts
+const template = html<MyElement>`
+  <span>${(x, c) => x.format(c.index)}</span>
+`;
 ```
 
 :::note
-Dynamic content is set via the `textContent` HTML property for security reasons. You *cannot* set HTML content this way. See the [Properties binding](#properties) section for the explicit, opt-in mechanism for setting HTML via `:innerHTML`, which is blocked by the default DOMPolicy unless you configure an `innerHTML` guard. Follow the [DOMPolicy and Trusted Types guide](../advanced/dom-policy-and-trusted-types.md) before rendering sanitized HTML.
+A non-function value passed to `${...}` is treated as a one-time static value and is not re-evaluated.
 :::
-
-### Booleans
-
-Boolean bindings use the `?` symbol, use these for Boolean attributes.
-
-**Example:**
-```typescript
-import { html } from "@microsoft/fast-element";
-
-export const template = html`
-  <button
-    ?disabled="${(x) => x.disabled}"
-  >
-    Button
-  </button>
-`;
-```
-
-### Events
-
-Events bindings use the `@` symbol. All Element events are available see the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Element#events) for details.
-
-**Example:**
-```typescript
-import { html } from "@microsoft/fast-element";
-
-export const template = html`
-  <button
-    @click="${(x, c) => x.clickHandler(c.event)}"
-  >
-    Button
-  </button>
-`;
-```
 
 :::important
-After your event handler is executed, `preventDefault()` will be called on the event object by default. You can return `true` from your handler to opt-out of this behavior.
+Dynamic content is set via the `textContent` HTML property for security reasons. You *cannot* set HTML content this way. See the [Property bindings](#property-bindings) section for the explicit, opt-in mechanism for setting HTML via `:innerHTML`, which is blocked by the default DOMPolicy unless you configure an `innerHTML` guard. Follow the [DOMPolicy and Trusted Types guide](../advanced/dom-policy-and-trusted-types/) before rendering sanitized HTML.
 :::
 
-### Properties
+### Content Bindings
 
-Property bindings use the `:` symbol.
+Content bindings are used to insert dynamic text or HTML content into the template. They are denoted by `${...}` interpolation, with an arrow function as the expression. FAST invokes the function with the current source (typically the component instance) and uses its return value as the bound content. Because the binding is a function, FAST can re-invoke it whenever an observable property it reads from changes.
 
-**Example:**
-```typescript
-import { html } from "@microsoft/fast-element";
+```ts
+import { FASTElement, html, observable } from "@microsoft/fast-element";
 
-export const template = html`
-  <input
-    :value="${(x) => x.value}"
-  />
+class HelloWorld extends FASTElement {
+  @observable
+  name = "World";
+}
+
+const template = html<HelloWorld>`
+  <span>Hello ${x => x.name}!</span>
+`;
+
+HelloWorld.define({
+  name: "hello-world",
+  template,
+});
+```
+
+In the example above, the content binding `${x => x.name}` reads from the `name` property of the component instance. When the observed `name` property changes, FAST re-evaluates the expression and updates the rendered text.
+
+### Attribute Bindings
+
+Attribute bindings are used to set the value of an HTML attribute on an element. While the appearance of attribute bindings are the same as content bindings, FAST treats them differently based on their position in the template. When an interpolation appears where an attribute value is expected, FAST creates an attribute binding instead of a content binding. The value returned by the binding function is set as the value of the attribute on the element.
+
+```ts
+const template = html<MyElement>`
+  <a href="${x => x.url}">Link</a>
 `;
 ```
 
-Some complex use cases include binding to a custom property, updating that property and observing it. To learn more about observing properties, check out the [FASTElement](./fast-element.md) document.
+Whenever `url` changes, FAST updates the `href` attribute on the rendered `<a>` element. If the same expression appeared between tags, it would create a content binding instead. The position in the template determines the type of binding FAST creates.
+
+### Boolean Attribute Bindings
+
+To toggle boolean attributes, prefix the attribute name with a question mark (`?`). The value returned by the binding function is converted to a boolean, and the attribute is added or removed based on that value.
+
+```ts
+const template = html<MyElement>`
+  <div ?hidden="${x => x.collapsed}">...</div>
+`;
+```
+
+The `?hidden` binding adds the `hidden` attribute when `collapsed` is truthy and removes it when `collapsed` is falsy. Boolean attribute bindings are useful for attributes whose meaning is their presence or absence, such as `hidden`, `disabled`, and `required`, where setting `attribute="false"` would not have the intended effect.
+
+### Property Bindings
+
+Property bindings are used to set the value of a DOM property on an element within the template. They are denoted by prefixing an attribute binding with a colon (`:`). The value returned by the binding function is assigned to the corresponding property on the DOM element rather than being serialized to an HTML attribute.
+
+```ts
+const template = html<MyElement>`
+  <input type="checkbox" :indeterminate="${x => x.isIndeterminate}">
+`;
+```
+
+In the example above, the property binding `:indeterminate="${x => x.isIndeterminate}"` sets the `indeterminate` property of the `<input>` element to the boolean value returned by `x.isIndeterminate`. The `indeterminate` property has no corresponding HTML attribute and can only be set through JavaScript, so a property binding is the only way to control it from a template.
+
+Property bindings are case-sensitive. Camel-cased property names such as `:tabIndex`, `:ariaLabel`, and `:scrollTop` are preserved as written and resolved against the corresponding DOM properties.
+
+:::note
+FAST does not allow binding to `innerHTML` without first attaching a [`DOMPolicy`](../../advanced/dom-policy-and-trusted-types/) to the template, to prevent accidental injection of untrusted markup.
+:::
+
+#### Binding to `classList`
+
+`:classList` is a special property binding that targets the element's `classList`. The binding accepts a space-separated string of class names and adds them to the element. Unlike a plain `class="${...}"` attribute binding, which overwrites the entire `class` attribute on every update, `:classList` only manages the classes it added on the previous evaluation. Classes added by other code, or by other `:classList` bindings on the same element, are left untouched.
+
+```ts
+const template = html<MyElement>`
+  <div :classList="${x => x.modifierClasses}">...</div>
+`;
+```
+
+When `modifierClasses` changes from `"foo bar"` to `"baz"`, FAST removes `foo` and `bar` and adds `baz`. Any classes set on the element through other means remain in place.
+
+### Event Bindings
+
+Event bindings attach an event listener to an element within the template. They are denoted by prefixing the event name with an at symbol (`@`). When the event fires, FAST evaluates the binding expression. Unlike some frameworks, the expression is not expected to return a handler function; instead it does the work directly, typically by calling a method on the component.
+
+```ts
+import { FASTElement, html } from "@microsoft/fast-element";
+
+class MyElement extends FASTElement {
+  handleClick() {
+    console.log("Button clicked!");
+  }
+}
+
+const template = html<MyElement>`
+  <button @click="${x => x.handleClick()}">Click Me</button>
+`;
+```
+
+The `@click` binding adds a `click` listener to the `<button>`. When the button is clicked, FAST evaluates `x => x.handleClick()`, calling `handleClick` with the component instance as `x`.
+
+#### Accessing the Event
+
+The current event is available on the context argument as `c.event`. Use it when the handler needs to inspect the event itself, for example to check a modifier key:
+
+```ts
+class MyElement extends FASTElement {
+  handleClick(event: MouseEvent) {
+    if (event.shiftKey) {
+      // ...
+    }
+  }
+}
+
+const template = html<MyElement>`
+  <button @click="${(x, c) => x.handleClick(c.event as MouseEvent)}">Click Me</button>
+`;
+```
+
+`c.event` is typed as `Event`, so a cast or narrowing is needed when the handler signature requires a more specific event type.
+
+#### Preventing Default Behavior
+
+FAST automatically calls `event.preventDefault()` after the handler runs. To opt out and allow the default behavior, return `true` from the handler:
+
+```ts
+handleClick(event: MouseEvent) {
+  console.log("Button clicked!", event);
+
+  return true; // Allow default behavior
+}
+```
+
+## Host Element Bindings
+
+By default, the content of a template is rendered into the shadow DOM of the component. To apply attributes, properties, or event listeners to the host element itself, use a `<template>` element as the root of the template. The `<template>` represents the host, and any binding placed on it is applied to the host element rather than to the shadow DOM. Content placed inside the `<template>` is still rendered into the shadow DOM as usual.
+
+The simplest case is a static attribute on the host:
+
+```ts
+const template = html`
+  <template role="progressbar">
+    <span>Hello World!</span>
+  </template>
+`;
+```
+
+When rendered, the host element receives the `role` attribute:
+
+```html
+<my-element role="progressbar">
+  #shadow-root
+    <span>Hello World!</span>
+</my-element>
+```
+
+If the consumer of the component sets the same attribute on the host directly, the consumer's value takes precedence over the value defined in the template.
+
+All of the bindings described in [Template Bindings](#template-bindings) (content, attribute, boolean attribute, property, and event) work on the `<template>` root. For example, a progress bar can mirror its state to ARIA attributes on the host:
+
+```ts
+const template = html<ProgressBar>`
+  <template
+    role="progressbar"
+    aria-valuenow="${x => x.value}"
+    aria-valuemin="${x => x.min}"
+    aria-valuemax="${x => x.max}"
+  >
+    ...
+  </template>
+`;
+```
+
+### Event Bindings on the Host
+
+Event bindings on the `<template>` root attach listeners to the host element. This is a convenient place to handle events that should apply across the whole component, particularly keyboard or focus events that should be handled at the component boundary.
+
+For example, a disclosure component might listen for the Escape key on the host to collapse, regardless of which descendant currently has focus:
+
+```ts
+const template = html<MyDisclosure>`
+  <template @keydown="${(x, c) => x.handleKeydown(c.event as KeyboardEvent)}">
+    <button @click="${x => x.toggle()}">${x => x.label}</button>
+    <section ?hidden="${x => x.collapsed}">
+      <slot></slot>
+    </section>
+  </template>
+`;
+```
+
+The `@keydown` binding on the `<template>` root listens for keyboard events on the host. The handler then inspects the event and updates component state when appropriate.
 
 ## Typed Templates
 
-Your templates can be typed to the data model that they are rendering over. In TypeScript, we provide the type as part of the tag: `html<NameTag>`.
+The `html` tagged template function accepts a TypeScript type parameter that constrains the type of the `source` argument in every binding expression. For component templates, this is typically the component class:
 
 ```ts
-import { html } from '@microsoft/fast-element';
-
-const template = html<NameTag>`
-  <div>${x => x.greeting}</div>
+const template = html<MyElement>`
+  <span>${x => x.name}</span>
 `;
 ```
+
+With the type parameter in place, `x` is typed as `MyElement` and the compiler reports an error for any reference to a property that does not exist on the component. Without it, `x` falls back to `any` and binding expressions are not type-checked. Typing the template is optional but recommended for any non-trivial component, because the binding system has no way to verify property references at runtime.

--- a/sites/website/src/docs/3.x/getting-started/quick-start.md
+++ b/sites/website/src/docs/3.x/getting-started/quick-start.md
@@ -133,9 +133,17 @@ HelloWorld.define({
 Now that our custom element is defined, we can use it in our HTML like any other element. Here's the complete code for our `HelloWorld` component, along with an example of how to use it in an HTML page:
 
 ```ts
-import { attr, css, FASTElement, html } from "@microsoft/fast-element";
+import { attr } from "@microsoft/fast-element/attr.js";
+import { css } from "@microsoft/fast-element/css.js";
+import { FASTElement } from "@microsoft/fast-element/fast-element.js";
+import { html } from "@microsoft/fast-element/html.js";
 
-const template = html`
+class HelloWorld extends FASTElement {
+    @attr
+    name?: string;
+}
+
+const template = html<HelloWorld>`
     <template>
         <span>Hello ${x => x.name}!</span>
     </template>
@@ -147,14 +155,9 @@ const styles = css`
     }
 
     span {
-        color: red;
+        color: green;
     }
 `;
-
-class HelloWorld extends FASTElement {
-    @attr
-    name?: string;
-}
 
 HelloWorld.define({
     name: "hello-world",

--- a/sites/website/src/docs/3.x/getting-started/quick-start.md
+++ b/sites/website/src/docs/3.x/getting-started/quick-start.md
@@ -32,7 +32,7 @@ If you're publishing a reusable component library, you can install `@microsoft/f
 
 You may need to adjust your `tsconfig.json` to accommodate the conventions used throughout this guide. The following options are recommended:
 
-```json
+```jsonc
 {
   "compilerOptions": {
     "experimentalDecorators": true, // required for decorators (`@attr`, `@observable`, `@volatile`, etc.)

--- a/sites/website/src/docs/3.x/getting-started/quick-start.md
+++ b/sites/website/src/docs/3.x/getting-started/quick-start.md
@@ -6,6 +6,7 @@ eleventyNavigation:
   key: quick-start3x
   parent: getting-started3x
   title: Quick Start
+  order: 1
 navigationOptions:
   activeKey: quick-start3x
 keywords:
@@ -15,70 +16,160 @@ keywords:
 
 # Quick Start
 
-## Install the package
+This guide provides a quick introduction to building a web component using FAST Element. It covers the basics of installation, setup, and creating a simple custom element with a template, styles, and attributes. By the end of this guide, you'll have a working web component that displays a personalized greeting.
+
+## Installation and Setup
+
+This guide assumes you're building a browser bundle with TypeScript, via a build tool such as esbuild, Rollup, Vite, or Webpack.
+
+Install `@microsoft/fast-element` as a dependency:
 
 ```bash
 npm install --save @microsoft/fast-element
 ```
 
-## Create a web component
+If you're publishing a reusable component library, you can install `@microsoft/fast-element` as a peer dependency instead with the `--save-peer` flag.
 
-A web component created using FAST is comprised of 3 parts, the HTML template, the CSS styles, and the component logic. Web components can be as simple as a button, or as complex as a full page interactive experience.
+You may need to adjust your `tsconfig.json` to accommodate the conventions used throughout this guide. The following options are recommended:
 
-To start, let's create a simple web component that combines all the necessary parts:
-```typescript
-import { attr, css, FASTElement, html } from "@microsoft/fast-element";
+```json
+{
+  "compilerOptions": {
+    "experimentalDecorators": true, // required for decorators (`@attr`, `@observable`, `@volatile`, etc.)
+    "module": "ESNext",
+    "moduleResolution": "Bundler",
+    "target": "ES2022",
+    "useDefineForClassFields": false
+  }
+}
+```
 
-/**
- * Create an HTML template using the html tag template literal,
- * this contains interpolated text content from a passed attribute
- */
-const template = html`<span>Hello ${x => x.name}!</span>`
+:::note
+TypeScript enables `useDefineForClassFields` by default when `target` is `ES2022` or higher. FAST's property decorators (`@attr`, `@observable`, and others) rely on the older field-assignment semantics, so this option must be set to `false` explicitly. Because the default changes with the compilation target, it's an easy setting to overlook. See [microsoft/fast#5261](https://github.com/microsoft/fast/issues/5261) for the tracking discussion.
+:::
 
-/**
- * Create CSS styles using the css tag template literal
- */
+## Create a Web Component
+
+A FAST Web Component is composed of three parts: a _component class_, an _HTML template_, and a _CSS stylesheet_. Once defined, the custom element can be used on a page like any other HTML element.
+
+To start, let's create a basic element that combines all the necessary parts.
+
+### Component Class
+
+Typically, when creating a custom element in the browser, you would extend `HTMLElement` and define your element's behavior in the class body. With FAST Element, you extend `FASTElement`, which provides additional features and optimizations on top of the standard Web Component APIs.
+
+```ts
+import { FASTElement } from "@microsoft/fast-element/fast-element.js";
+
+class HelloWorld extends FASTElement {}
+```
+
+Properties on the component class can be decorated with `@attr` to create an attribute that can be set on the element in HTML. For example, to create a `name` attribute that can be used to personalize our greeting:
+
+```ts
+import { attr } from "@microsoft/fast-element/attr.js";
+import { FASTElement } from "@microsoft/fast-element/fast-element.js";
+
+class HelloWorld extends FASTElement {
+    @attr
+    name?: string;
+}
+```
+
+This decorator enables two-way syncing between the `name` property and the `name` attribute on the element. When the attribute is updated in HTML, the property will be updated in JavaScript, and vice versa.
+
+### Template
+
+Next, we can use FAST Element's `html` tagged template literal to define the structure of our component and bind dynamic content from the class:
+
+```ts
+import { html } from "@microsoft/fast-element/html.js";
+
+const template = html<HelloWorld>`
+    <template>
+        <span>Hello ${x => x.name}!</span>
+    </template>
+`;
+```
+
+The `${x => x.name}` interpolation is a function that takes the component instance (`x`) and returns the value of the `name` property. When the component is processed, this expression will be turned into a one-way binding, and the content will update whenever the element instance's `name` property changes.
+
+Additionally, by providing the type parameter `<HelloWorld>` to the `html` function, we can get better type safety and autocompletion for our component's properties within the template.
+
+### Styles
+
+Let's define some styles for our component using the `css` tagged template literal:
+
+```ts
+import { css } from "@microsoft/fast-element/css.js";
+
 const styles = css`
     :host {
-      border: 1px solid blue;
+        border: 1px solid blue;
     }
 
     span {
-      color: red;
+        color: green;
     }
 `;
+```
 
-/**
- * Define your component logic by creating a class that extends
- * the FASTElement, note the addition of the attr decorator,
- * this creates an attribute on your component which can be passed.
- */
-class HelloWorld extends FASTElement {
-  @attr
-  name: string;
-}
+Styles applied via the component definition are isolated to the element's Shadow DOM, so they won't leak out and affect other elements on the page. The `:host` selector targets the custom element itself, while the `span` selector styles the `<span>` inside our template.
 
-/**
- * Define your custom web component for the browser, as soon as the file
- * containing this logic is imported, the element "hello-world" will be
- * defined in the DOM with it's html, styles, logic, and tag name.
- */
+### Define the Custom Element
+
+Calling the `define()` method on the component class associates it with the provided tag name, template, and styles, and registers it as a custom element in the browser:
+
+```ts
 HelloWorld.define({
-  name: "hello-world",
-  template,
-  styles,
+    name: "hello-world",
+    template,
+    styles,
 });
 ```
 
-## Add it to your project
+### Use the Custom Element
 
-Now that the "hello-world" custom web component has been defined, it can be included in your HTML like so:
+Now that our custom element is defined, we can use it in our HTML like any other element. Here's the complete code for our `HelloWorld` component, along with an example of how to use it in an HTML page:
 
-```html
-<script type="module" src="path/to/hello-world.js"></script>
-<hello-world name="Earth"></hello-world>
+```ts
+import { attr, css, FASTElement, html } from "@microsoft/fast-element";
+
+const template = html`
+    <template>
+        <span>Hello ${x => x.name}!</span>
+    </template>
+`;
+
+const styles = css`
+    :host {
+        border: 1px solid blue;
+    }
+
+    span {
+        color: red;
+    }
+`;
+
+class HelloWorld extends FASTElement {
+    @attr
+    name?: string;
+}
+
+HelloWorld.define({
+    name: "hello-world",
+    template,
+    styles,
+});
 ```
 
-It's as simple as that!
-
-Continue reading through the docs to understand all of the potential ways to use `@microsoft/fast-element` for your website or application.
+```html
+<html>
+  <head>
+    <script type="module" src="./hello-world.js"></script>
+  </head>
+  <body>
+    <hello-world name="World"></hello-world>
+  </body>
+</html>
+```


### PR DESCRIPTION
# Pull Request

## 📖 Description

Rewrites and expands the FAST Element v3 documentation site. The getting-started guides were dense and in places out of date; this branch reworks them and adds the missing DOM Policy reference.

- Reworked the **Quick Start**, **FAST Element**, **HTML Templates**, **CSS Templates**, and **HTML Directives** guides.
- Added previous/next pagination navigation, with supporting Eleventy includes and styles.
- Added the `--incremental` flag to the website's watch mode so local rebuilds are faster.

## 📑 Test Plan

Everything here touches `sites/website/**` (content, Eleventy config, styles). Run `npm run start` in `sites/website`, then check the updated pages render and the prev/next navigation links to the right neighbors. All existing tests pass.

## ✅ Checklist

### General

- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.