### PR TITLE
fix: release repeat views when the host disconnects

### DIFF
--- a/change/@microsoft-fast-element-7144a1b2-3c4d-4e5f-8a9b-0c1d2e3f4a5b.json
+++ b/change/@microsoft-fast-element-7144a1b2-3c4d-4e5f-8a9b-0c1d2e3f4a5b.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: stop repeat from resurrecting pre-disconnect views when its host reconnects",
+  "packageName": "@microsoft/fast-element",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/SIZES.md
+++ b/packages/fast-element/SIZES.md
@@ -4,7 +4,7 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 78.61 KB | 23.40 KB | 20.77 KB |
+| CDN Rollup Bundle | 79.11 KB | 23.49 KB | 20.87 KB |
 | FASTElement (@microsoft/fast-element/fast-element.js) | 23.11 KB | 7.12 KB | 6.41 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 290 B |
 | Observable (@microsoft/fast-element/observable.js) | 6.75 KB | 2.51 KB | 2.23 KB |
@@ -15,11 +15,11 @@ Bundle sizes for `@microsoft/fast-element` exports.
 | slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
 | volatile (@microsoft/fast-element/volatile.js) | 6.84 KB | 2.54 KB | 2.26 KB |
 | when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 589 B |
-| html (@microsoft/fast-element/html.js) | 27.73 KB | 8.96 KB | 8.02 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 31.80 KB | 10.00 KB | 9.03 KB |
+| html (@microsoft/fast-element/html.js) | 27.85 KB | 8.97 KB | 8.03 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 32.29 KB | 10.10 KB | 9.11 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 46.53 KB | 13.91 KB | 12.49 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.15 KB | 19.46 KB | 17.42 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 46.65 KB | 13.93 KB | 12.50 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.64 KB | 19.56 KB | 17.52 KB |
 | ArrayObserver (@microsoft/fast-element/arrays.js) | 12.55 KB | 4.46 KB | 4.03 KB |
 | observerMap (@microsoft/fast-element/observer-map.js) | 21.96 KB | 7.73 KB | 6.97 KB |
 | attributeMap (@microsoft/fast-element/attribute-map.js) | 15.31 KB | 5.41 KB | 4.88 KB |

--- a/packages/fast-element/docs/api-report.api.md
+++ b/packages/fast-element/docs/api-report.api.md
@@ -671,6 +671,8 @@ export class HTMLView<TSource = any, TParent = any> extends DefaultExecutionCont
     isBound: boolean;
     isHydrated: Promise<boolean>;
     isPrerendered: Promise<boolean>;
