### PR TITLE
fix: use download GitHub release ado task

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -19,7 +19,38 @@ Nightly publishing is split into two coordinated jobs so that npm credentials ne
   1. **`detect`** — checks out `main` with `fetch-depth: 0` and runs [`build/scripts/create-github-releases.mjs --check-only`](../../build/scripts/create-github-releases.mjs). The script walks the workspaces tree (no `npm ci` required), computes `${name}_v${version}` for every non-private workspace, and emits `hasMissingReleases=true` if any of those git tags do not yet exist.
   2. **`release`** runs only when missing releases exist. Installs Node, the Rust toolchain (for `cargo package`), and the npm workspace dependencies, builds the repo, then runs the script in default mode. For every missing release the script: packs the npm tarball into `publish_artifacts_npm/`, packs the paired Rust crate (if `crates/<crate-name>/Cargo.toml` exists) into `publish_artifacts_crates/`, and creates the GitHub release with both assets attached via `gh release create --target <sha>`. The `gh` CLI creates the git tag atomically with the release, so "tag exists" and "release exists" are always the same fact — a failed release is safely retried on the next workflow run, with no orphan tag stranded behind. The script errors if a paired crate's version does not match the npm package's version — but this is purely a safety net: the [`postbump` hook in `beachball.config.js`](../../beachball.config.js) rewrites the crate's `Cargo.toml` (and the matching entry in `Cargo.lock`) automatically whenever `npm run bump` bumps the paired npm package, so the two stay in sync from the same commit.
 - **`azure-pipelines-cd.yml`** (Azure Pipelines) runs every night at **1am PST (`0 9 * * *` UTC)** with `always: true` so it still runs on no-op nights (it is checking external GitHub state, not repo commits). It is split into two stages so the heavy publish work is skipped on no-op nights:
-  1. **`Check`** — runs [`build/scripts/download-github-releases.mjs --check-only`](../../build/scripts/download-github-releases.mjs). The script lists every git tag matching the beachball-style `${name}_v${version}` pattern that does **not** also have a `deployed/<tag>` counterpart and emits the comma-separated list via Azure Pipelines `setvariable` output variables (`needsDeployment`, `undeployedTags`). No network calls to npm or crates.io.
-  2. **`Package`** — depends on `Check` and runs only when `needsDeployment == 'true'`. Downloads every undeployed release's assets via `gh release download`, sorts them into `publish_artifacts_npm/` (`.tgz`) and `publish_artifacts_crates/` (`.crate`), hands off to `FAST.Release.PipelineTemplate.yml@fastPipelines` for the actual `npm publish` / `cargo publish`, and on success pushes a `deployed/<tag>` git marker tag for each release that was just published. The next nightly run will see those markers and skip the corresponding releases.
+  1. **`Check`** — runs [`build/scripts/download-github-releases.mjs --check-only`](../../build/scripts/download-github-releases.mjs). The script walks the current publishable workspaces, keeps only workspaces whose current `${name}_v${version}` release tag exists, filters out tags that already have a `deployed/<tag>` counterpart, and emits Azure Pipelines output variables for the overall deployment decision plus each package-specific release tag. No network calls to GitHub, npm, or crates.io are needed.
+  2. **`Package`** — depends on `Check` and runs only when `needsDeployment == 'true'`. Conditional `DownloadGitHubRelease@0` tasks download undeployed release assets through the `fast` GitHub service connection, a shell step sorts them into `publish_artifacts_npm/` (`.tgz`) and `publish_artifacts_crates/` (`.crate`), then `FAST.Release.PipelineTemplate.yml@fastPipelines` performs the actual `npm publish` / `cargo publish`. On success, the pipeline pushes a `deployed/<tag>` git marker tag for each release that was just published. The next nightly run will see those markers and skip the corresponding releases.
 
