### PR TITLE
chore: release packages

### DIFF
--- a/change/@microsoft-fast-build-2d3ea319-b5bf-44dc-ad0f-179e5619e6d4.json
+++ b/change/@microsoft-fast-build-2d3ea319-b5bf-44dc-ad0f-179e5619e6d4.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add beachball configs to all packages to prevent erroneous versions being published",
-  "packageName": "@microsoft/fast-build",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-build-3f5b5043-a394-440a-a6f6-73c828e37025.json
+++ b/change/@microsoft-fast-build-3f5b5043-a394-440a-a6f6-73c828e37025.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Move markdown design docs into docs folders",
-  "packageName": "@microsoft/fast-build",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-build-f3b0e3d1-4a91-498a-bc1d-7762776fcb8a.json
+++ b/change/@microsoft-fast-build-f3b0e3d1-4a91-498a-bc1d-7762776fcb8a.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Remove redundant package json scripts, normalize export paths",
-  "packageName": "@microsoft/fast-build",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-262079bc-d6c8-432a-bd92-a943733b1ee3.json
+++ b/change/@microsoft-fast-element-262079bc-d6c8-432a-bd92-a943733b1ee3.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Avoid rebinding internal attribute backing fields during connect.",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-5290546b-2479-4c8a-bd1b-dc20ef1d6f31.json
+++ b/change/@microsoft-fast-element-5290546b-2479-4c8a-bd1b-dc20ef1d6f31.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Update typescript skill file and fast element design doc",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-72b79e35-0b32-4a3b-8809-bd444d9b864a.json
+++ b/change/@microsoft-fast-element-72b79e35-0b32-4a3b-8809-bd444d9b864a.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add beachball configs to all packages to prevent erroneous versions being published",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-element-7c6288c3-4874-4df1-a0a0-98c58b1b8263.json
+++ b/change/@microsoft-fast-element-7c6288c3-4874-4df1-a0a0-98c58b1b8263.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Move markdown design docs into docs folders",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-router-e034feee-a885-494c-b23b-6a49d2989bfd.json
+++ b/change/@microsoft-fast-router-e034feee-a885-494c-b23b-6a49d2989bfd.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Remove redundant package json scripts, normalize export paths",
-  "packageName": "@microsoft/fast-router",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-router-e65fde07-d294-46dd-8675-070ac93319b1.json
+++ b/change/@microsoft-fast-router-e65fde07-d294-46dd-8675-070ac93319b1.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Fix missing router test script",
-  "packageName": "@microsoft/fast-router",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/change/@microsoft-fast-test-harness-eefe9f84-6a16-421b-a7aa-c2da27380430.json
+++ b/change/@microsoft-fast-test-harness-eefe9f84-6a16-421b-a7aa-c2da27380430.json
@@ -1,7 +1,0 @@
-{
-  "type": "none",
-  "comment": "Add beachball configs to all packages to prevent erroneous versions being published",
-  "packageName": "@microsoft/fast-test-harness",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/examples/csr/todo-app/package.json
+++ b/examples/csr/todo-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^3.0.0",
+    "@microsoft/fast-element": "^3.0.1",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "tslib": "^2.6.3"
   },

--- a/examples/csr/todo-mobx-app/package.json
+++ b/examples/csr/todo-mobx-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-mobx-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^3.0.0",
+    "@microsoft/fast-element": "^3.0.1",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "mobx": "^6.13.5",
     "tslib": "^2.6.3"

--- a/examples/ssr/chat-app/package.json
+++ b/examples/ssr/chat-app/package.json
@@ -23,7 +23,7 @@
     "directory": "examples/ssr/chat-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^3.0.0",
+    "@microsoft/fast-element": "^3.0.1",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "tslib": "^2.6.3"
   },

--- a/examples/ssr/webui-todo-app/package.json
+++ b/examples/ssr/webui-todo-app/package.json
@@ -25,7 +25,7 @@
     "directory": "examples/ssr/webui-todo-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^3.0.0",
+    "@microsoft/fast-element": "^3.0.1",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "@microsoft/webui": "^0.0.12",
     "tslib": "^2.6.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -53,7 +53,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^3.0.0",
+        "@microsoft/fast-element": "^3.0.1",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "tslib": "^2.6.3"
       },
@@ -67,7 +67,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^3.0.0",
+        "@microsoft/fast-element": "^3.0.1",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "mobx": "^6.13.5",
         "tslib": "^2.6.3"
