### PR TITLE
fix(fast-html): prevent stale array mutations from notifying replaced properties

### DIFF
--- a/packages/fast-html/src/components/utilities.ts
+++ b/packages/fast-html/src/components/utilities.ts
@@ -460,10 +460,110 @@ type Operator = (typeof Operator)[keyof typeof Operator];
  */
 const objectTargetsMap = new WeakMap<object, ObservedTargetsAndProperties[]>();
 
+const rawSymbol = Symbol("raw");
+
+interface ArrayObserverRegistration {
+    target: any;
+    rootProperty: string;
+    schema: JSONSchema | JSONSchemaDefinition;
+    rootSchema: JSONSchema;
+    subscriber: any;
+}
+
 /**
- * A map of arrays being observered
+ * A map of arrays being observed with their registrations
  */
-const observedArraysMap = new WeakSet<object>();
+const observedArraysMap = new WeakMap<object, ArrayObserverRegistration[]>();
+
+function isReachable(root: any, subject: any, visited = new Set<any>()): boolean {
+    if (root === null || typeof root !== "object") {
+        return false;
+    }
+    const rawRoot = root[rawSymbol] || root;
+    const rawSubject = subject[rawSymbol] || subject;
+    if (rawRoot === rawSubject) {
+        return true;
+    }
+    if (visited.has(rawRoot)) {
+        return false;
+    }
+    visited.add(rawRoot);
+
+    if (Array.isArray(rawRoot)) {
+        for (const item of rawRoot) {
+            if (isReachable(item, rawSubject, visited)) {
+                return true;
+            }
+        }
+    } else {
+        const keys = Object.keys(rawRoot);
+        for (const key of keys) {
+            try {
+                const val = rawRoot[key];
+                if (isReachable(val, rawSubject, visited)) {
+                    return true;
+                }
+            } catch {
+                // Ignore errors from property getters
+            }
+        }
+    }
+    return false;
+}
+
+function teardownRegistrations(
+    value: any,
+    target: any,
+    rootProperty: string,
+    visited = new Set<any>(),
+): void {
+    if (value === null || typeof value !== "object") {
+        return;
+    }
+    const rawValue = value[rawSymbol] || value;
+    if (visited.has(rawValue)) {
+        return;
+    }
+    visited.add(rawValue);
+
+    if (Array.isArray(rawValue)) {
+        const registrations = observedArraysMap.get(rawValue);
+        if (registrations) {
+            const rootVal = target[rootProperty];
+            const stillReachable = isReachable(rootVal, rawValue);
+
+            const remaining: ArrayObserverRegistration[] = [];
+            for (const reg of registrations) {
+                if (
+                    reg.target === target &&
+                    reg.rootProperty === rootProperty &&
+                    !stillReachable
+                ) {
+                    Observable.getNotifier(rawValue).unsubscribe(reg.subscriber);
+                } else {
+                    remaining.push(reg);
+                }
+            }
+            if (remaining.length > 0) {
+                observedArraysMap.set(rawValue, remaining);
+            } else {
+                observedArraysMap.delete(rawValue);
+            }
+        }
+        for (const item of rawValue) {
+            teardownRegistrations(item, target, rootProperty, visited);
+        }
+    } else {
+        const keys = Object.keys(rawValue);
+        for (const key of keys) {
+            try {
+                teardownRegistrations(rawValue[key], target, rootProperty, visited);
+            } catch {
+                // Ignore errors from property getters
+            }
+        }
+    }
+}
 
 function defineObservableProperty(
     targetObject: any,
@@ -502,6 +602,8 @@ function defineObservableProperty(
                     }
 
                     Observable.notify(source, key);
+
+                    teardownRegistrations(oldValue, target, rootProperty);
                 }
             },
         };
