### PR TITLE
chore: add fast element v3 rc finalizer

### DIFF
--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,7 +24,7 @@ Nightly publishing is split into two coordinated jobs so that npm credentials ne
 
 Both scripts are thin Node.js wrappers around existing CLI tools and repository metadata — no extra npm dependencies and no custom GitHub API client. Idempotency is enforced entirely through git tags (`${name}_v${version}` on the GitHub side, `deployed/${name}_v${version}` on the Azure side), so neither side needs to talk to npm.org or crates.io to decide whether work is required.
 
-The `releases/fast-element-v3-rc` branch is npm-only for paired artifacts: the `microsoft-fast-build` Rust crate is not packaged or published from that RC branch. The release scripts detect that branch automatically and skip paired crate validation/packaging; local previews can request the same behavior with `FAST_RELEASE_SKIP_CRATES=true`.
+The `releases/fast-element-v3-rc` branch is npm-only for paired artifacts: the `microsoft-fast-build` Rust crate is not packaged or published from that RC branch. The release scripts detect that branch automatically and skip paired crate validation/packaging; local previews can request the same behavior with `FAST_RELEASE_SKIP_CRATES=true`. This is temporary RC-only logic tracked by [issue #7595](https://github.com/microsoft/fast/issues/7595). Before merging the RC branch back to `main` after FAST Element 3.x stable, remove the crate-skip behavior and related finalizer workflow from [PR #7594](https://github.com/microsoft/fast/pull/7594), cross-checking the RC baseline/prep work in [PR #7591](https://github.com/microsoft/fast/pull/7591).
 
 ### Adding a publishable package
 

--- a/.github/workflows/README.md
+++ b/.github/workflows/README.md
@@ -24,6 +24,8 @@ Nightly publishing is split into two coordinated jobs so that npm credentials ne
 
 Both scripts are thin Node.js wrappers around existing CLI tools and repository metadata — no extra npm dependencies and no custom GitHub API client. Idempotency is enforced entirely through git tags (`${name}_v${version}` on the GitHub side, `deployed/${name}_v${version}` on the Azure side), so neither side needs to talk to npm.org or crates.io to decide whether work is required.
 
+The `releases/fast-element-v3-rc` branch is npm-only for paired artifacts: the `microsoft-fast-build` Rust crate is not packaged or published from that RC branch. The release scripts detect that branch automatically and skip paired crate validation/packaging; local previews can request the same behavior with `FAST_RELEASE_SKIP_CRATES=true`.
+
 ### Adding a publishable package
 
 `cd-github-releases.yml` discovers publishable workspaces automatically from the root `package.json` `workspaces` list, but `azure-pipelines-cd.yml` must be updated because Azure Pipelines cannot create `DownloadGitHubRelease@0` tasks dynamically from the runtime detection output.

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -227,6 +227,22 @@ The same flow works for a single-package release — just keep only the relevant
 npx beachball bump --package "@microsoft/fast-build"
 ```
 
+#### FAST Element v3 RC finalizer
+
+The `releases/fast-element-v3-rc` branch uses a custom RC version plan that Beachball cannot express directly. To finalize that branch, run the guarded local finalizer instead of raw `npm run bump`:
+
+```bash
+npm run finalize:fast-element-v3-rc
+```
+
+By default this creates a disposable worktree, runs the finalizer there, prints the resulting version table and diff summary, and removes the worktree. To apply the same edits to the current worktree after reviewing the dry run:
+
+```bash
+npm run finalize:fast-element-v3-rc -- --apply
+```
+
+The finalizer uses Beachball only to consume change files and generate changelog entries, then rewrites the explicit RC versions and exact internal dependency pins. It does not publish, tag, push, create GitHub releases, or invoke any release workflow. The v3 RC branch publishes npm packages only; paired Rust crate validation and packaging are skipped automatically for `releases/fast-element-v3-rc` and can be skipped explicitly with `FAST_RELEASE_SKIP_CRATES=true` during local previews.
+
 ### Manual version bumps
 
 `npm run checkchange` normally requires a beachball [change file](#change-files) for any edit to `packages/*/package.json`, including a single `"version"` line. Three maintainer-driven flows produce legitimate `package.json` edits without a change file:

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -243,6 +243,10 @@ npm run finalize:fast-element-v3-rc -- --apply
 
 The finalizer uses Beachball only to consume change files and generate changelog entries, then rewrites the explicit RC versions and exact internal dependency pins. It does not publish, tag, push, create GitHub releases, or invoke any release workflow. The v3 RC branch publishes npm packages only; paired Rust crate validation and packaging are skipped automatically for `releases/fast-element-v3-rc` and can be skipped explicitly with `FAST_RELEASE_SKIP_CRATES=true` during local previews.
 
+:::warning[Temporary RC branch logic]
+Before merging `releases/fast-element-v3-rc` back into `main` after FAST Element 3.x stable has been released, complete [issue #7595](https://github.com/microsoft/fast/issues/7595). Remove the temporary finalizer script, the `finalize:fast-element-v3-rc` package script, this documentation section, and the npm-only paired-crate skip logic added for the RC branch. Start from [PR #7594](https://github.com/microsoft/fast/pull/7594) and cross-check the RC baseline/prep work in [PR #7591](https://github.com/microsoft/fast/pull/7591) so the merge-back does not leave branch-specific version suffix, dist-tag, or crate-skip behavior on `main`.
+:::
+
 ### Manual version bumps
 
 `npm run checkchange` normally requires a beachball [change file](#change-files) for any edit to `packages/*/package.json`, including a single `"version"` line. Three maintainer-driven flows produce legitimate `package.json` edits without a change file:

--- a/build/scripts/create-github-releases.mjs
+++ b/build/scripts/create-github-releases.mjs
@@ -61,6 +61,7 @@ const NPM_DIR = "publish_artifacts_npm";
 const CRATES_DIR = "publish_artifacts_crates";
 const CHECK_ONLY = process.argv.includes("--check-only");
 const FAST_ELEMENT_V3_RC_BRANCH = "releases/fast-element-v3-rc";
+let skipCratesCache;
 
 function run(file, args, opts = {}) {
     return execFileSync(file, args, { encoding: "utf8", ...opts });
@@ -94,10 +95,13 @@ function currentBranchName() {
 }
 
 function shouldSkipCrates() {
-    return (
-        process.env.FAST_RELEASE_SKIP_CRATES === "true" ||
-        currentBranchName() === FAST_ELEMENT_V3_RC_BRANCH
-    );
+    if (skipCratesCache === undefined) {
+        skipCratesCache =
+            process.env.FAST_RELEASE_SKIP_CRATES === "true" ||
+            currentBranchName() === FAST_ELEMENT_V3_RC_BRANCH;
+    }
+
+    return skipCratesCache;
 }
 
 function readCargoTomlVersion(cargoTomlPath) {

--- a/build/scripts/create-github-releases.mjs
+++ b/build/scripts/create-github-releases.mjs
@@ -39,6 +39,9 @@
  * Set `FAST_RELEASE_SKIP_CRATES=true` to skip paired Rust crate validation and
  * packaging. This is also enabled automatically on `releases/fast-element-v3-rc`,
  * whose RC publishes npm packages only.
+ * TODO #7595: Remove this RC-only crate skip before merging
+ * `releases/fast-element-v3-rc` back to `main` after FAST Element 3.x stable
+ * has been released. See https://github.com/microsoft/fast/issues/7595.
  *
  * Authentication: the `gh` CLI reads `GH_TOKEN` from the environment.
  */

--- a/build/scripts/create-github-releases.mjs
+++ b/build/scripts/create-github-releases.mjs
@@ -36,6 +36,10 @@
  *     to `"true"` or `"false"`. Performs no packing, no tagging, no
  *     release creation. Safe to run without `node_modules` populated.
  *
+ * Set `FAST_RELEASE_SKIP_CRATES=true` to skip paired Rust crate validation and
+ * packaging. This is also enabled automatically on `releases/fast-element-v3-rc`,
+ * whose RC publishes npm packages only.
+ *
  * Authentication: the `gh` CLI reads `GH_TOKEN` from the environment.
  */
 
@@ -53,6 +57,7 @@ import { basename, join, resolve } from "node:path";
 const NPM_DIR = "publish_artifacts_npm";
 const CRATES_DIR = "publish_artifacts_crates";
 const CHECK_ONLY = process.argv.includes("--check-only");
+const FAST_ELEMENT_V3_RC_BRANCH = "releases/fast-element-v3-rc";
 
 function run(file, args, opts = {}) {
     return execFileSync(file, args, { encoding: "utf8", ...opts });
@@ -71,6 +76,25 @@ function gitTagExists(tag) {
 
 function npmNameToCrateName(npmName) {
     return npmName.replace(/^@/, "").replace(/\//g, "-");
+}
+
+function currentBranchName() {
+    if (process.env.GITHUB_REF_NAME) {
+        return process.env.GITHUB_REF_NAME;
+    }
+
+    try {
+        return run("git", ["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+    } catch {
+        return "";
+    }
+}
+
+function shouldSkipCrates() {
+    return (
+        process.env.FAST_RELEASE_SKIP_CRATES === "true" ||
+        currentBranchName() === FAST_ELEMENT_V3_RC_BRANCH
+    );
 }
 
 function readCargoTomlVersion(cargoTomlPath) {
@@ -118,7 +142,7 @@ function listPublishableWorkspaces() {
 
         const crateName = npmNameToCrateName(pkg.name);
         const cargoTomlPath = join("crates", crateName, "Cargo.toml");
-        const hasCrate = existsSync(cargoTomlPath);
+        const hasCrate = existsSync(cargoTomlPath) && !shouldSkipCrates();
 
         if (hasCrate) {
             const crateVersion = readCargoTomlVersion(cargoTomlPath);
@@ -147,6 +171,9 @@ function setGitHubOutput(name, value) {
 }
 
 const publishable = listPublishableWorkspaces();
+if (shouldSkipCrates()) {
+    console.log("Paired Rust crate assets are skipped for this release run.");
+}
 
 if (publishable.length === 0) {
     console.log("No publishable workspaces found.");

--- a/build/scripts/download-github-releases.mjs
+++ b/build/scripts/download-github-releases.mjs
@@ -20,6 +20,9 @@
  * Inputs:
  *
  *   - `GITHUB_REPOSITORY` env var (`owner/repo`) — required.
+ *   - `FAST_RELEASE_SKIP_CRATES=true` — skips paired Rust crate validation.
+ *     This is also enabled automatically on `releases/fast-element-v3-rc`,
+ *     whose RC publishes npm packages only.
  * The script reads workspace package manifests and paired Cargo manifests only:
  * the source of truth for "what should be published" is the current workspace
  * versions plus matching release tags. This keeps historical bare beachball tags
@@ -32,6 +35,7 @@ import { existsSync, readdirSync, readFileSync } from "node:fs";
 import { join } from "node:path";
 
 const CHECK_ONLY = process.argv.includes("--check-only");
+const FAST_ELEMENT_V3_RC_BRANCH = "releases/fast-element-v3-rc";
 if (!CHECK_ONLY) {
     console.error(
         "download-github-releases.mjs only supports --check-only; Azure Pipelines downloads assets with DownloadGitHubRelease@0.",
@@ -58,6 +62,33 @@ function listGitTags() {
 
 function npmNameToCrateName(npmName) {
     return npmName.replace(/^@/, "").replace(/\//g, "-");
+}
+
+function currentBranchName() {
+    if (process.env.BUILD_SOURCEBRANCH?.startsWith("refs/heads/")) {
+        return process.env.BUILD_SOURCEBRANCH.slice("refs/heads/".length);
+    }
+
+    if (process.env.BUILD_SOURCEBRANCHNAME) {
+        return process.env.BUILD_SOURCEBRANCHNAME;
+    }
+
+    if (process.env.GITHUB_REF_NAME) {
+        return process.env.GITHUB_REF_NAME;
+    }
+
+    try {
+        return run("git", ["rev-parse", "--abbrev-ref", "HEAD"]).trim();
+    } catch {
+        return "";
+    }
+}
+
+function shouldSkipCrates() {
+    return (
+        process.env.FAST_RELEASE_SKIP_CRATES === "true" ||
+        currentBranchName() === FAST_ELEMENT_V3_RC_BRANCH
+    );
 }
 
 function npmNameToOutputPrefix(npmName) {
@@ -111,7 +142,7 @@ function listPublishableWorkspaces() {
 
         const crateName = npmNameToCrateName(pkg.name);
         const cargoTomlPath = join("crates", crateName, "Cargo.toml");
-        const hasCrate = existsSync(cargoTomlPath);
+        const hasCrate = existsSync(cargoTomlPath) && !shouldSkipCrates();
 
         if (hasCrate) {
             const crateVersion = readCargoTomlVersion(cargoTomlPath);
@@ -145,6 +176,9 @@ const deployed = new Set(
     allTags.filter(t => t.startsWith("deployed/")).map(t => t.slice("deployed/".length)),
 );
 const publishable = listPublishableWorkspaces();
+if (shouldSkipCrates()) {
+    console.log("Paired Rust crate assets are skipped for this deployment check.");
+}
 const releaseCandidates = publishable
     .filter(({ tag }) => tagSet.has(tag))
     .sort((a, b) => a.tag.localeCompare(b.tag));

--- a/build/scripts/download-github-releases.mjs
+++ b/build/scripts/download-github-releases.mjs
@@ -39,6 +39,7 @@ import { join } from "node:path";
 
 const CHECK_ONLY = process.argv.includes("--check-only");
 const FAST_ELEMENT_V3_RC_BRANCH = "releases/fast-element-v3-rc";
+let skipCratesCache;
 if (!CHECK_ONLY) {
     console.error(
         "download-github-releases.mjs only supports --check-only; Azure Pipelines downloads assets with DownloadGitHubRelease@0.",
@@ -88,10 +89,13 @@ function currentBranchName() {
 }
 
 function shouldSkipCrates() {
-    return (
-        process.env.FAST_RELEASE_SKIP_CRATES === "true" ||
-        currentBranchName() === FAST_ELEMENT_V3_RC_BRANCH
-    );
+    if (skipCratesCache === undefined) {
+        skipCratesCache =
+            process.env.FAST_RELEASE_SKIP_CRATES === "true" ||
+            currentBranchName() === FAST_ELEMENT_V3_RC_BRANCH;
+    }
+
+    return skipCratesCache;
 }
 
 function npmNameToOutputPrefix(npmName) {

--- a/build/scripts/download-github-releases.mjs
+++ b/build/scripts/download-github-releases.mjs
@@ -23,6 +23,9 @@
  *   - `FAST_RELEASE_SKIP_CRATES=true` — skips paired Rust crate validation.
  *     This is also enabled automatically on `releases/fast-element-v3-rc`,
  *     whose RC publishes npm packages only.
+ * TODO #7595: Remove this RC-only crate skip before merging
+ * `releases/fast-element-v3-rc` back to `main` after FAST Element 3.x stable
+ * has been released. See https://github.com/microsoft/fast/issues/7595.
  * The script reads workspace package manifests and paired Cargo manifests only:
  * the source of truth for "what should be published" is the current workspace
  * versions plus matching release tags. This keeps historical bare beachball tags

--- a/build/scripts/finalize-fast-element-v3-rc.mjs
+++ b/build/scripts/finalize-fast-element-v3-rc.mjs
@@ -38,9 +38,15 @@ const args = new Set(process.argv.slice(2));
 const APPLY = args.has("--apply");
 const KEEP = args.has("--keep");
 const ALLOW_SCRIPT_OVERRIDES = args.has("--allow-script-overrides");
+const ALLOW_NON_RC_REF = args.has("--allow-non-rc-ref");
 const REF = readArg("--ref") ?? "HEAD";
-const RC_SUFFIX = "fast-element-v3-rc-20260616";
-const RC_DIST_TAG = "rc-20260616";
+const TARGET_RC_BRANCH = "releases/fast-element-v3-rc";
+const TARGET_RC_REF = readArg("--target-ref") ?? `origin/${TARGET_RC_BRANCH}`;
+// Single source for the branch-cut date used by companion versions and npm dist-tag.
+const RC_BRANCH_CUT_DATE = "2026-06-15";
+const RC_DATE = formatRcDate(RC_BRANCH_CUT_DATE);
+const RC_SUFFIX = `fast-element-v3-rc-${RC_DATE}`;
+const RC_DIST_TAG = `rc-${RC_DATE}`;
 
 const packageOrder = [
     "@microsoft/fast-build",
@@ -70,8 +76,32 @@ function run(file, commandArgs, options = {}) {
     });
 }
 
+function git(commandArgs, options = {}) {
+    return run("git", commandArgs, options).trim();
+}
+
+function gitSucceeds(commandArgs, options = {}) {
+    try {
+        execFileSync("git", commandArgs, {
+            cwd: options.cwd ?? repoRoot,
+            stdio: "ignore",
+        });
+        return true;
+    } catch {
+        return false;
+    }
+}
+
 function readJson(path) {
     return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function formatRcDate(value) {
+    if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
+        throw new Error(`Invalid RC branch-cut date ${value}. Expected YYYY-MM-DD.`);
+    }
+
+    return value.replaceAll("-", "");
 }
 
 function writeJson(path, value) {
@@ -118,6 +148,29 @@ function ensureCleanWorktree() {
         throw new Error(
             "The worktree must be clean before finalizing the RC.\n" +
                 "Commit, stash, or discard existing changes first.",
+        );
+    }
+}
+
+function ensureRcBaseRef(ref) {
+    if (ALLOW_NON_RC_REF) {
+        return;
+    }
+
+    let targetSha;
+    let refSha;
+    try {
+        targetSha = git(["rev-parse", "--verify", TARGET_RC_REF]);
+        refSha = git(["rev-parse", "--verify", ref]);
+    } catch {
+        throw new Error(
+            `Unable to resolve ${TARGET_RC_REF} and ${ref}. Fetch the RC branch or pass --target-ref/--allow-non-rc-ref.`,
+        );
+    }
+
+    if (!gitSucceeds(["merge-base", "--is-ancestor", targetSha, refSha])) {
+        throw new Error(
+            `${ref} is not based on ${TARGET_RC_REF}. The FAST Element v3 RC finalizer only runs on branches snapped from ${TARGET_RC_BRANCH}. Pass --allow-non-rc-ref to override intentionally.`,
         );
     }
 }
@@ -215,6 +268,28 @@ function computeFinalVersions() {
             rawVersions["@microsoft/fast-test-harness"],
         ),
     };
+}
+
+function parseFastElementRcNumber(version) {
+    const match = /^3\.0\.0-rc\.(\d+)$/.exec(version);
+    if (!match) {
+        throw new Error(
+            `Expected @microsoft/fast-element to be a 3.0.0 RC, got ${version}.`,
+        );
+    }
+
+    return Number(match[1]);
+}
+
+function assertFastElementRcAdvanced(beforeVersion, afterVersion) {
+    const before = parseFastElementRcNumber(beforeVersion);
+    const after = parseFastElementRcNumber(afterVersion);
+
+    if (after <= before) {
+        throw new Error(
+            `Expected @microsoft/fast-element RC version to advance beyond ${beforeVersion}, got ${afterVersion}. Check that prerelease change files are present before finalizing.`,
+        );
+    }
 }
 
 function rewritePackageVersions(finalVersions) {
@@ -344,7 +419,21 @@ function updateLockfile() {
     );
 }
 
-function verifyFinalState(finalVersions) {
+function readCargoVersion() {
+    const cargoToml = readFileSync(
+        join(repoRoot, "crates/microsoft-fast-build/Cargo.toml"),
+        "utf8",
+    );
+    const match = /^\s*version\s*=\s*"([^"]+)"/m.exec(cargoToml);
+
+    if (!match) {
+        throw new Error("Could not read microsoft-fast-build Cargo.toml version.");
+    }
+
+    return match[1];
+}
+
+function verifyFinalState(finalVersions, initialCrateVersion) {
     for (const packageName of packageOrder) {
         const pkg = getPackage(packageName);
         if (pkg.version !== finalVersions[packageName]) {
@@ -354,13 +443,10 @@ function verifyFinalState(finalVersions) {
         }
     }
 
-    const cargoToml = readFileSync(
-        join(repoRoot, "crates/microsoft-fast-build/Cargo.toml"),
-        "utf8",
-    );
-    if (!/version\s*=\s*"0\.7\.0"/.test(cargoToml)) {
+    const crateVersion = readCargoVersion();
+    if (crateVersion !== initialCrateVersion) {
         throw new Error(
-            "microsoft-fast-build Cargo.toml changed. The v3 RC finalizer must not version the Rust crate.",
+            `microsoft-fast-build Cargo.toml changed from ${initialCrateVersion} to ${crateVersion}. The v3 RC finalizer must not version the Rust crate.`,
         );
     }
 
@@ -381,6 +467,7 @@ function printVersionTable(finalVersions) {
     for (const packageName of packageOrder) {
         console.log(`  - ${packageName}@${finalVersions[packageName]}`);
     }
+    console.log(`\nRC branch-cut date: ${RC_BRANCH_CUT_DATE} (${RC_DATE})`);
     console.log(`\nUse npm dist-tag: ${RC_DIST_TAG}`);
     console.log("Rust crate packaging is intentionally excluded for this RC branch.");
 }
@@ -400,34 +487,50 @@ function previewReleases() {
 }
 
 function applyFinalizer() {
+    ensureRcBaseRef("HEAD");
     ensureCleanWorktree();
     ensureChangeFilesExist();
+
+    const baselineVersions = Object.fromEntries(
+        packageOrder.map(packageName => [packageName, getPackage(packageName).version]),
+    );
+    const initialCrateVersion = readCargoVersion();
 
     runBeachballBump();
 
     const rawVersions = Object.fromEntries(
         packageOrder.map(packageName => [packageName, getPackage(packageName).version]),
     );
+    assertFastElementRcAdvanced(
+        baselineVersions["@microsoft/fast-element"],
+        rawVersions["@microsoft/fast-element"],
+    );
     const finalVersions = computeFinalVersions();
 
     rewritePackageVersions(finalVersions);
     rewriteChangelogs(finalVersions, rawVersions);
     updateLockfile();
-    verifyFinalState(finalVersions);
+    verifyFinalState(finalVersions, initialCrateVersion);
     printVersionTable(finalVersions);
     previewReleases();
 }
 
 function dryRun() {
-    const temp = mkdtempSync(join(tmpdir(), "fast-element-v3-rc-finalizer-"));
-    const repoDir = join(temp, "repo");
-    console.log(`Creating disposable worktree at ${repoDir}`);
-    run("git", ["worktree", "add", "--detach", repoDir, REF], {
-        cwd: repoRoot,
-        stdio: "inherit",
-    });
+    ensureRcBaseRef(REF);
+
+    let temp;
+    let repoDir;
 
     try {
+        gitSucceeds(["worktree", "prune"]);
+        temp = mkdtempSync(join(tmpdir(), "fast-element-v3-rc-finalizer-"));
+        repoDir = join(temp, "repo");
+        console.log(`Creating disposable worktree at ${repoDir}`);
+        run("git", ["worktree", "add", "--detach", repoDir, REF], {
+            cwd: repoRoot,
+            stdio: "inherit",
+        });
+
         for (const file of [
             "build/scripts/finalize-fast-element-v3-rc.mjs",
             "build/scripts/create-github-releases.mjs",
@@ -450,13 +553,29 @@ function dryRun() {
         run("git", ["--no-pager", "diff", "--stat"], { cwd: repoDir, stdio: "inherit" });
     } finally {
         if (KEEP) {
-            console.log(`Keeping disposable worktree: ${repoDir}`);
+            if (repoDir) {
+                console.log(`Keeping disposable worktree: ${repoDir}`);
+            }
         } else {
-            run("git", ["worktree", "remove", "--force", repoDir], {
-                cwd: repoRoot,
-                stdio: "inherit",
-            });
-            rmSync(temp, { recursive: true, force: true });
+            if (repoDir && existsSync(repoDir)) {
+                try {
+                    run("git", ["worktree", "remove", "--force", repoDir], {
+                        cwd: repoRoot,
+                        stdio: "inherit",
+                    });
+                } catch (error) {
+                    console.warn(
+                        `Could not remove disposable worktree ${repoDir}: ${
+                            error instanceof Error ? error.message : String(error)
+                        }`,
+                    );
+                    gitSucceeds(["worktree", "prune"]);
+                }
+            }
+
+            if (temp) {
+                rmSync(temp, { recursive: true, force: true });
+            }
         }
     }
 }

--- a/build/scripts/finalize-fast-element-v3-rc.mjs
+++ b/build/scripts/finalize-fast-element-v3-rc.mjs
@@ -1,0 +1,473 @@
+#!/usr/bin/env node
+/**
+ * Finalize the FAST Element v3 RC package versions.
+ *
+ * This script is intentionally local-only. It runs Beachball's `bump` command
+ * to consume change files and generate changelog entries, then rewrites the
+ * package versions to the explicit RC plan for this branch. It never invokes
+ * publish, release creation, tag creation, or push commands.
+ *
+ * Default mode is a disposable dry run:
+ *
+ *   node build/scripts/finalize-fast-element-v3-rc.mjs
+ *
+ * To apply changes to the current worktree:
+ *
+ *   node build/scripts/finalize-fast-element-v3-rc.mjs --apply
+ */
+
+import { execFileSync } from "node:child_process";
+import {
+    copyFileSync,
+    existsSync,
+    mkdirSync,
+    mkdtempSync,
+    readdirSync,
+    readFileSync,
+    rmSync,
+    writeFileSync,
+} from "node:fs";
+import { tmpdir } from "node:os";
+import { dirname, join, resolve } from "node:path";
+import { fileURLToPath } from "node:url";
+
+const scriptPath = fileURLToPath(import.meta.url);
+const repoRoot = resolve(dirname(scriptPath), "..", "..");
+const args = new Set(process.argv.slice(2));
+
+const APPLY = args.has("--apply");
+const KEEP = args.has("--keep");
+const ALLOW_SCRIPT_OVERRIDES = args.has("--allow-script-overrides");
+const REF = readArg("--ref") ?? "HEAD";
+const RC_SUFFIX = "fast-element-v3-rc-20260616";
+const RC_DIST_TAG = "rc-20260616";
+
+const packageOrder = [
+    "@microsoft/fast-build",
+    "@microsoft/fast-element",
+    "@microsoft/fast-router",
+    "@microsoft/fast-test-harness",
+];
+
+const packagePaths = {
+    "@microsoft/fast-build": "packages/fast-build",
+    "@microsoft/fast-element": "packages/fast-element",
+    "@microsoft/fast-router": "packages/fast-router",
+    "@microsoft/fast-test-harness": "packages/fast-test-harness",
+};
+
+function readArg(name) {
+    const index = process.argv.indexOf(name);
+    return index === -1 ? undefined : process.argv[index + 1];
+}
+
+function run(file, commandArgs, options = {}) {
+    return execFileSync(file, commandArgs, {
+        cwd: options.cwd ?? repoRoot,
+        encoding: "utf8",
+        stdio: options.stdio ?? "pipe",
+        env: options.env ?? process.env,
+    });
+}
+
+function readJson(path) {
+    return JSON.parse(readFileSync(path, "utf8"));
+}
+
+function writeJson(path, value) {
+    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+}
+
+function packageJsonPath(packageName) {
+    return join(repoRoot, packagePaths[packageName], "package.json");
+}
+
+function changelogJsonPath(packageName) {
+    return join(repoRoot, packagePaths[packageName], "CHANGELOG.json");
+}
+
+function changelogMdPath(packageName) {
+    return join(repoRoot, packagePaths[packageName], "CHANGELOG.md");
+}
+
+function getPackage(packageName) {
+    return readJson(packageJsonPath(packageName));
+}
+
+function setDependency(pkg, section, dependencyName, version) {
+    if (pkg[section]?.[dependencyName] !== undefined) {
+        pkg[section][dependencyName] = version;
+    }
+}
+
+function ensureCleanWorktree() {
+    const status = run("git", ["status", "--porcelain"], { cwd: repoRoot });
+    const ignored = new Set([
+        "build/scripts/create-github-releases.mjs",
+        "build/scripts/finalize-fast-element-v3-rc.mjs",
+    ]);
+    const dirty = status
+        .split("\n")
+        .filter(Boolean)
+        .filter(line => {
+            const file = line.slice(3);
+            return !(ALLOW_SCRIPT_OVERRIDES && ignored.has(file));
+        });
+
+    if (dirty.length > 0) {
+        throw new Error(
+            "The worktree must be clean before finalizing the RC.\n" +
+                "Commit, stash, or discard existing changes first.",
+        );
+    }
+}
+
+function ensureChangeFilesExist() {
+    const changeDir = join(repoRoot, "change");
+    if (!existsSync(changeDir)) {
+        throw new Error("No change/ directory exists. Nothing is available to bump.");
+    }
+
+    const files = readdirSync(changeDir).filter(file => file.endsWith(".json"));
+    if (files.length === 0) {
+        throw new Error("No change/*.json files exist. Nothing is available to bump.");
+    }
+}
+
+function createTemporaryBeachballConfig() {
+    const tempDir = mkdtempSync(join(tmpdir(), "fast-element-v3-rc-beachball-"));
+    const configPath = join(tempDir, "beachball.config.cjs");
+    const content = [
+        `const baseConfig = require(${JSON.stringify(join(repoRoot, "beachball.config.js"))});`,
+        "",
+        "module.exports = {",
+        "  ...baseConfig,",
+        "  scope: [",
+        '    "packages/fast-element",',
+        '    "packages/fast-build",',
+        '    "packages/fast-router",',
+        '    "packages/fast-test-harness",',
+        "  ],",
+        "  hooks: {},",
+        `  tag: ${JSON.stringify(RC_DIST_TAG)},`,
+        `  defaultNpmTag: ${JSON.stringify(RC_DIST_TAG)},`,
+        "};",
+        "",
+    ].join("\n");
+
+    writeFileSync(configPath, content);
+    return { configPath, tempDir };
+}
+
+function removeTemporaryBeachballConfig({ tempDir }) {
+    rmSync(tempDir, { recursive: true, force: true });
+}
+
+function runBeachballBump() {
+    const config = createTemporaryBeachballConfig();
+    try {
+        run(
+            "npx",
+            [
+                "beachball",
+                "bump",
+                "--config-path",
+                config.configPath,
+                "--no-fetch",
+                "--scope",
+                "packages/fast-element",
+                "--scope",
+                "packages/fast-build",
+                "--scope",
+                "packages/fast-router",
+                "--scope",
+                "packages/fast-test-harness",
+                "--yes",
+            ],
+            { cwd: repoRoot, stdio: "inherit" },
+        );
+    } finally {
+        removeTemporaryBeachballConfig(config);
+    }
+}
+
+function appendSuffix(version) {
+    return version.includes(RC_SUFFIX) ? version : `${version}-${RC_SUFFIX}`;
+}
+
+function computeFinalVersions() {
+    const rawVersions = Object.fromEntries(
+        packageOrder.map(packageName => [packageName, getPackage(packageName).version]),
+    );
+
+    const fastElementVersion = rawVersions["@microsoft/fast-element"];
+    if (!/^3\.0\.0-rc\.\d+$/.test(fastElementVersion)) {
+        throw new Error(
+            `Expected @microsoft/fast-element to be a 3.0.0 RC after Beachball, got ${fastElementVersion}.`,
+        );
+    }
+
+    return {
+        "@microsoft/fast-build": appendSuffix(rawVersions["@microsoft/fast-build"]),
+        "@microsoft/fast-element": fastElementVersion,
+        "@microsoft/fast-router": appendSuffix(rawVersions["@microsoft/fast-router"]),
+        "@microsoft/fast-test-harness": appendSuffix(
+            rawVersions["@microsoft/fast-test-harness"],
+        ),
+    };
+}
+
+function rewritePackageVersions(finalVersions) {
+    for (const packageName of packageOrder) {
+        const pkg = getPackage(packageName);
+        pkg.version = finalVersions[packageName];
+
+        switch (packageName) {
+            case "@microsoft/fast-element":
+                setDependency(
+                    pkg,
+                    "devDependencies",
+                    "@microsoft/fast-build",
+                    finalVersions["@microsoft/fast-build"],
+                );
+                break;
+            case "@microsoft/fast-router":
+                setDependency(
+                    pkg,
+                    "devDependencies",
+                    "@microsoft/fast-element",
+                    finalVersions["@microsoft/fast-element"],
+                );
+                setDependency(
+                    pkg,
+                    "peerDependencies",
+                    "@microsoft/fast-element",
+                    finalVersions["@microsoft/fast-element"],
+                );
+                break;
+            case "@microsoft/fast-test-harness":
+                for (const section of ["devDependencies", "peerDependencies"]) {
+                    setDependency(
+                        pkg,
+                        section,
+                        "@microsoft/fast-build",
+                        finalVersions["@microsoft/fast-build"],
+                    );
+                    setDependency(
+                        pkg,
+                        section,
+                        "@microsoft/fast-element",
+                        finalVersions["@microsoft/fast-element"],
+                    );
+                }
+                break;
+        }
+
+        writeJson(packageJsonPath(packageName), pkg);
+    }
+}
+
+function rewriteChangelogJson(packageName, finalVersions, rawVersions) {
+    const path = changelogJsonPath(packageName);
+    if (!existsSync(path)) {
+        return;
+    }
+
+    const changelog = readJson(path);
+    const latest = changelog.entries?.[0];
+    if (!latest) {
+        return;
+    }
+
+    latest.version = finalVersions[packageName];
+    latest.tag = `${packageName}_v${finalVersions[packageName]}`;
+    rewriteChangelogComments(latest.comments, finalVersions, rawVersions);
+    writeJson(path, changelog);
+}
+
+function rewriteChangelogComments(value, finalVersions, rawVersions) {
+    if (Array.isArray(value)) {
+        for (const item of value) {
+            rewriteChangelogComments(item, finalVersions, rawVersions);
+        }
+        return;
+    }
+
+    if (value && typeof value === "object") {
+        for (const [key, child] of Object.entries(value)) {
+            if (key === "comment" && typeof child === "string") {
+                value[key] = rewriteVersionReferences(child, finalVersions, rawVersions);
+            } else {
+                rewriteChangelogComments(child, finalVersions, rawVersions);
+            }
+        }
+    }
+}
+
+function rewriteChangelogMd(packageName, finalVersions, rawVersions) {
+    const path = changelogMdPath(packageName);
+    if (!existsSync(path)) {
+        return;
+    }
+
+    let content = readFileSync(path, "utf8");
+    const rawVersion = rawVersions[packageName];
+    const finalVersion = finalVersions[packageName];
+    content = content.replace(`## ${rawVersion}\n`, `## ${finalVersion}\n`);
+    content = rewriteVersionReferences(content, finalVersions, rawVersions);
+    writeFileSync(path, content);
+}
+
+function rewriteVersionReferences(input, finalVersions, rawVersions) {
+    let output = input;
+    for (const packageName of packageOrder) {
+        output = output.replaceAll(
+            `${packageName} to v${rawVersions[packageName]}`,
+            `${packageName} to v${finalVersions[packageName]}`,
+        );
+    }
+    return output;
+}
+
+function rewriteChangelogs(finalVersions, rawVersions) {
+    for (const packageName of packageOrder) {
+        rewriteChangelogJson(packageName, finalVersions, rawVersions);
+        rewriteChangelogMd(packageName, finalVersions, rawVersions);
+    }
+}
+
+function updateLockfile() {
+    run(
+        "npm",
+        ["install", "--package-lock-only", "--ignore-scripts", "--no-audit", "--no-fund"],
+        { cwd: repoRoot, stdio: "inherit" },
+    );
+}
+
+function verifyFinalState(finalVersions) {
+    for (const packageName of packageOrder) {
+        const pkg = getPackage(packageName);
+        if (pkg.version !== finalVersions[packageName]) {
+            throw new Error(
+                `${packageName} version is ${pkg.version}, expected ${finalVersions[packageName]}.`,
+            );
+        }
+    }
+
+    const cargoToml = readFileSync(
+        join(repoRoot, "crates/microsoft-fast-build/Cargo.toml"),
+        "utf8",
+    );
+    if (!/version\s*=\s*"0\.7\.0"/.test(cargoToml)) {
+        throw new Error(
+            "microsoft-fast-build Cargo.toml changed. The v3 RC finalizer must not version the Rust crate.",
+        );
+    }
+
+    const lock = readJson(join(repoRoot, "package-lock.json"));
+    for (const packageName of packageOrder) {
+        const location = packagePaths[packageName];
+        const entry = lock.packages?.[location];
+        if (entry?.version !== finalVersions[packageName]) {
+            throw new Error(
+                `${location} lockfile version is ${entry?.version}, expected ${finalVersions[packageName]}.`,
+            );
+        }
+    }
+}
+
+function printVersionTable(finalVersions) {
+    console.log("\nFAST Element v3 RC final versions:");
+    for (const packageName of packageOrder) {
+        console.log(`  - ${packageName}@${finalVersions[packageName]}`);
+    }
+    console.log(`\nUse npm dist-tag: ${RC_DIST_TAG}`);
+    console.log("Rust crate packaging is intentionally excluded for this RC branch.");
+}
+
+function previewReleases() {
+    console.log(
+        "\nRelease preview (check-only; no packing, tags, releases, or publishing):",
+    );
+    run("node", ["build/scripts/create-github-releases.mjs", "--check-only"], {
+        cwd: repoRoot,
+        stdio: "inherit",
+        env: {
+            ...process.env,
+            FAST_RELEASE_SKIP_CRATES: "true",
+        },
+    });
+}
+
+function applyFinalizer() {
+    ensureCleanWorktree();
+    ensureChangeFilesExist();
+
+    runBeachballBump();
+
+    const rawVersions = Object.fromEntries(
+        packageOrder.map(packageName => [packageName, getPackage(packageName).version]),
+    );
+    const finalVersions = computeFinalVersions();
+
+    rewritePackageVersions(finalVersions);
+    rewriteChangelogs(finalVersions, rawVersions);
+    updateLockfile();
+    verifyFinalState(finalVersions);
+    printVersionTable(finalVersions);
+    previewReleases();
+}
+
+function dryRun() {
+    const temp = mkdtempSync(join(tmpdir(), "fast-element-v3-rc-finalizer-"));
+    const repoDir = join(temp, "repo");
+    console.log(`Creating disposable worktree at ${repoDir}`);
+    run("git", ["worktree", "add", "--detach", repoDir, REF], {
+        cwd: repoRoot,
+        stdio: "inherit",
+    });
+
+    try {
+        for (const file of [
+            "build/scripts/finalize-fast-element-v3-rc.mjs",
+            "build/scripts/create-github-releases.mjs",
+        ]) {
+            const dest = join(repoDir, file);
+            mkdirSync(dirname(dest), { recursive: true });
+            copyFileSync(join(repoRoot, file), dest);
+        }
+
+        run(
+            process.execPath,
+            [
+                join(repoDir, "build/scripts/finalize-fast-element-v3-rc.mjs"),
+                "--apply",
+                "--allow-script-overrides",
+            ],
+            { cwd: repoDir, stdio: "inherit" },
+        );
+        console.log("\nDry-run diff summary:");
+        run("git", ["--no-pager", "diff", "--stat"], { cwd: repoDir, stdio: "inherit" });
+    } finally {
+        if (KEEP) {
+            console.log(`Keeping disposable worktree: ${repoDir}`);
+        } else {
+            run("git", ["worktree", "remove", "--force", repoDir], {
+                cwd: repoRoot,
+                stdio: "inherit",
+            });
+            rmSync(temp, { recursive: true, force: true });
+        }
+    }
+}
+
+try {
+    if (APPLY) {
+        applyFinalizer();
+    } else {
+        dryRun();
+    }
+} catch (error) {
+    console.error(error instanceof Error ? error.message : String(error));
+    process.exit(1);
+}

