### PR TITLE
fix: keep short-circuited bindings subscribed so they can update again

### DIFF
--- a/change/@microsoft-fast-element-3f0a2c7b-9d41-4e6a-b0c5-7035aa1c4e2d.json
+++ b/change/@microsoft-fast-element-3f0a2c7b-9d41-4e6a-b0c5-7035aa1c4e2d.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Fix bindings that short-circuit before reading any observable, which left them with no dependencies and unable to ever update again, and stop repeat from re-evaluating its bindings against an unbound view.",
+  "packageName": "@microsoft/fast-element",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/DESIGN.md
+++ b/packages/fast-element/DESIGN.md
@@ -230,6 +230,18 @@ Backing slots are internal implementation details. Lifecycle rebinding treats pu
 
 This gives FAST automatic, fine-grained dependency tracking without explicit declarations.
 
+#### The zero-dependency fallback
+
+Fine-grained tracking only works if the expression actually reads an observable. A _volatile_ expression re-collects its dependencies on every pass, and it can short-circuit (`&&`, `||`, `?.`, `?:`) before reaching one — `x => x.plainField && x.observableField` collects nothing at all while `plainField` is falsy. With no subscriptions there is nothing left to wake the expression, and the binding is dead for the rest of its life.
+
+So when a tracking pass ends with zero records, the `ExpressionNotifier` falls back to a coarse subscription: it subscribes to the _source itself_ rather than to a property of it, via `Notifier.subscribe(subscriber)` with no property name (`PropertyChangeNotifier.subjectSubscribers`). Any observable change on the source then re-evaluates the expression, which either collects real dependencies again (the fallback is dropped) or re-arms the fallback.
+
+Consequences to be aware of:
+
+-   Only sources that can hold a notifier are watched. Primitives, `null` and arrays are skipped, so an expression that short-circuits over a primitive repeat item stays dead — but such an item cannot notify anyone in the first place.
+-   The subscription is deliberately coarse. A binding parked on the fallback re-evaluates on _every_ observable change on its source, including the `isConnected` notification that `ElementController` fires on connect and disconnect. This is bounded (async updates coalesce per microtask) and only affects expressions that track no dependencies, which today can never update at all — but expressions that are static _by design_ (`when(true, template)`, `x => x.plainField ? a : b`) pay for it too.
+-   The fallback record is not a property observation, so it is not yielded by `ExpressionNotifier.records()`, and `twoWay` bindings reject it (there is no property to write back to).
+
 ---
 
 ### Bindings

--- a/packages/fast-element/SIZES.md
+++ b/packages/fast-element/SIZES.md
@@ -4,22 +4,22 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 78.61 KB | 23.40 KB | 20.77 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.11 KB | 7.12 KB | 6.41 KB |
+| CDN Rollup Bundle | 79.09 KB | 23.51 KB | 20.91 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.54 KB | 7.24 KB | 6.51 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 290 B |
-| Observable (@microsoft/fast-element/observable.js) | 6.75 KB | 2.51 KB | 2.23 KB |
-| observable (@microsoft/fast-element/observable.js) | 6.79 KB | 2.52 KB | 2.24 KB |
+| Observable (@microsoft/fast-element/observable.js) | 7.18 KB | 2.62 KB | 2.34 KB |
+| observable (@microsoft/fast-element/observable.js) | 7.21 KB | 2.63 KB | 2.35 KB |
 | attr (@microsoft/fast-element/attr.js) | 477 B | 287 B | 244 B |
 | children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.66 KB |
 | ref (@microsoft/fast-element/ref.js) | 3.84 KB | 1.54 KB | 1.34 KB |
 | slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
-| volatile (@microsoft/fast-element/volatile.js) | 6.84 KB | 2.54 KB | 2.26 KB |
+| volatile (@microsoft/fast-element/volatile.js) | 7.27 KB | 2.65 KB | 2.36 KB |
 | when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 589 B |
-| html (@microsoft/fast-element/html.js) | 27.73 KB | 8.96 KB | 8.02 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 31.80 KB | 10.00 KB | 9.03 KB |
+| html (@microsoft/fast-element/html.js) | 28.16 KB | 9.07 KB | 8.14 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 32.25 KB | 10.12 KB | 9.16 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 46.53 KB | 13.91 KB | 12.49 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.15 KB | 19.46 KB | 17.42 KB |
-| ArrayObserver (@microsoft/fast-element/arrays.js) | 12.55 KB | 4.46 KB | 4.03 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 21.96 KB | 7.73 KB | 6.97 KB |
-| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.31 KB | 5.41 KB | 4.88 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 46.96 KB | 14.04 KB | 12.60 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.60 KB | 19.58 KB | 17.52 KB |
+| ArrayObserver (@microsoft/fast-element/arrays.js) | 12.98 KB | 4.58 KB | 4.12 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 22.39 KB | 7.84 KB | 7.07 KB |
+| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.74 KB | 5.53 KB | 4.98 KB |

--- a/packages/fast-element/src/binding/two-way.ts
+++ b/packages/fast-element/src/binding/two-way.ts
@@ -110,9 +110,14 @@ class TwoWayObserver<TSource = any, TReturn = any, TParent = any>
         const bindingSource = this.directive;
         const target = event.currentTarget as HTMLElement;
         const notifier = this.notifier;
-        const last = (notifier as any).last as ObservationRecord; // using internal API!!!
+        // using internal API!!!
+        const last = (notifier as any).last as Partial<ObservationRecord> | null;
 
-        if (!last) {
+        // `last` is null when the expression observed nothing at all. It carries no
+        // propertyName when the expression short-circuited before reading an
+        // observable and the observer fell back to watching the source itself.
+        // Neither case identifies a property that the view can write back to.
+        if (!last || last.propertyName === void 0) {
             FAST.warn(Message.twoWayBindingRequiresObservables);
             return;
         }

--- a/packages/fast-element/src/observation/observable.pw.spec.ts
+++ b/packages/fast-element/src/observation/observable.pw.spec.ts
@@ -949,6 +949,569 @@ test.describe("The Observable", () => {
         });
     });
 
