### PR TITLE
ci: use GITHUB_TOKEN for Pages deploy

### DIFF
--- a/.github/workflows/cd-gh-pages.yml
+++ b/.github/workflows/cd-gh-pages.yml
@@ -55,7 +55,6 @@ jobs:
     - name: Deploy GitHub Pages
       uses: JamesIves/github-pages-deploy-action@v4
       with:
-        token: ${{ secrets.GH_TOKEN }}
         branch: gh-pages # The branch the action should deploy to.
         folder: sites/website/build # The folder the action should deploy.
         target-folder: docs # The folder on the branch to deploy to.


### PR DESCRIPTION
# Pull Request

 ## 📖 Description

 Updates the GitHub Pages deploy workflow to use the default workflow `GITHUB_TOKEN` instead of the `GH_TOKEN` secret. The workflow already grants `contents: write`, so `JamesIves/github-pages-deploy-action@v4` can use the repository-scoped  token when deploying to `gh-pages`.

 ## 📑 Test Plan

 - `npm run biome:check`

 ## ✅ Checklist

 ### General

 - [ ] I have included a change request file using `$ npm run change`
 - [ ] I have added tests for my changes.
 - [x] I have tested my changes.
 - [ ] I have updated the project documentation to reflect my changes.
 - [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.