### PR TITLE
fix: deprecate compose APIs

### DIFF
--- a/.github/skills/typescript/SKILL.md
+++ b/.github/skills/typescript/SKILL.md
@@ -44,19 +44,16 @@ MyElement.define({
 });
 ```
 
-Use `compose()` when registration should be deferred — downstream libraries like Fluent
-Web Components use this pattern with a design-system registry:
+The `compose()` API is deprecated. Use `define()` with a definition object for
+new components:
 
 ```ts
-// my-element.definition.ts
-export const definition = MyElement.compose({
+// define.ts (side-effect import)
+MyElement.define({
     name: "my-element",
     template,
     styles,
 });
-
-// define.ts (side-effect import)
-definition.define();
 ```
 
 ## Templates

--- a/change/@microsoft-fast-element-deprecate-compose.json
+++ b/change/@microsoft-fast-element-deprecate-compose.json
@@ -1,6 +1,6 @@
 {
-  "type": "minor",
-  "comment": "Deprecate the compose APIs in favor of define() and update related docs and examples.",
+  "type": "patch",
+  "comment": "fix: deprecate the compose APIs in favor of define() and update related docs and examples.",
   "packageName": "@microsoft/fast-element",
   "email": "7559015+janechu@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change/@microsoft-fast-element-deprecate-compose.json
+++ b/change/@microsoft-fast-element-deprecate-compose.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Deprecate the compose APIs in favor of define() and update related docs and examples.",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/examples/csr/todo-app/src/main.ts
+++ b/examples/csr/todo-app/src/main.ts
@@ -1,5 +1,5 @@
 import "@microsoft/fast-examples-design-system/tokens.css";
-import { app } from "./todo-app.js";
+import { defineTodoApp } from "./todo-app.js";
 import { DefaultTodoList, TodoList } from "./todo-list.js";
 
 // Before we allow the app to be defined, we want to
@@ -12,4 +12,4 @@ import { DefaultTodoList, TodoList } from "./todo-list.js";
 TodoList.provide(document, new DefaultTodoList());
 
 // Define the todo-app custom element
-app.define();
+defineTodoApp();

--- a/examples/csr/todo-app/src/main.ts
+++ b/examples/csr/todo-app/src/main.ts
@@ -1,5 +1,7 @@
 import "@microsoft/fast-examples-design-system/tokens.css";
-import { defineTodoApp } from "./todo-app.js";
+import { TodoApp } from "./todo-app.js";
+import { styles } from "./todo-app.styles.js";
+import { template } from "./todo-app.template.js";
 import { DefaultTodoList, TodoList } from "./todo-list.js";
 
 // Before we allow the app to be defined, we want to
@@ -12,4 +14,8 @@ import { DefaultTodoList, TodoList } from "./todo-list.js";
 TodoList.provide(document, new DefaultTodoList());
 
 // Define the todo-app custom element
-defineTodoApp();
+TodoApp.define({
+    name: "todo-app",
+    template,
+    styles,
+});

--- a/examples/csr/todo-app/src/todo-app.ts
+++ b/examples/csr/todo-app/src/todo-app.ts
@@ -7,15 +7,10 @@ export class TodoApp extends FASTElement {
     @TodoList todos!: TodoList;
 }
 
-// By using this API instead of the @customElement
-// decorator, we are able to assemble the component
-// with its name, template, and styles, but without
-// immediately defining it with the platform. We do
-// this so that we can control the startup timing of
-// the app. See the main.ts file for further
-// explanation.
-export const app = TodoApp.compose({
-    name: "todo-app",
-    template,
-    styles,
-});
+export function defineTodoApp(): typeof TodoApp {
+    return TodoApp.define({
+        name: "todo-app",
+        template,
+        styles,
+    });
+}

--- a/examples/csr/todo-app/src/todo-app.ts
+++ b/examples/csr/todo-app/src/todo-app.ts
@@ -1,16 +1,6 @@
 import { FASTElement } from "@microsoft/fast-element";
-import { styles } from "./todo-app.styles.js";
-import { template } from "./todo-app.template.js";
 import { TodoList } from "./todo-list.js";
 
 export class TodoApp extends FASTElement {
     @TodoList todos!: TodoList;
-}
-
-export function defineTodoApp(): typeof TodoApp {
-    return TodoApp.define({
-        name: "todo-app",
-        template,
-        styles,
-    });
 }

--- a/examples/csr/todo-mobx-app/src/main.ts
+++ b/examples/csr/todo-mobx-app/src/main.ts
@@ -1,6 +1,6 @@
 import "@microsoft/fast-examples-design-system/tokens.css";
 import { connectStoreToStorage, todoStore } from "./state/index.js";
-import { app } from "./todo-app.js";
+import { defineTodoApp } from "./todo-app.js";
 import "./todo-form.js";
 
 // Wire MobX's autorun to localStorage so the store is hydrated on load and
@@ -8,4 +8,4 @@ import "./todo-form.js";
 // lifetime of the page.
 connectStoreToStorage(todoStore, "fast-todo-mobx-app");
 
-app.define();
+defineTodoApp();

--- a/examples/csr/todo-mobx-app/src/main.ts
+++ b/examples/csr/todo-mobx-app/src/main.ts
@@ -1,6 +1,8 @@
 import "@microsoft/fast-examples-design-system/tokens.css";
 import { connectStoreToStorage, todoStore } from "./state/index.js";
-import { defineTodoApp } from "./todo-app.js";
+import { TodoApp } from "./todo-app.js";
+import { styles } from "./todo-app.styles.js";
+import { template } from "./todo-app.template.js";
 import "./todo-form.js";
 
 // Wire MobX's autorun to localStorage so the store is hydrated on load and
@@ -8,4 +10,8 @@ import "./todo-form.js";
 // lifetime of the page.
 connectStoreToStorage(todoStore, "fast-todo-mobx-app");
 
-defineTodoApp();
+TodoApp.define({
+    name: "todo-app",
+    template,
+    styles,
+});

--- a/examples/csr/todo-mobx-app/src/todo-app.ts
+++ b/examples/csr/todo-mobx-app/src/todo-app.ts
@@ -51,8 +51,10 @@ export class TodoApp extends FASTElement {
     }
 }
 
-export const app = TodoApp.compose({
-    name: "todo-app",
-    template,
-    styles,
-});
+export function defineTodoApp(): typeof TodoApp {
+    return TodoApp.define({
+        name: "todo-app",
+        template,
+        styles,
+    });
+}

--- a/examples/csr/todo-mobx-app/src/todo-app.ts
+++ b/examples/csr/todo-mobx-app/src/todo-app.ts
@@ -1,8 +1,6 @@
 import { autorun } from "mobx";
 import { FASTElement, observable } from "@microsoft/fast-element";
 import { type Todo, type TodoListFilter, todoStore } from "./state/index.js";
-import { styles } from "./todo-app.styles.js";
-import { template } from "./todo-app.template.js";
 
 /**
  * Root component for the MobX-backed todo example.
@@ -49,12 +47,4 @@ export class TodoApp extends FASTElement {
             todoStore.setFilter(next);
         }
     }
-}
-
-export function defineTodoApp(): typeof TodoApp {
-    return TodoApp.define({
-        name: "todo-app",
-        template,
-        styles,
-    });
 }

--- a/packages/fast-element/DESIGN.md
+++ b/packages/fast-element/DESIGN.md
@@ -95,7 +95,7 @@ The `KernelServiceId` object controls which numeric/string keys are used for sha
 - On `disconnect()`: calls `disconnectedCallback` on behaviors, unbinds the view.
 - Exposes `addBehavior` / `removeBehavior` for dynamic `HostBehavior` management (used by `ElementStyles`).
 
-`FASTElementDefinition` wraps all the metadata for a custom element class: its tag name, template, styles, and observed attribute list. It is created by `FASTElement.compose()` and registered globally via `fastElementRegistry`.
+`FASTElementDefinition` wraps all the metadata for a custom element class: its tag name, template, styles, and observed attribute list. It is created by `FASTElement.define()` and registered globally via `fastElementRegistry`.
 
 ---
 
@@ -303,7 +303,7 @@ See `docs/di/api-report.api.md` for the full public API surface.
 ```mermaid
 flowchart TD
     A([Browser loads script]) --> B[FAST global created on globalThis]
-    B --> C[FASTElement subclass executes FASTElement.compose]
+    B --> C[FASTElement subclass executes FASTElement.define]
     C --> D[Observable decorators register accessors on the prototype]
     C --> E[Attribute decorators push AttributeDefinition to the class]
     C --> F[html tag is evaluated – ViewTemplate created with factories]
@@ -430,7 +430,7 @@ Below is a conceptual map of the major subsystems and their relationships:
 **Authoring flow summary**:
 
 1. Developer writes a class extending `FASTElement`, decorates properties with `@observable` / `@attr`, and calls `FASTElement.define({ name, template, styles })`.
-2. `FASTElement.define` → `FASTElementDefinition.compose(...).define()` registers the element with the Custom Element Registry.
+2. `FASTElement.define` creates the element definition and registers the element with the Custom Element Registry.
 3. When the browser upgrades the element, `ElementController.forCustomElement(element)` is called in the constructor.
 4. On `connectedCallback`, the controller renders the template (`ViewTemplate.render`) into the shadow root. Compilation is lazy: the first render call triggers `Compiler.compile()`, subsequent calls clone the already-compiled `DocumentFragment`.
 5. `HTMLView.bind(source)` wires up each `ViewBehavior`. `oneWay` bindings create `ExpressionNotifier`s that track observable dependencies automatically.

--- a/packages/fast-element/docs/api-report.api.md
+++ b/packages/fast-element/docs/api-report.api.md
@@ -443,6 +443,7 @@ export const FASTElement: {
 export class FASTElementDefinition<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>> {
     readonly attributeLookup: Record<string, AttributeDefinition>;
     readonly attributes: ReadonlyArray<AttributeDefinition>;
+    // @deprecated
     static compose<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(type: TType, nameOrDef?: string | PartialFASTElementDefinition): FASTElementDefinition<TType>;
     // @alpha
     static composeAsync<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(type: TType, nameOrDef?: string | PartialFASTElementDefinition): Promise<FASTElementDefinition<TType>>;
@@ -1111,10 +1112,10 @@ export function when<TSource = any, TReturn = any, TParent = any>(condition: Exp
 
 // Warnings were encountered during analysis:
 //
-// dist/dts/components/fast-element.d.ts:62:5 - (ae-forgotten-export) The symbol "define" needs to be exported by the entry point index.d.ts
-// dist/dts/components/fast-element.d.ts:63:5 - (ae-forgotten-export) The symbol "compose" needs to be exported by the entry point index.d.ts
-// dist/dts/components/fast-element.d.ts:64:5 - (ae-forgotten-export) The symbol "defineAsync" needs to be exported by the entry point index.d.ts
-// dist/dts/components/fast-element.d.ts:65:5 - (ae-forgotten-export) The symbol "from" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:70:5 - (ae-forgotten-export) The symbol "define" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:75:5 - (ae-forgotten-export) The symbol "compose" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:76:5 - (ae-forgotten-export) The symbol "defineAsync" needs to be exported by the entry point index.d.ts
+// dist/dts/components/fast-element.d.ts:77:5 - (ae-forgotten-export) The symbol "from" needs to be exported by the entry point index.d.ts
 // dist/dts/styles/css-binding-directive.d.ts:35:9 - (ae-forgotten-export) The symbol "CSSBindingEntry" needs to be exported by the entry point index.d.ts
 
 // (No @packageDocumentation comment for this package)

--- a/packages/fast-element/docs/architecture/overview.md
+++ b/packages/fast-element/docs/architecture/overview.md
@@ -2,7 +2,7 @@
 
 `FASTElement` is an extension of `HTMLElement` which makes use of Custom Element APIs native to the browser. It also supplies the following methods:
 
-- The `compose` method combines the Custom Element name, template, style, and other options to create the definition for the Custom Element.
+- The deprecated `compose` method combines the Custom Element name, template, style, and other options to create the definition for the Custom Element. Use `define` with a definition object for new code.
 - The `define` method makes use of the native Custom Element [`define()`](https://developer.mozilla.org/en-US/docs/Web/API/CustomElementRegistry/define) to register the Custom Element with a Custom Element Registry.
 - The `from` method allows the use of Customized Built-in elements, which extend from native elements such as `HTMLButtonElement`.
 
@@ -13,14 +13,14 @@ A basic developer flow for defining a custom element looks like this:
 ```mermaid
 flowchart TD
     A[Create a <code>FASTElement</code> web component by extending the <code>FASTElement</code> class] --> F
-    F[Compose with <code>FASTElement.compose</code> to include template and styles] --> G[Define the component in the browser with <code>FASTElement.define</code>]
+    F[Call <code>FASTElement.define</code> with template and styles] --> G[Register the component with a Custom Element Registry]
 ```
 
-Let's take a look at the compose step to see what the FAST architecture is doing at this stage.
+Let's take a look at the define step to see what the FAST architecture is doing at this stage.
 
-### Composing a Custom Element
+### Defining a Custom Element
 
-The `FASTElement.compose()` function creates a new `FASTElementDefinition`, which includes all metadata needed for the element (such as templates, attributes, and styles). The element definition is registered with the global `FAST` for re-use, and the `FASTElementDefinition` is returned. The resulting object can be retrieved via `ElementController.definition`.
+The `FASTElement.define()` function creates a new `FASTElementDefinition`, which includes all metadata needed for the element (such as templates, attributes, and styles), then registers the element with the configured Custom Element Registry. The resulting object can be retrieved via `ElementController.definition`.
 
 ## A Custom Element in JavaScript is sent to the Browser
 

--- a/packages/fast-element/src/components/fast-definitions.ts
+++ b/packages/fast-element/src/components/fast-definitions.ts
@@ -3,7 +3,7 @@ import { Observable } from "../observation/observable.js";
 import { createTypeRegistry, FAST, type TypeRegistry } from "../platform.js";
 import { type ComposableStyles, ElementStyles } from "../styles/element-styles.js";
 import type { ElementViewTemplate } from "../templating/template.js";
-import { AttributeConfiguration, AttributeDefinition } from "./attributes.js";
+import { type AttributeConfiguration, AttributeDefinition } from "./attributes.js";
 
 const defaultShadowOptions: ShadowRootInit = { mode: "open" };
 const defaultElementOptions: ElementDefinitionOptions = {};
@@ -15,7 +15,7 @@ const fastElementBaseTypes = new Set<Function>();
  */
 export const fastElementRegistry: TypeRegistry<FASTElementDefinition> = FAST.getById(
     KernelServiceId.elementRegistry,
-    () => createTypeRegistry<FASTElementDefinition>()
+    () => createTypeRegistry<FASTElementDefinition>(),
 );
 
 export type { TypeRegistry };
@@ -125,7 +125,7 @@ export interface PartialFASTElementDefinition {
  * @public
  */
 export class FASTElementDefinition<
-    TType extends Constructable<HTMLElement> = Constructable<HTMLElement>
+    TType extends Constructable<HTMLElement> = Constructable<HTMLElement>,
 > {
     private platformDefined = false;
 
@@ -204,7 +204,7 @@ export class FASTElementDefinition<
 
     private constructor(
         type: TType,
-        nameOrConfig: PartialFASTElementDefinition | string = (type as any).definition
+        nameOrConfig: PartialFASTElementDefinition | string = (type as any).definition,
     ) {
         if (isString(nameOrConfig)) {
             nameOrConfig = { name: nameOrConfig };
@@ -243,8 +243,8 @@ export class FASTElementDefinition<
             nameOrConfig.shadowOptions === void 0
                 ? defaultShadowOptions
                 : nameOrConfig.shadowOptions === null
-                ? void 0
-                : { ...defaultShadowOptions, ...nameOrConfig.shadowOptions };
+                  ? void 0
+                  : { ...defaultShadowOptions, ...nameOrConfig.shadowOptions };
 
         this.elementOptions =
             nameOrConfig.elementOptions === void 0
@@ -281,12 +281,13 @@ export class FASTElementDefinition<
      * @param type - The type this definition is being created for.
      * @param nameOrDef - The name of the element to define or a config object
      * that describes the element to define.
+     * @deprecated Use `FASTElement.define()` with a definition object instead.
      */
     public static compose<
-        TType extends Constructable<HTMLElement> = Constructable<HTMLElement>
+        TType extends Constructable<HTMLElement> = Constructable<HTMLElement>,
     >(
         type: TType,
-        nameOrDef?: string | PartialFASTElementDefinition
+        nameOrDef?: string | PartialFASTElementDefinition,
     ): FASTElementDefinition<TType> {
         if (fastElementBaseTypes.has(type) || fastElementRegistry.getByType(type)) {
             return new FASTElementDefinition<TType>(class extends type {}, nameOrDef);
@@ -329,7 +330,7 @@ export class FASTElementDefinition<
 
             Observable.getNotifier(FASTElementDefinition.isRegistered).subscribe(
                 { handleChange: () => resolve(FASTElementDefinition.isRegistered[name]) },
-                name
+                name,
             );
         });
     };
@@ -344,15 +345,15 @@ export class FASTElementDefinition<
      * @alpha
      */
     public static composeAsync<
-        TType extends Constructable<HTMLElement> = Constructable<HTMLElement>
+        TType extends Constructable<HTMLElement> = Constructable<HTMLElement>,
     >(
         type: TType,
-        nameOrDef?: string | PartialFASTElementDefinition
+        nameOrDef?: string | PartialFASTElementDefinition,
     ): Promise<FASTElementDefinition<TType>> {
         return new Promise(resolve => {
             if (fastElementBaseTypes.has(type) || fastElementRegistry.getByType(type)) {
                 resolve(
-                    new FASTElementDefinition<TType>(class extends type {}, nameOrDef)
+                    new FASTElementDefinition<TType>(class extends type {}, nameOrDef),
                 );
             }
 
@@ -362,12 +363,12 @@ export class FASTElementDefinition<
                 {
                     handleChange: () => {
                         definition.lifecycleCallbacks?.templateDidUpdate?.(
-                            definition.name
+                            definition.name,
                         );
                         resolve(definition);
                     },
                 },
-                "template"
+                "template",
             );
         });
     }

--- a/packages/fast-element/src/components/fast-element.ts
+++ b/packages/fast-element/src/components/fast-element.ts
@@ -27,7 +27,7 @@ export interface FASTElement extends HTMLElement {
     $emit(
         type: string,
         detail?: any,
-        options?: Omit<CustomEventInit, "detail">
+        options?: Omit<CustomEventInit, "detail">,
     ): boolean | void;
 
     /**
@@ -58,13 +58,13 @@ export interface FASTElement extends HTMLElement {
     attributeChangedCallback(
         name: string,
         oldValue: string | null,
-        newValue: string | null
+        newValue: string | null,
     ): void;
 }
 
 /* eslint-disable-next-line @typescript-eslint/explicit-function-return-type */
 function createFASTElement<T extends typeof HTMLElement>(
-    BaseType: T
+    BaseType: T,
 ): { new (): InstanceType<T> & FASTElement } {
     const type = class extends (BaseType as any) {
         public readonly $fastController!: ElementController;
@@ -78,7 +78,7 @@ function createFASTElement<T extends typeof HTMLElement>(
         public $emit(
             type: string,
             detail?: any,
-            options?: Omit<CustomEventInit, "detail">
+            options?: Omit<CustomEventInit, "detail">,
         ): boolean | void {
             return this.$fastController.emit(type, detail, options);
         }
@@ -94,7 +94,7 @@ function createFASTElement<T extends typeof HTMLElement>(
         public attributeChangedCallback(
             name: string,
             oldValue: string | null,
-            newValue: string | null
+            newValue: string | null,
         ): void {
             this.$fastController.onAttributeChangedCallback(name, oldValue, newValue);
         }
@@ -105,17 +105,25 @@ function createFASTElement<T extends typeof HTMLElement>(
     return type as any;
 }
 
+/**
+ * Defines metadata for a FASTElement which can be used to later define the element.
+ * @deprecated Use `define()` with a definition object instead.
+ */
 function compose<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(
     this: TType,
-    nameOrDef: string | PartialFASTElementDefinition
+    nameOrDef: string | PartialFASTElementDefinition,
 ): FASTElementDefinition<TType>;
+/**
+ * Defines metadata for a FASTElement which can be used to later define the element.
+ * @deprecated Use `define()` with a definition object instead.
+ */
 function compose<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(
     type: TType,
-    nameOrDef?: string | PartialFASTElementDefinition
+    nameOrDef?: string | PartialFASTElementDefinition,
 ): FASTElementDefinition<TType>;
 function compose<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(
     type: TType | string | PartialFASTElementDefinition,
-    nameOrDef?: string | PartialFASTElementDefinition
+    nameOrDef?: string | PartialFASTElementDefinition,
 ): FASTElementDefinition<TType> {
     if (isFunction(type)) {
         return FASTElementDefinition.compose(type, nameOrDef);
@@ -125,22 +133,22 @@ function compose<TType extends Constructable<HTMLElement> = Constructable<HTMLEl
 }
 
 function defineAsync<
-    TType extends Constructable<HTMLElement> = Constructable<HTMLElement>
+    TType extends Constructable<HTMLElement> = Constructable<HTMLElement>,
 >(
     this: TType,
-    nameOrDef: string | PartialFASTElementDefinition
+    nameOrDef: string | PartialFASTElementDefinition,
 ): Promise<FASTElementDefinition<TType>>;
 function defineAsync<
-    TType extends Constructable<HTMLElement> = Constructable<HTMLElement>
+    TType extends Constructable<HTMLElement> = Constructable<HTMLElement>,
 >(
     type: TType,
-    nameOrDef?: string | PartialFASTElementDefinition
+    nameOrDef?: string | PartialFASTElementDefinition,
 ): Promise<FASTElementDefinition<TType>>;
 function defineAsync<
-    TType extends Constructable<HTMLElement> = Constructable<HTMLElement>
+    TType extends Constructable<HTMLElement> = Constructable<HTMLElement>,
 >(
     type: TType | string | PartialFASTElementDefinition,
-    nameOrDef?: string | PartialFASTElementDefinition
+    nameOrDef?: string | PartialFASTElementDefinition,
 ): Promise<TType> {
     if (isFunction(type)) {
         return new Promise<FASTElementDefinition<TType>>(resolve => {
@@ -163,15 +171,15 @@ function defineAsync<
 
 function define<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(
     this: TType,
-    nameOrDef: string | PartialFASTElementDefinition
+    nameOrDef: string | PartialFASTElementDefinition,
 ): TType;
 function define<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(
     type: TType,
-    nameOrDef?: string | PartialFASTElementDefinition
+    nameOrDef?: string | PartialFASTElementDefinition,
 ): TType;
 function define<TType extends Constructable<HTMLElement> = Constructable<HTMLElement>>(
     type: TType | string | PartialFASTElementDefinition,
-    nameOrDef?: string | PartialFASTElementDefinition
+    nameOrDef?: string | PartialFASTElementDefinition,
 ): TType {
     if (isFunction(type)) {
         return FASTElementDefinition.compose(type, nameOrDef).define().type;
@@ -192,6 +200,10 @@ function from<TBase extends typeof HTMLElement>(BaseType: TBase) {
 export const FASTElement: {
     new (): FASTElement;
     define: typeof define;
+    /**
+     * Defines metadata for a FASTElement which can be used to later define the element.
+     * @deprecated Use `define()` with a definition object instead.
+     */
     compose: typeof compose;
     defineAsync: typeof defineAsync;
     from: typeof from;
@@ -214,6 +226,7 @@ export const FASTElement: {
     /**
      * Defines metadata for a FASTElement which can be used to later define the element.
      * @public
+     * @deprecated Use `define()` with a definition object instead.
      */
     compose,
 

--- a/sites/website/src/docs/2.x/api/fast-element.fastelementdefinition.compose.md
+++ b/sites/website/src/docs/2.x/api/fast-element.fastelementdefinition.compose.md
@@ -16,9 +16,9 @@ navigationOptions:
 ## FASTElementDefinition.compose() method
 
 > Warning: This API is now obsolete.
->
+> 
 > Use `FASTElement.define()` with a definition object instead.
->
+> 
 
 Creates an instance of FASTElementDefinition.
 

--- a/sites/website/src/docs/2.x/api/fast-element.fastelementdefinition.compose.md
+++ b/sites/website/src/docs/2.x/api/fast-element.fastelementdefinition.compose.md
@@ -15,6 +15,11 @@ navigationOptions:
 
 ## FASTElementDefinition.compose() method
 
+> Warning: This API is now obsolete.
+>
+> Use `FASTElement.define()` with a definition object instead.
+>
+
 Creates an instance of FASTElementDefinition.
 
 **Signature:**

--- a/sites/website/src/docs/2.x/getting-started/fast-element.md
+++ b/sites/website/src/docs/2.x/getting-started/fast-element.md
@@ -274,11 +274,12 @@ export const FooRegistry = Object.freeze({
   registry: customElements,
 });
 
-HelloWorld.compose({
+HelloWorld.define({
   name: `${FooRegistry.prefix}-tab`,
   template,
   styles,
-}).define(FooRegistry);
+  registry: FooRegistry.registry,
+});
 ```
 
 ## Lifecycle


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes the public API guidance for the deprecated compose APIs:

- Marks `FASTElement.compose` and `FASTElementDefinition.compose` as deprecated in TSDoc.
- Regenerates API docs so `FASTElementDefinition.compose()` is documented as obsolete.
- Updates `fast-element` architecture/design docs, website guidance, examples, and TypeScript agent guidance to prefer `define()`.
- Uses patch-level Beachball metadata for the deprecation fix.

## 👩‍💻 Reviewer Notes

A plain local `npm run test` repeatedly timed out in the `@microsoft/fast-test-harness` Firefox project under default local parallelism. The same Firefox harness tests pass serially, and the full root test command passes with `CI=true`.

## 📑 Test Plan

- `npm run build`
- `CI=true npm run test`
- `npm run biome:check`
- `npm run checkchange`
- `npm run test -w @microsoft/fast-element`
- `npm exec -w @microsoft/fast-test-harness -- playwright test --project=firefox --workers=1`
- `npm run build -w @microsoft/fast-todo-app-example -w @microsoft/fast-todo-mobx-app-example`

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.