+    test.describe("BindingObserver with short-circuited dependencies", () => {
+        test.beforeEach(async ({ page }) => {
+            await page.goto("/");
+        });
+
+        test("notifies when an observable short-circuited by && changes", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake, Updates } = await import("/main.js");
+
+                const model: any = { plainGuard: false };
+                Observable.defineProperty(model, "value");
+                model.value = 0;
+
+                const binding = (x: any) => x.plainGuard && x.value;
+
+                let notifyCount = 0;
+                const observer = Observable.binding(binding, {
+                    handleChange() {
+                        notifyCount++;
+                    },
+                });
+
+                const initialValue = observer.observe(model, Fake.executionContext());
+                const initialRecordCount = [...observer.records()].length;
+
+                model.value = 1;
+                await Updates.next();
+
+                const notifyCountAfterValue = notifyCount;
+
+                model.plainGuard = true;
+                model.value = 2;
+                await Updates.next();
+
+                const valueAfterGuard = observer.observe(model, Fake.executionContext());
+                const recordCountAfterGuard = [...observer.records()].length;
+
+                return {
+                    initialValue,
+                    initialRecordCount,
+                    notifyCountAfterValue,
+                    valueAfterGuard,
+                    recordCountAfterGuard,
+                };
+            });
+
+            expect(result.initialValue).toBe(false);
+            expect(result.initialRecordCount).toBe(0);
+            expect(result.notifyCountAfterValue).toBe(1);
+            expect(result.valueAfterGuard).toBe(2);
+            expect(result.recordCountAfterGuard).toBe(1);
+        });
+
+        test("recovers when a healthy binding evaluates to zero dependencies", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake, Updates } = await import("/main.js");
+
+                const model: any = { plainGuard: true };
+                Observable.defineProperty(model, "a");
+                Observable.defineProperty(model, "b");
+                model.a = 1;
+                model.b = 2;
+
+                const binding = (x: any) => (x.plainGuard ? x.a + x.b : 0);
+
+                let notifyCount = 0;
+                const observer = Observable.binding(binding, {
+                    handleChange() {
+                        notifyCount++;
+                    },
+                });
+
+                observer.observe(model, Fake.executionContext());
+                const healthyRecordCount = [...observer.records()].length;
+
+                model.plainGuard = false;
+                observer.observe(model, Fake.executionContext());
+                const deadRecordCount = [...observer.records()].length;
+
+                model.a = 10;
+                await Updates.next();
+
+                const notifyCountAfterA = notifyCount;
+
+                model.plainGuard = true;
+                const valueAfterRecovery = observer.observe(
+                    model,
+                    Fake.executionContext(),
+                );
+
+                notifyCount = 0;
+                model.b = 20;
+                await Updates.next();
+
+                return {
+                    healthyRecordCount,
+                    deadRecordCount,
+                    notifyCountAfterA,
+                    valueAfterRecovery,
+                    notifyCountAfterRecovery: notifyCount,
+                };
+            });
+
+            expect(result.healthyRecordCount).toBe(2);
+            expect(result.deadRecordCount).toBe(0);
+            expect(result.notifyCountAfterA).toBe(1);
+            expect(result.valueAfterRecovery).toBe(12);
+            expect(result.notifyCountAfterRecovery).toBe(1);
+        });
+
+        test("drops records left behind by a longer previous evaluation", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake } = await import("/main.js");
+
+                const model: any = { plainGuard: true };
+                Observable.defineProperty(model, "a");
+                Observable.defineProperty(model, "b");
+                model.a = 1;
+                model.b = 2;
+
+                const binding = (x: any) => (x.plainGuard ? x.a + x.b : x.a);
+                const observer = Observable.binding(binding);
+
+                observer.observe(model, Fake.executionContext());
+                const twoDepRecords = [...observer.records()].map(
+                    (r: any) => r.propertyName,
+                );
+
+                model.plainGuard = false;
+                observer.observe(model, Fake.executionContext());
+                const oneDepRecords = [...observer.records()].map(
+                    (r: any) => r.propertyName,
+                );
+
+                return { twoDepRecords, oneDepRecords };
+            });
+
+            expect(result.twoDepRecords).toEqual(["a", "b"]);
+            expect(result.oneDepRecords).toEqual(["a"]);
+        });
+
+        test("does not subject-watch a binding that collected a dependency", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake, Updates } = await import("/main.js");
+
+                const model: any = { plainGuard: "yes" };
+                Observable.defineProperty(model, "value");
+                model.value = 1;
+
+                const binding = (x: any) => x.value && x.plainGuard;
+
+                let notifyCount = 0;
+                const observer = Observable.binding(binding, {
+                    handleChange() {
+                        notifyCount++;
+                    },
+                });
+
+                const value = observer.observe(model, Fake.executionContext());
+                const records = [...observer.records()].map((r: any) => r.propertyName);
+                const notifier: any = Observable.getNotifier(model);
+                const hasSubjectSubscribers = notifier.subjectSubscribers !== null;
+
+                model.value = 2;
+                await Updates.next();
+
+                return {
+                    value,
+                    records,
+                    hasSubjectSubscribers,
+                    notifyCount,
+                };
+            });
+
+            expect(result.value).toBe("yes");
+            expect(result.records).toEqual(["value"]);
+            expect(result.hasSubjectSubscribers).toBe(false);
+            expect(result.notifyCount).toBe(1);
+        });
+
+        test("notifies for ||, ternary and optional chaining short-circuits", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake, Updates } = await import("/main.js");
+
+                async function observeZeroDep(binding: any) {
+                    const model: any = { plainGuard: true, maybeNull: null };
+                    Observable.defineProperty(model, "value");
+                    model.value = 0;
+
+                    let notifyCount = 0;
+                    const observer = Observable.binding(binding, {
+                        handleChange() {
+                            notifyCount++;
+                        },
+                    });
+
+                    observer.observe(model, Fake.executionContext());
+                    const recordCount = [...observer.records()].length;
+
+                    model.value = 1;
+                    await Updates.next();
+
+                    return { recordCount, notifyCount };
+                }
+
+                return {
+                    or: await observeZeroDep((x: any) => x.plainGuard || x.value),
+                    ternary: await observeZeroDep((x: any) =>
+                        x.plainGuard ? 1 : x.value,
+                    ),
+                    optional: await observeZeroDep((x: any) => x.maybeNull?.value),
+                };
+            });
+
+            expect(result.or).toEqual({ recordCount: 0, notifyCount: 1 });
+            expect(result.ternary).toEqual({ recordCount: 0, notifyCount: 1 });
+            expect(result.optional).toEqual({ recordCount: 0, notifyCount: 1 });
+        });
+
+        test("notifies when a trackVolatile getter reads no observables", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake, Updates } = await import("/main.js");
+
+                const model: any = { plainGuard: false };
+                Observable.defineProperty(model, "value");
+                model.value = 0;
+                Object.defineProperty(model, "guarded", {
+                    get(this: any) {
+                        Observable.trackVolatile();
+                        return this.plainGuard ? this.value : 42;
+                    },
+                });
+
+                const binding = (x: any) => x.guarded;
+
+                let notifyCount = 0;
+                const observer = Observable.binding(binding, {
+                    handleChange() {
+                        notifyCount++;
+                    },
+                });
+
+                const isVolatileBinding = Observable.isVolatileBinding(binding);
+                const initialValue = observer.observe(model, Fake.executionContext());
+                const recordCount = [...observer.records()].length;
+
+                model.value = 1;
+                await Updates.next();
+
+                return {
+                    isVolatileBinding,
+                    initialValue,
+                    recordCount,
+                    notifyCount,
+                };
+            });
+
+            expect(result.isVolatileBinding).toBe(false);
+            expect(result.initialValue).toBe(42);
+            expect(result.recordCount).toBe(0);
+            expect(result.notifyCount).toBe(1);
+        });
+
+        test("does not subscribe non-volatile bindings that read no observables", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake, Updates } = await import("/main.js");
+
+                async function observeConstant(binding: any) {
+                    const model: any = { plainField: "plain" };
+                    Observable.defineProperty(model, "value");
+                    model.value = 0;
+
+                    let notifyCount = 0;
+                    const observer = Observable.binding(binding, {
+                        handleChange() {
+                            notifyCount++;
+                        },
+                    });
+
+                    observer.observe(model, Fake.executionContext());
+                    const notifier: any = Observable.getNotifier(model);
+
+                    model.value = 1;
+                    await Updates.next();
+
+                    return {
+                        recordCount: [...observer.records()].length,
+                        hasSubjectSubscribers: notifier.subjectSubscribers !== null,
+                        notifyCount,
+                    };
+                }
+
+                return {
+                    text: await observeConstant(() => "hello"),
+                    number: await observeConstant(() => 42),
+                    field: await observeConstant((x: any) => x.plainField),
+                };
+            });
+
+            const expected = {
+                recordCount: 0,
+                hasSubjectSubscribers: false,
+                notifyCount: 0,
+            };
+
+            expect(result.text).toEqual(expected);
+            expect(result.number).toEqual(expected);
+            expect(result.field).toEqual(expected);
+        });
+
+        test("watches an object source that does not have a notifier yet", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake } = await import("/main.js");
+
+                const binding = (x: any) => (x.selected ? "danger" : "");
+
+                const plainSource: any = { selected: false };
+                const plainObserver = Observable.binding(binding);
+                plainObserver.observe(plainSource, Fake.executionContext());
+
+                const plainNotifier: any = Observable.getNotifier(plainSource);
+
+                const notifiedSource: any = { selected: false };
+                Observable.defineProperty(notifiedSource, "value");
+                notifiedSource.value = 0;
+
+                const notifiedObserver = Observable.binding(binding);
+                notifiedObserver.observe(notifiedSource, Fake.executionContext());
+
+                const notifiedNotifier: any = Observable.getNotifier(notifiedSource);
+
+                return {
+                    plainHasController: "$fastController" in plainSource,
+                    plainIsSubscribed:
+                        plainNotifier.subjectSubscribers.has(plainObserver),
+                    notifiedIsSubscribed:
+                        notifiedNotifier.subjectSubscribers.has(notifiedObserver),
+                };
+            });
+
+            expect(result.plainHasController).toBe(false);
+            expect(result.plainIsSubscribed).toBe(true);
+            expect(result.notifiedIsSubscribed).toBe(true);
+        });
+
+        test("notifies for an observable that was never written before binding", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake, Updates } = await import("/main.js");
+
+                // an observable that is declared but never assigned has no
+                // notifier: the accessor creates one on the first write.
+                class Item {
+                    // a plain field, so the expression below short-circuits
+                    // before it ever reads the observable.
+                    isVisible = false;
+                }
+
+                Observable.defineProperty(Item.prototype, "selected");
+
+                const item: any = new Item();
+
+                let notifyCount = 0;
+                const observer = Observable.binding(
+                    (x: any) => x.isVisible && x.selected,
+                    {
+                        handleChange() {
+                            notifyCount++;
+                        },
+                    },
+                );
+
+                const initialValue = observer.observe(item, Fake.executionContext());
+
+                // the first write is what creates the notifier for the item.
+                item.selected = true;
+                await Updates.next();
+
+                const notifyCountAfterWrite = notifyCount;
+
+                item.isVisible = true;
+                const valueAfterWrite = observer.observe(item, Fake.executionContext());
+
+                return { initialValue, notifyCountAfterWrite, valueAfterWrite };
+            });
+
+            expect(result.initialValue).toBe(false);
+            expect(result.notifyCountAfterWrite).toBe(1);
+            expect(result.valueAfterWrite).toBe(true);
+        });
+
+        test("does not throw or mutate when the source is an array", async ({ page }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake } = await import("/main.js");
+
+                let arrayObservationEnabled = true;
+
+                try {
+                    Observable.getNotifier([]);
+                } catch {
+                    arrayObservationEnabled = false;
+                }
+
+                const source: any = [1, 2, 3];
+                const observer = Observable.binding((x: any) =>
+                    x[0] ? "first" : "none",
+                );
+
+                let error: string | null = null;
+                let value: any;
+
+                try {
+                    value = observer.observe(source, Fake.executionContext());
+                } catch (e: any) {
+                    error = e.message;
+                }
+
+                return {
+                    arrayObservationEnabled,
+                    error,
+                    value,
+                    hasController: "$fastController" in source,
+                    recordCount: [...observer.records()].length,
+                };
+            });
+
+            expect(result.arrayObservationEnabled).toBe(false);
+            expect(result.error).toBe(null);
+            expect(result.value).toBe("first");
+            expect(result.hasController).toBe(false);
+            expect(result.recordCount).toBe(0);
+        });
+
+        test("does not throw for primitive, null or function sources", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake } = await import("/main.js");
+
+                const observer = Observable.binding((x: any, c: any) =>
+                    c.isFirst && x ? "yes" : "no",
+                );
+
+                const sources = ["a", 1, true, null, void 0, () => "fn"];
+                const errors: string[] = [];
+
+                for (const source of sources) {
+                    try {
+                        observer.observe(source, Fake.executionContext());
+                    } catch (e: any) {
+                        errors.push(`${String(source)}: ${e.message}`);
+                    }
+                }
+
+                return { errors, recordCount: [...observer.records()].length };
+            });
+
+            expect(result.errors).toEqual([]);
+            expect(result.recordCount).toBe(0);
+        });
+
+        test("does not accumulate subject subscribers across evaluations", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake } = await import("/main.js");
+
+                const model: any = { plainGuard: false };
+                Observable.defineProperty(model, "value");
+                model.value = 0;
+
+                const observer = Observable.binding((x: any) => x.plainGuard && x.value);
+
+                for (let i = 0; i < 10; i++) {
+                    observer.observe(model, Fake.executionContext());
+                }
+
+                const subscribers: any = (Observable.getNotifier(model) as any)
+                    .subjectSubscribers;
+
+                if (subscribers === null) {
+                    return { subscriberCount: 0, isSubscribed: false };
+                }
+
+                const subscriberCount = subscribers.spillover
+                    ? subscribers.spillover.length
+                    : (subscribers.sub1 ? 1 : 0) + (subscribers.sub2 ? 1 : 0);
+
+                return { subscriberCount, isSubscribed: subscribers.has(observer) };
+            });
+
+            expect(result.subscriberCount).toBe(1);
+            expect(result.isSubscribed).toBe(true);
+        });
+
+        test("stops notifying a zero dependency binding once disposed", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { Observable, Fake, Updates } = await import("/main.js");
+
+                const model: any = { plainGuard: false };
+                Observable.defineProperty(model, "value");
+                model.value = 0;
+
+                let notifyCount = 0;
+                const observer = Observable.binding((x: any) => x.plainGuard && x.value, {
+                    handleChange() {
+                        notifyCount++;
+                    },
+                });
+
+                observer.observe(model, Fake.executionContext());
+                observer.dispose();
+
+                model.value = 1;
+                await Updates.next();
+
+                const subscribers: any = (Observable.getNotifier(model) as any)
+                    .subjectSubscribers;
+
+                return {
+                    notifyCount,
+                    isSubscribed:
+                        subscribers === null ? false : subscribers.has(observer),
+                };
+            });
+
+            expect(result.notifyCount).toBe(0);
+            expect(result.isSubscribed).toBe(false);
+        });
+    });
+
     test.describe("DefaultObservableAccessor", () => {
         test("calls its own change callback", () => {
             const model = new Model();

--- a/packages/fast-element/src/observation/observable.ts
+++ b/packages/fast-element/src/observation/observable.ts
@@ -54,7 +54,12 @@ export interface ObservationRecord {
     propertyName: string;
 }
 
-interface SubscriptionRecord extends ObservationRecord {
+interface SubscriptionRecord extends Omit<ObservationRecord, "propertyName"> {
+    /**
+     * Undefined for the fallback subscription to the source itself,
+     * which watches every observable property rather than a single one.
+     */
+    propertyName: string | undefined;
     notifier: Notifier;
     next: SubscriptionRecord | undefined;
 }
@@ -144,8 +149,12 @@ export interface ExpressionNotifier<TSource = any, TReturn = any, TParent = any>
     observe(source: TSource, context?: ExecutionContext): TReturn;
 
     /**
-     * Gets {@link ObservationRecord|ObservationRecords} that the {@link ExpressionNotifier}
-     * is observing.
+     * Gets {@link ObservationRecord|ObservationRecords} for the observable properties
+     * that the {@link ExpressionNotifier} is observing.
+     * @remarks
+     * An expression that short-circuits before reading any observable property
+     * observes its source as a whole rather than a property of it, and yields no
+     * records.
      */
     records(): IterableIterator<ObservationRecord>;
 
@@ -186,6 +195,26 @@ export const Observable = (() => {
         }
 
         return found;
+    }
+
+    /**
+     * Gets the notifier used to watch a source in its entirety, or undefined
+     * when the source cannot be watched.
+     * @remarks
+     * Primitives and null are not valid WeakMap keys, and an array would have to
+     * be given an array observer, which is only available when array observation
+     * is enabled. Every other source gets a notifier, creating one if needed: an
+     * observable property that has never been written has no notifier yet either,
+     * so requiring an existing one would leave the expression permanently unable
+     * to re-evaluate, based on nothing more than whether some other property of
+     * the source happened to be written or observed first.
+     */
+    function getSubjectNotifier(source: any): Notifier | undefined {
+        return source === null ||
+            (typeof source !== "object" && typeof source !== "function") ||
+            Array.isArray(source)
+            ? void 0
+            : getNotifier(source);
     }
 
     const getAccessors = createMetadataLocator<Accessor>();
@@ -266,6 +295,12 @@ export const Observable = (() => {
             return (
                 controller.sourceLifetime !== SourceLifetime.coupled ||
                 this.first !== this.last ||
+                // A single property record on a coupled source is left subscribed,
+                // because it is torn down with the source. The fallback record is a
+                // subscription to *every* observable on the source, so it is worth
+                // disposing: an unbound view should not keep re-evaluating the
+                // expression on every change to the source it used to be bound to.
+                this.first.propertyName === void 0 ||
                 this.first.propertySource !== controller.source
             );
         }
@@ -279,14 +314,28 @@ export const Observable = (() => {
                 this.dispose();
             }
 
+            const isTracking = this.needsRefresh;
             const previousWatcher = watcher;
-            watcher = this.needsRefresh ? this : void 0;
+            watcher = isTracking ? this : void 0;
             this.needsRefresh = this.isVolatileBinding;
             let result;
             try {
                 result = this.expression(source, context);
             } finally {
                 watcher = previousWatcher;
+            }
+
+            // A volatile expression can short-circuit (&&, ||, ?., ternary) before
+            // reading any observable, which would leave the expression with zero
+            // subscriptions and therefore no way to ever be evaluated again. Watch
+            // the source itself instead, so that any observable change on it
+            // re-evaluates the expression.
+            if (this.last === null && isTracking && this.needsRefresh) {
+                const notifier = getSubjectNotifier(source);
+
+                if (notifier !== void 0) {
+                    this.watchSubject(source, notifier);
+                }
             }
 
             return result;
@@ -307,8 +356,31 @@ export const Observable = (() => {
                 }
 
                 this.last = null;
-                this.needsRefresh = this.needsQueue = this.isAsync;
+                // There are no subscriptions left, so the next evaluation must track again.
+                this.needsRefresh = true;
+                this.needsQueue = this.isAsync;
             }
+        }
+
+        /**
+         * Subscribes to every observable change on the source.
+         * @remarks
+         * Only called when the expression tracked no dependencies, so the record
+         * always reuses `first` and no record is allocated. The source is given a
+         * notifier if it does not have one, which is the only allocation on this
+         * path and happens at most once per source.
+         */
+        private watchSubject(propertySource: unknown, notifier: Notifier): void {
+            const current = this.first;
+
+            current.propertySource = propertySource;
+            current.propertyName = void 0;
+            current.notifier = notifier;
+            current.next = void 0;
+
+            notifier.subscribe(this);
+
+            this.last = current;
         }
 
         public watch(propertySource: unknown, propertyName: string): void {
@@ -322,7 +394,10 @@ export const Observable = (() => {
 
             notifier.subscribe(this, propertyName);
 
-            if (prev !== null) {
+            if (prev === null) {
+                // Drop the records left behind by a previous, longer evaluation.
+                current.next = void 0;
+            } else {
                 if (!this.needsRefresh) {
                     // Declaring the variable prior to assignment below circumvents
                     // a bug in Angular's optimization process causing infinite recursion
@@ -330,7 +405,8 @@ export const Observable = (() => {
                     // biome-ignore lint/style/useConst: see above
                     let prevValue;
                     watcher = void 0;
-                    prevValue = prev.propertySource[prev.propertyName];
+                    // prev is a property record: the subject record is always last.
+                    prevValue = prev.propertySource[prev.propertyName!];
                     watcher = this;
 
                     if (propertySource === prevValue) {
@@ -361,11 +437,22 @@ export const Observable = (() => {
         }
 
         public *records(): IterableIterator<ObservationRecord> {
-            let next = this.first;
+            // With no subscriptions, `first` holds either uninitialized fields
+            // or the leftovers of an evaluation that has since been disposed.
+            if (this.last === null) {
+                return;
+            }
+
+            let next: SubscriptionRecord | undefined = this.first;
 
             while (next !== void 0) {
-                yield next;
-                next = next.next!;
+                // The fallback subscription to the source is not a property
+                // observation, and ObservationRecord.propertyName is a string.
+                if (next.propertyName !== void 0) {
+                    yield next as ObservationRecord;
+                }
+
+                next = next.next;
             }
         }
     }

--- a/packages/fast-element/src/state/state.pw.spec.ts
+++ b/packages/fast-element/src/state/state.pw.spec.ts
@@ -398,4 +398,39 @@ test.describe("ComputedState", () => {
         expect(shutdown).toBe(2);
         expect(calledCount).toBe(2);
     });
+    test("updates a volatile computation whose dependencies change", () => {
+        const useFirst = state(true);
+        const first = state(1);
+        const second = state(2);
+        const sut = computedState(() => () => (useFirst() ? first() : second()));
+
+        expect(sut()).toBe(1);
+
+        first.set(10);
+
+        expect(sut()).toBe(10);
+
+        useFirst.set(false);
+
+        expect(sut()).toBe(2);
+
+        second.set(20);
+
+        expect(sut()).toBe(20);
+
+        useFirst.set(true);
+
+        expect(sut()).toBe(10);
+    });
+
+    test("does not throw when a volatile computation reads no state", () => {
+        let flag = true;
+        const sut = computedState(() => () => (flag ? "on" : "off"));
+
+        expect(sut()).toBe("on");
+
+        flag = false;
+
+        expect(sut()).toBe("on");
+    });
 });

--- a/packages/fast-element/src/templating/binding.pw.spec.ts
+++ b/packages/fast-element/src/templating/binding.pw.spec.ts
@@ -2707,6 +2707,70 @@ test.describe("The HTML binding directive", () => {
                 expect(didNotThrow).toBe(true);
             });
         }
+
+        test("skips the view=>model update when the expression short-circuits", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    HTMLBindingDirective,
+                    HTMLDirective,
+                    Observable,
+                    Fake,
+                    DOM,
+                    nextId,
+                    twoWay,
+                    Updates,
+                } = await import("/main.js");
+
+                class Model {
+                    constructor(value: any) {
+                        this.value = value;
+                    }
+                    value: any;
+                    missing: any = null;
+                }
+
+                Observable.defineProperty(Model.prototype, "value");
+
+                // Volatile (?.) and short-circuits before reading any observable,
+                // so the observer collects no property records at all.
+                const directive = new HTMLBindingDirective(
+                    twoWay((x: any) => x.missing?.value, {}),
+                );
+                HTMLDirective.assignAspect(directive, ":value");
+
+                const node = document.createElement("div");
+                directive.id = nextId();
+                directive.targetNodeId = "r";
+                directive.targetTagName = node.tagName ?? null;
+                directive.policy = DOM.policy;
+
+                const targets = { r: node };
+                const behavior = directive.createBehavior();
+                const parentNode = document.createElement("div");
+                parentNode.appendChild(node);
+
+                const model = new Model("original");
+                const controller = Fake.viewController(targets, behavior);
+                controller.bind(model);
+
+                (node as any).value = "typed-by-user";
+                node.dispatchEvent(new CustomEvent("change"));
+                await Updates.next();
+
+                return {
+                    // The view=>model write must be skipped, not aimed at a
+                    // property named "undefined".
+                    hasUndefinedProperty: Object.hasOwn(model, "undefined"),
+                    value: model.value,
+                };
+            });
+
+            expect(result.hasUndefinedProperty).toBe(false);
+            expect(result.value).toBe("original");
+        });
     });
 
     test.describe("when binding events", () => {

--- a/packages/fast-element/src/templating/repeat.pw.spec.ts
+++ b/packages/fast-element/src/templating/repeat.pw.spec.ts
@@ -348,7 +348,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -438,7 +438,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -551,7 +551,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -675,7 +675,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -759,7 +759,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -858,7 +858,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -972,7 +972,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -1076,7 +1076,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -1179,7 +1179,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -1281,7 +1281,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -1400,7 +1400,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -1506,7 +1506,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -1630,7 +1630,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -1736,7 +1736,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -1844,7 +1844,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -1963,7 +1963,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -2071,7 +2071,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -2162,7 +2162,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -2274,7 +2274,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -2378,7 +2378,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -2482,7 +2482,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -2587,7 +2587,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -2691,7 +2691,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -2795,7 +2795,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -2896,7 +2896,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -3000,7 +3000,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -3105,7 +3105,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -3210,7 +3210,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -3321,7 +3321,7 @@ test.describe("The repeat", () => {
                     function createController(source, targets) {
                         const unbindables = [];
                         return {
-                            isBound: false,
+                            isBound: true,
                             context: Fake.executionContext(),
                             onUnbind(object) {
                                 unbindables.push(object);
@@ -3365,5 +3365,346 @@ test.describe("The repeat", () => {
                 expect(result).toBe(true);
             });
         }
+    });
+    test.describe("with a short-circuited item binding", () => {
+        test("renders primitive items without throwing", async ({ page }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    FASTElement,
+                    html,
+                    observable,
+                    repeat,
+                    uniqueElementName,
+                    Updates,
+                } =
+                    // @ts-expect-error: Client module.
+                    await import("/main.js");
+
+                class TestElement extends FASTElement {
+                    items!: any[];
+                }
+
+                observable(TestElement.prototype, "items");
+
+                const name = uniqueElementName();
+                await TestElement.define({
+                    name,
+                    template: html`
+                        ${repeat(
+                            (x: any) => x.items,
+                            html`
+                                <span class="${(x: any) => (x.selected ? "danger" : "")}">
+                                    ${(x: any) => x}
+                                </span>
+                            `,
+                        )}
+                    `,
+                });
+
+                const element = document.createElement(name) as any;
+                element.items = ["a", 1, true];
+                document.body.appendChild(element);
+
+                let error: string | null = null;
+
+                try {
+                    await Updates.next();
+                } catch (e: any) {
+                    error = e.message;
+                }
+
+                const text = element.shadowRoot.textContent.replace(/\s+/g, " ").trim();
+
+                element.remove();
+
+                return { error, text };
+            });
+
+            expect(result.error).toBe(null);
+            expect(result.text).toBe("a 1 true");
+        });
+
+        test("renders array items without observing them", async ({ page }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    FASTElement,
+                    html,
+                    observable,
+                    repeat,
+                    uniqueElementName,
+                    Updates,
+                } =
+                    // @ts-expect-error: Client module.
+                    await import("/main.js");
+
+                class TestElement extends FASTElement {
+                    items!: any[];
+                }
+
+                observable(TestElement.prototype, "items");
+
+                const name = uniqueElementName();
+                await TestElement.define({
+                    name,
+                    template: html`
+                        ${repeat(
+                            (x: any) => x.items,
+                            html`
+                                <span class="${(x: any) => (x.selected ? "danger" : "")}">
+                                    ${(x: any) => x.length}
+                                </span>
+                            `,
+                        )}
+                    `,
+                });
+
+                const element = document.createElement(name) as any;
+                const items = [
+                    [1, 2],
+                    [3, 4, 5],
+                ];
+                element.items = items;
+                document.body.appendChild(element);
+
+                let error: string | null = null;
+
+                try {
+                    await Updates.next();
+                } catch (e: any) {
+                    error = e.message;
+                }
+
+                const text = element.shadowRoot.textContent.replace(/\s+/g, " ").trim();
+                const itemsWereObserved = items.some(x => "$fastController" in x);
+
+                element.remove();
+
+                return { error, text, itemsWereObserved };
+            });
+
+            expect(result.error).toBe(null);
+            expect(result.text).toBe("2 3");
+            expect(result.itemsWereObserved).toBe(false);
+        });
+
+        test("renders primitive items with a context-only binding", async ({ page }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    FASTElement,
+                    html,
+                    observable,
+                    repeat,
+                    uniqueElementName,
+                    Updates,
+                } =
+                    // @ts-expect-error: Client module.
+                    await import("/main.js");
+
+                class TestElement extends FASTElement {
+                    items!: any[];
+                }
+
+                observable(TestElement.prototype, "items");
+
+                const name = uniqueElementName();
+                await TestElement.define({
+                    name,
+                    template: html`
+                        ${repeat(
+                            (x: any) => x.items,
+                            html`
+                                <span>
+                                    ${(x: any, c: any) => (c.isFirst && x ? "first" : "rest")}
+                                </span>
+                            `,
+                            { positioning: true },
+                        )}
+                    `,
+                });
+
+                const element = document.createElement(name) as any;
+                element.items = ["a", "b"];
+                document.body.appendChild(element);
+
+                let error: string | null = null;
+
+                try {
+                    await Updates.next();
+                } catch (e: any) {
+                    error = e.message;
+                }
+
+                const text = element.shadowRoot.textContent.replace(/\s+/g, " ").trim();
+
+                element.remove();
+
+                return { error, text };
+            });
+
+            expect(result.error).toBe(null);
+            expect(result.text).toBe("first rest");
+        });
+    });
+
+    test.describe("with a short-circuited items binding", () => {
+        test("does not evaluate the items binding against an unbound view", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    FASTElement,
+                    html,
+                    observable,
+                    repeat,
+                    uniqueElementName,
+                    Updates,
+                } =
+                    // @ts-expect-error: Client module.
+                    await import("/main.js");
+
+                class TestElement extends FASTElement {
+                    // a plain field: reading it tracks nothing
+                    showList = true;
+                    items!: any[];
+                }
+
+                observable(TestElement.prototype, "items");
+
+                const name = uniqueElementName();
+                await TestElement.define({
+                    name,
+                    template: html`
+                        ${repeat(
+                            (x: any) => x.showList && x.items,
+                            html`
+                                <span>${(x: any) => x}</span>
+                            `,
+                        )}
+                    `,
+                });
+
+                const element = document.createElement(name) as any;
+                element.items = ["a"];
+                document.body.appendChild(element);
+                await Updates.next();
+
+                // connect, disconnect and reconnect so that the items binding is
+                // re-bound with a coupled source lifetime and a single dependency,
+                // which is the shape that is not registered as an unbindable.
+                element.remove();
+                await Updates.next();
+                document.body.appendChild(element);
+                await Updates.next();
+
+                const errors: string[] = [];
+                const handler = (event: ErrorEvent) => {
+                    event.preventDefault();
+                    errors.push(event.error?.message ?? String(event.message));
+                };
+                window.addEventListener("error", handler);
+
+                try {
+                    // the guard goes falsy, so the items binding now tracks
+                    // no dependencies and falls back to watching the source.
+                    element.showList = false;
+                    element.items = ["b"];
+                    await Updates.next();
+
+                    const textWhileHidden = element.shadowRoot.textContent
+                        .replace(/\s+/g, " ")
+                        .trim();
+
+                    // disconnecting notifies isConnected, which reaches the fallback
+                    // subscription, before the view unbinds.
+                    element.remove();
+                    await Updates.next();
+                    // let any asynchronously rethrown queue error surface.
+                    await new Promise(resolve => setTimeout(resolve, 0));
+
+                    return { errors, textWhileHidden };
+                } finally {
+                    window.removeEventListener("error", handler);
+                }
+            });
+
+            expect(result.errors).toEqual([]);
+            expect(result.textWhileHidden).toBe("");
+        });
+
+        test("renders again after the guard turns back on", async ({ page }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    FASTElement,
+                    html,
+                    observable,
+                    repeat,
+                    uniqueElementName,
+                    Updates,
+                } =
+                    // @ts-expect-error: Client module.
+                    await import("/main.js");
+
+                class TestElement extends FASTElement {
+                    showList = false;
+                    items!: any[];
+                }
+
+                observable(TestElement.prototype, "items");
+
+                const name = uniqueElementName();
+                await TestElement.define({
+                    name,
+                    template: html`
+                        ${repeat(
+                            (x: any) => x.showList && x.items,
+                            html`
+                                <span>${(x: any) => x}</span>
+                            `,
+                        )}
+                    `,
+                });
+
+                const element = document.createElement(name) as any;
+                element.items = ["a"];
+                document.body.appendChild(element);
+                await Updates.next();
+
+                const initialText = element.shadowRoot.textContent
+                    .replace(/\s+/g, " ")
+                    .trim();
+
+                // the items binding short-circuited on the plain guard, so only a
+                // change to an observable on the source can wake it back up.
+                element.showList = true;
+                element.items = ["a", "b"];
+                await Updates.next();
+
+                const textAfterShow = element.shadowRoot.textContent
+                    .replace(/\s+/g, " ")
+                    .trim();
+
+                element.remove();
+
+                return { initialText, textAfterShow };
+            });
+
+            expect(result.initialText).toBe("");
+            expect(result.textAfterShow).toBe("a b");
+        });
     });
 });

