### PR TITLE
chore: finalize fast element v3 rc versions

### DIFF
--- a/change/@microsoft-fast-build-2f1e5af3-c3bc-45bb-9abd-9d9bbd3d5c4b.json
+++ b/change/@microsoft-fast-build-2f1e5af3-c3bc-45bb-9abd-9d9bbd3d5c4b.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "feat: add simulated streaming output for fast-build",
-  "packageName": "@microsoft/fast-build",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-build-69e6e13b-c83c-4ef6-877b-990bfd9eaa65.json
+++ b/change/@microsoft-fast-build-69e6e13b-c83c-4ef6-877b-990bfd9eaa65.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Handle browser-valid whitespace in f-template wrapper tags",
-  "packageName": "@microsoft/fast-build",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-build-96416f46-7e1a-4d19-ab7f-e5c83bc07aa6.json
+++ b/change/@microsoft-fast-build-96416f46-7e1a-4d19-ab7f-e5c83bc07aa6.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: auto-escape code samples inside `<code>` elements during SSR — braces (`{`/`}`) everywhere and the angle brackets of FAST directive tags (`<f-when>`, `<f-repeat>`) — so literal binding-like text and directive syntax render correctly while real HTML/custom elements inside `<code>` remain live DOM elements. Also exposes a new `escape_code_samples(html)` WASM export so build-time tooling can apply the same escape to author HTML that is injected into a rendered page outside the normal render pipeline.",
-  "packageName": "@microsoft/fast-build",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-098902d3-3705-4f80-a43c-cca0635c0332.json
+++ b/change/@microsoft-fast-element-098902d3-3705-4f80-a43c-cca0635c0332.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add a registry path export for FAST element definition lookups.",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-15f98c55-f4bb-4b85-9c55-564b10cdd8c5.json
+++ b/change/@microsoft-fast-element-15f98c55-f4bb-4b85-9c55-564b10cdd8c5.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Improve hydration mismatch behaviour: render() falls back to client rendering when SSR view boundaries are empty, repeat() reconciles SSR/client item-count mismatches by creating missing client views or removing extra SSR ranges, and unrecoverable mismatches throw via a pluggable HydrationDiagnostic. Opt in to the rich 'Expected / Received' format with the SSR HTML snippet and structured expected/received fields on HydrationBindingError / HydrationTargetElementError by passing enableHydration({ debugger: hydrationDebugger() }) (hydrationDebugger is exported from '@microsoft/fast-element/hydration.js').",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-21f5ec9e-5a25-44f7-8504-682ae8488103.json
+++ b/change/@microsoft-fast-element-21f5ec9e-5a25-44f7-8504-682ae8488103.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Add hydration configuration for streamed Declarative Shadow DOM.",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-2613f3cc-434d-4262-96ad-f1ab70e28a86.json
+++ b/change/@microsoft-fast-element-2613f3cc-434d-4262-96ad-f1ab70e28a86.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Avoid mutating render template bindings",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-2fe5f4dd-28e6-4c5a-b583-d74cbd8b56e2.json
+++ b/change/@microsoft-fast-element-2fe5f4dd-28e6-4c5a-b583-d74cbd8b56e2.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "docs: clean up fast-element API report surface",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-3b4bc9ff-fe92-4caa-a471-0f4895fe24b8.json
+++ b/change/@microsoft-fast-element-3b4bc9ff-fe92-4caa-a471-0f4895fe24b8.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "feat: propagate shadowroot attributes from f-template to declarative shadow DOM template",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-4191163e-9b3b-4137-8fd6-1e949386443d.json
+++ b/change/@microsoft-fast-element-4191163e-9b3b-4137-8fd6-1e949386443d.json
@@ -1,7 +1,0 @@
-{
-  "comment": "Preserve view context when rebinding the same source.",
-  "type": "prerelease",
-  "packageName": "@microsoft/fast-element",
-  "dependentChangeType": "none",
-  "email": "7559015+janechu@users.noreply.github.com"
-}