@@ -83,7 +83,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^3.0.0",
+        "@microsoft/fast-element": "^3.0.1",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "tslib": "^2.6.3"
       },
@@ -96,7 +96,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^3.0.0",
+        "@microsoft/fast-element": "^3.0.1",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "@microsoft/webui": "^0.0.12",
         "tslib": "^2.6.3"
@@ -6772,7 +6772,7 @@
     },
     "packages/fast-element": {
       "name": "@microsoft/fast-element",
-      "version": "3.0.0",
+      "version": "3.0.1",
       "license": "MIT"
     },
     "packages/fast-router": {
@@ -6783,10 +6783,10 @@
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@microsoft/fast-element": "^3.0.0"
+        "@microsoft/fast-element": "^3.0.1"
       },
       "peerDependencies": {
-        "@microsoft/fast-element": "^3.0.0"
+        "@microsoft/fast-element": "^3.0.1"
       }
     },
     "packages/fast-test-harness": {
@@ -6801,14 +6801,14 @@
       },
       "devDependencies": {
         "@microsoft/fast-build": "^0.9.0",
-        "@microsoft/fast-element": "^3.0.0"
+        "@microsoft/fast-element": "^3.0.1"
       },
       "engines": {
         "node": ">=22.18.0"
       },
       "peerDependencies": {
         "@microsoft/fast-build": "^0.9.0",
-        "@microsoft/fast-element": "^3.0.0",
+        "@microsoft/fast-element": "^3.0.1",
         "@playwright/test": ">=1.40.0",
         "vite": ">=7.0.0"
       },
@@ -6826,7 +6826,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@microsoft/fast-build": "^0.9.0",
-        "@microsoft/fast-element": "^3.0.0"
+        "@microsoft/fast-element": "^3.0.1"
       }
     },
     "sites/website": {
@@ -6841,7 +6841,7 @@
       },
       "devDependencies": {
         "@microsoft/fast-build": "^0.9.0",
-        "@microsoft/fast-element": "^3.0.0"
+        "@microsoft/fast-element": "^3.0.1"
       }
     }
   }

