### PR TITLE
chore: add beachball configs to all packages

### DIFF
--- a/change/@microsoft-fast-build-2d3ea319-b5bf-44dc-ad0f-179e5619e6d4.json
+++ b/change/@microsoft-fast-build-2d3ea319-b5bf-44dc-ad0f-179e5619e6d4.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add beachball configs to all packages to prevent erroneous versions being published",
+  "packageName": "@microsoft/fast-build",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-element-72b79e35-0b32-4a3b-8809-bd444d9b864a.json
+++ b/change/@microsoft-fast-element-72b79e35-0b32-4a3b-8809-bd444d9b864a.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add beachball configs to all packages to prevent erroneous versions being published",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/change/@microsoft-fast-test-harness-eefe9f84-6a16-421b-a7aa-c2da27380430.json
+++ b/change/@microsoft-fast-test-harness-eefe9f84-6a16-421b-a7aa-c2da27380430.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Add beachball configs to all packages to prevent erroneous versions being published",
+  "packageName": "@microsoft/fast-test-harness",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-build/package.json
+++ b/packages/fast-build/package.json
@@ -33,5 +33,11 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "beachball": {
+    "disallowedChangeTypes": [
+      "prerelease",
+      "major"
+    ]
   }
 }

--- a/packages/fast-element/package.json
+++ b/packages/fast-element/package.json
@@ -193,5 +193,11 @@
   "files": [
     "dist",
     "CHANGELOG.md"
-  ]
+  ],
+  "beachball": {
+    "disallowedChangeTypes": [
+      "prerelease",
+      "major"
+    ]
+  }
 }

--- a/packages/fast-test-harness/package.json
+++ b/packages/fast-test-harness/package.json
@@ -93,5 +93,11 @@
   },
   "engines": {
     "node": ">=22.18.0"
+  },
+  "beachball": {
+    "disallowedChangeTypes": [
+      "prerelease",
+      "major"
+    ]
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Only the `@microsoft/fast-router` package contained a beachball config, this has been updated to include all packages which have individual configs. The use of individual configs is intentional, we want to keep anything to do with versioning the individual files to their respective packages without promoting it to a top level which may become confusing in future.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.