--- a/change/@microsoft-fast-element-4dbc9ebd-2055-4ad1-af2a-5f3dacb6decc.json
+++ b/change/@microsoft-fast-element-4dbc9ebd-2055-4ad1-af2a-5f3dacb6decc.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "feat: warn when duplicate render instruction registrations replace existing entries",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-5c38c988-9f5e-4b5e-8d64-5b7d5efd75e4.json
+++ b/change/@microsoft-fast-element-5c38c988-9f5e-4b5e-8d64-5b7d5efd75e4.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "dependentChangeType": "none",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "comment": "Add package export smoke coverage and docs sync checks.",
-  "packageName": "@microsoft/fast-element"
-}

--- a/change/@microsoft-fast-element-7463774d-d761-4aaa-a60e-f51e4866b63d.json
+++ b/change/@microsoft-fast-element-7463774d-d761-4aaa-a60e-f51e4866b63d.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "fix: align @attr({ mode: 'boolean' }) and booleanConverter with native HTML boolean attribute semantics",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-7e4a9b21-3c8d-4f12-91e0-8a6f2d4cb09b.json
+++ b/change/@microsoft-fast-element-7e4a9b21-3c8d-4f12-91e0-8a6f2d4cb09b.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "feat: expose declarative HTML syntax constants from declarative utilities",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-b023c87d-8b81-4dc1-bb78-3b3da73fe9ff.json
+++ b/change/@microsoft-fast-element-b023c87d-8b81-4dc1-bb78-3b3da73fe9ff.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "fix: restore CaptureType generic type capture for template directives",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-c20e636d-e975-46f4-9e0b-c7b6c8143ef6.json
+++ b/change/@microsoft-fast-element-c20e636d-e975-46f4-9e0b-c7b6c8143ef6.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "feat: change default attribute-name-strategy from none to camelCase",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-c74392ec-7a62-4196-a74d-78d3cb1ce61c.json
+++ b/change/@microsoft-fast-element-c74392ec-7a62-4196-a74d-78d3cb1ce61c.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Allow duplicate f-template names to keep the first template assignment",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-c83200b6-e767-47cd-9726-03f03016b77b.json
+++ b/change/@microsoft-fast-element-c83200b6-e767-47cd-9726-03f03016b77b.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Harden DOM policy guard merging and unsafe URL filtering.",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-e20e07d7-c8d3-4207-b936-127afe6fe744.json
+++ b/change/@microsoft-fast-element-e20e07d7-c8d3-4207-b936-127afe6fe744.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "feat: auto-escape `{` and `}` inside `<code>` elements so binding-like syntax in code samples renders as literal text (mirrors webui-press and the server-side `escape_code_sample_elements` pass in `@microsoft/fast-build`, which additionally handles `<f-when>`/`<f-repeat>` directive tags)",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-f878ae28-4c0e-4b08-a0c7-c21283f4b721.json
+++ b/change/@microsoft-fast-element-f878ae28-4c0e-4b08-a0c7-c21283f4b721.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "Filter late attribute MutationObserver records.",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-router-rc-dependency-alignment.json
+++ b/change/@microsoft-fast-router-rc-dependency-alignment.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "chore: align FAST Element peer and dev dependency ranges for v3 RC publish prep",
-  "packageName": "@microsoft/fast-router",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-test-harness-027c67c0-76d3-4cb1-bcca-f0c341f65cd2.json
+++ b/change/@microsoft-fast-test-harness-027c67c0-76d3-4cb1-bcca-f0c341f65cd2.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Handle browser-valid whitespace in f-template wrapper tags",
-  "packageName": "@microsoft/fast-test-harness",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-test-harness-7e4a9b22-4d8c-4e12-92f0-9b6f3d4cb19c.json
+++ b/change/@microsoft-fast-test-harness-7e4a9b22-4d8c-4e12-92f0-9b6f3d4cb19c.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "fix: migrate build utilities to consume declarative HTML syntax from @microsoft/fast-element",
-  "packageName": "@microsoft/fast-test-harness",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/examples/csr/todo-app/package.json
+++ b/examples/csr/todo-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "3.0.0-rc.1",
+    "@microsoft/fast-element": "3.0.0-rc.2",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "tslib": "^2.6.3"
   },

