### PR TITLE
chore: fix erroneous router test script

### DIFF
--- a/change/@microsoft-fast-router-e65fde07-d294-46dd-8675-070ac93319b1.json
+++ b/change/@microsoft-fast-router-e65fde07-d294-46dd-8675-070ac93319b1.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Fix missing router test script",
+  "packageName": "@microsoft/fast-router",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-router/package.json
+++ b/packages/fast-router/package.json
@@ -31,8 +31,8 @@
     "lint": "biome-changed",
     "lint:fix": "biome-changed -- --fix",
     "test:node": "tsgo -p ./tsconfig.json && node --test dist/esm/recognizer.spec.js",
-    "test": "npm run lint && npm run doc:ci && npm run test:recognizer",
-    "test:ci": "npm run doc:ci && npm run test:recognizer"
+    "test": "npm run lint && npm run doc:ci && npm run test:node",
+    "test:ci": "npm run doc:ci && npm run test:node"
   },
   "dependencies": {
     "tslib": "^2.6.3"


### PR DESCRIPTION
# Pull Request

## 📖 Description

The `@microsoft/fast-router` package had an erroneous npm script it was pointing to for automated testing.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.