### PR TITLE
docs(fast-element): document client runtime boundary

### DIFF
--- a/packages/fast-element/DESIGN.md
+++ b/packages/fast-element/DESIGN.md
@@ -45,13 +45,21 @@ For deep dives into specific areas, see the linked detailed documents.
 | Declarative templating | `html` tagged template literal → `ViewTemplate` → compiled `HTMLView` |
 | Declarative HTML runtime | `@microsoft/fast-element/declarative.js` → `declarativeTemplate()`, `TemplateParser`; `@microsoft/fast-element/schema.js` → `Schema` |
 | Schema-driven extensions | `@microsoft/fast-element/attribute-map.js` and `@microsoft/fast-element/observer-map.js` → map helpers usable with declarative or manually supplied schemas |
-| Async DOM updates | `Updates` queue (batched, `requestAnimationFrame`-aligned) |
+| Async DOM updates | `Updates` queue (batched with `requestAnimationFrame`) |
 | Scoped styles | `css` tagged template literal → `ElementStyles` → `adoptedStylesheets` / `<style>` |
 | Dependency injection | `DI` container, `@inject`, `@singleton`, `@transient`, resolvers |
 | Context protocol | W3C community Context protocol (`Context.create`, `Context.for`) |
 | Reactive state helpers | `state()`, `watch()` (beta) |
 
 The library's kernel is module-scoped rather than stored on `globalThis`: import `FAST` from `@microsoft/fast-element`, `Updates` from `@microsoft/fast-element`, and `Observable` from `@microsoft/fast-element`.
+
+FAST Element is designed for client-side browser `Window` runtimes. Core
+element authoring and binding paths depend on browser platform APIs including
+Custom Elements, DOM, Shadow DOM, and `requestAnimationFrame` for async update
+batching. Worker contexts, server-side JavaScript runtimes, and other non-window
+hosts are outside the supported runtime boundary for the FAST Element client
+runtime. Server rendering should produce HTML for a browser to hydrate or render,
+rather than executing the FAST Element client runtime in the server process.
 
 The root entrypoint exports the FAST Element implementation APIs. Focused package
 path exports remain available when a consumer wants a narrower entrypoint,
@@ -549,7 +557,7 @@ Below is a conceptual map of the major subsystems and their relationships:
 3. When the browser upgrades the element, `ElementController.forCustomElement(element)` is called in the constructor.
 4. On `connectedCallback`, the controller renders the template into the shadow root. If the element already has a shadow root from SSR (prerendered content) and hydration has been enabled via `enableHydration()`, the installed hydration hook uses `template.hydrate()` to map existing DOM nodes to binding targets instead of cloning new DOM. If no template is available yet, the element connects without rendering until a later `definition.template` update recreates the controller. Compilation is lazy: the first render call triggers `Compiler.compile()`, subsequent calls clone the already-compiled `DocumentFragment`.
 5. `HTMLView.bind(source)` wires up each `ViewBehavior`. `oneWay` bindings create `ExpressionNotifier`s that track observable dependencies automatically.
-6. When an observed property changes, its notifier fans out to all subscribers. Each binding enqueues a DOM update via `Updates`. The next animation frame drains the queue and applies the mutations.
+6. When an observed property changes, its notifier fans out to all subscribers. Each binding enqueues a DOM update via `Updates`. In the supported browser `Window` runtime, the next animation frame drains the queue and applies the mutations.
 7. On `disconnectedCallback`, `HTMLView.unbind()` tears down all bindings; behaviors disconnect; styles are removed.
 
 ---
@@ -571,7 +579,7 @@ src/
 │   ├── observable.ts      # Observable, @observable, ExpressionNotifier, ExecutionContext
 │   ├── notifier.ts        # Subscriber, Notifier, SubscriberSet, PropertyChangeNotifier
 │   ├── arrays.ts          # ArrayObserver, Splice, SpliceStrategy
