### PR TITLE
chore: enable noImplicitAny and strictPropertyInitialization for fast-router

### DIFF
--- a/change/@microsoft-fast-router-abd3b231-9bfa-49ef-ac95-fd31ee43f6d3.json
+++ b/change/@microsoft-fast-router-abd3b231-9bfa-49ef-ac95-fd31ee43f6d3.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Enable noImplicitAny and strictPropertyInitialization for fast-router.",
+  "packageName": "@microsoft/fast-router",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-router/tsconfig.json
+++ b/packages/fast-router/tsconfig.json
@@ -7,8 +7,6 @@
         "experimentalDecorators": true,
         "types": ["node"],
         "useUnknownInCatchVariables": false,
-        "noImplicitAny": false,
-        "strictPropertyInitialization": false,
         "target": "es2015",
         "module": "NodeNext",
         "importHelpers": true,


### PR DESCRIPTION
## What this does
Turns on two stricter TypeScript checks for the `fast-router` package.

## Why
`fast-router` was opting out of two safety checks the rest of the repo already uses. Turning them on catches a whole class of mistakes at build time instead of at runtime.

## What changed
- Removed the two local opt-outs in `packages/fast-router/tsconfig.json`, so the package now inherits the strict settings from the root config

## How to see it
The typecheck itself is the test. It passes with zero errors, and all 10,917 router tests still pass.

Closes #5341