--- a/packages/fast-element/src/templating/repeat.ts
+++ b/packages/fast-element/src/templating/repeat.ts
@@ -199,8 +199,19 @@ export class RepeatBehavior<TSource = any> implements ViewBehavior, Subscriber {
      * Handles changes in the array, its items, and the repeat template.
      * @param source - The source of the change.
      * @param args - The details about what was changed.
+     * @remarks
+     * Guards against stale notifications. An observer with a coupled source lifetime
+     * and a single dependency is not registered as an unbindable, so it can still
+     * hold subscriptions after the view unbinds. Re-binding it here would evaluate
+     * the expression against the unbound view's null source.
      */
     public handleChange(source: any, args: Splice[] | Sort[] | ExpressionObserver): void {
+        // https://github.com/microsoft/fast/issues/7444
+        // This guard will be reconsidered in the next major version.
+        if (!this.controller.isBound) {
+            return;
+        }
+
         if (args === this.itemsBindingObserver) {
             this.items = this.itemsBindingObserver.bind(this.controller);
             this.observeItems();

--- a/packages/fast-element/src/templating/when.pw.spec.ts
+++ b/packages/fast-element/src/templating/when.pw.spec.ts
@@ -163,4 +163,226 @@ test.describe("The 'when' template function", () => {
             expect(result).toBe(true);
         });
     });
+
+    test.describe("with a short-circuited condition", () => {
+        test("renders when an observable short-circuited by && changes", async ({
+            page,
+        }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    FASTElement,
+                    html,
+                    observable,
+                    uniqueElementName,
+                    Updates,
+                    when,
+                } =
+                    // @ts-expect-error: Client module.
+                    await import("/main.js");
+
+                class TestElement extends FASTElement {
+                    ready = false;
+                    show!: boolean;
+
+                    get isReady() {
+                        return this.ready;
+                    }
+                }
+
+                observable(TestElement.prototype, "show");
+
+                const name = uniqueElementName();
+                await TestElement.define({
+                    name,
+                    template: html`
+                        ${when(
+                            (x: any) => x.isReady && x.show,
+                            html`
+                                <span>shown</span>
+                            `,
+                        )}
+                    `,
+                });
+
+                const element = document.createElement(name) as any;
+                element.show = false;
+                document.body.appendChild(element);
+
+                await Updates.next();
+
+                const initialText = element.shadowRoot.textContent.trim();
+
+                element.ready = true;
+                element.show = true;
+                await Updates.next();
+
+                const textAfterShow = element.shadowRoot.textContent.trim();
+
+                element.show = false;
+                await Updates.next();
+
+                const textAfterHide = element.shadowRoot.textContent.trim();
+
+                element.remove();
+
+                return { initialText, textAfterShow, textAfterHide };
+            });
+
+            expect(result.initialText).toBe("");
+            expect(result.textAfterShow).toBe("shown");
+            expect(result.textAfterHide).toBe("");
+        });
+
+        test("survives repeated connect and disconnect cycles", async ({ page }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    FASTElement,
+                    html,
+                    observable,
+                    uniqueElementName,
+                    Updates,
+                    when,
+                } =
+                    // @ts-expect-error: Client module.
+                    await import("/main.js");
+
+                class TestElement extends FASTElement {
+                    ready = false;
+                    show!: boolean;
+
+                    get isReady() {
+                        return this.ready;
+                    }
+                }
+
+                observable(TestElement.prototype, "show");
+
+                const name = uniqueElementName();
+                await TestElement.define({
+                    name,
+                    template: html`
+                        ${when(
+                            (x: any) => x.isReady && x.show,
+                            html`
+                                <span>shown</span>
+                            `,
+                        )}
+                    `,
+                });
+
+                const element = document.createElement(name) as any;
+                element.show = false;
+                document.body.appendChild(element);
+
+                await Updates.next();
+
+                const errors: string[] = [];
+                const texts: string[] = [];
+
+                for (let i = 0; i < 3; i++) {
+                    try {
+                        element.remove();
+                        element.show = true;
+                        await Updates.next();
+
+                        document.body.appendChild(element);
+                        await Updates.next();
+
+                        element.show = false;
+                        await Updates.next();
+
+                        texts.push(element.shadowRoot.textContent.trim());
+                    } catch (e: any) {
+                        errors.push(e.message);
+                    }
+                }
+
+                element.ready = true;
+                element.show = true;
+                await Updates.next();
+
+                const finalText = element.shadowRoot.textContent.trim();
+
+                element.remove();
+
+                return { errors, texts, finalText };
+            });
+
+            expect(result.errors).toEqual([]);
+            expect(result.texts).toEqual(["", "", ""]);
+            expect(result.finalText).toBe("shown");
+        });
+
+        test("does not re-evaluate itself in a loop", async ({ page }) => {
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    FASTElement,
+                    html,
+                    observable,
+                    uniqueElementName,
+                    Updates,
+                    when,
+                } =
+                    // @ts-expect-error: Client module.
+                    await import("/main.js");
+
+                let evaluations = 0;
+
+                class TestElement extends FASTElement {
+                    ready = false;
+                    show!: boolean;
+
+                    get isReady() {
+                        return this.ready;
+                    }
+                }
+
+                observable(TestElement.prototype, "show");
+
+                const condition = (x: any) => {
+                    evaluations++;
+                    return x.isReady && x.show;
+                };
+
+                const name = uniqueElementName();
+                await TestElement.define({
+                    name,
+                    template: html`
+                        ${when(
+                            condition,
+                            html`
+                                <span>shown</span>
+                            `,
+                        )}
+                    `,
+                });
+
+                const element = document.createElement(name) as any;
+                element.show = false;
+                document.body.appendChild(element);
+
+                await Updates.next();
+                await Updates.next();
+                await Updates.next();
+
+                const evaluationsAfterConnect = evaluations;
+
+                await Updates.next();
+                await Updates.next();
+                await Updates.next();
+
+                const evaluationsWhenIdle = evaluations;
+
+                element.remove();
+
+                return { evaluationsAfterConnect, evaluationsWhenIdle };
+            });
+
+            expect(result.evaluationsAfterConnect).toBeLessThanOrEqual(2);
+            expect(result.evaluationsWhenIdle).toBe(result.evaluationsAfterConnect);
+        });
+    });
 });

