### PR TITLE
chore: release packages

### DIFF
--- a/build/scripts/finalize-fast-element-v3-rc.mjs
+++ b/build/scripts/finalize-fast-element-v3-rc.mjs
@@ -443,8 +443,25 @@ function rewriteChangelogMd(packageName, finalVersions, rawVersions) {
     const rawVersion = rawVersions[packageName];
     const finalVersion = finalVersions[packageName];
     content = content.replace(`## ${rawVersion}\n`, `## ${finalVersion}\n`);
-    content = rewriteVersionReferences(content, finalVersions, rawVersions);
+    content = rewriteChangelogSection(content, finalVersion, section =>
+        rewriteVersionReferences(section, finalVersions, rawVersions),
+    );
     writeFileSync(path, content);
+}
+
+function rewriteChangelogSection(content, version, rewrite) {
+    const heading = `## ${version}\n`;
+    const start = content.indexOf(heading);
+    if (start === -1) {
+        throw new Error(`Could not find generated changelog heading ${heading.trim()}.`);
+    }
+
+    const nextHeading = content.indexOf("\n## ", start + heading.length);
+    const end = nextHeading === -1 ? content.length : nextHeading;
+
+    return (
+        content.slice(0, start) + rewrite(content.slice(start, end)) + content.slice(end)
+    );
 }
 
 function rewriteVersionReferences(input, finalVersions, rawVersions) {

--- a/build/scripts/finalize-fast-element-v3-rc.mjs
+++ b/build/scripts/finalize-fast-element-v3-rc.mjs
@@ -207,6 +207,38 @@ function ensureChangeFilesExist() {
     }
 }
 