--- a/examples/csr/todo-mobx-app/package.json
+++ b/examples/csr/todo-mobx-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-mobx-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "3.0.0-rc.1",
+    "@microsoft/fast-element": "3.0.0-rc.2",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "mobx": "^6.13.5",
     "tslib": "^2.6.3"

--- a/examples/ssr/chat-app/package.json
+++ b/examples/ssr/chat-app/package.json
@@ -23,7 +23,7 @@
         "directory": "examples/ssr/chat-app"
     },
     "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.1",
+        "@microsoft/fast-element": "3.0.0-rc.2",
         "@microsoft/fast-examples-design-system": "*",
         "tslib": "^2.6.3"
     },

--- a/examples/ssr/webui-todo-app/package.json
+++ b/examples/ssr/webui-todo-app/package.json
@@ -25,7 +25,7 @@
         "directory": "examples/ssr/webui-todo-app"
     },
     "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.1",
+        "@microsoft/fast-element": "3.0.0-rc.2",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "@microsoft/webui": "^0.0.12",
         "tslib": "^2.6.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.1",
+        "@microsoft/fast-element": "3.0.0-rc.2",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "tslib": "^2.6.3"
       },
@@ -66,7 +66,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.1",
+        "@microsoft/fast-element": "3.0.0-rc.2",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "mobx": "^6.13.5",
         "tslib": "^2.6.3"
@@ -82,7 +82,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.1",
+        "@microsoft/fast-element": "3.0.0-rc.2",
         "@microsoft/fast-examples-design-system": "*",
         "tslib": "^2.6.3"
       },
@@ -95,7 +95,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.1",
+        "@microsoft/fast-element": "3.0.0-rc.2",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "@microsoft/webui": "^0.0.12",
         "tslib": "^2.6.3"
@@ -6760,7 +6760,7 @@
     },
     "packages/fast-build": {
       "name": "@microsoft/fast-build",
-      "version": "0.7.0",
+      "version": "0.8.0-fast-element-v3-rc-20260615",
       "license": "MIT",
       "bin": {
         "fast": "bin/fast.js"
@@ -6771,30 +6771,30 @@
     },
     "packages/fast-element": {
       "name": "@microsoft/fast-element",
-      "version": "3.0.0-rc.1",
+      "version": "3.0.0-rc.2",
       "license": "MIT",
       "devDependencies": {
-        "@microsoft/fast-build": "0.7.0",
+        "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
         "@microsoft/webui": "0.0.12"
       }
     },
     "packages/fast-router": {
       "name": "@microsoft/fast-router",
-      "version": "1.0.0-alpha.30",
+      "version": "1.0.0-alpha.30-fast-element-v3-rc-20260615",
       "license": "MIT",
       "dependencies": {
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.1"
+        "@microsoft/fast-element": "3.0.0-rc.2"
       },
       "peerDependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.1"
+        "@microsoft/fast-element": "3.0.0-rc.2"
       }
     },
     "packages/fast-test-harness": {
       "name": "@microsoft/fast-test-harness",
-      "version": "0.3.1",
+      "version": "0.4.0-fast-element-v3-rc-20260615",
       "license": "MIT",
       "dependencies": {
         "cheerio": "1.2.0"
@@ -6803,15 +6803,15 @@
         "fast-test-harness": "start.mjs"
       },
       "devDependencies": {
-        "@microsoft/fast-build": "0.7.0",
-        "@microsoft/fast-element": "3.0.0-rc.1"
+        "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+        "@microsoft/fast-element": "3.0.0-rc.2"
       },
       "engines": {
         "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@microsoft/fast-build": "0.7.0",
-        "@microsoft/fast-element": "3.0.0-rc.1",
+        "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+        "@microsoft/fast-element": "3.0.0-rc.2",
         "@playwright/test": ">=1.40.0",
         "vite": ">=7.0.0"
       },
@@ -6829,7 +6829,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@microsoft/fast-build": "*",
-        "@microsoft/fast-element": "3.0.0-rc.1"
+        "@microsoft/fast-element": "3.0.0-rc.2"
       }
     },
     "sites/website": {
@@ -6843,8 +6843,8 @@
         "github-markdown-css": "5.9.0"
       },
       "devDependencies": {
-        "@microsoft/fast-build": "^0.7.0",
-        "@microsoft/fast-element": "3.0.0-rc.1"
+        "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+        "@microsoft/fast-element": "3.0.0-rc.2"
       }
     }
   }

