### PR TITLE
chore: hoist @microsoft/webui dependency and remove devDependencies from fast-element

### DIFF
--- a/change/@microsoft-fast-element-b5e88c91-c090-45a0-9f60-0dd56c8da5a6.json
+++ b/change/@microsoft-fast-element-b5e88c91-c090-45a0-9f60-0dd56c8da5a6.json
@@ -1,0 +1,7 @@
+{
+  "type": "prerelease",
+  "comment": "chore: hoist @microsoft/webui dependency and remove devDependencies from fast-element",
+  "packageName": "@microsoft/fast-element",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/lage.config.js
+++ b/lage.config.js
@@ -5,6 +5,10 @@ module.exports = {
             dependsOn: ["^build"],
             outputs: ["dist/**", "wasm/**"],
         },
+        "@microsoft/fast-element#build": {
+            dependsOn: ["@microsoft/fast-build#build"],
+            outputs: ["dist/**"],
+        },
         "test:node": {
             dependsOn: ["build"],
             outputs: [],

--- a/package-lock.json
+++ b/package-lock.json
@@ -20,6 +20,7 @@
         "@ast-grep/cli": "0.37.0",
         "@biomejs/biome": "2.4.8",
         "@microsoft/api-extractor": "7.58.1",
+        "@microsoft/webui": "0.0.12",
         "@playwright/test": "1.56.1",
         "@rollup/plugin-node-resolve": "16.0.3",
         "@rollup/plugin-terser": "1.0.0",
@@ -6772,11 +6773,7 @@
     "packages/fast-element": {
       "name": "@microsoft/fast-element",
       "version": "3.0.0-rc.3",
-      "license": "MIT",
-      "devDependencies": {
-        "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
-        "@microsoft/webui": "0.0.12"
-      }
+      "license": "MIT"
     },
     "packages/fast-router": {
       "name": "@microsoft/fast-router",

--- a/package.json
+++ b/package.json
@@ -56,6 +56,7 @@
     "@ast-grep/cli": "0.37.0",
     "@biomejs/biome": "2.4.8",
     "@microsoft/api-extractor": "7.58.1",
+    "@microsoft/webui": "0.0.12",
     "@playwright/test": "1.56.1",
     "@rollup/plugin-node-resolve": "16.0.3",
     "@rollup/plugin-terser": "1.0.0",

--- a/packages/fast-element/package.json
+++ b/packages/fast-element/package.json
@@ -190,10 +190,6 @@
     "test:ui:declarative": "concurrently -k -n tsc,playwright \"npm run dev\" \"npx playwright test --config=playwright.declarative.config.ts --ui\"",
     "test:webui-integration": "npm run build:fixtures:webui && playwright test --config=playwright.declarative.webui.config.ts"
   },
-  "devDependencies": {
-    "@microsoft/fast-build": "0.8.1-fast-element-v3-rc-20260615",
-    "@microsoft/webui": "0.0.12"
-  },
   "files": [
     "dist",
     "CHANGELOG.md"


### PR DESCRIPTION
# Pull Request

## 📖 Description

Hoists the `@microsoft/webui` dependency up to the workspace root and removes the `@microsoft/webui` and `@microsoft/fast-build` `devDependencies` from the `@microsoft/fast-element` package.

These packages are only needed for the WebUI/declarative integration test tooling, not for building or consuming `fast-element` itself. Hoisting them to the root keeps the published `fast-element` package free of dev-only dependencies, deduplicates the lockfile, and centralizes version management for the shared tooling.

This is a chore with no runtime or API impact.

## 📑 Test Plan

- Existing `fast-element` and `fast-test-harness` test suites (including the WebUI declarative integration tests) should continue to pass against the hoisted dependency.
- Verify the workspace installs cleanly (`npm ci`) and that `fast-element` builds without the removed `devDependencies`.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.