-Both scripts are thin Node.js wrappers around `gh`, `npm`, `cargo`, and `git` — no extra npm dependencies and no custom GitHub API client. Idempotency is enforced entirely through git tags (`${name}_v${version}` on the GitHub side, `deployed/${name}_v${version}` on the Azure side), so neither side needs to talk to npm.org or crates.io to decide whether work is required.
+Both scripts are thin Node.js wrappers around existing CLI tools and repository metadata — no extra npm dependencies and no custom GitHub API client. Idempotency is enforced entirely through git tags (`${name}_v${version}` on the GitHub side, `deployed/${name}_v${version}` on the Azure side), so neither side needs to talk to npm.org or crates.io to decide whether work is required.
+
+### Adding a publishable package
+
+`cd-github-releases.yml` discovers publishable workspaces automatically from the root `package.json` `workspaces` list, but `azure-pipelines-cd.yml` must be updated because Azure Pipelines cannot create `DownloadGitHubRelease@0` tasks dynamically from the runtime detection output.
+
+When adding a new non-private workspace that should publish through CD:
+
+1. Ensure the workspace is included in the root `package.json` `workspaces` list and has a `name` and `version`.
+2. If the package has a paired crate, place it at `crates/<crate-name>/Cargo.toml`, where `<crate-name>` is the npm package name with the leading `@` removed and `/` replaced by `-`. For example, `@microsoft/fast-build` pairs with `crates/microsoft-fast-build/Cargo.toml`.
+3. Add package-specific output variables to the `Package` stage in `azure-pipelines-cd.yml`. The output prefix is generated from the npm package name by converting `@microsoft/<name>` to camel case. For example, `@microsoft/fast-foo` emits `fastFooNeedsDeployment` and `fastFooReleaseTag`.
+4. Add a conditional `DownloadGitHubRelease@0` task for the package using the `fast` GitHub service connection, `defaultVersionType: 'specificTag'`, and the package's `$(<prefix>ReleaseTag)` variable.
+5. Confirm the artifact sorting step still covers the package assets. Packages should attach `.tgz` assets, and paired crates should also attach `.crate` assets.
+
+Example Azure additions for `@microsoft/fast-foo`:
+
+```yml
+variables:
+  fastFooNeedsDeployment: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastFooNeedsDeployment'] ]
+  fastFooReleaseTag: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastFooReleaseTag'] ]
+
+steps:
+- task: DownloadGitHubRelease@0
+  displayName: "Download @microsoft/fast-foo release assets"
+  condition: and(succeeded(), eq(variables['fastFooNeedsDeployment'], 'true'))
+  inputs:
+    connection: fast
+    userRepository: microsoft/fast
+    defaultVersionType: 'specificTag'
+    version: '$(fastFooReleaseTag)'
+    downloadPath: '$(System.ArtifactsDirectory)'
+```

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -28,6 +28,8 @@ Both scripts are thin Node.js wrappers around existing CLI tools and repository 
 
 `cd-github-releases.yml` discovers publishable workspaces automatically from the root `package.json` `workspaces` list, but `azure-pipelines-cd.yml` must be updated because Azure Pipelines cannot create `DownloadGitHubRelease@0` tasks dynamically from the runtime detection output.
 
+The `npm run checkchange` command runs `build/scripts/check-publish-pipeline.mjs` to verify that every non-private workspace has matching Azure CD variables and a conditional `DownloadGitHubRelease@0` task. This guardrail runs in PR validation and fails when a new publishable package is added without updating the publish pipeline.
+
 When adding a new non-private workspace that should publish through CD:
 
 1. Ensure the workspace is included in the root `package.json` `workspaces` list and has a `name` and `version`.

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -174,20 +174,47 @@ extends:
 
           - script: |
               set -euo pipefail
-              mkdir -p publish_artifacts_npm publish_artifacts_crates publish_artifacts_meta
-              find "$(System.ArtifactsDirectory)" -name "*.tgz" -exec cp {} publish_artifacts_npm/ \;
-              find "$(System.ArtifactsDirectory)" -name "*.crate" -exec cp {} publish_artifacts_crates/ \;
+              rm -rf publish_artifacts_npm publish_artifacts_crates publish_artifacts_meta
+              mkdir -p publish_artifacts_meta
+
+              if find "$(System.ArtifactsDirectory)" -name "*.tgz" -print -quit | grep -q .; then
+                mkdir -p publish_artifacts_npm
+                find "$(System.ArtifactsDirectory)" -name "*.tgz" -exec cp {} publish_artifacts_npm/ \;
+              fi
+
+              if find "$(System.ArtifactsDirectory)" -name "*.crate" -print -quit | grep -q .; then
+                mkdir -p publish_artifacts_crates
+                find "$(System.ArtifactsDirectory)" -name "*.crate" -exec cp {} publish_artifacts_crates/ \;
+              fi
+
               printf '%s\n' "$(undeployedTags)" | tr ',' '\n' | sed '/^$/d' > publish_artifacts_meta/undeployed-tags.txt
 
-              if ! find publish_artifacts_npm publish_artifacts_crates -type f | grep -q .; then
+              has_assets=false
+              if [ -d publish_artifacts_npm ] && find publish_artifacts_npm -maxdepth 1 -type f -print -quit | grep -q .; then
+                has_assets=true
+              fi
+              if [ -d publish_artifacts_crates ] && find publish_artifacts_crates -maxdepth 1 -type f -print -quit | grep -q .; then
+                has_assets=true
+              fi
+              if [ "$has_assets" != "true" ]; then
                 echo "No GitHub release assets were downloaded."
                 exit 1
               fi
 
               echo "npm artifacts:"