-│   └── update-queue.ts    # Updates (UpdateQueue)
+│   └── update-queue.ts    # Updates (UpdateQueue; browser Window scheduling)
 ├── binding/
 │   ├── binding.ts         # Binding abstract base class, BindingDirective
 │   ├── one-way.ts         # oneWay, listener

--- a/packages/fast-element/MIGRATION.md
+++ b/packages/fast-element/MIGRATION.md
@@ -24,6 +24,9 @@
 
 ### Changed behavior
 
+- **Browser `Window` runtime required**: `@microsoft/fast-element` is a
+  client-side browser runtime. It expects browser DOM, Custom Elements, Shadow
+  DOM, and scheduling APIs such as `requestAnimationFrame`.
 - **Native `globalThis` required**: `@microsoft/fast-element` no longer installs
   a `globalThis` polyfill as a side effect.
 - **No idle-callback polyfill**: FAST Element v3 no longer installs or depends
@@ -32,12 +35,14 @@
 
 ### Migration steps
 
-1. Verify that the browsers and JS runtimes you support provide native
-   `globalThis` and, when using async DOM updates, `requestAnimationFrame`.
-2. If you still target an older runtime without `globalThis` or
-   `requestAnimationFrame`, load those polyfills before importing
-   `@microsoft/fast-element`.
-3. You do not need to polyfill `requestIdleCallback` or `cancelIdleCallback`
+1. Verify that the browsers you support provide native `globalThis` and
+   `requestAnimationFrame`.
+2. If you still target an older browser without `globalThis`, load that polyfill
+   before importing `@microsoft/fast-element`.
+3. Do not import or run the FAST Element client runtime in workers,
+   server-side JavaScript runtimes, or other non-window hosts. SSR tools may
+   emit HTML, but hydration and client rendering run in the browser `Window`.
+4. You do not need to polyfill `requestIdleCallback` or `cancelIdleCallback`
    for FAST Element itself. Only provide them if your application or another
    dependency calls those APIs directly.
 