+    // @internal
+    isUnbinding: boolean;
     lastChild: Node;
     // (undocumented)
     onUnbind(behavior: {
@@ -917,7 +919,7 @@ export class RepeatBehavior<TSource = any> implements ViewBehavior, Subscriber {
     constructor(directive: RepeatDirective);
     bind(controller: ViewController): void;
     handleChange(source: any, args: Splice[] | Sort[] | ExpressionObserver): void;
-    unbind(): void;
+    unbind(controller: ViewController): void;
     // @internal (undocumented)
     views: SyntheticView[];
 }
@@ -1252,6 +1254,8 @@ export type ViewBehaviorTargets = {
 export interface ViewController<TSource = any, TParent = any> extends ExpressionController<TSource, TParent> {
     readonly isHydrated?: Promise<boolean>;
     readonly isPrerendered?: Promise<boolean>;
+    // @internal
+    readonly isUnbinding?: boolean;
     // @internal
     readonly _skipAttrUpdates?: boolean;
     readonly targets: ViewBehaviorTargets;

--- a/packages/fast-element/docs/declarative/api-report.api.md
+++ b/packages/fast-element/docs/declarative/api-report.api.md
@@ -251,6 +251,8 @@ export class HTMLView<TSource = any, TParent = any> extends DefaultExecutionCont
     isBound: boolean;
     isHydrated: Promise<boolean>;
     isPrerendered: Promise<boolean>;
+    // @internal
+    isUnbinding: boolean;
     lastChild: Node;
     // (undocumented)
     onUnbind(behavior: {

--- a/packages/fast-element/src/templating/html-directive.ts
+++ b/packages/fast-element/src/templating/html-directive.ts
@@ -34,6 +34,14 @@ export interface ViewController<TSource = any, TParent = any>
     readonly _skipAttrUpdates?: boolean;
 
     /**
+     * When true, the controller is being torn down rather than
+     * rebound to a new source. Behaviors that own DOM or child
+     * views use this to know when those resources can be released.
+     * @internal
+     */
+    readonly isUnbinding?: boolean;
+
+    /**
      * Resolves `true` when the view's host element had prerendered
      * content (existing shadow root).
      */

--- a/packages/fast-element/src/templating/hydration-view.ts
+++ b/packages/fast-element/src/templating/hydration-view.ts
@@ -109,6 +109,14 @@ export class HydrationView<TSource = any, TParent = any>
     public context: ExecutionContext<any> = this;
     public source: TSource | null = null;
     public isBound = false;
+
+    /**
+     * Indicates that the view is being torn down rather than rebound to a new
+     * source. Behaviors that own DOM or child views consult this to know when
+     * those resources can be released.
+     * @internal
+     */
+    public isUnbinding = false;
     public get hydrationStage() {
         return this._hydrationStage;
     }
@@ -300,7 +308,9 @@ export class HydrationView<TSource = any, TParent = any>
             return;
         }
 
+        this.isUnbinding = true;
         this.evaluateUnbindables();
+        this.isUnbinding = false;
 
         this.source = null;
         this.context = this;

--- a/packages/fast-element/src/templating/repeat-reconnect.pw.spec.ts
+++ b/packages/fast-element/src/templating/repeat-reconnect.pw.spec.ts
@@ -1,0 +1,556 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Coverage for https://github.com/microsoft/fast/issues/7144
+ *
+ * When a host element that owns a repeat is disconnected and later reconnected,
+ * the repeat must not resurrect the views it rendered before the disconnect, and
+ * must not evaluate its bindings while it is unbound. It must, however, keep
+ * reusing views when a recycled view is simply rebound to new data -- that is
+ * the hot path for nested repeats and array splices.
+ */
+test.describe("The repeat directive when its host is disconnected and reconnected", () => {
+    test("does not throw a binding error when an items dependency changes while unbound", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const errors = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FASTElement, html, repeat, Observable, Updates } = await import(
+                "/main.js"
+            );
+
+            // The update queue swallows a throwing task and rethrows it from a
+            // `setTimeout(..., 0)`, so the failure only ever surfaces as an
+            // uncaught error a macrotask later. Listen for it, and below, give
+            // that timer a chance to run before asserting.
+            const errors: string[] = [];
+            const onError = (e: ErrorEvent) => {
+                errors.push(String(e.message));
+            };
+            addEventListener("error", onError);
+
+            class Host extends FASTElement {
+                items: any = [{ name: "a" }, { name: "b" }];
+            }
+            Observable.defineProperty(Host.prototype, "items");
+            Host.define({
+                name: "unbound-notification-host",
+                template: html`${repeat(
+                    (x: any) => x.items,
+                    html`<span>${(x: any) => x.name}</span>`,
+                )}`,
+            });
+
+            const from = document.createElement("div");
+            const to = document.createElement("div");
+            document.body.appendChild(from);
+            document.body.appendChild(to);
+
+            const host: any = document.createElement("unbound-notification-host");
+            from.appendChild(host);
+            await Updates.next();
+
+            // The first bind happens inside `render()`, before the element
+            // controller marks the view's source lifetime as coupled, so the
+            // items observer registers itself for unbind. Rebinding the view
+            // once the lifetime *is* coupled makes `requiresUnbind()` false, so
+            // the observer stops registering and keeps its subscription to
+            // `host.items` through every later unbind.
+            to.appendChild(host);
+            await Updates.next();
+
+            host.remove();
+            await Updates.next();
+
+            // The repeat is now unbound with a null source, but still subscribed.
+            // Evaluating `x => x.items` against that null source throws.
+            host.items = [{ name: "x" }];
+            await Updates.next();
+
+            // Let the queue's deferred rethrow actually run.
+            await new Promise(resolve => setTimeout(resolve, 0));
+            await new Promise(resolve => setTimeout(resolve, 0));
+
+            removeEventListener("error", onError);
+
+            return errors;
+        });
+
+        expect(errors).toEqual([]);
+    });
+
+    test("does not connect and immediately disconnect repeated elements when items are cleared while unbound", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const log = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FASTElement, html, repeat, Observable, Updates } = await import(
+                "/main.js"
+            );
+
+            const log: string[] = [];
+
+            class Row extends FASTElement {
+                label: any;
+                connectedCallback() {
+                    super.connectedCallback();
+                    log.push(`connected:${this.label}`);
+                }
+                disconnectedCallback() {
+                    super.disconnectedCallback();
+                    log.push(`disconnected:${this.label}`);
+                }
+            }
+            Observable.defineProperty(Row.prototype, "label");
+            Row.define({ name: "churn-row", template: html`${(x: any) => x.label}` });
+
+            class Host extends FASTElement {
+                items: any = [{ name: "a" }, { name: "b" }];
+                disconnectedCallback() {
+                    super.disconnectedCallback();
+                    this.items = [];
+                }
+            }
+            Observable.defineProperty(Host.prototype, "items");
+            Host.define({
+                name: "churn-host",
+                template: html`${repeat(
+                    (x: any) => x.items,
+                    html`<churn-row :label="${(x: any) => x.name}"></churn-row>`,
+                )}`,
+            });
+
+            const parent = document.createElement("div");
+            document.body.appendChild(parent);
+
+            const host: any = document.createElement("churn-host");
+            parent.appendChild(host);
+            await Updates.next();
+
+            host.remove();
+            await Updates.next();
+
+            log.push("--- reconnect ---");
+            parent.appendChild(host);
+            await Updates.next();
+
+            return log;
+        });
+
+        // Each row connects once and disconnects once. Nothing may happen after
+        // the host comes back: the rows were removed while the host was detached.
+        expect(log).toEqual([
+            "connected:a",
+            "connected:b",
+            "disconnected:a",
+            "disconnected:b",
+            "--- reconnect ---",
+        ]);
+    });
+
+    test("releases the DOM of its views when the host is disconnected", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FASTElement, html, repeat, Observable, Updates } = await import(
+                "/main.js"
+            );
+
+            class Host extends FASTElement {
+                items: any = [{ name: "a" }, { name: "b" }, { name: "c" }];
+            }
+            Observable.defineProperty(Host.prototype, "items");
+            Host.define({
+                name: "release-dom-host",
+                template: html`${repeat(
+                    (x: any) => x.items,
+                    html`<span>${(x: any) => x.name}</span>`,
+                )}`,
+            });
+
+            const parent = document.createElement("div");
+            document.body.appendChild(parent);
+
+            const host: any = document.createElement("release-dom-host");
+            parent.appendChild(host);
+            await Updates.next();
+
+            const connected = host.shadowRoot.querySelectorAll("span").length;
+
+            host.remove();
+            await Updates.next();
+
+            const afterUnbind = host.shadowRoot.querySelectorAll("span").length;
+
+            parent.appendChild(host);
+            await Updates.next();
+
+            return {
+                connected,
+                afterUnbind,
+                afterRebind: host.shadowRoot.querySelectorAll("span").length,
+                text: host.shadowRoot.textContent.replace(/\s+/g, ""),
+            };
+        });
+
+        expect(result.connected).toBe(3);
+        expect(result.afterUnbind).toBe(0);
+        expect(result.afterRebind).toBe(3);
+        expect(result.text).toBe("abc");
+    });
+
+    test("reuses the same repeated element instances across a DOM move", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FASTElement, html, repeat, Observable, Updates } = await import(
+                "/main.js"
+            );
+
+            class Row extends FASTElement {
+                label: any;
+            }
+            Observable.defineProperty(Row.prototype, "label");
+            Row.define({ name: "move-row", template: html`${(x: any) => x.label}` });
+
+            class Host extends FASTElement {
+                items: any = [{ name: "a" }, { name: "b" }];
+            }
+            Observable.defineProperty(Host.prototype, "items");
+            Host.define({
+                name: "move-host",
+                template: html`${repeat(
+                    (x: any) => x.items,
+                    html`<move-row :label="${(x: any) => x.name}"></move-row>`,
+                )}`,
+            });
+
+            const from = document.createElement("div");
+            const to = document.createElement("div");
+            document.body.appendChild(from);
+            document.body.appendChild(to);
+
+            const host: any = document.createElement("move-host");
+            from.appendChild(host);
+            await Updates.next();
+
+            const before = Array.from(host.shadowRoot.querySelectorAll("move-row"));
+
+            // A DOM move: disconnect and reconnect in one task.
+            to.appendChild(host);
+            await Updates.next();
+
+            const after = Array.from(host.shadowRoot.querySelectorAll("move-row"));
+
+            return {
+                sameInstances:
+                    before.length === after.length &&
+                    before.every((el, i) => el === after[i]),
+                count: after.length,
+                labels: after.map((el: any) => el.label),
+                allConnected: after.every((el: any) => el.isConnected === true),
+            };
+        });
+
+        expect(result.count).toBe(2);
+        expect(result.sameInstances).toBe(true);
+        expect(result.allConnected).toBe(true);
+        expect(result.labels).toEqual(["a", "b"]);
+    });
+
+    test("renders replacement items when the array changed while unbound", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const text = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FASTElement, html, repeat, Observable, Updates } = await import(
+                "/main.js"
+            );
+
+            class Host extends FASTElement {
+                items: any = [{ name: "a" }, { name: "b" }];
+            }
+            Observable.defineProperty(Host.prototype, "items");
+            Host.define({
+                name: "replaced-items-host",
+                template: html`${repeat(
+                    (x: any) => x.items,
+                    html`<span>${(x: any) => x.name}</span>`,
+                )}`,
+            });
+
+            const parent = document.createElement("div");
+            document.body.appendChild(parent);
+
+            const host: any = document.createElement("replaced-items-host");
+            parent.appendChild(host);
+            await Updates.next();
+
+            host.remove();
+            await Updates.next();
+
+            host.items = [{ name: "x" }, { name: "y" }, { name: "z" }];
+            await Updates.next();
+
+            parent.appendChild(host);
+            await Updates.next();
+
+            return host.shadowRoot.textContent.replace(/\s+/g, "");
+        });
+
+        expect(text).toBe("xyz");
+    });
+
+    test("keeps reusing nested repeat DOM when an outer view is recycled", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FASTElement, html, repeat, Observable, Updates } = await import(
+                "/main.js"
+            );
+
+            const innerTemplate = html`<span>${(x: any) => x}</span>`;
+            const outerTemplate = html`<section>
+                ${repeat((x: any) => x.children, innerTemplate)}
+            </section>`;
+
+            class Host extends FASTElement {
+                groups: any = [{ children: ["a1", "a2"] }, { children: ["b1", "b2"] }];
+            }
+            Observable.defineProperty(Host.prototype, "groups");
+            Host.define({
+                name: "nested-recycle-host",
+                template: html`${repeat((x: any) => x.groups, outerTemplate)}`,
+            });
+
+            const host: any = document.createElement("nested-recycle-host");
+            document.body.appendChild(host);
+            await Updates.next();
+
+            const before = Array.from(host.shadowRoot.querySelectorAll("span"));
+
+            // Recycles the first outer view against a new source. The nested
+            // repeat is unbound and immediately rebound; its DOM must survive.
+            host.groups.splice(0, 1, { children: ["c1", "c2"] });
+            await Updates.next();
+
+            const after = Array.from(host.shadowRoot.querySelectorAll("span"));
+
+            return {
+                reusedNodes:
+                    before.length === after.length &&
+                    before.every((el, i) => el === after[i]),
+                text: host.shadowRoot.textContent.replace(/\s+/g, ""),
+            };
+        });
+
+        expect(result.reusedNodes).toBe(true);
+        expect(result.text).toBe("c1c2b1b2");
+    });
+
+    test("re-renders a nested repeat after the outer array is emptied and refilled", async ({
+        page,
+    }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", e => pageErrors.push(String(e.message ?? e)));
+
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FASTElement, html, repeat, Observable, Updates } = await import(
+                "/main.js"
+            );
+
+            const innerTemplate = html`<span class="item">${(x: any) => x}</span>`;
+            const outerTemplate = html`${repeat((x: any) => x.items, innerTemplate)}`;
+
+            class Host extends FASTElement {
+                groups: any = [{ items: ["a"] }];
+            }
+            Observable.defineProperty(Host.prototype, "groups");
+            Host.define({
+                name: "outer-emptied-host",
+                template: html`<div>
+                    ${repeat((x: any) => x.groups, outerTemplate)}
+                </div>`,
+            });
+
+            const host: any = document.createElement("outer-emptied-host");
+            document.body.appendChild(host);
+            await Updates.next();
+
+            const initial = host.shadowRoot.querySelectorAll(".item").length;
+
+            // Disposing the outer views detaches their nodes before unbinding
+            // them, so the nested repeat must not try to detach that DOM again.
+            host.groups = [];
+            await Updates.next();
+
+            const emptied = host.shadowRoot.querySelectorAll(".item").length;
+
+            host.groups = [{ items: ["b", "c"] }];
+            await Updates.next();
+
+            return {
+                initial,
+                emptied,
+                refilled: host.shadowRoot.querySelectorAll(".item").length,
+                text: host.shadowRoot.textContent.replace(/\s+/g, ""),
+            };
+        });
+
+        expect(pageErrors).toEqual([]);
+        expect(result.initial).toBe(1);
+        expect(result.emptied).toBe(0);
+        expect(result.refilled).toBe(2);
+        expect(result.text).toBe("bc");
+    });
+
+    test("survives an empty repeat, a double unbind, and a rebind", async ({ page }) => {
+        const pageErrors: string[] = [];
+        page.on("pageerror", e => pageErrors.push(String(e.message ?? e)));
+
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { html, repeat, Observable, Updates, Fake, toHTML, removeWhitespace } =
+                await import("/main.js");
+
+            class ViewModel {
+                items: any;
+                constructor(items: any) {
+                    this.items = items;
+                }
+            }
+            Observable.defineProperty(ViewModel.prototype, "items");
+
+            function createController(source: any, targets: any) {
+                const unbindables: any[] = [];
+                return {
+                    isBound: false,
+                    isUnbinding: false,
+                    context: Fake.executionContext(),
+                    onUnbind(object: any) {
+                        unbindables.push(object);
+                    },
+                    source,
+                    targets,
+                    unbind() {
+                        this.isUnbinding = true;
+                        unbindables.forEach(x => x.unbind(this));
+                        this.isUnbinding = false;
+                        this.isBound = false;
+                    },
+                };
+            }
+
+            const results: string[] = [];
+
+            for (const items of [null, undefined, [], [{ name: "a" }]]) {
+                const parent = document.createElement("div");
+                const location = document.createComment("");
+                parent.appendChild(location);
+
+                const directive: any = repeat(
+                    (x: any) => x.items,
+                    html`${(x: any) => x.name}`,
+                );
+                directive.targetNodeId = "r";
+
+                const behavior: any = directive.createBehavior();
+                const vm: any = new ViewModel(items);
+                const controller: any = createController(vm, { r: location });
+
+                behavior.bind(controller);
+                controller.isBound = true;
+                await Updates.next();
+
+                controller.unbind();
+                controller.unbind();
+                await Updates.next();
+
+                // A notification while unbound must be ignored, not evaluated.
+                vm.items = null;
+                await Updates.next();
+
+                behavior.bind(controller);
+                controller.isBound = true;
+                await Updates.next();
+
+                results.push(removeWhitespace(toHTML(parent)));
+            }
+
+            return results;
+        });
+
+        expect(pageErrors).toEqual([]);
+        expect(result).toEqual(["", "", "", ""]);
+    });
+
+    test("reconnects correctly with positioning enabled and recycling disabled", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { FASTElement, html, repeat, Observable, Updates } = await import(
+                "/main.js"
+            );
+
+            class Host extends FASTElement {
+                items: any = ["a", "b", "c"];
+            }
+            Observable.defineProperty(Host.prototype, "items");
+            Host.define({
+                name: "options-host",
+                template: html`${repeat(
+                    (x: any) => x.items,
+                    html`<span>${(x: any, c: any) => `${c.index}:${x}`}</span>`,
+                    { positioning: true, recycle: false },
+                )}`,
+            });
+
+            const parent = document.createElement("div");
+            document.body.appendChild(parent);
+
+            const host: any = document.createElement("options-host");
+            parent.appendChild(host);
+            await Updates.next();
+
+            const before = host.shadowRoot.textContent.replace(/\s+/g, "");
+
+            host.remove();
+            await Updates.next();
+            parent.appendChild(host);
+            await Updates.next();
+
+            return {
+                before,
+                after: host.shadowRoot.textContent.replace(/\s+/g, ""),
+                count: host.shadowRoot.querySelectorAll("span").length,
+            };
+        });
+
+        expect(result.before).toBe("0:a1:b2:c");
+        expect(result.after).toBe("0:a1:b2:c");
+        expect(result.count).toBe(3);
+    });
+});