-              find publish_artifacts_npm -maxdepth 1 -type f -print | sort
+              if [ -d publish_artifacts_npm ]; then
+                find publish_artifacts_npm -maxdepth 1 -type f -print | sort
+              else
+                echo "none"
+              fi
+
               echo "crate artifacts:"
-              find publish_artifacts_crates -maxdepth 1 -type f -print | sort
+              if [ -d publish_artifacts_crates ]; then
+                find publish_artifacts_crates -maxdepth 1 -type f -print | sort
+              else
+                echo "none"
+              fi
+
               echo "deployment markers:"
               cat publish_artifacts_meta/undeployed-tags.txt
             displayName: "Separate release artifacts"

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -60,10 +60,11 @@ extends:
               version: "22.x"
             displayName: "Install Node.js"
 
-          # The check enumerates GitHub Releases rather than every local git tag
-          # because historical beachball tags may not have release assets. The
-          # Package stage pushes a `deployed/<tag>` marker tag after a successful
-          # publish, and the next pipeline run sees that marker via `git tag -l`.
+          # The check enumerates current workspace release tags rather than every
+          # historical package tag so older beachball tags are not deployment
+          # candidates. The Package stage pushes a `deployed/<tag>` marker tag
+          # after a successful publish, and the next pipeline run sees that
+          # marker via `git tag -l`.
           - script: |
               node build/scripts/download-github-releases.mjs --check-only
             displayName: "Detect releases whose tarballs have not been published"
@@ -78,6 +79,20 @@ extends:
       condition: eq(dependencies.Check.outputs['CheckVersion.deploymentCheck.needsDeployment'], 'true')
       variables:
         npm_config_cache: $(Pipeline.Workspace)/.npm
+        undeployedTags: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.undeployedTags'] ]
+        # When adding a new publishable workspace, add its package-specific
+        # deployment outputs here and a matching DownloadGitHubRelease@0 task
+        # below. See .github/workflows/README.md > Continuous Deployment.
+        fastBuildNeedsDeployment: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastBuildNeedsDeployment'] ]
+        fastBuildReleaseTag: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastBuildReleaseTag'] ]
+        fastElementNeedsDeployment: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastElementNeedsDeployment'] ]
+        fastElementReleaseTag: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastElementReleaseTag'] ]
+        fastHtmlNeedsDeployment: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastHtmlNeedsDeployment'] ]
+        fastHtmlReleaseTag: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastHtmlReleaseTag'] ]
+        fastRouterNeedsDeployment: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastRouterNeedsDeployment'] ]
+        fastRouterReleaseTag: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastRouterReleaseTag'] ]
+        fastTestHarnessNeedsDeployment: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastTestHarnessNeedsDeployment'] ]
+        fastTestHarnessReleaseTag: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastTestHarnessReleaseTag'] ]
       jobs:
       - job: Deploy
         steps:
@@ -88,7 +103,6 @@ extends:
           - script: |
               git config --global user.email fastsvc@microsoft.com
               git config --global user.name "Microsoft FAST Builds"
-              git remote set-url origin https://$(GH_TOKEN)@github.com/microsoft/fast.git
             displayName: "Configure git for tag push"
 
           - task: UseNode@1
@@ -108,18 +122,81 @@ extends:
               npm ci
             displayName: "Install package dependencies"
 
+          - task: DownloadGitHubRelease@0
+            displayName: "Download @microsoft/fast-build release assets"
+            condition: and(succeeded(), eq(variables['fastBuildNeedsDeployment'], 'true'))
+            inputs:
+              connection: fast
+              userRepository: microsoft/fast
+              defaultVersionType: 'specificTag'
+              version: '$(fastBuildReleaseTag)'
+              downloadPath: '$(System.ArtifactsDirectory)'
+
+          - task: DownloadGitHubRelease@0
+            displayName: "Download @microsoft/fast-element release assets"
+            condition: and(succeeded(), eq(variables['fastElementNeedsDeployment'], 'true'))
+            inputs:
+              connection: fast
+              userRepository: microsoft/fast
+              defaultVersionType: 'specificTag'
+              version: '$(fastElementReleaseTag)'
+              downloadPath: '$(System.ArtifactsDirectory)'
+
+          - task: DownloadGitHubRelease@0
+            displayName: "Download @microsoft/fast-html release assets"
+            condition: and(succeeded(), eq(variables['fastHtmlNeedsDeployment'], 'true'))
+            inputs:
+              connection: fast
+              userRepository: microsoft/fast
+              defaultVersionType: 'specificTag'
+              version: '$(fastHtmlReleaseTag)'
+              downloadPath: '$(System.ArtifactsDirectory)'
+
+          - task: DownloadGitHubRelease@0
+            displayName: "Download @microsoft/fast-router release assets"
+            condition: and(succeeded(), eq(variables['fastRouterNeedsDeployment'], 'true'))
+            inputs:
+              connection: fast
+              userRepository: microsoft/fast
+              defaultVersionType: 'specificTag'
+              version: '$(fastRouterReleaseTag)'
+              downloadPath: '$(System.ArtifactsDirectory)'
+
+          - task: DownloadGitHubRelease@0
+            displayName: "Download @microsoft/fast-test-harness release assets"
+            condition: and(succeeded(), eq(variables['fastTestHarnessNeedsDeployment'], 'true'))
+            inputs:
+              connection: fast
+              userRepository: microsoft/fast
+              defaultVersionType: 'specificTag'
+              version: '$(fastTestHarnessReleaseTag)'
+              downloadPath: '$(System.ArtifactsDirectory)'
+
           - script: |