--- a/build/scripts/finalize-fast-element-v3-rc.mjs
+++ b/build/scripts/finalize-fast-element-v3-rc.mjs
@@ -14,6 +14,10 @@
  * To apply changes to the current worktree:
  *
  *   node build/scripts/finalize-fast-element-v3-rc.mjs --apply
+ *
+ * TODO #7595: Remove this RC-only finalizer before merging
+ * `releases/fast-element-v3-rc` back to `main` after FAST Element 3.x stable
+ * has been released. See https://github.com/microsoft/fast/issues/7595.
  */
 
 import { execFileSync } from "node:child_process";
@@ -42,6 +46,7 @@ const ALLOW_NON_RC_REF = args.has("--allow-non-rc-ref");
 const REF = readArg("--ref") ?? "HEAD";
 const TARGET_RC_BRANCH = "releases/fast-element-v3-rc";
 const TARGET_RC_REF = readArg("--target-ref") ?? `origin/${TARGET_RC_BRANCH}`;
+// TODO #7595: Remove branch-suffixed RC versioning before merge-back to main.
 // Single source for the branch-cut date used by companion versions and npm dist-tag.
 const RC_BRANCH_CUT_DATE = "2026-06-15";
 const RC_DATE = formatRcDate(RC_BRANCH_CUT_DATE);