--- a/packages/fast-element/README.md
+++ b/packages/fast-element/README.md
@@ -55,10 +55,16 @@ Looking for a quick guide on building components?  Check out [our Cheat Sheet](.
 
 ## Browser Requirements
 
-FAST Element v3 assumes a modern runtime with native `globalThis`. The `FAST`
-object is now a module-scoped export (not on `globalThis`). If you need to
-support an environment without `globalThis`, load that polyfill before
+FAST Element v3 assumes a client-side browser `Window` runtime with native
+`globalThis`, Custom Elements, DOM, Shadow DOM, and `requestAnimationFrame`.
+The `FAST` object is now a module-scoped export (not on `globalThis`). If you
+need to support an older browser without `globalThis`, load that polyfill before
 importing `@microsoft/fast-element`.
+
+The FAST Element client runtime is not intended to execute in workers,
+server-side JavaScript runtimes, or other non-window hosts. Use server-side
+rendering tools to produce HTML for the browser, and run FAST Element in the
+client window where custom elements connect, render, update, and hydrate.
 
 ## Debug entrypoint
 

--- a/packages/fast-element/docs/architecture/fastelement.md
+++ b/packages/fast-element/docs/architecture/fastelement.md
@@ -4,6 +4,11 @@ The `FASTElement` is our extension of the `HTMLElement`. As such it leverages th
 
 For an explanation into `HTMLElement` lifecycle hooks refer to the [MDN documentation](https://developer.mozilla.org/en-US/docs/Web/API/Web_components/Using_custom_elements#custom_element_lifecycle_callbacks).
 
+Because `FASTElement` extends `HTMLElement`, it is a browser `Window` runtime
+API. It is not intended to execute in workers, server-side JavaScript runtimes,
+or other non-window hosts where custom element lifecycle callbacks and animation
+frame scheduling are unavailable.
+
 ## A Custom Element is Detected by the Browser
 
 Because the `FASTElement` is an extension of the `HTMLElement`, it makes use of the same lifecycle hooks and extends them with `$fastController`. It also initializes using another class `ElementController`, the methods this are called during the custom elements native `constructor`, `connectedCallback`, `disconnectedCallback`, and `attributeChangedCallback` lifecycle hooks.

--- a/packages/fast-element/docs/architecture/intro.md
+++ b/packages/fast-element/docs/architecture/intro.md
@@ -2,6 +2,12 @@
 
 This document (and the linked documents) explains how the exports and side effects of `@microsoft/fast-element` are used to create custom elements.
 
+`@microsoft/fast-element` is designed to run in a client-side browser `Window`
+runtime. Its element lifecycle, rendering, and update queue assume browser DOM,
+Custom Elements, Shadow DOM, and `requestAnimationFrame` are available. Workers,
+server-side JavaScript runtimes, and other non-window hosts are not supported
+targets for the FAST Element client runtime.
+
 ## Glossary
 
 - [Overview](./overview.md): How the `@microsoft/fast-element` should be used by a developer and what code is executed during the first render.

--- a/packages/fast-element/docs/architecture/overview.md
+++ b/packages/fast-element/docs/architecture/overview.md
@@ -26,6 +26,11 @@ The `FASTElement.compose()` function creates a new `FASTElementDefinition`, whic
 
 Let's step back from defining the Custom Element and consider what is happening when we import from the `@microsoft/fast-element` package.
 
+The FAST Element client runtime is expected to run in the browser `Window`.
+Custom element definition, connection, rendering, and update scheduling all rely
+on browser APIs such as the Custom Element Registry, DOM, Shadow DOM, and
+`requestAnimationFrame`.
+
 First, a global `FAST` property will be created if one does not already exist, typically in browser on the `window`.
 
 Additionally, when Custom Elements are included in a script a few things might happen even before a Custom Element gets detected by the browser. First, there are initial side effects caused by the use of decorators. These include the `attr` decorator from `@microsoft/fast-element` and the `observable` decorator from `@microsoft/fast-element`.

--- a/packages/fast-element/docs/architecture/updates.md
+++ b/packages/fast-element/docs/architecture/updates.md
@@ -1,6 +1,14 @@
 # `Updates`
 
-The `Updates` API is part of the `FAST` global. The updates that are queued include updates to attributes, observables, and observed arrays.
+The `Updates` API batches FAST Element DOM work in the client-side browser
+`Window` runtime. Queued work includes updates to attributes, observables, and
+observed arrays. The async queue is aligned to `requestAnimationFrame`, which is
+expected to be available in the supported runtime.
+
+FAST Element is not intended to run its client runtime in workers, server-side
+JavaScript runtimes, or other non-window hosts. Code that needs server rendering
+should generate HTML for the browser, then let the browser window run FAST
+Element, connect custom elements, and process queued updates.
 
 ## Attributes
 

--- a/packages/fast-element/docs/declarative-html.md
+++ b/packages/fast-element/docs/declarative-html.md
@@ -58,9 +58,11 @@ required.
 
 One of the benefits of FAST declarative HTML templates is that the server can
 be stack agnostic because JavaScript does not need to be interpreted to emit
-the initial HTML. The declarative runtime expects hydratable comment markers
-and datasets when prerendered content is generated. For the required marker
-format and initial-state application details, see
+the initial HTML. This does not mean the FAST Element client runtime runs on the
+server: custom element definition, hydration, client rendering, and reactive
+updates still run in the browser `Window`. The declarative runtime expects
+hydratable comment markers and datasets when prerendered content is generated.
+For the required marker format and initial-state application details, see
 [declarative-rendering.md](./declarative-rendering.md).
 
 ## Lifecycle Callbacks

--- a/packages/fast-element/docs/declarative-rendering.md
+++ b/packages/fast-element/docs/declarative-rendering.md
@@ -3,7 +3,7 @@
 1. [Initial State](#initial-state)
 2. [Hydrating Comments and Datasets](#hydration-comments-and-datasets)
 
-This document details information on rendering hydratable content and includes some pointers on how Dependency Injection can be used to create services that hydrate a custom elements state.
+This document details information on rendering hydratable content and includes some pointers on how Dependency Injection can be used to create services that hydrate a custom elements state. Non-browser rendering in this context means producing HTML that a browser can parse and hydrate later; it does not mean running the FAST Element client runtime in a worker, server-side JavaScript runtime, or other non-window host.
 
 ## Initial State
 

--- a/sites/website/src/docs/3.x/declarative-templates/overview.md
+++ b/sites/website/src/docs/3.x/declarative-templates/overview.md
@@ -26,7 +26,7 @@ FAST Element provides two ways to author web component templates:
 1. **Imperative** — JavaScript tagged template literals using the `html` function.
 2. **Declarative** — Plain HTML `<f-template>` elements parsed at runtime.
 
-The declarative model moves template authoring from JavaScript into HTML. Because templates are expressed as standard markup, they can be rendered by any server-side technology without a JavaScript runtime — enabling true stack-agnostic server-side rendering.
+The declarative model moves template authoring from JavaScript into HTML. Because templates are expressed as standard markup, they can be rendered by any server-side technology without running the FAST Element client runtime — enabling true stack-agnostic server-side rendering. Hydration and client rendering still run in the browser `Window`.
 
 ## When to Use Declarative Templates
 

--- a/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
+++ b/sites/website/src/docs/3.x/declarative-templates/server-rendering.md
@@ -22,7 +22,12 @@ keywords:
 
 # Server-Side Rendering
 
-One of the core benefits of FAST's declarative HTML templates is stack-agnostic server-side rendering. Because `<f-template>` markup is standard HTML with binding expressions — not JavaScript — any server technology can render the initial page without a JS runtime.
+One of the core benefits of FAST's declarative HTML templates is stack-agnostic server-side rendering. Because `<f-template>` markup is standard HTML with binding expressions — not JavaScript — any server technology can render the initial page without running the FAST Element client runtime.
+
+The FAST Element client runtime remains browser-only. Servers emit HTML and
+hydration markers; the browser `Window` parses Declarative Shadow DOM, defines
+custom elements, runs `enableHydration()`, and processes reactive updates with
+browser scheduling APIs such as `requestAnimationFrame`.
 
 ## The Rendering Contract
 

--- a/sites/website/src/docs/3.x/migration-guide.md
+++ b/sites/website/src/docs/3.x/migration-guide.md
@@ -15,6 +15,12 @@ keywords:
 
 # Migrating from 2.x to 3.x
 
+FAST Element 3.x targets client-side browser `Window` runtimes. Do not import or
+run the FAST Element client runtime in workers, server-side JavaScript runtimes,
+or other non-window hosts. Server rendering tools may emit HTML, but hydration
+and client rendering run in the browser window where DOM, Custom Elements,
+Shadow DOM, and `requestAnimationFrame` are available.
+
 ## Breaking Changes
 
 ### `HydratableElementController` removed

--- a/sites/website/src/docs/3.x/resources/browser-support.md
+++ b/sites/website/src/docs/3.x/resources/browser-support.md
@@ -14,10 +14,12 @@ keywords:
 ---
 
 FAST Element v3 builds on native web platform features. The baseline
-client-rendered runtime expects autonomous custom elements, Shadow DOM, and
-native `globalThis` support. Optional capabilities, such as Declarative Shadow
-DOM hydration and constructable stylesheets, use newer browser features when
-they are available.
+client-rendered runtime expects a browser `Window` environment with autonomous
+custom elements, Shadow DOM, `requestAnimationFrame`, and native `globalThis`
+support. Worker contexts, server-side JavaScript runtimes, and other non-window
+hosts are outside the supported runtime boundary for FAST Element's client
+runtime. Optional capabilities, such as Declarative Shadow DOM hydration and
+constructable stylesheets, use newer browser features when they are available.
 
 ## Baseline runtime support
 
@@ -47,10 +49,11 @@ an application opts into those features.
 |---|---|---|
 | Web Components / custom elements | Supported by the baseline browsers above for autonomous custom elements. FAST Element does not use customized built-in elements. | No FAST fallback. Browsers must provide native custom elements, or the application must load compatible platform polyfills before defining FAST elements. |
 | Shadow DOM | Supported by the baseline browsers above. FAST creates an open shadow root by default for templates and style encapsulation. | No FAST Shadow DOM polyfill. Components that intentionally set `shadowOptions: null` can render to light DOM, but default FAST Element authoring expects browser Shadow DOM support. |
+| `requestAnimationFrame` | Required by the FAST Element client runtime for asynchronous DOM update batching through `Updates`. Supported by the baseline browser `Window` environments above. | FAST Element does not support worker or non-window runtimes where `requestAnimationFrame` is unavailable. Run FAST Element in the browser window and use server-rendering tools only to produce HTML for the browser to consume. |
 | Declarative Shadow DOM | Optional for client-only rendering. Hydration requires browser support for `<template shadowrootmode>`, such as Chrome/Edge 111+, Firefox 123+, Safari/iOS Safari 16.4+, Opera 97+, Samsung Internet 22+, and current Chromium-based mobile browsers. | FAST hydrates an existing shadow root; it does not make unsupported browsers parse Declarative Shadow DOM. Older browsers need an application-level DSD transform/polyfill before components connect, or they should use client rendering. |
 | `adoptedStyleSheets` / constructable stylesheets | Supported in Chrome 73+, Edge 79+, Firefox 101+, Safari/iOS Safari 16.4+, Opera 60+, Samsung Internet 11.1+, and current Chromium-based mobile browsers. | FAST falls back to injected `<style>` elements for string-based `css` styles when adopted stylesheets are unavailable. Passing `CSSStyleSheet` instances directly requires browser constructable stylesheet support. |
 | Trusted Types | Not part of the FAST Element baseline. Available in Chrome/Edge 83+, Firefox 148+, Safari/iOS Safari 26+, Opera 69+, Samsung Internet 13+, and matching current Chromium-based mobile browsers. | FAST creates a Trusted Types policy when `globalThis.trustedTypes` exists and otherwise uses its string-based DOM policy. Apps that enforce `require-trusted-types-for` must configure an appropriate DOM policy before templates compile. |
-| `globalThis` | Required by FAST Element v3. The baseline versions above include native `globalThis` support. | FAST Element v3 no longer polyfills `globalThis`. Load a `globalThis` polyfill before importing FAST in older browsers or non-browser runtimes. |
+| `globalThis` | Required by FAST Element v3. The baseline browser versions above include native `globalThis` support. | FAST Element v3 no longer polyfills `globalThis`. Load a `globalThis` polyfill before importing FAST in older browsers. |
 
 ## SSR and hydration notes
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Documents the supported runtime boundary for `@microsoft/fast-element`: the client runtime is expected to run in a browser `Window` environment where DOM, Custom Elements, Shadow DOM, and `requestAnimationFrame` are available.

This replaces the need for the scheduler fallback proposed in #7549 by making the support boundary explicit:

- FAST Element should not be imported or executed as a worker runtime, server-side JavaScript runtime, or other non-window host.
- Server-side rendering tools may emit HTML and hydration markers, but hydration and client rendering happen in the browser window.
- `Updates` remains documented as browser `requestAnimationFrame`-batched work.

## 👩‍💻 Reviewer Notes

This PR intentionally documents the runtime contract rather than adding a `setTimeout` fallback for non-window environments.

## 📑 Test Plan

- `npx --yes -p @biomejs/biome@2.4.8 biome check --no-errors-on-unmatched --files-ignore-unknown=true --colors=off <changed docs>`
- `npx --yes -p beachball@2.63.0 beachball check --scope "!sites/*" --changehint "Run 'npm run change' to generate a change file" --branch origin/releases/fast-element-v3`

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