@@ -1555,30 +1657,50 @@ function assignObservablesToArray(
 ): any {
     const schemaProperties = getSchemaProperties(schema);
 
+    const rawData = proxiedData[rawSymbol] || proxiedData;
+    const isAlreadyMapped = observedArraysMap.has(rawData);
+
     // If the schema has no properties, the array contains primitives (e.g. string[])
     // — observe the array for changes but skip per-item proxying.
-    const data = schemaProperties
-        ? proxiedData.map((item: any) => {
-              const originalItem = Object.assign({}, item);
+    const data =
+        schemaProperties && !isAlreadyMapped
+            ? rawData.map((item: any) => {
+                  const originalItem = Object.assign({}, item);
 
-              assignProxyToItemsInArray(
-                  item,
-                  originalItem,
-                  schema,
-                  rootSchema,
-                  target,
-                  rootProperty,
-              );
+                  assignProxyToItemsInArray(
+                      item,
+                      originalItem,
+                      schema,
+                      rootSchema,
+                      target,
+                      rootProperty,
+                  );
 
-              return Object.assign(item, originalItem);
-          })
-        : proxiedData;
+                  return Object.assign(item, originalItem);
+              })
+            : rawData;
 
-    if (!observedArraysMap.has(data)) {
-        observedArraysMap.add(data);
+    let registrations = observedArraysMap.get(data);
+    if (!registrations) {
+        registrations = [];
+        observedArraysMap.set(data, registrations);
+    }
 
-        Observable.getNotifier(data).subscribe({
-            handleChange(subject, args) {
+    const alreadyObserved = registrations.some(
+        reg =>
+            reg.target === target &&
+            reg.rootProperty === rootProperty &&
+            reg.schema === schema &&
+            reg.rootSchema === rootSchema,
+    );
+
+    if (!alreadyObserved) {
+        const subscriber = {
+            handleChange(subject: any, args: any) {
+                if (!isReachable(target[rootProperty], subject)) {
+                    return;
+                }
+
                 args.forEach((arg: any) => {
                     if (arg.addedCount > 0) {
                         if (schemaProperties) {
@@ -1604,7 +1726,17 @@ function assignObservablesToArray(
                     }
                 });
             },
+        };
+
+        registrations.push({
+            target,
+            rootProperty,
+            schema,
+            rootSchema,
+            subscriber,
         });
+
+        Observable.getNotifier(data).subscribe(subscriber);
     }
 
     if (schemaProperties !== null) {
@@ -1630,6 +1762,15 @@ function assignObservablesToArray(
             }
 
             return true;
+        },
+        get: (arr: any, prop: string | symbol) => {
+            if (prop === rawSymbol) {
+                return arr;
+            }
+            if (prop === "$isProxy") {
+                return true;
+            }
+            return arr[prop];
         },
     });
 }
@@ -1973,9 +2114,14 @@ export function assignProxy(
 
                 notifyObservables(proxy);
 
+                teardownRegistrations(currentValue, target, rootProperty);
+
                 return true;
             },
             get: (target, key) => {
+                if (key === rawSymbol) {
+                    return target;
+                }
                 if (key !== "$isProxy") {
                     return target[key];
                 }
@@ -1986,6 +2132,7 @@ export function assignProxy(
                 if (prop in obj) {
                     const propName = typeof prop === "string" ? prop : String(prop);
                     const childSchema = schemaProperties?.[propName];
+                    const currentValue = obj[prop];
 
                     delete obj[prop];
 
@@ -1995,6 +2142,8 @@ export function assignProxy(
                     }
 
                     notifyObservables(proxy);
+
+                    teardownRegistrations(currentValue, target, rootProperty);
 
                     return true;
                 }

--- a/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts
@@ -371,4 +371,144 @@ test.describe("Deep Merge Test Fixture", () => {
         expect(result.currentItemCount).toBe(1);
         expect(result.oldItemCount).toBe(3);
     });
+
+    test("should prevent stale root array mutations from notifying after deepMerge replacement", async ({
+        page,
+    }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.testStaleRootArrayMutate());
+
+        expect(result.currentOrdersLength).toBe(1);
+        expect(result.staleOrdersLength).toBe(3);
+
+        const firstUser = page.locator(".user-card").first();
+        await expect(firstUser.locator(".order")).toHaveCount(1);
+        await expect(firstUser).not.toContainText("Order #999");
+    });
+
+    test("should prevent stale root array mutations from notifying after direct assignment replacement", async ({
+        page,
+    }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) =>
+                element.testStaleRootArrayDirectAssignmentMutate(),
+            );
+
+        expect(result.currentOrdersLength).toBe(1);
+        expect(result.staleOrdersLength).toBe(3);
+
+        const firstUser = page.locator(".user-card").first();
+        await expect(firstUser.locator(".order")).toHaveCount(1);
+        await expect(firstUser).not.toContainText("Order #999");
+    });
+
+    test("should prevent stale nested array mutations from notifying after deepMerge replacement", async ({
+        page,
+    }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.testStaleNestedArrayMutate());
+
+        expect(result.currentItemsLength).toBe(1);
+        expect(result.staleItemsLength).toBe(3);
+
+        const firstUser = page.locator(".user-card").first();
+        await expect(firstUser.locator(".item")).toHaveCount(1);
+        await expect(firstUser).not.toContainText("Stale Item");
+    });
+
+    test("should prevent stale nested array mutations from notifying after direct assignment replacement", async ({
+        page,
+    }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) =>
+                element.testStaleNestedArrayDirectAssignmentMutate(),
+            );
+
+        expect(result.currentItemsLength).toBe(1);
+        expect(result.staleItemsLength).toBe(3);
+
+        const firstUser = page.locator(".user-card").first();
+        await expect(firstUser.locator(".item")).toHaveCount(1);
+        await expect(firstUser).not.toContainText("Stale Item");
+    });
+
+    test("should continue notifying active owners of a shared array after another owner replaces its property via deepMerge", async ({
+        page,
+    }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.testSharedArray());
+
+        expect(result.sameBefore).toBe(true);
+        expect(result.user0OrdersLength).toBe(1);
+        expect(result.user1OrdersLength).toBe(2);
+        expect(result.sharedLength).toBe(2);
+
+        const firstUser = page.locator(".user-card").nth(0);
+        const secondUser = page.locator(".user-card").nth(1);
+
+        await expect(firstUser.locator(".order")).toHaveCount(1);
+        await expect(secondUser.locator(".order")).toHaveCount(2);
+        await expect(secondUser).toContainText("Order #301");
+    });
+
+    test("should continue notifying active owners of a shared array after another owner replaces its property via direct assignment", async ({
+        page,
+    }) => {
+        const hydrationCompleted = page.waitForFunction(
+            () => (window as any).hydrationCompleted === true,
+        );
+        await page.goto("/fixtures/deep-merge/");
+        await hydrationCompleted;
+
+        const result = await page
+            .locator("deep-merge-test-element")
+            .evaluate((element: any) => element.testSharedArrayDirectAssignment());
+
+        expect(result.sameBefore).toBe(true);
+        expect(result.user0OrdersLength).toBe(1);
+        expect(result.user1OrdersLength).toBe(2);
+        expect(result.sharedLength).toBe(2);
+
+        const firstUser = page.locator(".user-card").nth(0);
+        const secondUser = page.locator(".user-card").nth(1);
+
+        await expect(firstUser.locator(".order")).toHaveCount(1);
+        await expect(secondUser.locator(".order")).toHaveCount(2);
+        await expect(secondUser).toContainText("Order #301");
+    });
 });

