### PR TITLE
docs: document change file comment format

### DIFF
--- a/.github/skills/shipping/SKILL.md
+++ b/.github/skills/shipping/SKILL.md
@@ -126,6 +126,17 @@ npm run change
 
 This walks through the steps to create a change description file that is required for versioning and publishing. The CI gate `npm run checkchange` will fail if a change file is missing for a modified package.
 
+## Change comments
+
+Write the `comment` field as release-note text, not as a commit message. Use a
+concise sentence that starts with a capital letter and ends with a period. Do not
+prefix comments with conventional commit types such as `fix:`, `feat:`, or
+`chore:`.
+
+Beachball uses change-file comments to generate package changelogs and release
+notes. Sentence-style comments read cleanly in those user-facing outputs, while
+commit-style prefixes duplicate the separate change type metadata and add noise.
+
 ## Change types
 
 When prompted, select the appropriate change type:


### PR DESCRIPTION
# Pull Request

## 📖 Description

Adds guidance to the shipping skill for Beachball change-file comment formatting.

The new guidance explains that change-file comments are release-note text rather than commit messages, so they should be concise sentence-style comments instead of conventional-commit-prefixed strings.

## 👩‍💻 Reviewer Notes

This is documentation-only guidance for AI agents and contributors using the FAST shipping skill.

## 📑 Test Plan

- `git diff --check -- .github/skills/shipping/SKILL.md`

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