--- a/packages/fast-build/CHANGELOG.json
+++ b/packages/fast-build/CHANGELOG.json
@@ -2,6 +2,37 @@
   "name": "@microsoft/fast-build",
   "entries": [
     {
+      "date": "Fri, 19 Jun 2026 22:15:55 GMT",
+      "version": "0.8.0-fast-element-v3-rc-20260615",
+      "tag": "@microsoft/fast-build_v0.8.0-fast-element-v3-rc-20260615",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-build",
+            "commit": "fecdf78b76616272df88775ad647a9a54f410891",
+            "comment": "feat: add simulated streaming output for fast-build"
+          }
+        ],
+        "patch": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-build",
+            "commit": "b77e83f8d6dec276001746aca13557dd7cba706b",
+            "comment": "Handle browser-valid whitespace in f-template wrapper tags"
+          }
+        ],
+        "minor": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-build",
+            "commit": "0be252483e571f0615fadc11352c230e55b61f15",
+            "comment": "feat: auto-escape code samples inside `<code>` elements during SSR — braces (`{`/`}`) everywhere and the angle brackets of FAST directive tags (`<f-when>`, `<f-repeat>`) — so literal binding-like text and directive syntax render correctly while real HTML/custom elements inside `<code>` remain live DOM elements. Also exposes a new `escape_code_samples(html)` WASM export so build-time tooling can apply the same escape to author HTML that is injected into a rendered page outside the normal render pipeline."
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 21 May 2026 00:04:58 GMT",
       "version": "0.7.0",
       "tag": "@microsoft/fast-build_v0.7.0",

--- a/packages/fast-build/CHANGELOG.md
+++ b/packages/fast-build/CHANGELOG.md
@@ -1,8 +1,24 @@
 # Change Log - @microsoft/fast-build
 
-<!-- This log was last generated on Thu, 21 May 2026 00:04:58 GMT and should not be manually modified. -->
+<!-- This log was last generated on Fri, 19 Jun 2026 22:15:55 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 0.8.0-fast-element-v3-rc-20260615
+
+Fri, 19 Jun 2026 22:15:55 GMT
+
+### Minor changes
+
+- feat: auto-escape code samples inside `<code>` elements during SSR — braces (`{`/`}`) everywhere and the angle brackets of FAST directive tags (`<f-when>`, `<f-repeat>`) — so literal binding-like text and directive syntax render correctly while real HTML/custom elements inside `<code>` remain live DOM elements. Also exposes a new `escape_code_samples(html)` WASM export so build-time tooling can apply the same escape to author HTML that is injected into a rendered page outside the normal render pipeline. (7559015+janechu@users.noreply.github.com)
+
+### Patches
+
+- Handle browser-valid whitespace in f-template wrapper tags (7559015+janechu@users.noreply.github.com)
+
+### Changes
+
+- feat: add simulated streaming output for fast-build (7559015+janechu@users.noreply.github.com)
 
 ## 0.7.0
 