+const changeTypePriority = {
+    none: 0,
+    patch: 1,
+    minor: 2,
+    major: 3,
+    prerelease: 4,
+};
+
+function readChangeTypes() {
+    const changeDir = join(repoRoot, "change");
+    const changes = new Map();
+
+    for (const file of readdirSync(changeDir).filter(file => file.endsWith(".json"))) {
+        const change = readJson(join(changeDir, file));
+        if (!packageOrder.includes(change.packageName)) {
+            continue;
+        }
+
+        const priority = changeTypePriority[change.type];
+        if (priority === undefined) {
+            throw new Error(`Unsupported change type ${change.type} in ${file}.`);
+        }
+
+        const current = changes.get(change.packageName);
+        if (current === undefined || priority > changeTypePriority[current]) {
+            changes.set(change.packageName, change.type);
+        }
+    }
+
+    return changes;
+}
+
 function createTemporaryBeachballConfig() {
     const tempDir = mkdtempSync(join(tmpdir(), "fast-element-v3-rc-beachball-"));
     const configPath = join(tempDir, "beachball.config.cjs");
@@ -268,11 +300,59 @@ function appendSuffix(version) {
     return version.includes(RC_SUFFIX) ? version : `${version}-${RC_SUFFIX}`;
 }
 
-function computeFinalVersions() {
-    const rawVersions = Object.fromEntries(
-        packageOrder.map(packageName => [packageName, getPackage(packageName).version]),
-    );
+function stripSuffix(version) {
+    const suffix = `-${RC_SUFFIX}`;
+    return version.endsWith(suffix) ? version.slice(0, -suffix.length) : version;
+}
 
+function parseStableVersion(version) {
+    const match = /^(\d+)\.(\d+)\.(\d+)$/.exec(version);
+    if (!match) {
+        throw new Error(
+            `Expected a stable semver version before applying the RC suffix, got ${version}.`,
+        );
+    }
+
+    return {
+        major: Number(match[1]),
+        minor: Number(match[2]),
+        patch: Number(match[3]),
+    };
+}
+
+function bumpStableVersion(version, changeType) {
+    switch (changeType) {
+        case undefined:
+        case "none":
+            return version;
+    }
+
+    const { major, minor, patch } = parseStableVersion(version);
+
+    switch (changeType) {
+        case "patch":
+            return `${major}.${minor}.${patch + 1}`;
+        case "minor":
+            return `${major}.${minor + 1}.0`;
+        case "major":
+            return `${major + 1}.0.0`;
+        default:
+            throw new Error(
+                `Change type ${changeType} is not supported for FAST Element v3 RC companion packages.`,
+            );
+    }
+}
+
+function computeCompanionVersion(packageName, baselineVersions, changeTypes) {
+    const baselineVersion = stripSuffix(baselineVersions[packageName]);
+    const bumpedVersion = bumpStableVersion(
+        baselineVersion,
+        changeTypes.get(packageName),
+    );
+    return appendSuffix(bumpedVersion);
+}
+
+function computeFinalVersions(baselineVersions, rawVersions, changeTypes) {
     const fastElementVersion = rawVersions["@microsoft/fast-element"];
     if (!/^3\.0\.0-rc\.\d+$/.test(fastElementVersion)) {
         throw new Error(
@@ -281,11 +361,21 @@ function computeFinalVersions() {
     }
 
     return {
-        "@microsoft/fast-build": appendSuffix(rawVersions["@microsoft/fast-build"]),
+        "@microsoft/fast-build": computeCompanionVersion(
+            "@microsoft/fast-build",
+            baselineVersions,
+            changeTypes,
+        ),
         "@microsoft/fast-element": fastElementVersion,
-        "@microsoft/fast-router": appendSuffix(rawVersions["@microsoft/fast-router"]),
-        "@microsoft/fast-test-harness": appendSuffix(
-            rawVersions["@microsoft/fast-test-harness"],
+        "@microsoft/fast-router": computeCompanionVersion(
+            "@microsoft/fast-router",
+            baselineVersions,
+            changeTypes,
+        ),
+        "@microsoft/fast-test-harness": computeCompanionVersion(
+            "@microsoft/fast-test-harness",
+            baselineVersions,
+            changeTypes,
         ),
     };
 }
@@ -565,6 +655,7 @@ function applyFinalizer() {
     const baselineVersions = Object.fromEntries(
         packageOrder.map(packageName => [packageName, getPackage(packageName).version]),
     );
+    const changeTypes = readChangeTypes();
     const initialCrateVersion = readCargoVersion();
 
     runBeachballBump();
@@ -576,7 +667,11 @@ function applyFinalizer() {
         baselineVersions["@microsoft/fast-element"],
         rawVersions["@microsoft/fast-element"],
     );
-    const finalVersions = computeFinalVersions();
+    const finalVersions = computeFinalVersions(
+        baselineVersions,
+        rawVersions,
+        changeTypes,
+    );
 
     rewritePackageVersions(finalVersions);
     rewritePrivateWorkspaceDependencies(finalVersions);

--- a/change/@microsoft-fast-build-9f12fb7d-43d6-4790-8869-c1bc5c9f2abc.json
+++ b/change/@microsoft-fast-build-9f12fb7d-43d6-4790-8869-c1bc5c9f2abc.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore: include fast-build in the fast-element v3 RC prerelease train.",
-  "packageName": "@microsoft/fast-build",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-365d47d4-0bd5-4ffe-ab53-a1c15d6b4064.json
+++ b/change/@microsoft-fast-element-365d47d4-0bd5-4ffe-ab53-a1c15d6b4064.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "BREAKING: Remove FASTElement.compose from the public API.",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-router-acae6e7b-a087-4b04-b325-b64219728471.json
+++ b/change/@microsoft-fast-router-acae6e7b-a087-4b04-b325-b64219728471.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "chore: include fast-router in the fast-element v3 RC prerelease train.",
-  "packageName": "@microsoft/fast-router",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-test-harness-6639cb0e-427b-47f5-9867-759164d80061.json
+++ b/change/@microsoft-fast-test-harness-6639cb0e-427b-47f5-9867-759164d80061.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "chore: include fast-test-harness in the fast-element v3 RC prerelease train.",
-  "packageName": "@microsoft/fast-test-harness",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/examples/csr/todo-app/package.json
+++ b/examples/csr/todo-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "3.0.0-rc.2",
+    "@microsoft/fast-element": "3.0.0-rc.3",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "tslib": "^2.6.3"
   },

--- a/examples/csr/todo-mobx-app/package.json
+++ b/examples/csr/todo-mobx-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-mobx-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "3.0.0-rc.2",
+    "@microsoft/fast-element": "3.0.0-rc.3",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "mobx": "^6.13.5",
     "tslib": "^2.6.3"

--- a/examples/ssr/chat-app/package.json
+++ b/examples/ssr/chat-app/package.json
@@ -23,7 +23,7 @@
         "directory": "examples/ssr/chat-app"
     },
     "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.2",
+        "@microsoft/fast-element": "3.0.0-rc.3",
         "@microsoft/fast-examples-design-system": "*",
         "tslib": "^2.6.3"
     },

--- a/examples/ssr/webui-todo-app/package.json
+++ b/examples/ssr/webui-todo-app/package.json
@@ -25,7 +25,7 @@
         "directory": "examples/ssr/webui-todo-app"
     },
     "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.2",
+        "@microsoft/fast-element": "3.0.0-rc.3",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "@microsoft/webui": "^0.0.12",
         "tslib": "^2.6.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -6760,7 +6760,7 @@
     },
     "packages/fast-build": {
       "name": "@microsoft/fast-build",
-      "version": "0.8.0-fast-element-v3-rc-20260615",
+      "version": "0.8.1-fast-element-v3-rc-20260615",
       "license": "MIT",
       "bin": {
         "fast": "bin/fast.js"
@@ -6774,7 +6774,7 @@
       "version": "3.0.0-rc.3",
       "license": "MIT",
       "devDependencies": {
-        "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+        "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
         "@microsoft/webui": "0.0.12"
       }
     },
@@ -6794,7 +6794,7 @@
     },
     "packages/fast-test-harness": {
       "name": "@microsoft/fast-test-harness",
-      "version": "0.4.0-fast-element-v3-rc-20260615",
+      "version": "0.4.1-fast-element-v3-rc-20260615",
       "license": "MIT",
       "dependencies": {
         "cheerio": "1.2.0"
@@ -6803,14 +6803,14 @@
         "fast-test-harness": "start.mjs"
       },
       "devDependencies": {
-        "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+        "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
         "@microsoft/fast-element": "3.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+        "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
         "@microsoft/fast-element": "3.0.0-rc.3",
         "@playwright/test": ">=1.40.0",
         "vite": ">=7.0.0"
@@ -6843,21 +6843,8 @@
         "github-markdown-css": "5.9.0"
       },
       "devDependencies": {
-        "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+        "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
         "@microsoft/fast-element": "3.0.0-rc.3"
-      }
-    },
-    "sites/website/node_modules/@microsoft/fast-build": {
-      "version": "0.8.0-fast-element-v3-rc-20260615",
-      "resolved": "https://registry.npmjs.org/@microsoft/fast-build/-/fast-build-0.8.0-fast-element-v3-rc-20260615.tgz",
-      "integrity": "sha512-wyyyH/xuuUnxjxUdvgkqR+ul1NJ9o778eFnhCGEXuz1uoNeuaX2mMGctfH+3jow0KrxNzJ+TLj7RxKepSrk1vg==",
-      "dev": true,
-      "license": "MIT",
-      "bin": {
-        "fast": "bin/fast.js"
-      },
-      "engines": {
-        "node": ">=22.18.0"
       }
     }
   }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.2",