-              node build/scripts/download-github-releases.mjs
-            displayName: "Download undeployed release assets and sort into npm/crates folders"
-            env:
-              GH_TOKEN: $(GH_TOKEN)
-              GITHUB_REPOSITORY: microsoft/fast
+              set -euo pipefail
+              mkdir -p publish_artifacts_npm publish_artifacts_crates publish_artifacts_meta
+              find "$(System.ArtifactsDirectory)" -name "*.tgz" -exec cp {} publish_artifacts_npm/ \;
+              find "$(System.ArtifactsDirectory)" -name "*.crate" -exec cp {} publish_artifacts_crates/ \;
+              printf '%s\n' "$(undeployedTags)" | tr ',' '\n' | sed '/^$/d' > publish_artifacts_meta/undeployed-tags.txt
+
+              if ! find publish_artifacts_npm publish_artifacts_crates -type f | grep -q .; then
+                echo "No GitHub release assets were downloaded."
+                exit 1
+              fi
+
+              echo "npm artifacts:"
+              find publish_artifacts_npm -maxdepth 1 -type f -print | sort
+              echo "crate artifacts:"
+              find publish_artifacts_crates -maxdepth 1 -type f -print | sort
+              echo "deployment markers:"
+              cat publish_artifacts_meta/undeployed-tags.txt
+            displayName: "Separate release artifacts"
 
           - template: FAST.Release.PipelineTemplate.yml@fastPipelines  # Template reference
 
           # Push a `deployed/<tag>` marker tag for each release that was just
           # published so that the next nightly Check stage sees it and skips
-          # the release. Reads the list of tags written by the download script.
+          # the release. Reads the list of tags prepared before publishing.
           # Idempotent: a marker tag that already exists locally (i.e. fetched
           # from origin via `fetchTags: true`) is left alone instead of failing.
           - script: |

