### PR TITLE
fix: use workflow token for GitHub releases

### DIFF
--- a/.github/workflows/cd-github-releases.yml
+++ b/.github/workflows/cd-github-releases.yml
@@ -75,4 +75,4 @@ jobs:
     - name: Pack and create GitHub releases
       run: node build/scripts/create-github-releases.mjs
       env:
-        GH_TOKEN: ${{ secrets.GH_TOKEN }}
+        GH_TOKEN: ${{ github.token }}


### PR DESCRIPTION
# Pull Request
 
 ## 📖 Description
 
 Updates the GitHub release workflow to authenticate `gh release create` with the workflow-scoped `github.token` instead of the custom `GH_TOKEN` secret.
 
 This allows the existing `permissions: { contents: write }` grant to apply when creating package GitHub releases and tags.
 
 ## 👩‍💻 Reviewer Notes
 
 This fixes the failed `cd-github-releases.yml` run where `gh release create` returned `HTTP 403: Resource not accessible by personal access token`.
 
 ## 📑 Test Plan
 
 - `npm run checkchange`
 
 ## ✅ Checklist
 
 ### General
 
 - [ ] I have included a change request file using `$ npm run change`
 - [ ] I have added tests for my changes.
 - [x] I have tested my changes.
 - [ ] I have updated the project documentation to reflect my changes.
 - [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
 
 ## ⏭ Next Steps
 
 After this lands on `main`, rerun the GitHub release workflow so it can create the missing releases for `@microsoft/fast-html@1.0.0-alpha.54` and `@microsoft/fast-test-harness@0.3.1`.