--- a/packages/fast-build/package.json
+++ b/packages/fast-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fast-build",
-  "version": "0.7.0",
+  "version": "0.8.0-fast-element-v3-rc-20260615",
   "description": "CLI and Node.js API for server-side rendering of FAST declarative HTML templates.",
   "author": {
     "name": "Microsoft",

--- a/packages/fast-element/CHANGELOG.json
+++ b/packages/fast-element/CHANGELOG.json
@@ -2,6 +2,125 @@
   "name": "@microsoft/fast-element",
   "entries": [
     {
+      "date": "Fri, 19 Jun 2026 22:15:55 GMT",
+      "version": "3.0.0-rc.2",
+      "tag": "@microsoft/fast-element_v3.0.0-rc.2",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "afb9a41aa5c5b31717098395f217b8cce2ba2d04",
+            "comment": "Filter late attribute MutationObserver records."
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "8a6be9b30bc2d3403fb1f75b3852438686735462",
+            "comment": "fix: align @attr({ mode: 'boolean' }) and booleanConverter with native HTML boolean attribute semantics"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "b77e83f8d6dec276001746aca13557dd7cba706b",
+            "comment": "feat: expose declarative HTML syntax constants from declarative utilities"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "ccc149b33ac80afe5b87c528ad987847756a0df9",
+            "comment": "fix: restore CaptureType generic type capture for template directives"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "8a24df4dc67b10cb11940d004f4697fe6f2f22e9",
+            "comment": "feat: change default attribute-name-strategy from none to camelCase"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "0be252483e571f0615fadc11352c230e55b61f15",
+            "comment": "feat: auto-escape `{` and `}` inside `<code>` elements so binding-like syntax in code samples renders as literal text (mirrors webui-press and the server-side `escape_code_sample_elements` pass in `@microsoft/fast-build`, which additionally handles `<f-when>`/`<f-repeat>` directive tags)"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "7505d9e6fa32748dfea8933a149d46b2c1ddc942",
+            "comment": "Improve hydration mismatch behaviour: render() falls back to client rendering when SSR view boundaries are empty, repeat() reconciles SSR/client item-count mismatches by creating missing client views or removing extra SSR ranges, and unrecoverable mismatches throw via a pluggable HydrationDiagnostic. Opt in to the rich 'Expected / Received' format with the SSR HTML snippet and structured expected/received fields on HydrationBindingError / HydrationTargetElementError by passing enableHydration({ debugger: hydrationDebugger() }) (hydrationDebugger is exported from '@microsoft/fast-element/hydration.js')."
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "78467e3cd18750325627aba80be1a51ecf8c9a5a",
+            "comment": "Add hydration configuration for streamed Declarative Shadow DOM."
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "7e433a8616bcbd71c30dac04586924e5214bf9ab",
+            "comment": "Avoid mutating render template bindings"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "8a24df4dc67b10cb11940d004f4697fe6f2f22e9",
+            "comment": "feat: propagate shadowroot attributes from f-template to declarative shadow DOM template"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "dd41435d6c28fb0f0fa67f2fe0a50c84f17c20b8",
+            "comment": "Preserve view context when rebinding the same source."
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "749367f0e9279bcfef97f3d4a40fc36f01059546",
+            "comment": "feat: warn when duplicate render instruction registrations replace existing entries"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "a8b85c1a6abb844722f1625c85b5cba1a41d5c2b",
+            "comment": "Add a registry path export for FAST element definition lookups."
+          },
+          {
+            "author": "beachball",
+            "package": "@microsoft/fast-element",
+            "comment": "Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615",
+            "commit": "not available"
+          }
+        ],
+        "none": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "f364382ba67a0765bbd3a5e567a3d5a5c66f68c7",
+            "comment": "Allow duplicate f-template names to keep the first template assignment"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "fd939d5b9130afc7cb7457e5aba7fbca5273954f",
+            "comment": "Harden DOM policy guard merging and unsafe URL filtering."
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "218f8d35c1ec3ede4f2a7f8ca8b5556e2de18f2e",
+            "comment": "docs: clean up fast-element API report surface"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "fc18caa0dcf43553cde975da871580babf673ed0",
+            "comment": "Add package export smoke coverage and docs sync checks."
+          }
+        ]
+      }
+    },
+    {
       "date": "Tue, 28 Apr 2026 04:42:02 GMT",
       "version": "3.0.0-rc.1",
       "tag": "@microsoft/fast-element_v3.0.0-rc.1",

--- a/packages/fast-element/CHANGELOG.md
+++ b/packages/fast-element/CHANGELOG.md
@@ -1,8 +1,29 @@
 # Change Log - @microsoft/fast-element
 
-<!-- This log was last generated on Fri, 17 Apr 2026 00:26:37 GMT and should not be manually modified. -->
+<!-- This log was last generated on Fri, 19 Jun 2026 22:15:55 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 3.0.0-rc.2
+
+Fri, 19 Jun 2026 22:15:55 GMT
+
+### Changes
+
+- Filter late attribute MutationObserver records. (7559015+janechu@users.noreply.github.com)
+- fix: align @attr({ mode: 'boolean' }) and booleanConverter with native HTML boolean attribute semantics (7559015+janechu@users.noreply.github.com)
+- feat: expose declarative HTML syntax constants from declarative utilities (7559015+janechu@users.noreply.github.com)
+- fix: restore CaptureType generic type capture for template directives (7559015+janechu@users.noreply.github.com)
+- feat: change default attribute-name-strategy from none to camelCase (7559015+janechu@users.noreply.github.com)
+- feat: auto-escape `{` and `}` inside `<code>` elements so binding-like syntax in code samples renders as literal text (mirrors webui-press and the server-side `escape_code_sample_elements` pass in `@microsoft/fast-build`, which additionally handles `<f-when>`/`<f-repeat>` directive tags) (7559015+janechu@users.noreply.github.com)
+- Improve hydration mismatch behaviour: render() falls back to client rendering when SSR view boundaries are empty, repeat() reconciles SSR/client item-count mismatches by creating missing client views or removing extra SSR ranges, and unrecoverable mismatches throw via a pluggable HydrationDiagnostic. Opt in to the rich 'Expected / Received' format with the SSR HTML snippet and structured expected/received fields on HydrationBindingError / HydrationTargetElementError by passing enableHydration({ debugger: hydrationDebugger() }) (hydrationDebugger is exported from '@microsoft/fast-element/hydration.js'). (7559015+janechu@users.noreply.github.com)
+- Add hydration configuration for streamed Declarative Shadow DOM. (7559015+janechu@users.noreply.github.com)
+- Avoid mutating render template bindings (7559015+janechu@users.noreply.github.com)
+- feat: propagate shadowroot attributes from f-template to declarative shadow DOM template (7559015+janechu@users.noreply.github.com)
+- Preserve view context when rebinding the same source. (7559015+janechu@users.noreply.github.com)
+- feat: warn when duplicate render instruction registrations replace existing entries (7559015+janechu@users.noreply.github.com)
+- Add a registry path export for FAST element definition lookups. (7559015+janechu@users.noreply.github.com)
+- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
 
 ## 3.0.0-rc.1
 

--- a/packages/fast-element/package.json
+++ b/packages/fast-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/fast-element",
   "description": "A library for constructing Web Components",
-  "version": "3.0.0-rc.1",
+  "version": "3.0.0-rc.2",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"
@@ -232,7 +232,7 @@
     "test:webui-integration": "npm run build:fixtures:webui && playwright test --config=playwright.declarative.webui.config.ts"
   },
   "devDependencies": {
-    "@microsoft/fast-build": "0.7.0",
+    "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
     "@microsoft/webui": "0.0.12"
   },
   "files": [

--- a/packages/fast-router/CHANGELOG.json
+++ b/packages/fast-router/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/fast-router",
   "entries": [
     {
+      "date": "Fri, 19 Jun 2026 22:15:55 GMT",
+      "version": "1.0.0-alpha.30-fast-element-v3-rc-20260615",
+      "tag": "@microsoft/fast-router_v1.0.0-alpha.30-fast-element-v3-rc-20260615",
+      "comments": {
+        "none": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-router",
+            "commit": "b77e83f8d6dec276001746aca13557dd7cba706b",
+            "comment": "chore: align FAST Element peer and dev dependency ranges for v3 RC publish prep"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 01 May 2026 00:15:38 GMT",
       "version": "1.0.0-alpha.30",
       "tag": "@microsoft/fast-router_v1.0.0-alpha.30",

--- a/packages/fast-router/CHANGELOG.md
+++ b/packages/fast-router/CHANGELOG.md
@@ -4,7 +4,7 @@
 
 <!-- Start content -->
 
-## 1.0.0-alpha.30
+## 1.0.0-alpha.30-fast-element-v3-rc-20260615
 
 Tue, 27 Jan 2026 17:28:54 GMT
 

--- a/packages/fast-router/package.json
+++ b/packages/fast-router/package.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/fast-router",
   "description": "A web-components-based router.",
   "sideEffects": false,
-  "version": "1.0.0-alpha.30",
+  "version": "1.0.0-alpha.30-fast-element-v3-rc-20260615",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"
@@ -38,10 +38,10 @@
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@microsoft/fast-element": "3.0.0-rc.1"
+    "@microsoft/fast-element": "3.0.0-rc.2"
   },
   "peerDependencies": {
-    "@microsoft/fast-element": "3.0.0-rc.1"
+    "@microsoft/fast-element": "3.0.0-rc.2"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/fast-test-harness/CHANGELOG.json
+++ b/packages/fast-test-harness/CHANGELOG.json
@@ -2,6 +2,41 @@
   "name": "@microsoft/fast-test-harness",
   "entries": [
     {
+      "date": "Fri, 19 Jun 2026 22:15:55 GMT",
+      "version": "0.4.0-fast-element-v3-rc-20260615",
+      "tag": "@microsoft/fast-test-harness_v0.4.0-fast-element-v3-rc-20260615",
+      "comments": {
+        "patch": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-test-harness",
+            "commit": "b77e83f8d6dec276001746aca13557dd7cba706b",
+            "comment": "Handle browser-valid whitespace in f-template wrapper tags"
+          }
+        ],
+        "minor": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-test-harness",
+            "commit": "8a24df4dc67b10cb11940d004f4697fe6f2f22e9",
+            "comment": "fix: migrate build utilities to consume declarative HTML syntax from @microsoft/fast-element"
+          },
+          {
+            "author": "beachball",
+            "package": "@microsoft/fast-test-harness",
+            "comment": "Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615",
+            "commit": "not available"
+          },
+          {
+            "author": "beachball",
+            "package": "@microsoft/fast-test-harness",
+            "comment": "Bump @microsoft/fast-element to v3.0.0-rc.2",
+            "commit": "not available"
+          }
+        ]
+      }
+    },
+    {
       "date": "Mon, 08 Jun 2026 20:39:45 GMT",
       "version": "0.3.1",
       "tag": "@microsoft/fast-test-harness_v0.3.1",

--- a/packages/fast-test-harness/CHANGELOG.md
+++ b/packages/fast-test-harness/CHANGELOG.md
@@ -1,8 +1,22 @@
 # Change Log - @microsoft/fast-test-harness
 
-<!-- This log was last generated on Mon, 08 Jun 2026 20:39:45 GMT and should not be manually modified. -->
+<!-- This log was last generated on Fri, 19 Jun 2026 22:15:55 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 0.4.0-fast-element-v3-rc-20260615
+
+Fri, 19 Jun 2026 22:15:55 GMT
+
+### Minor changes
+
+- fix: migrate build utilities to consume declarative HTML syntax from @microsoft/fast-element (7559015+janechu@users.noreply.github.com)
+- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
+- Bump @microsoft/fast-element to v3.0.0-rc.2
+
+### Patches
+
+- Handle browser-valid whitespace in f-template wrapper tags (7559015+janechu@users.noreply.github.com)
 
 ## 0.3.1
 

--- a/packages/fast-test-harness/package.json
+++ b/packages/fast-test-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fast-test-harness",
-  "version": "0.3.1",
+  "version": "0.4.0-fast-element-v3-rc-20260615",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"
@@ -71,15 +71,15 @@
     "*.d.ts"
   ],
   "devDependencies": {
-    "@microsoft/fast-build": "0.7.0",
-    "@microsoft/fast-element": "3.0.0-rc.1"
+    "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+    "@microsoft/fast-element": "3.0.0-rc.2"
   },
   "dependencies": {
     "cheerio": "1.2.0"
   },
   "peerDependencies": {
-    "@microsoft/fast-build": "0.7.0",
-    "@microsoft/fast-element": "3.0.0-rc.1",
+    "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+    "@microsoft/fast-element": "3.0.0-rc.2",
     "@playwright/test": ">=1.40.0",
     "vite": ">=7.0.0"
   },

--- a/sites/benchmarks/package.json
+++ b/sites/benchmarks/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "@microsoft/fast-build": "*",
-    "@microsoft/fast-element": "3.0.0-rc.1"
+    "@microsoft/fast-element": "3.0.0-rc.2"
   }
 }

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -30,7 +30,7 @@
     "github-markdown-css": "5.9.0"
   },
   "devDependencies": {
-    "@microsoft/fast-build": "^0.7.0",
-    "@microsoft/fast-element": "3.0.0-rc.1"
+    "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+    "@microsoft/fast-element": "3.0.0-rc.2"
   }
 }


