### PR TITLE
fix: align private rc workspace dependencies

### DIFF
--- a/build/scripts/finalize-fast-element-v3-rc.mjs
+++ b/build/scripts/finalize-fast-element-v3-rc.mjs
@@ -67,6 +67,15 @@ const packagePaths = {
     "@microsoft/fast-test-harness": "packages/fast-test-harness",
 };
 
+const privateWorkspaceDependencyPaths = [
+    "examples/csr/todo-app",
+    "examples/csr/todo-mobx-app",
+    "examples/ssr/chat-app",
+    "examples/ssr/webui-todo-app",
+    "sites/benchmarks",
+    "sites/website",
+];
+
 function readArg(name) {
     const index = process.argv.indexOf(name);
     return index === -1 ? undefined : process.argv[index + 1];
@@ -101,6 +110,12 @@ function readJson(path) {
     return JSON.parse(readFileSync(path, "utf8"));
 }
 
+function readJsonIndent(path) {
+    const content = readFileSync(path, "utf8");
+    const match = /^\n?([ \t]+)"/m.exec(content);
+    return match?.[1] ?? "  ";
+}
+
 function formatRcDate(value) {
     if (!/^\d{4}-\d{2}-\d{2}$/.test(value)) {
         throw new Error(`Invalid RC branch-cut date ${value}. Expected YYYY-MM-DD.`);
@@ -110,7 +125,7 @@ function formatRcDate(value) {
 }
 
 function writeJson(path, value) {
-    writeFileSync(path, `${JSON.stringify(value, null, 2)}\n`);
+    writeFileSync(path, `${JSON.stringify(value, null, readJsonIndent(path))}\n`);
 }
 
 function packageJsonPath(packageName) {
@@ -347,6 +362,40 @@ function rewritePackageVersions(finalVersions) {
     }
 }
 
+function rewritePrivateWorkspaceDependencies(finalVersions) {
+    for (const packagePath of privateWorkspaceDependencyPaths) {
+        const path = join(repoRoot, packagePath, "package.json");
+        if (!existsSync(path)) {
+            continue;
+        }
+
+        const pkg = readJson(path);
+
+        for (const section of ["dependencies", "devDependencies", "peerDependencies"]) {
+            setDependency(
+                pkg,
+                section,
+                "@microsoft/fast-element",
+                finalVersions["@microsoft/fast-element"],
+            );
+
+            if (
+                pkg[section]?.["@microsoft/fast-build"] !== undefined &&
+                pkg[section]["@microsoft/fast-build"] !== "*"
+            ) {
+                setDependency(
+                    pkg,
+                    section,
+                    "@microsoft/fast-build",
+                    finalVersions["@microsoft/fast-build"],
+                );
+            }
+        }
+
+        writeJson(path, pkg);
+    }
+}
+
 function rewriteChangelogJson(packageName, finalVersions, rawVersions) {
     const path = changelogJsonPath(packageName);
     if (!existsSync(path)) {
@@ -513,6 +562,7 @@ function applyFinalizer() {
     const finalVersions = computeFinalVersions();
 
     rewritePackageVersions(finalVersions);
+    rewritePrivateWorkspaceDependencies(finalVersions);
     rewriteChangelogs(finalVersions, rawVersions);
     updateLockfile();
     verifyFinalState(finalVersions, initialCrateVersion);

--- a/package.json
+++ b/package.json
@@ -42,7 +42,7 @@
     "test:validation": "npm run test:diff",
     "test": "lage test:node test:playwright",
     "test:chromium": "lage test:node test:chromium",
-    "test:e2e": "npm run test:e2e -w @microsoft/fast-examples-e2e",
+    "test:e2e": "npm run build -w @microsoft/fast-element && npm run test:e2e -w @microsoft/fast-examples-e2e",
     "watch": "tsgo -p ./tsconfig.json -w --preserveWatchOutput",
     "format:check": "biome format --changed --no-errors-on-unmatched .",
     "format": "biome format --changed --no-errors-on-unmatched --fix --write .",


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds some scripting missing from the original work for publishing tagged releases for the `@microsoft/fast-element` 3.x-rc.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.