--- a/packages/fast-build/CHANGELOG.json
+++ b/packages/fast-build/CHANGELOG.json
@@ -2,6 +2,33 @@
   "name": "@microsoft/fast-build",
   "entries": [
     {
+      "date": "Fri, 26 Jun 2026 21:42:49 GMT",
+      "version": "0.9.0",
+      "tag": "@microsoft/fast-build_v0.9.0",
+      "comments": {
+        "none": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-build",
+            "commit": "a833e3df0debd4d4422b5393a6ace6b4936ce17c",
+            "comment": "Add beachball configs to all packages to prevent erroneous versions being published"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-build",
+            "commit": "92e406be5f0588fb299fc0ca0cf8e3e9abe24203",
+            "comment": "Move markdown design docs into docs folders"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-build",
+            "commit": "2675184e91f437c009a2aaf4e3e10fa407096709",
+            "comment": "Remove redundant package json scripts, normalize export paths"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 25 Jun 2026 05:31:59 GMT",
       "version": "0.9.0",
       "tag": "@microsoft/fast-build_v0.9.0",

--- a/packages/fast-element/CHANGELOG.json
+++ b/packages/fast-element/CHANGELOG.json
@@ -2,6 +2,41 @@
   "name": "@microsoft/fast-element",
   "entries": [
     {
+      "date": "Fri, 26 Jun 2026 21:42:49 GMT",
+      "version": "3.0.1",
+      "tag": "@microsoft/fast-element_v3.0.1",
+      "comments": {
+        "none": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "92e406be5f0588fb299fc0ca0cf8e3e9abe24203",
+            "comment": "Move markdown design docs into docs folders"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "b4a9205f3c342995b10cbda89768e5e839b5a1ef",
+            "comment": "Update typescript skill file and fast element design doc"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "a833e3df0debd4d4422b5393a6ace6b4936ce17c",
+            "comment": "Add beachball configs to all packages to prevent erroneous versions being published"
+          }
+        ],
+        "patch": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "6ad856f60ba509b82d65961e78285e9c89373a3f",
+            "comment": "Avoid rebinding internal attribute backing fields during connect."
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 25 Jun 2026 05:31:58 GMT",
       "version": "3.0.0",
       "tag": "@microsoft/fast-element_v3.0.0",

--- a/packages/fast-element/CHANGELOG.md
+++ b/packages/fast-element/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @microsoft/fast-element
 
-<!-- This log was last generated on Thu, 25 Jun 2026 05:31:58 GMT and should not be manually modified. -->
+<!-- This log was last generated on Fri, 26 Jun 2026 21:42:49 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 3.0.1
+
+Fri, 26 Jun 2026 21:42:49 GMT
+
+### Patches
+
+- Avoid rebinding internal attribute backing fields during connect. (7559015+janechu@users.noreply.github.com)
 
 ## 3.0.0
 

--- a/packages/fast-element/package.json
+++ b/packages/fast-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/fast-element",
   "description": "A library for constructing Web Components",
-  "version": "3.0.0",
+  "version": "3.0.1",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"

--- a/packages/fast-router/CHANGELOG.json
+++ b/packages/fast-router/CHANGELOG.json
@@ -2,6 +2,27 @@
   "name": "@microsoft/fast-router",
   "entries": [
     {
+      "date": "Fri, 26 Jun 2026 21:42:49 GMT",
+      "version": "1.0.0-alpha.31",
+      "tag": "@microsoft/fast-router_v1.0.0-alpha.31",
+      "comments": {
+        "none": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-router",
+            "commit": "2675184e91f437c009a2aaf4e3e10fa407096709",
+            "comment": "Remove redundant package json scripts, normalize export paths"
+          },
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-router",
+            "commit": "cd709bcf69c33be2224058be86abff56fd6523ed",
+            "comment": "Fix missing router test script"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 25 Jun 2026 05:31:58 GMT",
       "version": "1.0.0-alpha.31",
       "tag": "@microsoft/fast-router_v1.0.0-alpha.31",

--- a/packages/fast-router/package.json
+++ b/packages/fast-router/package.json
@@ -43,10 +43,10 @@
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@microsoft/fast-element": "^3.0.0"
+    "@microsoft/fast-element": "^3.0.1"
   },
   "peerDependencies": {
-    "@microsoft/fast-element": "^3.0.0"
+    "@microsoft/fast-element": "^3.0.1"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/fast-test-harness/CHANGELOG.json
+++ b/packages/fast-test-harness/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/fast-test-harness",
   "entries": [
     {
+      "date": "Fri, 26 Jun 2026 21:42:49 GMT",
+      "version": "0.4.0",
+      "tag": "@microsoft/fast-test-harness_v0.4.0",
+      "comments": {
+        "none": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-test-harness",
+            "commit": "a833e3df0debd4d4422b5393a6ace6b4936ce17c",
+            "comment": "Add beachball configs to all packages to prevent erroneous versions being published"
+          }
+        ]
+      }
+    },
+    {
       "date": "Thu, 25 Jun 2026 05:31:58 GMT",
       "version": "0.4.0",
       "tag": "@microsoft/fast-test-harness_v0.4.0",

--- a/packages/fast-test-harness/package.json
+++ b/packages/fast-test-harness/package.json
@@ -72,14 +72,14 @@
   ],
   "devDependencies": {
     "@microsoft/fast-build": "^0.9.0",
-    "@microsoft/fast-element": "^3.0.0"
+    "@microsoft/fast-element": "^3.0.1"
   },
   "dependencies": {
     "cheerio": "1.2.0"
   },
   "peerDependencies": {
     "@microsoft/fast-build": "^0.9.0",
-    "@microsoft/fast-element": "^3.0.0",
+    "@microsoft/fast-element": "^3.0.1",
     "@playwright/test": ">=1.40.0",
     "vite": ">=7.0.0"
   },

--- a/sites/benchmarks/package.json
+++ b/sites/benchmarks/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "@microsoft/fast-build": "^0.9.0",
-    "@microsoft/fast-element": "^3.0.0"
+    "@microsoft/fast-element": "^3.0.1"
   }
 }

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "@microsoft/fast-build": "^0.9.0",
-    "@microsoft/fast-element": "^3.0.0"
+    "@microsoft/fast-element": "^3.0.1"
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Release bump for `@microsoft/fast-element` from `3.0.0` to `3.0.1`.

This consumes the pending Beachball change files and updates generated changelogs and dependent workspace ranges so the post-merge release workflows can create the GitHub release and later publish from CI.

## 📑 Test Plan

- `node build/scripts/create-github-releases.mjs --check-only`
- `npm run checkchange`

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [ ] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.