+        "@microsoft/fast-element": "3.0.0-rc.3",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "tslib": "^2.6.3"
       },
@@ -66,7 +66,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.2",
+        "@microsoft/fast-element": "3.0.0-rc.3",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "mobx": "^6.13.5",
         "tslib": "^2.6.3"
@@ -82,7 +82,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.2",
+        "@microsoft/fast-element": "3.0.0-rc.3",
         "@microsoft/fast-examples-design-system": "*",
         "tslib": "^2.6.3"
       },
@@ -95,7 +95,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.2",
+        "@microsoft/fast-element": "3.0.0-rc.3",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "@microsoft/webui": "^0.0.12",
         "tslib": "^2.6.3"
@@ -6771,7 +6771,7 @@
     },
     "packages/fast-element": {
       "name": "@microsoft/fast-element",
-      "version": "3.0.0-rc.2",
+      "version": "3.0.0-rc.3",
       "license": "MIT",
       "devDependencies": {
         "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
@@ -6786,10 +6786,10 @@
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.2"
+        "@microsoft/fast-element": "3.0.0-rc.3"
       },
       "peerDependencies": {
-        "@microsoft/fast-element": "3.0.0-rc.2"
+        "@microsoft/fast-element": "3.0.0-rc.3"
       }
     },
     "packages/fast-test-harness": {
@@ -6804,14 +6804,14 @@
       },
       "devDependencies": {
         "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
-        "@microsoft/fast-element": "3.0.0-rc.2"
+        "@microsoft/fast-element": "3.0.0-rc.3"
       },
       "engines": {
         "node": ">=22.18.0"
       },
       "peerDependencies": {
         "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
-        "@microsoft/fast-element": "3.0.0-rc.2",
+        "@microsoft/fast-element": "3.0.0-rc.3",
         "@playwright/test": ">=1.40.0",
         "vite": ">=7.0.0"
       },
