### PR TITLE
fix: parse filter elements(...) syntax in f-children directive

### DIFF
--- a/packages/fast-element/src/declarative/template-parser.pw.spec.ts
+++ b/packages/fast-element/src/declarative/template-parser.pw.spec.ts
@@ -1,0 +1,125 @@
+import { expect, test } from "@playwright/test";
+
+// Vite serves local filesystem files under the /@fs/ prefix.
+// Using .pathname (not fileURLToPath) mirrors the template-bridge pattern and
+// correctly produces a leading slash on Windows (e.g. /@fs/E:/fast/...).
+const pureDeclarativeEntrypointUrl = `/@fs${
+    new URL("../../test/pure-declarative-main.ts", import.meta.url).pathname
+}`;
+
+test.describe("TemplateParser", () => {
+    test.describe("f-children directive", () => {
+        test("without filter produces a ChildrenDirective with the correct property", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async declarativeUrl => {
+                // @ts-expect-error: Client module.
+                const { Schema, TemplateParser } = await import(declarativeUrl);
+                // @ts-expect-error: Client module.
+                const { ChildrenDirective } = await import("/main.js");
+
+                const parser = new TemplateParser();
+                const schema = new Schema("test-element");
+                const { values } = parser.parse(
+                    '<ul f-children="{listItems}"></ul>',
+                    schema,
+                );
+                const directive = values[0];
+
+                return {
+                    isChildrenDirective: directive instanceof ChildrenDirective,
+                    property: directive.options.property,
+                    hasFilter: "filter" in directive.options,
+                };
+            }, pureDeclarativeEntrypointUrl);
+
+            expect(result.isChildrenDirective).toBe(true);
+            expect(result.property).toBe("listItems");
+            expect(result.hasFilter).toBe(false);
+        });
+
+        test("with filter elements() produces a ChildrenDirective with an element filter", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async declarativeUrl => {
+                // @ts-expect-error: Client module.
+                const { Schema, TemplateParser } = await import(declarativeUrl);
+                // @ts-expect-error: Client module.
+                const { ChildrenDirective } = await import("/main.js");
+
+                const parser = new TemplateParser();
+                const schema = new Schema("test-element");
+                const { values } = parser.parse(
+                    '<ul f-children="{childItems filter elements()}"></ul>',
+                    schema,
+                );
+                const directive = values[0];
+                const filter = directive.options.filter;
+
+                // Use real DOM nodes so element.matches() is available.
+                const elementNode = document.createElement("div");
+                const textNode = document.createTextNode("hello");
+
+                return {
+                    isChildrenDirective: directive instanceof ChildrenDirective,
+                    property: directive.options.property,
+                    hasFilter: typeof filter === "function",
+                    filterAcceptsElement: filter(elementNode),
+                    filterRejectsText: filter(textNode),
+                };
+            }, pureDeclarativeEntrypointUrl);
+
+            expect(result.isChildrenDirective).toBe(true);
+            expect(result.property).toBe("childItems");
+            expect(result.hasFilter).toBe(true);
+            expect(result.filterAcceptsElement).toBe(true);
+            expect(result.filterRejectsText).toBe(false);
+        });
+
+        test("with filter elements(li) produces a ChildrenDirective with a selector filter", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async declarativeUrl => {
+                // @ts-expect-error: Client module.
+                const { Schema, TemplateParser } = await import(declarativeUrl);
+                // @ts-expect-error: Client module.
+                const { ChildrenDirective } = await import("/main.js");
+
+                const parser = new TemplateParser();
+                const schema = new Schema("test-element");
+                const { values } = parser.parse(
+                    '<ul f-children="{childItems filter elements(li)}"></ul>',
+                    schema,
+                );
+                const directive = values[0];
+                const filter = directive.options.filter;
+
+                const li = document.createElement("li");
+                const div = document.createElement("div");
+                const text = document.createTextNode("hello");
+
+                return {
+                    isChildrenDirective: directive instanceof ChildrenDirective,
+                    property: directive.options.property,
+                    hasFilter: typeof filter === "function",
+                    filterAcceptsLi: filter(li),
+                    filterResultDiv: filter(div),
+                    filterResultText: filter(text),
+                };
+            }, pureDeclarativeEntrypointUrl);
+
+            expect(result.isChildrenDirective).toBe(true);
+            expect(result.property).toBe("childItems");
+            expect(result.hasFilter).toBe(true);
+            expect(result.filterAcceptsLi).toBe(true);
+            expect(result.filterResultDiv).toBe(false);
+            expect(result.filterResultText).toBe(false);
+        });
+    });
+});