### PR DESCRIPTION
# Pull Request
 
 ## 📖 Description
 
 Finalizes the FAST Element v3 RC package versions from the accumulated RC change files.
 
 This bump PR consumes the pending change files, updates package versions and changelogs, aligns exact internal dependency pins across package and private workspace manifests, and refreshes `package-lock.json` for the RC branch.
 
 Planned npm RC versions:
 
 - `@microsoft/fast-build@0.8.0-fast-element-v3-rc-20260615`
 - `@microsoft/fast-element@3.0.0-rc.2`
 - `@microsoft/fast-router@1.0.0-alpha.30-fast-element-v3-rc-20260615`
 - `@microsoft/fast-test-harness@0.4.0-fast-element-v3-rc-20260615`
 
 The paired `microsoft-fast-build` Rust crate remains unchanged and excluded from this RC publish flow.
 
 ## 👩‍💻 Reviewer Notes
 
 Generated by:
 
 ```bash
 npm run finalize:fast-element-v3-rc -- --apply
```

This branch intentionally uses the publish_<timestamp> naming convention so checkchange recognizes it as a maintainer bump PR after change files have been consumed.

📑 Test Plan

 - npm run finalize:fast-element-v3-rc
 - npm run finalize:fast-element-v3-rc -- --apply
 - npm run build
 - npm run test:validation
 - npm run checkchange --silent
 - FAST_RELEASE_SKIP_CRATES=true node build/scripts/create-github-releases.mjs --check-only

✅ Checklist

General

 - [ ]  I have included a change request file using $ npm run change
 - [ ]  I have added tests for my changes.
 - [x]  I have tested my changes.
 - [x]  I have updated the project documentation to reflect my changes.
 - [x]  I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.