### PR TITLE
chore: release packages

### DIFF
--- a/change/@microsoft-fast-build-55a1f33b-494e-4e34-b3f9-57a8648e4a3a.json
+++ b/change/@microsoft-fast-build-55a1f33b-494e-4e34-b3f9-57a8648e4a3a.json
@@ -1,7 +1,0 @@
-{
-  "type": "minor",
-  "comment": "feat: auto-escape code samples inside `<code>` elements during SSR — braces (`{`/`}`) everywhere and the angle brackets of FAST directive tags (`<f-when>`, `<f-repeat>`) — so literal binding-like text and directive syntax render correctly while real HTML/custom elements inside `<code>` remain live DOM elements. Also exposes a new `escape_code_samples(html)` WASM export so build-time tooling can apply the same escape to author HTML that is injected into a rendered page outside the normal render pipeline.",
-  "packageName": "@microsoft/fast-build",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-deprecate-compose.json
+++ b/change/@microsoft-fast-element-deprecate-compose.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "fix: deprecate the compose APIs in favor of define() and update related docs and examples.",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-html-93d1977d-5780-49d1-8ef2-9834af8fea3e.json
+++ b/change/@microsoft-fast-html-93d1977d-5780-49d1-8ef2-9834af8fea3e.json
@@ -1,7 +1,0 @@
-{
-  "type": "prerelease",
-  "comment": "feat: auto-escape `{` and `}` inside `<code>` elements so binding-like syntax in code samples renders as literal text (mirrors webui-press and the server-side `escape_code_sample_elements` pass in `@microsoft/fast-build`, which additionally handles `<f-when>`/`<f-repeat>` directive tags)",
-  "packageName": "@microsoft/fast-html",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/crates/microsoft-fast-build/Cargo.lock
+++ b/crates/microsoft-fast-build/Cargo.lock
@@ -144,7 +144,7 @@ checksum = "f8ca58f447f06ed17d5fc4043ce1b10dd205e060fb3ce5b979b8ed8e59ff3f79"
 
 [[package]]
 name = "microsoft-fast-build"
-version = "0.7.0"
+version = "0.8.0"
 dependencies = [
  "tempfile",
  "wasm-bindgen",

--- a/crates/microsoft-fast-build/Cargo.toml
+++ b/crates/microsoft-fast-build/Cargo.toml
@@ -1,6 +1,6 @@
 [package]
 name = "microsoft-fast-build"
-version = "0.7.0"
+version = "0.8.0"
 edition = "2021"
 description = "Server-side renderer for FAST declarative HTML templates — resolves bindings, evaluates conditionals, iterates repeats, and expands custom elements into Declarative Shadow DOM."
 license = "MIT"

--- a/examples/csr/todo-app/package.json
+++ b/examples/csr/todo-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^2.10.4",
+    "@microsoft/fast-element": "^2.10.5",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "tslib": "^2.6.3"
   },

--- a/examples/csr/todo-mobx-app/package.json
+++ b/examples/csr/todo-mobx-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-mobx-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^2.10.4",
+    "@microsoft/fast-element": "^2.10.5",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "mobx": "^6.13.5",
     "tslib": "^2.6.3"

--- a/examples/ssr/webui-todo-app/package.json
+++ b/examples/ssr/webui-todo-app/package.json
@@ -1,38 +1,38 @@
 {
-    "name": "@microsoft/fast-webui-todo-app-example",
-    "version": "1.0.0",
-    "description": "A Todo app demonstrating FAST declarative HTML with webui prerendering.",
-    "type": "module",
-    "private": true,
-    "scripts": {
-        "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --metafile=dist/meta.json",
-        "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
-        "start:server": "webui serve ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 8081 --watch",
-        "start:server:nowatch": "webui serve ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 8081",
-        "start": "npm run build && npm run start:server",
-        "start:e2e": "npm run build && npm run start:server:nowatch",
-        "test": "npm run build"
-    },
-    "author": {
-        "name": "Microsoft",
-        "url": "https://discord.gg/FcSNfg4"
-    },
-    "homepage": "https://www.fast.design/",
-    "license": "MIT",
-    "repository": {
-        "type": "git",
-        "url": "git+https://github.com/Microsoft/fast.git",
-        "directory": "examples/ssr/webui-todo-app"
-    },
-    "dependencies": {
-        "@microsoft/fast-element": "^2.10.3",
-        "@microsoft/fast-examples-design-system": "^1.0.0",
-        "@microsoft/fast-html": "*",
-        "@microsoft/webui": "^0.0.12",
-        "tslib": "^2.6.3"
-    },
-    "devDependencies": {
-        "esbuild": "^0.28.1",
-        "typescript": "^5.8.0"
-    }
+  "name": "@microsoft/fast-webui-todo-app-example",
+  "version": "1.0.0",
+  "description": "A Todo app demonstrating FAST declarative HTML with webui prerendering.",
+  "type": "module",
+  "private": true,
+  "scripts": {
+    "build": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --metafile=dist/meta.json",
+    "start:client": "esbuild src/index.ts --bundle --outfile=dist/index.js --format=esm --sourcemap --watch",
+    "start:server": "webui serve ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 8081 --watch",
+    "start:server:nowatch": "webui serve ./src --state ./data/state.json --plugin=fast --servedir ./dist --port 8081",
+    "start": "npm run build && npm run start:server",
+    "start:e2e": "npm run build && npm run start:server:nowatch",
+    "test": "npm run build"
+  },
+  "author": {
+    "name": "Microsoft",
+    "url": "https://discord.gg/FcSNfg4"
+  },
+  "homepage": "https://www.fast.design/",
+  "license": "MIT",
+  "repository": {
+    "type": "git",
+    "url": "git+https://github.com/Microsoft/fast.git",
+    "directory": "examples/ssr/webui-todo-app"
+  },
+  "dependencies": {
+    "@microsoft/fast-element": "^2.10.5",
+    "@microsoft/fast-examples-design-system": "^1.0.0",
+    "@microsoft/fast-html": "*",
+    "@microsoft/webui": "^0.0.12",
+    "tslib": "^2.6.3"
+  },
+  "devDependencies": {
+    "esbuild": "^0.28.1",
+    "typescript": "^5.8.0"
+  }
 }

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^2.10.4",
+        "@microsoft/fast-element": "^2.10.5",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "tslib": "^2.6.3"
       },
@@ -66,7 +66,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^2.10.4",
+        "@microsoft/fast-element": "^2.10.5",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "mobx": "^6.13.5",
         "tslib": "^2.6.3"
@@ -80,10 +80,7 @@
     "examples/ssr": {
       "name": "@microsoft/fast-ssr-example",
       "version": "1.0.0",
-      "dev": true,
       "license": "MIT",
-      "optional": true,
-      "peer": true,
       "dependencies": {
         "@microsoft/fast-element": "^2.10.3",
         "@microsoft/fast-ssr": "^1.0.0-beta.40",
@@ -706,7 +703,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^2.10.3",
+        "@microsoft/fast-element": "^2.10.5",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "@microsoft/fast-html": "*",
         "@microsoft/webui": "^0.0.12",
@@ -6889,7 +6886,7 @@
     },
     "packages/fast-build": {
       "name": "@microsoft/fast-build",
-      "version": "0.7.0",
+      "version": "0.8.0",
       "license": "MIT",
       "bin": {
         "fast": "bin/fast.js"
@@ -6900,20 +6897,20 @@
     },
     "packages/fast-element": {
       "name": "@microsoft/fast-element",
-      "version": "2.10.4",
+      "version": "2.10.5",
       "license": "MIT"
     },
     "packages/fast-html": {
       "name": "@microsoft/fast-html",
-      "version": "1.0.0-alpha.54",
+      "version": "1.0.0-alpha.55",
       "license": "MIT",
       "devDependencies": {
-        "@microsoft/fast-build": "^0.7.0",
-        "@microsoft/fast-element": "^2.10.4",
+        "@microsoft/fast-build": "^0.8.0",
+        "@microsoft/fast-element": "^2.10.5",
         "@microsoft/webui": "0.0.12"
       },
       "peerDependencies": {
-        "@microsoft/fast-element": "^2.10.4"
+        "@microsoft/fast-element": "^2.10.5"
       }
     },
     "packages/fast-html/node_modules/@microsoft/webui": {
@@ -7030,10 +7027,10 @@
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@microsoft/fast-element": "^2.10.4"
+        "@microsoft/fast-element": "^2.10.5"
       },
       "peerDependencies": {
-        "@microsoft/fast-element": "^2.10.4"
+        "@microsoft/fast-element": "^2.10.5"
       }
     },
     "packages/fast-ssr": {
@@ -7065,17 +7062,17 @@
         "fast-test-harness": "start.mjs"
       },
       "devDependencies": {
-        "@microsoft/fast-build": "^0.7.0",
-        "@microsoft/fast-element": "^2.10.4",
-        "@microsoft/fast-html": "^1.0.0-alpha.54"
+        "@microsoft/fast-build": "^0.8.0",
+        "@microsoft/fast-element": "^2.10.5",
+        "@microsoft/fast-html": "^1.0.0-alpha.55"
       },
       "engines": {
         "node": ">=22.18.0"
       },
       "peerDependencies": {
-        "@microsoft/fast-build": "^0.7.0",
-        "@microsoft/fast-element": "^2.10.4 || ^3.0.0",
-        "@microsoft/fast-html": ">=1.0.0-alpha.54 <1.0.0",
+        "@microsoft/fast-build": "^0.8.0",
+        "@microsoft/fast-element": "^2.10.5 || ^3.0.0",
+        "@microsoft/fast-html": ">=1.0.0-alpha.55 <1.0.0",
         "@playwright/test": ">=1.40.0",
         "vite": ">=7.0.0"
       },
@@ -7107,8 +7104,8 @@
         "github-markdown-css": "5.9.0"
       },
       "devDependencies": {
-        "@microsoft/fast-build": "^0.7.0",
-        "@microsoft/fast-element": "^2.10.4"
+        "@microsoft/fast-build": "^0.8.0",
+        "@microsoft/fast-element": "^2.10.5"
       }
     },
     "sites/website/node_modules/@microsoft/api-documenter": {

--- a/packages/fast-build/CHANGELOG.json
+++ b/packages/fast-build/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/fast-build",
   "entries": [
     {
+      "date": "Wed, 24 Jun 2026 20:34:51 GMT",
+      "version": "0.8.0",
+      "tag": "@microsoft/fast-build_v0.8.0",
+      "comments": {
+        "minor": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-build",
+            "commit": "5c533dd28151097d946959a84508afb4974217ab",
+            "comment": "feat: auto-escape code samples inside `<code>` elements during SSR — braces (`{`/`}`) everywhere and the angle brackets of FAST directive tags (`<f-when>`, `<f-repeat>`) — so literal binding-like text and directive syntax render correctly while real HTML/custom elements inside `<code>` remain live DOM elements. Also exposes a new `escape_code_samples(html)` WASM export so build-time tooling can apply the same escape to author HTML that is injected into a rendered page outside the normal render pipeline."
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 21 May 2026 00:04:58 GMT",
       "version": "0.7.0",
       "tag": "@microsoft/fast-build_v0.7.0",

--- a/packages/fast-build/CHANGELOG.md
+++ b/packages/fast-build/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @microsoft/fast-build
 
-<!-- This log was last generated on Thu, 21 May 2026 00:04:58 GMT and should not be manually modified. -->
+<!-- This log was last generated on Wed, 24 Jun 2026 20:34:51 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 0.8.0
+
+Wed, 24 Jun 2026 20:34:51 GMT
+
+### Minor changes
+
+- feat: auto-escape code samples inside `<code>` elements during SSR — braces (`{`/`}`) everywhere and the angle brackets of FAST directive tags (`<f-when>`, `<f-repeat>`) — so literal binding-like text and directive syntax render correctly while real HTML/custom elements inside `<code>` remain live DOM elements. Also exposes a new `escape_code_samples(html)` WASM export so build-time tooling can apply the same escape to author HTML that is injected into a rendered page outside the normal render pipeline. (7559015+janechu@users.noreply.github.com)
 
 ## 0.7.0
 

--- a/packages/fast-build/package.json
+++ b/packages/fast-build/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fast-build",
-  "version": "0.7.0",
+  "version": "0.8.0",
   "description": "CLI and Node.js API for server-side rendering of FAST declarative HTML templates.",
   "author": {
     "name": "Microsoft",

--- a/packages/fast-element/CHANGELOG.json
+++ b/packages/fast-element/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/fast-element",
   "entries": [
     {
+      "date": "Wed, 24 Jun 2026 20:34:51 GMT",
+      "version": "2.10.5",
+      "tag": "@microsoft/fast-element_v2.10.5",
+      "comments": {
+        "patch": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "165d5b2578238cf1c15094cb1a951c89b3d60907",
+            "comment": "fix: deprecate the compose APIs in favor of define() and update related docs and examples."
+          }
+        ]
+      }
+    },
+    {
       "date": "Sat, 23 May 2026 00:13:09 GMT",
       "version": "2.10.4",
       "tag": "@microsoft/fast-element_v2.10.4",

--- a/packages/fast-element/CHANGELOG.md
+++ b/packages/fast-element/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @microsoft/fast-element
 
-<!-- This log was last generated on Fri, 17 Apr 2026 00:26:37 GMT and should not be manually modified. -->
+<!-- This log was last generated on Wed, 24 Jun 2026 20:34:51 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 2.10.5
+
+Wed, 24 Jun 2026 20:34:51 GMT
+
+### Patches
+
+- fix: deprecate the compose APIs in favor of define() and update related docs and examples. (7559015+janechu@users.noreply.github.com)
 
 ## 2.10.4
 

--- a/packages/fast-element/package.json
+++ b/packages/fast-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/fast-element",
   "description": "A library for constructing Web Components",
-  "version": "2.10.4",
+  "version": "2.10.5",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"

--- a/packages/fast-html/CHANGELOG.json
+++ b/packages/fast-html/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@microsoft/fast-html",
   "entries": [
     {
+      "date": "Wed, 24 Jun 2026 20:34:51 GMT",
+      "version": "1.0.0-alpha.55",
+      "tag": "@microsoft/fast-html_v1.0.0-alpha.55",
+      "comments": {
+        "prerelease": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-html",
+            "commit": "5c533dd28151097d946959a84508afb4974217ab",
+            "comment": "feat: auto-escape `{` and `}` inside `<code>` elements so binding-like syntax in code samples renders as literal text (mirrors webui-press and the server-side `escape_code_sample_elements` pass in `@microsoft/fast-build`, which additionally handles `<f-when>`/`<f-repeat>` directive tags)"
+          },
+          {
+            "author": "beachball",
+            "package": "@microsoft/fast-html",
+            "comment": "Bump @microsoft/fast-build to v0.8.0",
+            "commit": "not available"
+          },
+          {
+            "author": "beachball",
+            "package": "@microsoft/fast-html",
+            "comment": "Bump @microsoft/fast-element to v2.10.5",
+            "commit": "not available"
+          }
+        ]
+      }
+    },
+    {
       "date": "Mon, 08 Jun 2026 20:39:45 GMT",
       "version": "1.0.0-alpha.54",
       "tag": "@microsoft/fast-html_v1.0.0-alpha.54",

--- a/packages/fast-html/CHANGELOG.md
+++ b/packages/fast-html/CHANGELOG.md
@@ -1,8 +1,18 @@
 # Change Log - @microsoft/fast-html
 
-<!-- This log was last generated on Mon, 08 Jun 2026 20:39:45 GMT and should not be manually modified. -->
+<!-- This log was last generated on Wed, 24 Jun 2026 20:34:51 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 1.0.0-alpha.55
+
+Wed, 24 Jun 2026 20:34:51 GMT
+
+### Changes
+
+- feat: auto-escape `{` and `}` inside `<code>` elements so binding-like syntax in code samples renders as literal text (mirrors webui-press and the server-side `escape_code_sample_elements` pass in `@microsoft/fast-build`, which additionally handles `<f-when>`/`<f-repeat>` directive tags) (7559015+janechu@users.noreply.github.com)
+- Bump @microsoft/fast-build to v0.8.0
+- Bump @microsoft/fast-element to v2.10.5
 
 ## 1.0.0-alpha.54
 

--- a/packages/fast-html/package.json
+++ b/packages/fast-html/package.json
@@ -1,6 +1,6 @@
 {
   "name": "@microsoft/fast-html",
-  "version": "1.0.0-alpha.54",
+  "version": "1.0.0-alpha.55",
   "type": "module",
   "author": {
     "name": "Microsoft",
@@ -65,11 +65,11 @@
     "./dist/esm/index.js"
   ],
   "peerDependencies": {
-    "@microsoft/fast-element": "^2.10.4"
+    "@microsoft/fast-element": "^2.10.5"
   },
   "devDependencies": {
-    "@microsoft/fast-build": "^0.7.0",
-    "@microsoft/fast-element": "^2.10.4",
+    "@microsoft/fast-build": "^0.8.0",
+    "@microsoft/fast-element": "^2.10.5",
     "@microsoft/webui": "0.0.12"
   },
   "beachball": {

--- a/packages/fast-router/package.json
+++ b/packages/fast-router/package.json
@@ -38,10 +38,10 @@
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@microsoft/fast-element": "^2.10.4"
+    "@microsoft/fast-element": "^2.10.5"
   },
   "peerDependencies": {
-    "@microsoft/fast-element": "^2.10.4"
+    "@microsoft/fast-element": "^2.10.5"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/fast-test-harness/package.json
+++ b/packages/fast-test-harness/package.json
@@ -71,17 +71,17 @@
     "*.d.ts"
   ],
   "devDependencies": {
-    "@microsoft/fast-element": "^2.10.4",
-    "@microsoft/fast-build": "^0.7.0",
-    "@microsoft/fast-html": "^1.0.0-alpha.54"
+    "@microsoft/fast-element": "^2.10.5",
+    "@microsoft/fast-build": "^0.8.0",
+    "@microsoft/fast-html": "^1.0.0-alpha.55"
   },
   "dependencies": {
     "cheerio": "1.2.0"
   },
   "peerDependencies": {
-    "@microsoft/fast-element": "^2.10.4 || ^3.0.0",
-    "@microsoft/fast-build": "^0.7.0",
-    "@microsoft/fast-html": ">=1.0.0-alpha.54 <1.0.0",
+    "@microsoft/fast-element": "^2.10.5 || ^3.0.0",
+    "@microsoft/fast-build": "^0.8.0",
+    "@microsoft/fast-html": ">=1.0.0-alpha.55 <1.0.0",
     "@playwright/test": ">=1.40.0",
     "vite": ">=7.0.0"
   },

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -30,7 +30,7 @@
     "github-markdown-css": "5.9.0"
   },
   "devDependencies": {
-    "@microsoft/fast-build": "^0.7.0",
-    "@microsoft/fast-element": "^2.10.4"
+    "@microsoft/fast-build": "^0.8.0",
+    "@microsoft/fast-element": "^2.10.5"
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Creates the publish bump PR for the accumulated release changes:

- Bumps `@microsoft/fast-build` to `0.8.0` and syncs the paired `microsoft-fast-build` crate to `0.8.0`.
- Bumps `@microsoft/fast-element` to `2.10.5`.
- Bumps `@microsoft/fast-html` to `1.0.0-alpha.55`.
- Updates generated changelogs, dependency ranges, lockfiles, and consumes the corresponding Beachball change files.

## 👩‍💻 Reviewer Notes

The generated dependency update for `@microsoft/fast-test-harness` was adjusted to preserve the existing `@microsoft/fast-element` `^3.0.0` peer compatibility while moving the v2 floor to `^2.10.5`.

## 📑 Test Plan

- `npm ci`
- `npx playwright install --with-deps`
- `npm run build`
- `npm run checkchange`
- `node build/scripts/create-github-releases.mjs --check-only`
- `npm run biome:ci`
- `npm run test` was run; the full concurrent run failed in the `@microsoft/fast-test-harness` Firefox project with setup timeouts. The affected Firefox project was rerun serially with `npm run test:playwright -w @microsoft/fast-test-harness -- --project=firefox --workers=1` and passed.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