--- a/packages/fast-element/src/declarative/template-parser.ts
+++ b/packages/fast-element/src/declarative/template-parser.ts
@@ -220,6 +220,29 @@ export class TemplateParser {
     }
 
     /**
+     * Parses a directive attribute value that may include a " filter elements(...)" suffix.
+     * Returns an options object with `property` and, when a filter is specified, `filter`.
+     * Shared by the `children` and `slotted` directive cases.
+     */
+    private parseNodeDirectiveOptions(propName: string): {
+        property: string;
+        filter?: ReturnType<typeof elements>;
+    } {
+        const parts = propName.trim().split(" filter ");
+        const options: { property: string; filter?: ReturnType<typeof elements> } = {
+            property: parts[0],
+        };
+
+        if (parts[1]?.startsWith("elements(")) {
+            const inner = parts[1].slice("elements(".length);
+            const params = inner.substring(0, inner.lastIndexOf(")"));
+            options.filter = elements(params || undefined);
+        }
+
+        return options;
+    }
+
+    /**
      * Resolve an attribute directive (children/slotted/ref).
      * @param name - The name of the directive.
      * @param propName - The property name to pass to the directive.
@@ -232,27 +255,17 @@ export class TemplateParser {
     ): void {
         switch (name) {
             case "children": {
-                externalValues.push(children(propName));
+                const options = this.parseNodeDirectiveOptions(propName);
+                externalValues.push(
+                    options.filter !== undefined
+                        ? children(options)
+                        : children(options.property),
+                );
 
                 break;
             }
             case "slotted": {
-                const parts = propName.trim().split(" filter ");
-                const slottedOption = {
-                    property: parts[0],
-                };
-
-                if (parts[1]) {
-                    if (parts[1].startsWith("elements(")) {
-                        let params = parts[1].replace("elements(", "");
-                        params = params.substring(0, params.lastIndexOf(")"));
-                        Object.assign(slottedOption, {
-                            filter: elements(params || undefined),
-                        });
-                    }
-                }
-
-                externalValues.push(slotted(slottedOption));
+                externalValues.push(slotted(this.parseNodeDirectiveOptions(propName)));
 
                 break;
             }


### PR DESCRIPTION
<!---
Thanks for filing a pull request 😄 ! Before you submit, please read the following:

Search open/closed issues before submitting. Someone may have pushed the same thing before!

Provide a summary of your changes in the title field above.
-->

# Pull Request

## 📖 Description

This PR fixes parsing of the `filter elements(...)` syntax for the declarative `f-children` directive.

Previously, `TemplateParser` passed the entire directive value directly to `children()`, causing expressions such as `f-children="{childItems filter elements(li)}"` to be treated as a literal property name instead of parsing the filter. As a result, no element filter was applied.

This change extracts the filter parsing into a shared helper used by both the `children` and `slotted` directive cases. When a `filter elements(...)` clause is present, the parser now constructs the appropriate options object and passes it to `children()`, while preserving the existing behavior for directives without filters.

### 🎫 Issues

Closes #7631

## 👩‍💻 Reviewer Notes

* The change is isolated to `packages/fast-element/src/declarative/template-parser.ts`.
* Parsing of the `filter elements(...)` syntax is now shared between the `children` and `slotted` directive implementations to avoid duplicate logic.
* Existing behavior for `f-children="{property}"` is preserved. The options object is only used when a filter is specified.

## 📑 Test Plan

Added declarative parser tests covering:

* `f-children="{listItems}"` resolves to a `ChildrenDirective` with the expected property and no filter.
* `f-children="{childItems filter elements()}"` produces a filter that accepts element nodes and rejects text nodes.
* `f-children="{childItems filter elements(li)}"` produces a selector-based filter that accepts `<li>` elements and rejects other elements and text nodes.

## ✅ Checklist

### General

* [ ] I have included a change request file using `$ npm run change`
* [x] I have added tests for my changes.
* [x] I have tested my changes.
* [ ] I have updated the project documentation to reflect my changes.
* [x] I have read the [[CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md)](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [[standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards)](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Agents

* [x] I have linked to an existing issue in this project that this change addresses.
* [x ] I have read the skills.
* [x ] I have read the DESIGN.md file(s) in packages relevent to my changes.
* [ ] I have updated the DESIGN.md file(s) in packages relevent to my changes.

## ⏭ Next Steps

* Add a change file using `npm run change` if required by the maintainers.
* Update documentation if the declarative `f-children` filter syntax is intended to be part of the public API.