--- a/package.json
+++ b/package.json
@@ -34,6 +34,7 @@
     "checkchange": "node build/scripts/check-publish-pipeline.mjs && node build/scripts/checkchange.mjs",
     "check": "beachball check ",
     "build:gh-pages": "npm run build -w @microsoft/fast-site",
+    "finalize:fast-element-v3-rc": "node build/scripts/finalize-fast-element-v3-rc.mjs",
     "publish": "beachball publish",
     "sync": "beachball sync",
     "test:diff:error": "echo \"Untracked files exist, try running npm run build to identify the culprit.\" && exit 1",


### PR DESCRIPTION
# Pull Request
 
## 📖 Description
 
Adds a guarded FAST Element v3 RC finalizer workflow for the `releases/fast-element-v3-rc` branch.
 
This change adds `npm run finalize:fast-element-v3-rc`, which dry-runs by default in a disposable worktree and requires `-- --apply` before modifying the current worktree. The finalizer uses Beachball to consume change files and generate changelog entries, then rewrites the explicit v3 RC package versions and exact internal dependency pins.
 
It also updates release detection so paired Rust crate validation/packaging is skipped for the FAST Element v3 RC branch, since this RC flow publishes npm packages only.
 
 ## 👩‍💻 Reviewer Notes
 
 Please review the finalizer guardrails closely:
 - default execution must remain dry-run only
 - `-- --apply` must be required for local edits
 - no publish, push, tag, GitHub release, or workflow-dispatch commands should be invoked by the finalizer
 
 ## 📑 Test Plan
 
 - `npm run finalize:fast-element-v3-rc`
 - `node --check build/scripts/finalize-fast-element-v3-rc.mjs`
 - `node --check build/scripts/create-github-releases.mjs`
 - `node --check build/scripts/download-github-releases.mjs`
 - `FAST_RELEASE_SKIP_CRATES=true node build/scripts/create-github-releases.mjs --check-only`
 - `GITHUB_REPOSITORY=microsoft/fast FAST_RELEASE_SKIP_CRATES=true node build/scripts/download-github-releases.mjs --check-only`
 - `npm run test:validation`
 - `npm run checkchange --silent`
 
 ## ✅ Checklist
 
 ### General
 
 - [ ] I have included a change request file using `$ npm run change`
 - [ ] I have added tests for my changes.
 - [x] I have tested my changes.
 - [x] I have updated the project documentation to reflect my changes.
 - [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.