@@ -6829,7 +6829,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@microsoft/fast-build": "*",
-        "@microsoft/fast-element": "3.0.0-rc.2"
+        "@microsoft/fast-element": "3.0.0-rc.3"
       }
     },
     "sites/website": {
@@ -6844,7 +6844,20 @@
       },
       "devDependencies": {
         "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
-        "@microsoft/fast-element": "3.0.0-rc.2"
+        "@microsoft/fast-element": "3.0.0-rc.3"
+      }
+    },
+    "sites/website/node_modules/@microsoft/fast-build": {
+      "version": "0.8.0-fast-element-v3-rc-20260615",
+      "resolved": "https://registry.npmjs.org/@microsoft/fast-build/-/fast-build-0.8.0-fast-element-v3-rc-20260615.tgz",
+      "integrity": "sha512-wyyyH/xuuUnxjxUdvgkqR+ul1NJ9o778eFnhCGEXuz1uoNeuaX2mMGctfH+3jow0KrxNzJ+TLj7RxKepSrk1vg==",
+      "dev": true,
+      "license": "MIT",
+      "bin": {
+        "fast": "bin/fast.js"
+      },
+      "engines": {
+        "node": ">=22.18.0"
       }
     }
   }

--- a/packages/fast-build/CHANGELOG.json
+++ b/packages/fast-build/CHANGELOG.json
@@ -2,9 +2,9 @@
   "name": "@microsoft/fast-build",
   "entries": [
     {
-      "date": "Tue, 23 Jun 2026 02:12:54 GMT",
-      "version": "0.8.0-fast-element-v3-rc-20260615",
-      "tag": "@microsoft/fast-build_v0.8.0-fast-element-v3-rc-20260615",
+      "date": "Tue, 23 Jun 2026 03:06:37 GMT",
+      "version": "0.8.1-fast-element-v3-rc-20260615",
+      "tag": "@microsoft/fast-build_v0.8.1-fast-element-v3-rc-20260615",
       "comments": {
         "patch": [
           {

--- a/packages/fast-build/CHANGELOG.json
+++ b/packages/fast-build/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/fast-build",
   "entries": [
     {
+      "date": "Tue, 23 Jun 2026 02:12:54 GMT",
+      "version": "0.8.0-fast-element-v3-rc-20260615",
+      "tag": "@microsoft/fast-build_v0.8.0-fast-element-v3-rc-20260615",
+      "comments": {
+        "patch": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-build",
+            "commit": "d2021ef7456d8f4b7d227c8fd78df82aaec18590",
+            "comment": "chore: include fast-build in the fast-element v3 RC prerelease train."
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 19 Jun 2026 22:15:55 GMT",
       "version": "0.8.0-fast-element-v3-rc-20260615",
       "tag": "@microsoft/fast-build_v0.8.0-fast-element-v3-rc-20260615",

--- a/packages/fast-build/CHANGELOG.md
+++ b/packages/fast-build/CHANGELOG.md
@@ -1,12 +1,12 @@
 # Change Log - @microsoft/fast-build
 
-<!-- This log was last generated on Tue, 23 Jun 2026 02:12:54 GMT and should not be manually modified. -->
+<!-- This log was last generated on Tue, 23 Jun 2026 03:06:37 GMT and should not be manually modified. -->
 
 <!-- Start content -->
 
-## 0.8.0-fast-element-v3-rc-20260615
+## 0.8.1-fast-element-v3-rc-20260615
 
-Tue, 23 Jun 2026 02:12:54 GMT
+Tue, 23 Jun 2026 03:06:37 GMT
 
 ### Patches
 

--- a/packages/fast-build/CHANGELOG.md
+++ b/packages/fast-build/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @microsoft/fast-build
 
-<!-- This log was last generated on Fri, 19 Jun 2026 22:15:55 GMT and should not be manually modified. -->
+<!-- This log was last generated on Tue, 23 Jun 2026 02:12:54 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 0.8.0-fast-element-v3-rc-20260615
+
+Tue, 23 Jun 2026 02:12:54 GMT
+
+### Patches
+
+- chore: include fast-build in the fast-element v3 RC prerelease train. (7559015+janechu@users.noreply.github.com)
 
 ## 0.8.0-fast-element-v3-rc-20260615
 

--- a/packages/fast-build/package.json
+++ b/packages/fast-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fast-build",
-  "version": "0.8.0-fast-element-v3-rc-20260615",
+  "version": "0.8.1-fast-element-v3-rc-20260615",
   "description": "CLI and Node.js API for server-side rendering of FAST declarative HTML templates.",
   "author": {
     "name": "Microsoft",

--- a/packages/fast-element/CHANGELOG.json
+++ b/packages/fast-element/CHANGELOG.json
@@ -2,6 +2,27 @@
   "name": "@microsoft/fast-element",
   "entries": [
     {
+      "date": "Tue, 23 Jun 2026 02:12:54 GMT",
+      "version": "3.0.0-rc.3",
+      "tag": "@microsoft/fast-element_v3.0.0-rc.3",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "d2021ef7456d8f4b7d227c8fd78df82aaec18590",
+            "comment": "BREAKING: Remove FASTElement.compose from the public API."
+          },
+          {
+            "author": "beachball",
+            "package": "@microsoft/fast-element",
+            "comment": "Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615",
+            "commit": "not available"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 19 Jun 2026 22:15:55 GMT",
       "version": "3.0.0-rc.2",
       "tag": "@microsoft/fast-element_v3.0.0-rc.2",

--- a/packages/fast-element/CHANGELOG.json
+++ b/packages/fast-element/CHANGELOG.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/fast-element",
   "entries": [
     {
-      "date": "Tue, 23 Jun 2026 02:12:54 GMT",
+      "date": "Tue, 23 Jun 2026 03:06:37 GMT",
       "version": "3.0.0-rc.3",
       "tag": "@microsoft/fast-element_v3.0.0-rc.3",
       "comments": {
@@ -16,7 +16,7 @@
           {
             "author": "beachball",
             "package": "@microsoft/fast-element",
-            "comment": "Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615",
+            "comment": "Bump @microsoft/fast-build to v0.8.1-fast-element-v3-rc-20260615",
             "commit": "not available"
           }
         ]

--- a/packages/fast-element/CHANGELOG.md
+++ b/packages/fast-element/CHANGELOG.md
@@ -1,17 +1,17 @@
 # Change Log - @microsoft/fast-element
 
-<!-- This log was last generated on Tue, 23 Jun 2026 02:12:54 GMT and should not be manually modified. -->
+<!-- This log was last generated on Tue, 23 Jun 2026 03:06:37 GMT and should not be manually modified. -->
 
 <!-- Start content -->
 
 ## 3.0.0-rc.3
 
-Tue, 23 Jun 2026 02:12:54 GMT
+Tue, 23 Jun 2026 03:06:37 GMT
 
 ### Changes
 
 - BREAKING: Remove FASTElement.compose from the public API. (7559015+janechu@users.noreply.github.com)
-- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
+- Bump @microsoft/fast-build to v0.8.1-fast-element-v3-rc-20260615
 
 ## 3.0.0-rc.2
 

--- a/packages/fast-element/CHANGELOG.md
+++ b/packages/fast-element/CHANGELOG.md
@@ -32,7 +32,7 @@ Fri, 19 Jun 2026 22:15:55 GMT
 - Preserve view context when rebinding the same source. (7559015+janechu@users.noreply.github.com)
 - feat: warn when duplicate render instruction registrations replace existing entries (7559015+janechu@users.noreply.github.com)
 - Add a registry path export for FAST element definition lookups. (7559015+janechu@users.noreply.github.com)
-- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615-fast-element-v3-rc-20260615
+- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
 
 ## 3.0.0-rc.1
 

--- a/packages/fast-element/CHANGELOG.md
+++ b/packages/fast-element/CHANGELOG.md
@@ -1,8 +1,17 @@
 # Change Log - @microsoft/fast-element
 
-<!-- This log was last generated on Fri, 19 Jun 2026 22:15:55 GMT and should not be manually modified. -->
+<!-- This log was last generated on Tue, 23 Jun 2026 02:12:54 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 3.0.0-rc.3
+
+Tue, 23 Jun 2026 02:12:54 GMT
+
+### Changes
+
+- BREAKING: Remove FASTElement.compose from the public API. (7559015+janechu@users.noreply.github.com)
+- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
 
 ## 3.0.0-rc.2
 
@@ -23,7 +32,7 @@ Fri, 19 Jun 2026 22:15:55 GMT
 - Preserve view context when rebinding the same source. (7559015+janechu@users.noreply.github.com)
 - feat: warn when duplicate render instruction registrations replace existing entries (7559015+janechu@users.noreply.github.com)
 - Add a registry path export for FAST element definition lookups. (7559015+janechu@users.noreply.github.com)
-- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
+- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615-fast-element-v3-rc-20260615
 
 ## 3.0.0-rc.1
 

--- a/packages/fast-element/package.json
+++ b/packages/fast-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/fast-element",
   "description": "A library for constructing Web Components",
-  "version": "3.0.0-rc.2",
+  "version": "3.0.0-rc.3",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"

--- a/packages/fast-element/package.json
+++ b/packages/fast-element/package.json
@@ -232,7 +232,7 @@
     "test:webui-integration": "npm run build:fixtures:webui && playwright test --config=playwright.declarative.webui.config.ts"
   },
   "devDependencies": {
-    "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+    "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
     "@microsoft/webui": "0.0.12"
   },
   "files": [

--- a/packages/fast-router/CHANGELOG.json
+++ b/packages/fast-router/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/fast-router",
   "entries": [
     {
+      "date": "Tue, 23 Jun 2026 02:12:54 GMT",
+      "version": "1.0.0-alpha.30-fast-element-v3-rc-20260615",
+      "tag": "@microsoft/fast-router_v1.0.0-alpha.30-fast-element-v3-rc-20260615",
+      "comments": {
+        "none": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-router",
+            "commit": "d2021ef7456d8f4b7d227c8fd78df82aaec18590",
+            "comment": "chore: include fast-router in the fast-element v3 RC prerelease train."
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 19 Jun 2026 22:15:55 GMT",
       "version": "1.0.0-alpha.30-fast-element-v3-rc-20260615",
       "tag": "@microsoft/fast-router_v1.0.0-alpha.30-fast-element-v3-rc-20260615",

--- a/packages/fast-router/CHANGELOG.json
+++ b/packages/fast-router/CHANGELOG.json
@@ -2,7 +2,7 @@
   "name": "@microsoft/fast-router",
   "entries": [
     {
-      "date": "Tue, 23 Jun 2026 02:12:54 GMT",
+      "date": "Tue, 23 Jun 2026 03:06:37 GMT",
       "version": "1.0.0-alpha.30-fast-element-v3-rc-20260615",
       "tag": "@microsoft/fast-router_v1.0.0-alpha.30-fast-element-v3-rc-20260615",
       "comments": {

--- a/packages/fast-router/package.json
+++ b/packages/fast-router/package.json
@@ -38,10 +38,10 @@
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@microsoft/fast-element": "3.0.0-rc.2"
+    "@microsoft/fast-element": "3.0.0-rc.3"
   },
   "peerDependencies": {
-    "@microsoft/fast-element": "3.0.0-rc.2"
+    "@microsoft/fast-element": "3.0.0-rc.3"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/fast-test-harness/CHANGELOG.json
+++ b/packages/fast-test-harness/CHANGELOG.json
@@ -2,9 +2,9 @@
   "name": "@microsoft/fast-test-harness",
   "entries": [
     {
-      "date": "Tue, 23 Jun 2026 02:12:54 GMT",
-      "version": "0.4.0-fast-element-v3-rc-20260615",
-      "tag": "@microsoft/fast-test-harness_v0.4.0-fast-element-v3-rc-20260615",
+      "date": "Tue, 23 Jun 2026 03:06:37 GMT",
+      "version": "0.4.1-fast-element-v3-rc-20260615",
+      "tag": "@microsoft/fast-test-harness_v0.4.1-fast-element-v3-rc-20260615",
       "comments": {
         "patch": [
           {
@@ -16,7 +16,7 @@
           {
             "author": "beachball",
             "package": "@microsoft/fast-test-harness",
-            "comment": "Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615",
+            "comment": "Bump @microsoft/fast-build to v0.8.1-fast-element-v3-rc-20260615",
             "commit": "not available"
           },
           {

--- a/packages/fast-test-harness/CHANGELOG.json
+++ b/packages/fast-test-harness/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@microsoft/fast-test-harness",
   "entries": [
     {
+      "date": "Tue, 23 Jun 2026 02:12:54 GMT",
+      "version": "0.4.0-fast-element-v3-rc-20260615",
+      "tag": "@microsoft/fast-test-harness_v0.4.0-fast-element-v3-rc-20260615",
+      "comments": {
+        "patch": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-test-harness",
+            "commit": "d2021ef7456d8f4b7d227c8fd78df82aaec18590",
+            "comment": "chore: include fast-test-harness in the fast-element v3 RC prerelease train."
+          },
+          {
+            "author": "beachball",
+            "package": "@microsoft/fast-test-harness",
+            "comment": "Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615",
+            "commit": "not available"
+          },
+          {
+            "author": "beachball",
+            "package": "@microsoft/fast-test-harness",
+            "comment": "Bump @microsoft/fast-element to v3.0.0-rc.3",
+            "commit": "not available"
+          }
+        ]
+      }
+    },
+    {
       "date": "Fri, 19 Jun 2026 22:15:55 GMT",
       "version": "0.4.0-fast-element-v3-rc-20260615",
       "tag": "@microsoft/fast-test-harness_v0.4.0-fast-element-v3-rc-20260615",

--- a/packages/fast-test-harness/CHANGELOG.md
+++ b/packages/fast-test-harness/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Change Log - @microsoft/fast-test-harness
 
-<!-- This log was last generated on Fri, 19 Jun 2026 22:15:55 GMT and should not be manually modified. -->
+<!-- This log was last generated on Tue, 23 Jun 2026 02:12:54 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 0.4.0-fast-element-v3-rc-20260615
+
+Tue, 23 Jun 2026 02:12:54 GMT
+
+### Patches
+
+- chore: include fast-test-harness in the fast-element v3 RC prerelease train. (7559015+janechu@users.noreply.github.com)
+- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
+- Bump @microsoft/fast-element to v3.0.0-rc.3
 
 ## 0.4.0-fast-element-v3-rc-20260615
 
@@ -11,7 +21,7 @@ Fri, 19 Jun 2026 22:15:55 GMT
 ### Minor changes
 
 - fix: migrate build utilities to consume declarative HTML syntax from @microsoft/fast-element (7559015+janechu@users.noreply.github.com)
-- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
+- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615-fast-element-v3-rc-20260615
 - Bump @microsoft/fast-element to v3.0.0-rc.2
 
 ### Patches

--- a/packages/fast-test-harness/CHANGELOG.md
+++ b/packages/fast-test-harness/CHANGELOG.md
@@ -1,17 +1,17 @@
 # Change Log - @microsoft/fast-test-harness
 
-<!-- This log was last generated on Tue, 23 Jun 2026 02:12:54 GMT and should not be manually modified. -->
+<!-- This log was last generated on Tue, 23 Jun 2026 03:06:37 GMT and should not be manually modified. -->
 
 <!-- Start content -->
 
-## 0.4.0-fast-element-v3-rc-20260615
+## 0.4.1-fast-element-v3-rc-20260615
 
-Tue, 23 Jun 2026 02:12:54 GMT
+Tue, 23 Jun 2026 03:06:37 GMT
 
 ### Patches
 
 - chore: include fast-test-harness in the fast-element v3 RC prerelease train. (7559015+janechu@users.noreply.github.com)
-- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
+- Bump @microsoft/fast-build to v0.8.1-fast-element-v3-rc-20260615
 - Bump @microsoft/fast-element to v3.0.0-rc.3
 
 ## 0.4.0-fast-element-v3-rc-20260615

--- a/packages/fast-test-harness/CHANGELOG.md
+++ b/packages/fast-test-harness/CHANGELOG.md
@@ -21,7 +21,7 @@ Fri, 19 Jun 2026 22:15:55 GMT
 ### Minor changes
 
 - fix: migrate build utilities to consume declarative HTML syntax from @microsoft/fast-element (7559015+janechu@users.noreply.github.com)
-- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615-fast-element-v3-rc-20260615
+- Bump @microsoft/fast-build to v0.8.0-fast-element-v3-rc-20260615
 - Bump @microsoft/fast-element to v3.0.0-rc.2
 
 ### Patches

--- a/packages/fast-test-harness/package.json
+++ b/packages/fast-test-harness/package.json
@@ -72,14 +72,14 @@
   ],
   "devDependencies": {
     "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
-    "@microsoft/fast-element": "3.0.0-rc.2"
+    "@microsoft/fast-element": "3.0.0-rc.3"
   },
   "dependencies": {
     "cheerio": "1.2.0"
   },
   "peerDependencies": {
     "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
-    "@microsoft/fast-element": "3.0.0-rc.2",
+    "@microsoft/fast-element": "3.0.0-rc.3",
     "@playwright/test": ">=1.40.0",
     "vite": ">=7.0.0"
   },

--- a/packages/fast-test-harness/package.json
+++ b/packages/fast-test-harness/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fast-test-harness",
-  "version": "0.4.0-fast-element-v3-rc-20260615",
+  "version": "0.4.1-fast-element-v3-rc-20260615",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"
@@ -71,14 +71,14 @@
     "*.d.ts"
   ],
   "devDependencies": {
-    "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+    "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
     "@microsoft/fast-element": "3.0.0-rc.3"
   },
   "dependencies": {
     "cheerio": "1.2.0"
   },
   "peerDependencies": {
-    "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+    "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
     "@microsoft/fast-element": "3.0.0-rc.3",
     "@playwright/test": ">=1.40.0",
     "vite": ">=7.0.0"

--- a/sites/benchmarks/package.json
+++ b/sites/benchmarks/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "@microsoft/fast-build": "*",
-    "@microsoft/fast-element": "3.0.0-rc.2"
+    "@microsoft/fast-element": "3.0.0-rc.3"
   }
 }

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -30,7 +30,7 @@
     "github-markdown-css": "5.9.0"
   },
   "devDependencies": {
-    "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
+    "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
     "@microsoft/fast-element": "3.0.0-rc.3"
   }
 }

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "@microsoft/fast-build": "0.8.0-fast-element-v3-rc-20260615",
-    "@microsoft/fast-element": "3.0.0-rc.2"
+    "@microsoft/fast-element": "3.0.0-rc.3"
   }
 }


### PR DESCRIPTION
# Pull Request

 ## 📖 Description

 This PR finalizes the next FAST Element v3 RC publish branch using the RC finalizer.

 - Consumes the pending change files for the v3 RC train.
 - Bumps `@microsoft/fast-element` to `3.0.0-rc.3`.
 - Bumps patch RC companion packages to `@microsoft/fast-build@0.8.1-fast-element-v3-rc-20260615` and `@microsoft/fast-test-harness@0.4.1-fast-element-v3-rc-20260615`.
 - Keeps `@microsoft/fast-router` on `1.0.0-alpha.30-fast-element-v3-rc-20260615`.
 - Updates changelogs, package manifests, private workspace dependency pins, and the lockfile.
 - Updates the RC finalizer so companion package patch/minor/major changes are calculated from the unsuffixed baseline before reapplying the RC suffix.

 ## 👩‍💻 Reviewer Notes

 This branch intentionally uses the `publish_<timestamp>` naming convention. `checkchange` should use the documented maintainer bump bypass and confirm the actor has admin permissions.

 ## 📑 Test Plan

 - `npm run test:validation`
 - `npm run checkchange --silent -- --branch origin/releases/fast-element-v3-rc`
 - `GITHUB_REPOSITORY=microsoft/fast FAST_RELEASE_SKIP_CRATES=true node build/scripts/create-github-releases.mjs --check-only`

 Release preview reports missing releases for:
 - `@microsoft/fast-build@0.8.1-fast-element-v3-rc-20260615`
 - `@microsoft/fast-element@3.0.0-rc.3`
 - `@microsoft/fast-test-harness@0.4.1-fast-element-v3-rc-20260615`

 ## ✅ Checklist

 ### General

 - [ ] I have included a change request file using `$ npm run change`
 - [ ] I have added tests for my changes.
 - [x] I have tested my changes.
 - [x] I have updated the project documentation to reflect my changes.
 - [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.