--- a/packages/fast-html/test/fixtures/deep-merge/main.ts
+++ b/packages/fast-html/test/fixtures/deep-merge/main.ts
@@ -490,6 +490,163 @@ class DeepMergeTestElement extends FASTElement {
             sameArray: items === this.users[0].orders[0].items,
         };
     }
+
+    public testStaleRootArrayMutate() {
+        const rootArray = this.users[0].orders;
+        this.updateUserOrders();
+        rootArray.push({
+            id: 999,
+            date: "2024-12-31",
+            total: 0,
+            items: [],
+        });
+        return {
+            currentOrdersLength: this.users[0].orders.length,
+            staleOrdersLength: rootArray.length,
+        };
+    }
+
+    public testStaleRootArrayDirectAssignmentMutate() {
+        const rootArray = this.users[0].orders;
+        this.users[0].orders = [
+            {
+                id: 105,
+                date: "2024-04-01",
+                total: 99.99,
+                items: [],
+            },
+        ];
+        rootArray.push({
+            id: 999,
+            date: "2024-12-31",
+            total: 0,
+            items: [],
+        });
+        return {
+            currentOrdersLength: this.users[0].orders.length,
+            staleOrdersLength: rootArray.length,
+        };
+    }
+
+    public testStaleNestedArrayMutate() {
+        const nestedArray = this.users[0].orders[0].items;
+        this.updateUserOrders();
+        nestedArray.push({
+            id: 9999,
+            name: "Stale Item",
+            price: 0,
+            inStock: true,
+            tags: ["stale"],
+            metadata: { views: 0, rating: 0 },
+        });
+        return {
+            currentItemsLength: this.users[0].orders[0].items.length,
+            staleItemsLength: nestedArray.length,
+        };
+    }
+
+    public testStaleNestedArrayDirectAssignmentMutate() {
+        const nestedArray = this.users[0].orders[0].items;
+        this.users[0].orders = [
+            {
+                id: 101,
+                date: "2024-01-15",
+                total: 150.5,
+                items: [
+                    {
+                        id: 1004,
+                        name: "Replacement Monitor",
+                        price: 99.99,
+                        inStock: true,
+                        tags: ["electronics"],
+                        metadata: { views: 1, rating: 5 },
+                    },
+                ],
+            },
+        ];
+        nestedArray.push({
+            id: 9999,
+            name: "Stale Item",
+            price: 0,
+            inStock: true,
+            tags: ["stale"],
+            metadata: { views: 0, rating: 0 },
+        });
+        return {
+            currentItemsLength: this.users[0].orders[0].items.length,
+            staleItemsLength: nestedArray.length,
+        };
+    }
+
+    public testSharedArray() {
+        const shared = [
+            {
+                id: 300,
+                date: "2024-05-01",
+                total: 10,
+                items: [],
+            },
+        ];
+        this.users[0].orders = shared;
+        this.users[1].orders = this.users[0].orders;
+        const sameBefore = this.users[0].orders === this.users[1].orders;
+        deepMerge(this.users[0], {
+            orders: [
+                {
+                    id: 103,
+                    date: "2024-04-01",
+                    total: 99.99,
+                    items: [],
+                },
+            ],
+        });
+        this.users[1].orders.push({
+            id: 301,
+            date: "2024-05-02",
+            total: 20,
+            items: [],
+        });
+        return {
+            sameBefore,
+            user0OrdersLength: this.users[0].orders.length,
+            user1OrdersLength: this.users[1].orders.length,
+            sharedLength: this.users[1].orders.length,
+        };
+    }
+
+    public testSharedArrayDirectAssignment() {
+        const shared = [
+            {
+                id: 300,
+                date: "2024-05-01",
+                total: 10,
+                items: [],
+            },
+        ];
+        this.users[0].orders = shared;
+        this.users[1].orders = this.users[0].orders;
+        const sameBefore = this.users[0].orders === this.users[1].orders;
+        this.users[0].orders = [
+            {
+                id: 103,
+                date: "2024-04-01",
+                total: 99.99,
+                items: [],
+            },
+        ];
+        this.users[1].orders.push({
+            id: 301,
+            date: "2024-05-02",
+            total: 20,
+            items: [],
+        });
+        return {
+            sameBefore,
+            user0OrdersLength: this.users[0].orders.length,
+            user1OrdersLength: this.users[1].orders.length,
+            sharedLength: this.users[1].orders.length,
+        };
+    }
 }
 
 TemplateElement.options({


### PR DESCRIPTION
# Pull Request

## 📖 Description

This PR resolves the issue where mutating a stale reference to a replaced array/nested array triggered incorrect change notifications on the root property of the element (fixes #7579).

### Key Changes
1. **Context-Scoped Array Observers**: Replaced the global `observedArraysMap` WeakSet with a context-aware `WeakMap<object, ArrayObserverRegistration[]>` tracking target instances, root properties, schemas, and subscribers.
2. **Reachability Check (`isReachable`)**: Added a recursive reachability check traversing the current data hierarchy starting from the target property to confirm if the mutated array is still reachable before notifying the root property.
3. **Stale Registration Cleanup (`teardownRegistrations`)**: Integrates cleanup logic in observable setters, `set` proxy traps, and `deleteProperty` proxy traps to unsubscribe stale observers when a property or nested branch is replaced.
4. **Proxy Unwrapping**: Exposes a private `rawSymbol` to get the underlying raw objects and arrays from proxies, ensuring identity checks and traversal are fully accurate.
5. **Shared Array Observation**: Ensures that when an array is shared among multiple elements/properties, replacing it for one owner does not terminate notifications or tracking for the other owners.

### 🎫 Issues

- Fixes #7579

## 👩‍💻 Reviewer Notes

Focus areas:
- Check the reachability algorithm `isReachable` and the teardown logic `teardownRegistrations` in [utilities.ts](file:///packages/fast-html/src/components/utilities.ts).
- Verify the test coverage for different assignment paths (both direct assignment/proxy set and deep merge) added to [main.ts](file:///packages/fast-html/test/fixtures/deep-merge/main.ts) and [deep-merge.spec.ts](file:///packages/fast-html/test/fixtures/deep-merge/deep-merge.spec.ts).

## 📑 Test Plan

I added comprehensive Playwright browser tests verifying:
- Stale root array mutations (after replacement via both `deepMerge` and direct assignment).
- Stale nested array mutations (after replacement via both `deepMerge` and direct assignment).
- Shared arrays (active owners continue to receive notifications after another owner replaces its property reference).

To run the Playwright tests:
```bash
cd packages/fast-html
npm run build
npm run test:chromium