--- a/packages/fast-element/src/templating/repeat.pw.spec.ts
+++ b/packages/fast-element/src/templating/repeat.pw.spec.ts
@@ -355,8 +355,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -370,6 +374,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     return removeWhitespace(toHTML(parent)) === createOutput(s);
                 }, size);
@@ -445,8 +450,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -472,6 +481,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const posCorrect = expectViewPositionToBeCorrect(behavior);
                     const htmlCorrect =
@@ -558,8 +568,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -572,6 +586,7 @@ test.describe("The repeat", () => {
                     const controller = createController(data, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const before =
                         removeWhitespace(toHTML(parent)) ===
@@ -682,8 +697,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -696,6 +715,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
                     vm.items.push({ name: "newitem" });
 
                     await Updates.next();
@@ -766,8 +786,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -780,6 +804,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
                     vm.items.reverse();
 
                     await Updates.next();
@@ -865,8 +890,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -879,6 +908,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
                     const sortAlgo = (a, b) => b.index - a.index;
                     vm.items.sort(sortAlgo);
 
@@ -979,8 +1009,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -993,6 +1027,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const index = s - 1;
                     vm.items.splice(index, 1);
@@ -1083,8 +1118,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -1097,6 +1136,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.splice(0, 1);
 
@@ -1186,8 +1226,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -1200,6 +1244,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const index = s - 1;
                     vm.items.splice(index, 1, { name: "newitem1" }, { name: "newitem2" });
@@ -1288,8 +1333,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -1314,6 +1363,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
                     const posBefore = expectViewPositionToBeCorrect(behavior);
 
                     const index = s - 1;
@@ -1407,8 +1457,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -1421,6 +1475,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const mid = Math.floor(vm.items.length / 2);
                     vm.items.splice(mid, 1, { name: "newitem1" });
@@ -1513,8 +1568,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -1539,6 +1598,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
                     const posBefore = expectViewPositionToBeCorrect(behavior);
 
                     const mid = Math.floor(vm.items.length / 2);
@@ -1637,8 +1697,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -1651,6 +1715,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const mid = Math.floor(vm.items.length / 2);
                     vm.items.splice(mid, 2, { name: "newitem1" }, { name: "newitem2" });
@@ -1743,8 +1808,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -1759,6 +1828,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const mid = Math.floor(vm.items.length / 2);
                     vm.items.splice(mid, 2, { name: "newitem1" }, { name: "newitem2" });
@@ -1851,8 +1921,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -1876,6 +1950,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const pos1 = expectViewPositionToBeCorrect(behavior);
 
@@ -1970,8 +2045,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -1984,6 +2063,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.splice(0, 1, { name: "newitem1" }, { name: "newitem2" });
 
@@ -2078,8 +2158,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -2095,6 +2179,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const before = removeWhitespace(toHTML(parent)) === createOutput(s);
 
@@ -2169,8 +2254,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -2193,6 +2282,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     const text = removeWhitespace(toHTML(parent));
 
@@ -2281,8 +2371,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -2295,6 +2389,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.shift();
                     vm.items.unshift({ name: "shift" });
@@ -2385,8 +2480,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -2399,6 +2498,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.shift();
                     vm.items.unshift({ name: "shift" }, { name: "shift" });
@@ -2489,8 +2589,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -2503,6 +2607,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.shift();
                     vm.items.unshift({ name: "shift1" }, { name: "shift2" });
@@ -2594,8 +2699,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -2608,6 +2717,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.shift();
                     vm.items.push({ name: "shift3" });
@@ -2698,8 +2808,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -2712,6 +2826,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.push({ name: "shift3" });
                     vm.items.shift();
@@ -2802,8 +2917,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -2816,6 +2935,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.push({ name: "shift3" });
                     vm.items.pop();
@@ -2903,8 +3023,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -2917,6 +3041,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.pop();
                     vm.items.push({ name: "shift3" });
@@ -3007,8 +3132,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -3021,6 +3150,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.pop();
                     vm.items.push({ name: "shift3" });
@@ -3112,8 +3242,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -3126,6 +3260,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.push({ name: "shift3" });
                     vm.items.pop();
@@ -3217,8 +3352,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -3231,6 +3370,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     vm.items.shift();
                     vm.items.shift();
@@ -3328,8 +3468,12 @@ test.describe("The repeat", () => {
                             },
                             source,
                             targets,
+                            isUnbinding: false,
                             unbind() {
+                                this.isUnbinding = true;
                                 unbindables.forEach(x => x.unbind(this));
+                                this.isUnbinding = false;
+                                this.isBound = false;
                             },
                         };
                     }
@@ -3342,6 +3486,7 @@ test.describe("The repeat", () => {
                     const controller = createController(vm, targets);
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     await Updates.next();
 
@@ -3350,6 +3495,7 @@ test.describe("The repeat", () => {
                     await Updates.next();
 
                     behavior.bind(controller);
+                    controller.isBound = true;
 
                     await Updates.next();
 

--- a/packages/fast-element/src/templating/repeat.ts
+++ b/packages/fast-element/src/templating/repeat.ts
@@ -136,6 +136,12 @@ export class RepeatBehavior<TSource = any> implements ViewBehavior, Subscriber {
     private itemsBindingObserver: ExpressionObserver<TSource, any[]>;
     private bindView: typeof bindWithoutPositioning = bindWithoutPositioning;
 
+    /**
+     * Indicates that unbind() moved the views' nodes out of the DOM, so the
+     * next refresh must put them back before reusing them.
+     */
+    private viewsAreDetached: boolean = false;
+
     /** @internal */
     public views: SyntheticView[] = [];
 
@@ -176,6 +182,7 @@ export class RepeatBehavior<TSource = any> implements ViewBehavior, Subscriber {
             isHydratable(controller) &&
             controller.hydrationStage !== HydrationStage.hydrated
         ) {
+            this.viewsAreDetached = false;
             this.hydrateViews(this.template);
         } else {
             this.refreshAllViews();
@@ -186,13 +193,39 @@ export class RepeatBehavior<TSource = any> implements ViewBehavior, Subscriber {
 
     /**
      * Unbinds this behavior.
+     * @param controller - The view controller that manages the lifecycle of this behavior.
      */
-    public unbind(): void {
+    public unbind(controller: ViewController): void {
         if (this.itemsObserver !== null) {
             this.itemsObserver.unsubscribe(this);
+            this.itemsObserver = null;
         }
 
         this.unbindAllViews();
+
+        // A recycled view is unbound and immediately rebound to a new item, so
+        // its views must survive. When the controller is going away instead, they
+        // must not: leaving them in the DOM lets the next bind() resurrect the
+        // pre-disconnect views and then tear them down again from inside the
+        // host's connectedCallback.
+        // https://github.com/microsoft/fast/issues/7144
+        //
+        // A disposing view removes its nodes before it unbinds, so when the
+        // location has no parent an ancestor has already taken this repeat's DOM
+        // and there is nothing left to detach.
+        if (
+            controller.isUnbinding &&
+            !this.viewsAreDetached &&
+            this.location.parentNode !== null
+        ) {
+            const views = this.views;
+
+            for (let i = 0, ii = views.length; i < ii; ++i) {
+                views[i].remove();
+            }
+
+            this.viewsAreDetached = true;
+        }
     }
 
     /**
@@ -201,6 +234,18 @@ export class RepeatBehavior<TSource = any> implements ViewBehavior, Subscriber {
      * @param args - The details about what was changed.
      */
     public handleChange(source: any, args: Splice[] | Sort[] | ExpressionObserver): void {
+        // An items observer whose source lifetime is coupled to the controller's
+        // does not register itself for unbind, so it keeps its subscription to the
+        // source while this behavior is unbound. Evaluating the expression here
+        // would run it against the controller's nulled-out source and throw.
+        // The same guard, for the same reason, is applied in
+        // HTMLBindingDirective.handleChange and RenderBehavior.handleChange.
+        // https://github.com/microsoft/fast/issues/7144
+        // This guard will be reconsidered in the next major version.
+        if (!this.controller.isBound) {
+            return;
+        }
+
         if (args === this.itemsBindingObserver) {
             this.items = this.itemsBindingObserver.bind(this.controller);
             this.observeItems();
@@ -335,13 +380,25 @@ export class RepeatBehavior<TSource = any> implements ViewBehavior, Subscriber {
         const location = this.location;
         const bindView = this.bindView;
         const controller = this.controller;
+        // unbind() takes the views out of the DOM, so they are neither contiguous
+        // nor attached until this refresh puts them back.
+        const detached = this.viewsAreDetached;
         let itemsLength = items.length;
         let views = this.views;
         let viewsLength = views.length;
 
+        this.viewsAreDetached = false;
+
         if (itemsLength === 0 || templateChanged || !this.directive.options.recycle) {
             // all views need to be removed
-            HTMLView.disposeContiguousBatch(views);
+            if (detached) {
+                for (let i = 0; i < viewsLength; ++i) {
+                    views[i].dispose();
+                }
+            } else {
+                HTMLView.disposeContiguousBatch(views);
+            }
+
             viewsLength = 0;
         }
 
@@ -384,6 +441,10 @@ export class RepeatBehavior<TSource = any> implements ViewBehavior, Subscriber {
                         );
                     }
                     bindView(view, items, i, controller);
+
+                    if (detached) {
+                        view.insertBefore(location);
+                    }
                 } else {
                     const view = template.create();
                     bindView(view, items, i, controller);

--- a/packages/fast-element/src/templating/view.ts
+++ b/packages/fast-element/src/templating/view.ts
@@ -230,6 +230,14 @@ export class HTMLView<TSource = any, TParent = any>
     public isBound = false;
 
     /**
+     * Indicates that the view is being torn down rather than rebound to a new
+     * source. Behaviors that own DOM or child views consult this to know when
+     * those resources can be released.
+     * @internal
+     */
+    public isUnbinding = false;
+
+    /**
      * Indicates how the source's lifetime relates to the controller's lifetime.
      */
     readonly sourceLifetime: SourceLifetime = SourceLifetime.unknown;
@@ -413,7 +421,10 @@ export class HTMLView<TSource = any, TParent = any>
             return;
         }
 
+        this.isUnbinding = true;
         this.evaluateUnbindables();
+        this.isUnbinding = false;
+
         this.source = null;
         this.context = this;
         this.isBound = false;

--- a/sites/website/src/docs/3.x/api/fast-element.repeatbehavior.md
+++ b/sites/website/src/docs/3.x/api/fast-element.repeatbehavior.md
@@ -106,7 +106,7 @@ Handles changes in the array, its items, and the repeat template.
 </td></tr>
 <tr><td>
 
-[unbind()](../fast-element.repeatbehavior.unbind/)
+[unbind(controller)](../fast-element.repeatbehavior.unbind/)
 
 
 </td><td>

--- a/sites/website/src/docs/3.x/api/fast-element.repeatbehavior.unbind.md
+++ b/sites/website/src/docs/3.x/api/fast-element.repeatbehavior.unbind.md
@@ -20,8 +20,45 @@ Unbinds this behavior.
 **Signature:**
 
 ```typescript
-unbind(): void;
+unbind(controller: ViewController): void;
 ```
+
+## Parameters
+
+<table><thead><tr><th>
+
+Parameter
+
+
+</th><th>
+
+Type
+
+
+</th><th>
+
+Description
+
+
+</th></tr></thead>
+<tbody><tr><td>
+
+controller
+
+
+</td><td>
+
+[ViewController](../fast-element.viewcontroller/)
+
+
+</td><td>
+
+The view controller that manages the lifecycle of this behavior.
+
+
+</td></tr>
+</tbody></table>
+
 **Returns:**
 
 void

--- a/sites/website/src/docs/3.x/resources/export-sizes.md
+++ b/sites/website/src/docs/3.x/resources/export-sizes.md
@@ -19,7 +19,7 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 78.61 KB | 23.40 KB | 20.77 KB |
+| CDN Rollup Bundle | 79.11 KB | 23.49 KB | 20.87 KB |
 | FASTElement (@microsoft/fast-element/fast-element.js) | 23.11 KB | 7.12 KB | 6.41 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 290 B |
 | Observable (@microsoft/fast-element/observable.js) | 6.75 KB | 2.51 KB | 2.23 KB |
@@ -30,11 +30,11 @@ Bundle sizes for `@microsoft/fast-element` exports.
 | slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
 | volatile (@microsoft/fast-element/volatile.js) | 6.84 KB | 2.54 KB | 2.26 KB |
 | when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 589 B |
-| html (@microsoft/fast-element/html.js) | 27.73 KB | 8.96 KB | 8.02 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 31.80 KB | 10.00 KB | 9.03 KB |
+| html (@microsoft/fast-element/html.js) | 27.85 KB | 8.97 KB | 8.03 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 32.29 KB | 10.10 KB | 9.11 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
-| enableHydration (@microsoft/fast-element/hydration.js) | 46.53 KB | 13.91 KB | 12.49 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.15 KB | 19.46 KB | 17.42 KB |
+| enableHydration (@microsoft/fast-element/hydration.js) | 46.65 KB | 13.93 KB | 12.50 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.64 KB | 19.56 KB | 17.52 KB |
 | ArrayObserver (@microsoft/fast-element/arrays.js) | 12.55 KB | 4.46 KB | 4.03 KB |
 | observerMap (@microsoft/fast-element/observer-map.js) | 21.96 KB | 7.73 KB | 6.97 KB |
 | attributeMap (@microsoft/fast-element/attribute-map.js) | 15.31 KB | 5.41 KB | 4.88 KB |


### PR DESCRIPTION
## What this does

Fixes a list (`repeat`) that comes back wrong after its component is taken out of the page and put back — which is what happens on a route change, a tab switch, or any time the DOM is moved.

## Why

When a component was removed from the page, `repeat` let go of its data but kept its rendered rows. So when the component came back, it reused those stale rows instead of rebuilding them.

Two things went wrong as a result:

- If the list data changed while the component was away, you got errors from bindings pointing at data that no longer existed.
- Every row in the list fired its "disconnected" lifecycle callback **twice**, and both times before the parent's "connected" callback — the kind of ordering bug that is nearly impossible to attribute to its cause.

## What changed
<img width="1920" height="1730" alt="01-before-bug" src="https://github.com/user-attachments/assets/da775700-6e43-4ef7-86a5-7467ae7d9fe0" />
<img width="1920" height="1652" alt="02-after-fixed" src="https://github.com/user-attachments/assets/838d63b2-8c1e-4353-b772-6c0d2541d1a4" />


- When a list is genuinely being torn down, its rows' DOM is now parked and restored on the way back, rather than left dangling. Element instances and their state survive a DOM move.
- A list that is simply being handed new data (the recycling path used by nested lists) is untouched, so the fast path stays fast.
- Notifications that arrive while a list is detached are now ignored, matching the guards that already exist on the other view behaviors.

## How to see it

Run the `fast-element` test suite. `templating/repeat-reconnect.pw.spec.ts` is new: it removes a component containing a list, changes the data, puts it back, and asserts the rows are rebuilt rather than resurrected. Those tests fail on `main`.

Performance was measured, because this is a hot path. Every steady-state scenario — create, reuse, splice, and the nested-recycle case that a naive version of this fix would have wrecked — comes out at parity with `main`. The added cost lands only on disconnect and reconnect (roughly 0.2 ms for a 500-row list per full cycle), which is not a per-frame path, and it is the price of actually taking the DOM out while detached. In the scenario this issue describes, the fixed version is likely faster, since `main` currently resurrects rows and then tears them down again.

## Note for reviewers

`RepeatBehavior.unbind()` now takes the controller, and views carry an internal `isUnbinding` flag. That flag is what distinguishes "this controller is going away" from "this view is being recycled with new data" — without it, teardown would rebuild every nested list's DOM on every recycled row, which would be a real regression.

Fixes #7144