--- a/build/scripts/check-publish-pipeline.mjs
+++ b/build/scripts/check-publish-pipeline.mjs
@@ -1,0 +1,166 @@
+#!/usr/bin/env node
+/**
+ * Guardrail for Azure CD coverage.
+ *
+ * `cd-github-releases.yml` discovers publishable workspaces dynamically, but
+ * `azure-pipelines-cd.yml` must declare one `DownloadGitHubRelease@0` task per
+ * package because Azure Pipelines cannot create tasks from runtime output. This
+ * script keeps those surfaces in sync.
+ */
+
+import { existsSync, readdirSync, readFileSync } from "node:fs";
+import { dirname, join } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const repoRoot = join(dirname(fileURLToPath(import.meta.url)), "..", "..");
+const pipelinePath = join(repoRoot, "azure-pipelines-cd.yml");
+
+function readJson(relativePath) {
+    return JSON.parse(readFileSync(join(repoRoot, relativePath), "utf8"));
+}
+
+function npmNameToCrateName(npmName) {
+    return npmName.replace(/^@/, "").replace(/\//g, "-");
+}
+
+function npmNameToOutputPrefix(npmName) {
+    return npmNameToCrateName(npmName)
+        .replace(/^microsoft-/, "")
+        .replace(/-([a-z0-9])/g, (_, char) => char.toUpperCase());
+}
+
+function listWorkspaceLocations() {
+    const rootPkg = readJson("package.json");
+    const locations = new Set();
+
+    for (const pattern of rootPkg.workspaces || []) {
+        if (pattern.endsWith("/*")) {
+            const parent = pattern.slice(0, -2);
+            const parentPath = join(repoRoot, parent);
+            if (!existsSync(parentPath)) continue;
+            for (const entry of readdirSync(parentPath, { withFileTypes: true })) {
+                if (entry.isDirectory()) {
+                    locations.add(join(parent, entry.name));
+                }
+            }
+        } else {
+            locations.add(pattern);
+        }
+    }
+
+    return [...locations].sort();
+}
+
+function listPublishableWorkspaces() {
+    return listWorkspaceLocations()
+        .map(location => {
+            const pkgPath = join(location, "package.json");
+            const absolutePkgPath = join(repoRoot, pkgPath);
+            if (!existsSync(absolutePkgPath)) return null;
+
+            const pkg = readJson(pkgPath);
+            if (pkg.private === true || !pkg.name || !pkg.version) return null;
+
+            return {
+                location,
+                name: pkg.name,
+                outputPrefix: npmNameToOutputPrefix(pkg.name),
+            };
+        })
+        .filter(Boolean);
+}
+
+function getStepBlocks(pipeline, stepHeader) {
+    const lines = pipeline.split(/\r?\n/);
+    const blocks = [];
+
+    for (let i = 0; i < lines.length; i++) {
+        const line = lines[i];
+        if (!line.includes(stepHeader)) continue;
+
+        const indent = line.match(/^(\s*)-/)?.[1].length;
+        if (indent === undefined) continue;
+
+        const block = [];
+        for (let j = i; j < lines.length; j++) {
+            const current = lines[j];
+            const nextStep = current.match(/^(\s*)- (checkout|script|task|template):/);
+            if (j > i && nextStep && nextStep[1].length === indent) {
+                break;
+            }
+            block.push(current);
+        }
+        blocks.push(block.join("\n"));
+    }
+
+    return blocks;
+}
+
+function validateUniquePrefixes(workspaces) {
+    const seen = new Map();
+    const failures = [];
+
+    for (const workspace of workspaces) {
+        const previous = seen.get(workspace.outputPrefix);
+        if (previous) {
+            failures.push(
+                `${workspace.name} and ${previous.name} both map to Azure output prefix '${workspace.outputPrefix}'. Rename one package or update the prefix mapping.`,
+            );
+        } else {
+            seen.set(workspace.outputPrefix, workspace);
+        }
+    }
+
+    return failures;
+}
+
+const pipeline = readFileSync(pipelinePath, "utf8");
+const publishable = listPublishableWorkspaces();
+const downloadBlocks = getStepBlocks(pipeline, "- task: DownloadGitHubRelease@0");
+const failures = validateUniquePrefixes(publishable);
+
+for (const { name, outputPrefix } of publishable) {
+    const needsVariable = `${outputPrefix}NeedsDeployment: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.${outputPrefix}NeedsDeployment'] ]`;
+    const tagVariable = `${outputPrefix}ReleaseTag: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.${outputPrefix}ReleaseTag'] ]`;
+    const condition = `condition: and(succeeded(), eq(variables['${outputPrefix}NeedsDeployment'], 'true'))`;
+    const version = `version: '$(${outputPrefix}ReleaseTag)'`;
+
+    if (!pipeline.includes(needsVariable)) {
+        failures.push(`Missing Package stage variable for ${name}: ${needsVariable}`);
+    }
+
+    if (!pipeline.includes(tagVariable)) {
+        failures.push(`Missing Package stage variable for ${name}: ${tagVariable}`);
+    }
+
+    const hasDownloadTask = downloadBlocks.some(
+        block =>
+            block.includes(`Download ${name} release assets`) &&
+            block.includes(condition) &&
+            block.includes("connection: fast") &&
+            block.includes("userRepository: microsoft/fast") &&
+            block.includes("defaultVersionType: 'specificTag'") &&
+            block.includes(version),
+    );
+
+    if (!hasDownloadTask) {
+        failures.push(
+            `Missing DownloadGitHubRelease@0 task for ${name}. Add a task conditioned on '${outputPrefix}NeedsDeployment' and using '$(${outputPrefix}ReleaseTag)'.`,
+        );
+    }
+}
+
+if (failures.length > 0) {
+    console.error("[check-publish-pipeline] Azure CD publish coverage is incomplete.");
+    console.error(
+        "Every non-private workspace must be represented in azure-pipelines-cd.yml. See .github/workflows/README.md > Adding a publishable package.",
+    );
+    for (const failure of failures) {
+        console.error(`- ${failure}`);
+    }
+    process.exit(1);
+}
+
+console.log(
+    `[check-publish-pipeline] Verified Azure CD coverage for ${publishable.length} publishable workspace(s).`,
+);

--- a/build/scripts/download-github-releases.mjs
+++ b/build/scripts/download-github-releases.mjs
@@ -1,11 +1,7 @@
 #!/usr/bin/env node
 /**
- * Download GitHub release assets whose `${name}_v${version}` GitHub release
- * has no `deployed/<tag>` counterpart, and sort them into separate folders
- * for the publish template:
- *
- *   - `.tgz`   -> `publish_artifacts_npm/`
- *   - `.crate` -> `publish_artifacts_crates/`
+ * Detect current publishable workspaces whose `${name}_v${version}` release tag
+ * has no `deployed/<tag>` counterpart.
  *
  * Invoked by `azure-pipelines-cd.yml` before the existing
  * `FAST.Release.PipelineTemplate` runs. We use a `deployed/<tag>` git
@@ -16,59 +12,36 @@
  * `deployed/<tag>` marker tag for each release that was published; the
  * next run sees it via `git tag -l` and skips that release.
  *
- * Modes:
- *
- *   - default: download assets for every undeployed release. Writes the
- *     processed tag list to `publish_artifacts_meta/undeployed-tags.txt`
- *     so the Azure pipeline can push `deployed/<tag>` markers after the
- *     publish template completes.
- *   - `--check-only`: enumerate undeployed releases only. Sets the
- *     `needsDeployment` and `undeployedTags` Azure Pipelines output
- *     variables (when running under `TF_BUILD`). No downloads.
+ * The Azure pipeline uses this script during its Check stage, then downloads
+ * release assets through `DownloadGitHubRelease@0` using the repo's GitHub
+ * service connection. This avoids direct GitHub API calls from this script and
+ * keeps the flow aligned with the WebUI CD pipeline.
  *
  * Inputs:
  *
  *   - `GITHUB_REPOSITORY` env var (`owner/repo`) — required.
- *   - `GH_TOKEN` env var — required for non-`--check-only` mode so the
- *     `gh` CLI can download release assets.
- *
- * The script never reads any package.json or Cargo.toml: the
- * source of truth for "what should be published" is the set of actual GitHub
- * releases. This keeps historical bare beachball tags from being treated as
- * deployable releases while still working on a freshly-cloned 1ES agent with
- * no `node_modules` or cargo registry.
+ * The script reads workspace package manifests and paired Cargo manifests only:
+ * the source of truth for "what should be published" is the current workspace
+ * versions plus matching release tags. This keeps historical bare beachball tags
+ * from being treated as deployable releases while still working on a
+ * freshly-cloned 1ES agent with no `node_modules` or cargo registry.
  */
 
 import { execFileSync } from "node:child_process";
-import {
-    mkdirSync,
-    readdirSync,
-    renameSync,
-    rmSync,
-    unlinkSync,
-    writeFileSync,
-} from "node:fs";
+import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
-const NPM_DIR = "publish_artifacts_npm";
-const CRATES_DIR = "publish_artifacts_crates";
-const META_DIR = "publish_artifacts_meta";
-const STAGE_DIR = "publish_artifacts_stage";
-
 const CHECK_ONLY = process.argv.includes("--check-only");
+if (!CHECK_ONLY) {
+    console.error(
+        "download-github-releases.mjs only supports --check-only; Azure Pipelines downloads assets with DownloadGitHubRelease@0.",
+    );
+    process.exit(1);
+}
 
 const repo = process.env.GITHUB_REPOSITORY;
 if (!repo) {
     console.error("GITHUB_REPOSITORY must be set to owner/repo");
-    process.exit(1);
-}
-
-// `--check-only` enumerates public GitHub Releases through the REST API, so it
-// does not need an Azure secret. In non-check mode we call `gh release download`,
-// which fails with a generic auth error if `GH_TOKEN` is missing; fail fast here
-// with a clearer message.
-if (!CHECK_ONLY && !process.env.GH_TOKEN) {
-    console.error("GH_TOKEN must be set so the `gh` CLI can download release assets.");
     process.exit(1);
 }
 
@@ -83,46 +56,82 @@ function listGitTags() {
         .filter(Boolean);
 }
 
-function getNextUrl(linkHeader) {
-    if (!linkHeader) return null;
+function npmNameToCrateName(npmName) {
+    return npmName.replace(/^@/, "").replace(/\//g, "-");
+}
 
-    for (const part of linkHeader.split(",")) {
-        const match = /<([^>]+)>;\s*rel="next"/.exec(part.trim());
-        if (match) return match[1];
+function npmNameToOutputPrefix(npmName) {
+    return npmNameToCrateName(npmName)
+        .replace(/^microsoft-/, "")
+        .replace(/-([a-z0-9])/g, (_, char) => char.toUpperCase());
+}
+
+function readCargoTomlVersion(cargoTomlPath) {
+    const content = readFileSync(cargoTomlPath, "utf8");
+    let inPackage = false;
+    for (const rawLine of content.split("\n")) {
+        const line = rawLine.trim();
+        if (line.startsWith("[")) {
+            inPackage = line === "[package]";
+            continue;
+        }
+        if (!inPackage) continue;
+        const m = /^version\s*=\s*"([^"]+)"/.exec(line);
+        if (m) return m[1];
     }
-
     return null;
 }
 
-async function listGitHubReleases() {
-    let url = `https://api.github.com/repos/${repo}/releases?per_page=100`;
-    const releases = [];
-    const headers = {
-        Accept: "application/vnd.github+json",
-        "User-Agent": "fast-release-downloader",
-    };
+function listPublishableWorkspaces() {
+    const rootPkg = JSON.parse(readFileSync("package.json", "utf8"));
+    const patterns = rootPkg.workspaces || [];
+    const locations = new Set();
 
-    while (url) {
-        const response = await fetch(url, { headers });
-
-        if (!response.ok) {
-            const body = await response.text();
-            throw new Error(
-                `Failed to list GitHub releases (${response.status} ${response.statusText}): ${body}`,
-            );
+    for (const pattern of patterns) {
+        if (pattern.endsWith("/*")) {
+            const parent = pattern.slice(0, -2);
+            if (!existsSync(parent)) continue;
+            for (const entry of readdirSync(parent, { withFileTypes: true })) {
+                if (entry.isDirectory()) {
+                    locations.add(join(parent, entry.name));
+                }
+            }
+        } else {
+            locations.add(pattern);
         }
-
-        for (const release of await response.json()) {
-            releases.push({
-                tagName: release.tag_name,
-                isDraft: release.draft,
-            });
-        }
-
-        url = getNextUrl(response.headers.get("link"));
     }
 
-    return releases;
+    const workspaces = [];
+    for (const location of locations) {
+        const pkgPath = join(location, "package.json");
+        if (!existsSync(pkgPath)) continue;
+        const pkg = JSON.parse(readFileSync(pkgPath, "utf8"));
+        if (pkg.private === true) continue;
+        if (!pkg.name || !pkg.version) continue;
+
+        const crateName = npmNameToCrateName(pkg.name);
+        const cargoTomlPath = join("crates", crateName, "Cargo.toml");
+        const hasCrate = existsSync(cargoTomlPath);
+
+        if (hasCrate) {
+            const crateVersion = readCargoTomlVersion(cargoTomlPath);
+            if (crateVersion !== pkg.version) {
+                throw new Error(
+                    `Version mismatch for ${pkg.name}: package.json is ${pkg.version} but ${cargoTomlPath} is ${crateVersion}. Update one to match the other.`,
+                );
+            }
+        }
+
+        workspaces.push({
+            location,
+            name: pkg.name,
+            version: pkg.version,
+            tag: `${pkg.name}_v${pkg.version}`,
+            outputPrefix: npmNameToOutputPrefix(pkg.name),
+        });
+    }
+
+    return workspaces;
 }
 
 function setAzureOutput(name, value) {
@@ -131,108 +140,35 @@ function setAzureOutput(name, value) {
 }
 
 const allTags = listGitTags();
+const tagSet = new Set(allTags);
 const deployed = new Set(
     allTags.filter(t => t.startsWith("deployed/")).map(t => t.slice("deployed/".length)),
 );
-// Match beachball's release tag format: `${name}_v${major}.${minor}.${patch}`,
-// where the version is the publishable portion (`1.0.0` or `1.0.0-alpha.3`).
-// Anchored at the end of the tag name so trailing junk (e.g. a stray
-// suffix accidentally appended after a real version) does not get
-// misclassified as a release. We enumerate actual GitHub releases here,
-// so historical bare beachball tags are not deployment candidates.
-const RELEASE_TAG_RE = /_v\d+\.\d+\.\d+(?:-[\w.-]+)?$/;
-const githubReleases = await listGitHubReleases();
-const releaseTags = githubReleases
-    .filter(({ tagName, isDraft }) => !isDraft && RELEASE_TAG_RE.test(tagName))
-    .map(({ tagName }) => tagName)
-    .sort();
-const undeployed = releaseTags.filter(t => !deployed.has(t)).sort();
+const publishable = listPublishableWorkspaces();
+const releaseCandidates = publishable
+    .filter(({ tag }) => tagSet.has(tag))
+    .sort((a, b) => a.tag.localeCompare(b.tag));
+const undeployed = releaseCandidates.filter(({ tag }) => !deployed.has(tag));
+const undeployedTagSet = new Set(undeployed.map(({ tag }) => tag));
 
-console.log(`GitHub releases total:     ${githubReleases.length}`);
-console.log(`Package releases:          ${releaseTags.length}`);
-console.log(`Already deployed:          ${releaseTags.length - undeployed.length}`);
+console.log(`Publishable workspaces:    ${publishable.length}`);
+console.log(`Current release tags:      ${releaseCandidates.length}`);
+console.log(`Already deployed:          ${releaseCandidates.length - undeployed.length}`);
 console.log(`Undeployed:                ${undeployed.length}`);
 
 if (undeployed.length > 0) {
     console.log("\nUndeployed tags:");
-    for (const tag of undeployed) {
+    for (const { tag } of undeployed) {
         console.log(`  - ${tag}`);
     }
 }
 
 setAzureOutput("needsDeployment", undeployed.length > 0 ? "true" : "false");
-setAzureOutput("undeployedTags", undeployed.join(","));
-
-if (CHECK_ONLY || undeployed.length === 0) {
-    process.exit(0);
-}
-
-// Clear the publish artifact directories before recreating them so a
-// re-run (locally or after a partially-failed Azure attempt) cannot
-// pick up stale `.tgz` / `.crate` files from a previous invocation.
-for (const dir of [NPM_DIR, CRATES_DIR, META_DIR]) {
-    rmSync(dir, { recursive: true, force: true });
-    mkdirSync(dir, { recursive: true });
-}
-
-let hasErrors = false;
-const processed = [];
-
-for (const tag of undeployed) {
-    try {
-        console.log(`\nDownloading assets for ${tag}...`);
-        // Clear the stage dir before each iteration so leftover unknown-type
-        // files from a previous release are not reprocessed (or warned about
-        // repeatedly).
-        rmSync(STAGE_DIR, { recursive: true, force: true });
-        mkdirSync(STAGE_DIR, { recursive: true });
-        run(
-            "gh",
-            ["release", "download", tag, "--repo", repo, "--dir", STAGE_DIR, "--clobber"],
-            { stdio: "inherit" },
-        );
-
-        let foundAssets = 0;
-        for (const file of readdirSync(STAGE_DIR)) {
-            const src = join(STAGE_DIR, file);
-            if (file.endsWith(".tgz")) {
-                renameSync(src, join(NPM_DIR, file));
-                foundAssets += 1;
-            } else if (file.endsWith(".crate")) {
-                renameSync(src, join(CRATES_DIR, file));
-                foundAssets += 1;
-            } else {
-                console.warn(`  Ignoring unknown asset type: ${file}`);
-                unlinkSync(src);
-            }
-        }
-
-        // Refuse to mark a tag as processed if its release had no
-        // recognised publish assets. Otherwise the Azure pipeline would
-        // push the `deployed/<tag>` marker, and the (presumably broken)
-        // release would never be retried.
-        if (foundAssets === 0) {
-            throw new Error(
-                `Release ${tag} contained no .tgz or .crate assets; refusing to mark as deployed.`,
-            );
-        }
-
-        processed.push(tag);
-    } catch (error) {
-        hasErrors = true;
-        const message = error instanceof Error ? error.message : String(error);
-        console.error(`Failed to download release ${tag}: ${message}`);
-    }
-}
-
-writeFileSync(
-    join(META_DIR, "undeployed-tags.txt"),
-    processed.join("\n") + (processed.length ? "\n" : ""),
-);
-
-console.log(`\nProcessed ${processed.length}/${undeployed.length} release(s).`);
-console.log(`Tag list written to ${join(META_DIR, "undeployed-tags.txt")}`);
-
-if (hasErrors) {
-    process.exitCode = 1;
+setAzureOutput("undeployedTags", undeployed.map(({ tag }) => tag).join(","));
+for (const workspace of publishable) {
+    setAzureOutput(`${workspace.outputPrefix}ReleaseTag`, workspace.tag);
+    setAzureOutput(
+        `${workspace.outputPrefix}NeedsDeployment`,
+        undeployedTagSet.has(workspace.tag) ? "true" : "false",
+    );
 }

--- a/package.json
+++ b/package.json
@@ -31,7 +31,7 @@
     "bump": "beachball bump",
     "build": "lage build",
     "change": "beachball change --dependent-change-type none",
-    "checkchange": "node build/scripts/checkchange.mjs",
+    "checkchange": "node build/scripts/check-publish-pipeline.mjs && node build/scripts/checkchange.mjs",
     "check": "beachball check ",
     "build:gh-pages": "npm run build -w @microsoft/fast-site",
     "publish": "beachball publish",


### PR DESCRIPTION
# Pull Request

## 📖 Description

Uses the DownloadGithubRelease ADO task instead of the manual script run against the workspace, includes a check during checkchange for packages added that are not part of the ADO task being run.