--- a/sites/website/src/docs/3.x/advanced/reactivity.md
+++ b/sites/website/src/docs/3.x/advanced/reactivity.md
@@ -224,3 +224,22 @@ for (const record of bindingObserver.records()) {
   console.log(record.propertySource, record.propertyName)
 }
 ```
+
+### Short-circuited bindings
+
+A volatile binding re-collects its dependencies every time it is evaluated, and it can short-circuit before it reads any observable at all:
+
+```ts
+class MyClass {
+  isEditing = false; // not observable
+  @observable value: string;
+}
+
+// while isEditing is false, `value` is never read, so it is never observed
+const binding = (x: MyClass) => x.isEditing && x.value;
+```
+
+A binding in this state has no observable dependencies, so nothing could ever cause it to be evaluated again. Instead of leaving it stranded, the binding observer subscribes to the source itself, and any observable change on that source re-evaluates the binding. Two things follow from this:
+
+* `records()` yields nothing for such a binding, because it is not observing a specific property.
+* The subscription is coarse: the binding is re-evaluated on every observable change on the source, not just on the changes it would depend on once it stops short-circuiting. Where that matters, keep the guard observable (`@observable isEditing = false`) so the binding tracks it directly.

--- a/sites/website/src/docs/3.x/resources/export-sizes.md
+++ b/sites/website/src/docs/3.x/resources/export-sizes.md
@@ -19,22 +19,22 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 78.61 KB | 23.40 KB | 20.77 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.11 KB | 7.12 KB | 6.41 KB |
+| CDN Rollup Bundle | 79.12 KB | 23.51 KB | 20.91 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.59 KB | 7.24 KB | 6.51 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 290 B |
-| Observable (@microsoft/fast-element/observable.js) | 6.75 KB | 2.51 KB | 2.23 KB |
-| observable (@microsoft/fast-element/observable.js) | 6.79 KB | 2.52 KB | 2.24 KB |
+| Observable (@microsoft/fast-element/observable.js) | 7.23 KB | 2.62 KB | 2.34 KB |
+| observable (@microsoft/fast-element/observable.js) | 7.26 KB | 2.63 KB | 2.35 KB |
 | attr (@microsoft/fast-element/attr.js) | 477 B | 287 B | 244 B |
 | children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.66 KB |
 | ref (@microsoft/fast-element/ref.js) | 3.84 KB | 1.54 KB | 1.34 KB |
 | slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
-| volatile (@microsoft/fast-element/volatile.js) | 6.84 KB | 2.54 KB | 2.26 KB |
+| volatile (@microsoft/fast-element/volatile.js) | 7.32 KB | 2.65 KB | 2.37 KB |
 | when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 589 B |
-| html (@microsoft/fast-element/html.js) | 27.73 KB | 8.96 KB | 8.02 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 31.80 KB | 10.00 KB | 9.03 KB |
+| html (@microsoft/fast-element/html.js) | 28.21 KB | 9.07 KB | 8.13 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 32.28 KB | 10.12 KB | 9.13 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 46.53 KB | 13.91 KB | 12.49 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.15 KB | 19.46 KB | 17.42 KB |
-| ArrayObserver (@microsoft/fast-element/arrays.js) | 12.55 KB | 4.46 KB | 4.03 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 21.96 KB | 7.73 KB | 6.97 KB |
-| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.31 KB | 5.41 KB | 4.88 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 47.01 KB | 14.04 KB | 12.60 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.63 KB | 19.58 KB | 17.50 KB |
+| ArrayObserver (@microsoft/fast-element/arrays.js) | 13.04 KB | 4.58 KB | 4.12 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 22.45 KB | 7.84 KB | 7.08 KB |
+| attributeMap (@microsoft/fast-element/attribute-map.js) | 15.79 KB | 5.54 KB | 4.99 KB |


### PR DESCRIPTION
## What this does

Fixes a bug where a piece of your UI could quietly stop responding to data — forever — just because of the order you wrote two conditions in.

## Why

Consider a condition like "show this if the feature is on **and** we have a value":

```ts
when(x => x.observableValue && x.plainValue, html`...`)   // works
when(x => x.plainValue && x.observableValue, html`...`)   // silently dead
```

Both read the same, but only the first one keeps working. JavaScript stops evaluating an `&&` as soon as it finds something falsy, so in the second version the observable value is never actually read. FAST tracks what a binding *reads*, so nothing gets tracked, the binding ends up watching nothing at all, and once that happens it can never wake up again.

It is worse than a binding that never works: a binding can start out healthy and go permanently dead the first time the guard is false. There is no error and no warning. Reversing two words in a condition should not silently break your app.

## What changed

- A binding that finishes an evaluation having read no observable data now watches its source object as a whole, so a later change still wakes it. This uses a subscription path that already existed and was simply unused.
- `repeat` binds each item, and items can be plain strings or numbers, so the fallback is guarded to only apply where it is safe.
- A binding that observes nothing no longer reports a phantom dependency record.
- `when`'s handling of a value that arrives while unbound is now covered too.

## Scope

This rescues the "read nothing at all" case, which is the one that dies permanently. A binding that reads *some* of its dependencies (`x => x.tracked && x.getter && x.other`) still tracks only what it read on the last pass — that is existing, intended behavior and is unchanged.

## How to see it

Run the `fast-element` test suite. The new tests in `observation/observable.pw.spec.ts` and `templating/when.pw.spec.ts` assert that both orderings of `&&` produce identical update counts. They fail on `main` and pass here.

Performance was measured, since this touches the code every binding in every FAST app runs through. Benchmarks (`basic`, `when`, `repeat`, in both client-render and hydration) were run interleaved against `main` across multiple rounds: all differences fell inside the harness's own round-to-round noise. The added cost on the common path is a single field read and comparison, which short-circuits before any new work.

Fixes #7035
