### PR TITLE
chore: remove an unused npm ci command from CD pipeline

### DIFF
--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -116,10 +116,6 @@ extends:
               path: $(npm_config_cache)
             displayName: "Cache npm"
 
-          - script: |
-              npm ci
-            displayName: "Install package dependencies"
-
           - task: DownloadGitHubRelease@0
             displayName: "Download @microsoft/fast-build release assets"
             condition: and(succeeded(), eq(variables['fastBuildNeedsDeployment'], 'true'))


### PR DESCRIPTION
# Pull Request

## 📖 Description

An unused `npm ci` was still in the CD pipeline. This is causing an issue with security.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.