### PR TITLE
fix: detect array length drift so cleared arrays re-render

### DIFF
--- a/change/@microsoft-fast-element-43aa89bd-1e3a-4030-a62c-55960630a639.json
+++ b/change/@microsoft-fast-element-43aa89bd-1e3a-4030-a62c-55960630a639.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Deliver an array reset when an array's length is changed without a tracked mutation (e.g. `array.length = 0`), so repeat no longer renders stale items, and react to reset splices in the observer map so items added during such a change are still made observable.",
+  "packageName": "@microsoft/fast-element",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/SIZES.md
+++ b/packages/fast-element/SIZES.md
@@ -4,7 +4,7 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 78.61 KB | 23.40 KB | 20.77 KB |
+| CDN Rollup Bundle | 78.91 KB | 23.47 KB | 20.86 KB |
 | FASTElement (@microsoft/fast-element/fast-element.js) | 23.11 KB | 7.12 KB | 6.41 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 290 B |
 | Observable (@microsoft/fast-element/observable.js) | 6.75 KB | 2.51 KB | 2.23 KB |
@@ -16,10 +16,10 @@ Bundle sizes for `@microsoft/fast-element` exports.
 | volatile (@microsoft/fast-element/volatile.js) | 6.84 KB | 2.54 KB | 2.26 KB |
 | when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 589 B |
 | html (@microsoft/fast-element/html.js) | 27.73 KB | 8.96 KB | 8.02 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 31.80 KB | 10.00 KB | 9.03 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 32.09 KB | 10.10 KB | 9.08 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
 | enableHydration (@microsoft/fast-element/hydration.js) | 46.53 KB | 13.91 KB | 12.49 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.15 KB | 19.46 KB | 17.42 KB |
-| ArrayObserver (@microsoft/fast-element/arrays.js) | 12.55 KB | 4.46 KB | 4.03 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 21.96 KB | 7.73 KB | 6.97 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.44 KB | 19.54 KB | 17.50 KB |
+| ArrayObserver (@microsoft/fast-element/arrays.js) | 12.84 KB | 4.56 KB | 4.11 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 22.04 KB | 7.74 KB | 6.99 KB |
 | attributeMap (@microsoft/fast-element/attribute-map.js) | 15.31 KB | 5.41 KB | 4.88 KB |

--- a/packages/fast-element/src/components/hydration.pw.spec.ts
+++ b/packages/fast-element/src/components/hydration.pw.spec.ts
@@ -634,6 +634,159 @@ test.describe("The prerendered content optimization", () => {
         expect(result.spanCount).toBe(1);
     });
 
+    test("should hydrate a repeat whose array has a pending untracked length change", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const errors: string[] = [];
+        page.on("pageerror", error => errors.push(error.message));
+
+        const element = await page.evaluateHandle(async () => {
+            const {
+                ArrayObserver,
+                enableHydration,
+                FASTElement,
+                FASTElementDefinition,
+                html,
+                Observable,
+                repeat,
+                uniqueElementName,
+                // @ts-expect-error: Client module.
+            } = await import("/main.js");
+
+            enableHydration();
+            ArrayObserver.enable();
+            const name = uniqueElementName();
+
+            const items = ["one", "two", "three"];
+
+            class TestElement extends FASTElement {
+                items = items;
+
+                static definition = {
+                    name,
+                    template: html<TestElement>`
+                        ${repeat((x: { items: any }) => x.items, html<string>`<span>${(x: any) => x}</span>`)}
+                    `,
+                };
+            }
+
+            await (await FASTElementDefinition.compose(TestElement)).define();
+
+            // Leave a drift pending against the array before the repeat ever binds.
+            // RepeatBehavior.bind() -> observeItems(true) -> subscribe() -> flush()
+            // drains it while the repeat is still outside the subscriber set, so the
+            // repeat must survive on what hydrateViews() finds in the DOM alone.
+            Observable.getNotifier(items);
+            items.length = 0;
+            items.push("only");
+
+            const container = document.createElement("div");
+            document.body.appendChild(container);
+            (container as any).setHTMLUnsafe(
+                `<${name}><template shadowrootmode="open"><!--fe:b--><!--fe:r--><span><!--fe:b-->server-one<!--fe:/b--></span><!--fe:/r--><!--fe:r--><span><!--fe:b-->server-two<!--fe:/b--></span><!--fe:/r--><!--fe:r--><span><!--fe:b-->server-three<!--fe:/b--></span><!--fe:/r--><!--fe:/b--></template></${name}>`,
+            );
+
+            return container.firstElementChild;
+        });
+
+        const result = await element.evaluate(async (element: any) => {
+            await element.$fastController.isHydrated;
+            await new Promise(resolve => requestAnimationFrame(resolve));
+
+            return {
+                text: element.shadowRoot?.textContent?.replace(/\s+/g, "") ?? "",
+                spanCount: element.shadowRoot?.querySelectorAll("span").length ?? 0,
+            };
+        });
+
+        expect(errors).toEqual([]);
+        expect(result.text).toBe("only");
+        expect(result.spanCount).toBe(1);
+    });
+
+    test("should not reset prerendered repeat views for a tracked mutation", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const element = await page.evaluateHandle(async () => {
+            const {
+                enableHydration,
+                FASTElement,
+                FASTElementDefinition,
+                html,
+                repeat,
+                uniqueElementName,
+                // @ts-expect-error: Client module.
+            } = await import("/main.js");
+
+            enableHydration();
+            const name = uniqueElementName();
+
+            class TestElement extends FASTElement {
+                items = ["one", "two", "three"];
+
+                static definition = {
+                    name,
+                    template: html<TestElement>`
+                        ${repeat(
+                            (x: { items: any }) => x.items,
+                            html<string>`<span>${(x: any) => x}</span>`,
+                            // recycle: false forces refreshAllViews() to dispose every
+                            // view and rebuild it from the template. Under the default
+                            // (recycle: true) a reset of a non-empty array quietly
+                            // rebinds the existing views in place, so the prerendered
+                            // nodes would survive a reset and the assertions below
+                            // could not tell a reset from an incremental splice.
+                            { recycle: false },
+                        )}
+                    `,
+                };
+            }
+
+            await (await FASTElementDefinition.compose(TestElement)).define();
+
+            const container = document.createElement("div");
+            document.body.appendChild(container);
+            // The prerendered spans carry an attribute the template never renders, so
+            // it survives only for as long as the original DOM does.
+            (container as any).setHTMLUnsafe(
+                `<${name}><template shadowrootmode="open"><!--fe:b--><!--fe:r--><span data-ssr><!--fe:b-->one<!--fe:/b--></span><!--fe:/r--><!--fe:r--><span data-ssr><!--fe:b-->two<!--fe:/b--></span><!--fe:/r--><!--fe:r--><span data-ssr><!--fe:b-->three<!--fe:/b--></span><!--fe:/r--><!--fe:/b--></template></${name}>`,
+            );
+
+            return container.firstElementChild;
+        });
+
+        const result = await element.evaluate(async (element: any) => {
+            await element.$fastController.isHydrated;
+            await new Promise(resolve => requestAnimationFrame(resolve));
+
+            // A tracked mutation. It queues a splice, so the flush runs the length
+            // compare for real: the predicted length (3 + 1) has to match the actual
+            // length (4) or drift detection wrongly reports a reset. A reset would run
+            // refreshAllViews(), and with recycle: false that disposes all three
+            // prerendered views and rebuilds four fresh ones from the template —
+            // dropping every data-ssr attribute. An incremental splice creates exactly
+            // one new view and leaves the prerendered DOM alone.
+            element.items.push("four");
+
+            await new Promise(resolve => requestAnimationFrame(resolve));
+
+            return {
+                text: element.shadowRoot?.textContent?.replace(/\s+/g, "") ?? "",
+                spanCount: element.shadowRoot?.querySelectorAll("span").length ?? 0,
+                prerenderedCount:
+                    element.shadowRoot?.querySelectorAll("span[data-ssr]").length ?? 0,
+            };
+        });
+
+        expect(result.text).toBe("onetwothreefour");
+        expect(result.spanCount).toBe(4);
+        expect(result.prerenderedCount).toBe(3);
+    });
+
     test("HydrationBindingError emits a minimal message when the debugger is not installed", async ({
         page,
     }) => {

--- a/packages/fast-element/src/declarative/observer-map-array.pw.spec.ts
+++ b/packages/fast-element/src/declarative/observer-map-array.pw.spec.ts
@@ -1,0 +1,135 @@
+import { expect, test } from "@playwright/test";
+
+/**
+ * Sets up an ObserverMap over `{ items: Item[] }`, applies `mutate` to the observed
+ * array, waits a tick, and reports what the observer map did with the change.
+ */
+async function observeArrayMutation(
+    page: import("@playwright/test").Page,
+    mutation: "resetByLengthDrift" | "push",
+) {
+    await page.goto("/");
+
+    return await page.evaluate(async (mutation: string) => {
+        const {
+            ArrayObserver,
+            conditionalTimeout,
+            defsPropertyName,
+            Observable,
+            ObserverMap,
+            Schema,
+            schemaRegistry,
+            Updates,
+            // @ts-expect-error: Client module.
+        } = await import("/main.js");
+
+        ArrayObserver.enable();
+
+        const elementName = `observer-map-array-${mutation}`;
+        const schema = new Schema(elementName);
+        const schemaMap = schemaRegistry.get(elementName);
+
+        schemaMap.set("someData", {
+            $schema: "https://json-schema.org/draft/2019-09/schema",
+            $id: `https://fast.design/schemas/${elementName}/someData.json`,
+            type: "object",
+            properties: {
+                items: {
+                    type: "array",
+                    items: { $ref: "#/$defs/Item" },
+                },
+            },
+            [defsPropertyName]: {
+                Item: {
+                    $fast_context: "items",
+                    $fast_parent_contexts: ["someData"],
+                    type: "object",
+                    properties: {
+                        name: { type: "string" },
+                    },
+                },
+            },
+        });
+
+        class TestClass {
+            public someData: any;
+        }
+
+        new ObserverMap(TestClass.prototype, schema).defineProperties();
+
+        const instance = new TestClass();
+        instance.someData = { items: [{ name: "first" }] };
+
+        const rootNotifications: string[] = [];
+        Observable.getNotifier(instance).subscribe(
+            {
+                handleChange(_source: any, propertyName: string) {
+                    rootNotifications.push(propertyName);
+                },
+            },
+            "someData",
+        );
+
+        const items = instance.someData.items;
+
+        if (mutation === "resetByLengthDrift") {
+            // `length = 0` records no splice, so the queued push cannot describe the
+            // array's real contents and the observer falls back to a reset.
+            items.length = 0;
+        }
+
+        items.push({ name: "second" });
+
+        await Promise.race([
+            Updates.next(),
+            conditionalTimeout(rootNotifications.length > 0),
+        ]);
+
+        const pushed = instance.someData.items[instance.someData.items.length - 1];
+        const itemNotifications: string[] = [];
+
+        Observable.getNotifier(pushed).subscribe(
+            {
+                handleChange(_source: any, propertyName: string) {
+                    itemNotifications.push(propertyName);
+                },
+            },
+            "name",
+        );
+
+        pushed.name = "changed";
+
+        return {
+            isObservable: Observable.getAccessors(pushed).some(
+                (accessor: any) => accessor.name === "name",
+            ),
+            rootNotifications,
+            itemNotifications,
+        };
+    }, mutation);
+}
+
+test.describe("The observer map's array observation", () => {
+    test("makes pushed items observable and notifies the root property", async ({
+        page,
+    }) => {
+        // The tracked-splice baseline the reset path has to match.
+        const result = await observeArrayMutation(page, "push");
+
+        expect(result.isObservable).toBe(true);
+        expect(result.rootNotifications).toEqual(["someData"]);
+        expect(result.itemNotifications).toEqual(["name"]);
+    });
+
+    test("makes items observable and notifies the root property when an untracked length change forces a reset", async ({
+        page,
+    }) => {
+        // A reset splice carries `addedCount === 0`, so an observer map that only
+        // reacts to additions would silently leave the new item unobservable.
+        const result = await observeArrayMutation(page, "resetByLengthDrift");
+
+        expect(result.isObservable).toBe(true);
+        expect(result.rootNotifications).toEqual(["someData"]);
+        expect(result.itemNotifications).toEqual(["name"]);
+    });
+});

--- a/packages/fast-element/src/declarative/observer-map-utilities.ts
+++ b/packages/fast-element/src/declarative/observer-map-utilities.ts
@@ -283,6 +283,29 @@ function isSameArrayObserverContext(
     );
 }
 
+function proxyArrayItemRange(
+    registration: ArrayObserverRegistration,
+    subject: any,
+    startIndex: number,
+    endIndex: number,
+): void {
+    for (let i = endIndex - 1; i >= startIndex; i--) {
+        const item = subject[i];
+        const originalItem = Object.assign({}, item);
+
+        assignProxyToItemsInArray(
+            item,
+            originalItem,
+            registration.schema,
+            registration.rootSchema,
+            registration.target,
+            registration.rootProperty,
+        );
+
+        Object.assign(item, originalItem);
+    }
+}
+
 function handleArrayChange(
     registration: ArrayObserverRegistration,
     subject: any,
@@ -296,23 +319,24 @@ function handleArrayChange(
     const schemaProperties = getSchemaProperties(registration.schema);
 
     args.forEach((arg: any) => {
-        if (arg.addedCount > 0) {
+        if (arg.reset) {
+            // A reset carries no index or addedCount: the array observer is telling
+            // us it cannot describe what changed, so every item has to be treated as
+            // new. Skipping this leaves items added during the resetting tick without
+            // observable accessors, and later edits to them go unnoticed.
             if (schemaProperties) {
-                for (let i = arg.addedCount - 1; i >= 0; i--) {
-                    const item = subject[arg.index + i];
-                    const originalItem = Object.assign({}, item);
+                proxyArrayItemRange(registration, subject, 0, subject.length);
+            }
 
-                    assignProxyToItemsInArray(
-                        item,
-                        originalItem,
-                        registration.schema,
-                        registration.rootSchema,
-                        registration.target,
-                        registration.rootProperty,
-                    );
-
-                    Object.assign(item, originalItem);
-                }
+            notifyArrayRegistration(registration);
+        } else if (arg.addedCount > 0) {
+            if (schemaProperties) {
+                proxyArrayItemRange(
+                    registration,
+                    subject,
+                    arg.index,
+                    arg.index + arg.addedCount,
+                );
             }
 
             notifyArrayRegistration(registration);

--- a/packages/fast-element/src/observation/arrays.pw.spec.ts
+++ b/packages/fast-element/src/observation/arrays.pw.spec.ts
@@ -630,6 +630,982 @@ test.describe("The ArrayObserver", () => {
     });
 });
 
+// An array's `length` is a non-configurable own property, so array observation cannot
+// trap it. Mutations such as `array.length = 0` therefore record no splices. The
+// observer detects the resulting length drift at flush time and converts the whole
+// change set into a reset.
+test.describe("The ArrayObserver with untracked length changes", () => {
+    test("delivers a reset when the array is cleared with length = 0 and then refilled", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3, 4, 5];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array.length = 0;
+            array.push("new");
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["RESET"]);
+    });
+
+    test("delivers a reset when an untracked truncation follows a tracked mutation", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const { notifications, length } = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                lengthOf,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3, 4, 5];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array.push("new");
+            array.length = 0;
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return { notifications, length: lengthOf(array) };
+        });
+
+        expect(notifications).toEqual(["RESET"]);
+        expect(length).toBe(0);
+    });
+
+    test("delivers a reset when length is truncated to a non-zero value", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3, 4, 5];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array.length = 2;
+            array.push("new");
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["RESET"]);
+    });
+
+    test("delivers a reset when length grows, creating holes", async ({ page }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array.length = 5;
+            array.push("new");
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["RESET"]);
+    });
+
+    test("delivers a reset for an out-of-bounds index write", async ({ page }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3, 4, 5];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array[10] = "x";
+            array.push("new");
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["RESET"]);
+    });
+
+    test("delivers a reset rather than a sort when a sort accompanies drift", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [3, 1, 2];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array.length = 1;
+            array.sort();
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["RESET"]);
+    });
+
+    test("delivers exactly one reset for several untracked and tracked changes in a tick", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3, 4, 5];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array.length = 3;
+            array.push("a");
+            array.length = 1;
+            array.push("b");
+            array.unshift("c");
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["RESET"]);
+    });
+
+    test("returns to incremental splices on the ticks following a reset", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3, 4, 5];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            // Tick one: drift, so a reset.
+            array.length = 1;
+            array.push("a");
+            await Updates.next();
+
+            // Tick two: a plain tracked mutation, so an incremental splice. A broken
+            // implementation leaves the baseline stale here and resets forever.
+            array.push("b");
+            await Updates.next();
+
+            // Tick three: likewise.
+            array.pop();
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 2),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["RESET", "spl(i=2,-0,+1)", "spl(i=2,-1,+0)"]);
+    });
+
+    test("routes the reset through a custom SpliceStrategy's normalize", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                Splice,
+                SpliceStrategy,
+                Updates,
+                // @ts-expect-error: Client module.
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            // A strategy that owns its own reset payload. `support: reset` strategies
+            // are free to record splices purely as bookkeeping markers, so the drift
+            // path must hand the reset back to normalize() rather than short-circuit
+            // to the built-in reset splices.
+            const customReset = new Splice(0, [], 0);
+            customReset.reset = true;
+            (customReset as any).customMarker = true;
+
+            SpliceStrategy.setDefaultStrategy({
+                support: 1,
+                normalize(previous: any, current: any, changes: any) {
+                    return previous === void 0 ? (changes ?? []) : [customReset];
+                },
+                pop: (array: any, o: any, pop: any, args: any) => pop.apply(array, args),
+                push(array: any, observer: any, push: any, args: any) {
+                    const result = push.apply(array, args);
+                    observer.addSplice(
+                        new Splice(array.length - args.length, [], args.length),
+                    );
+                    return result;
+                },
+                reverse: (array: any, o: any, reverse: any, args: any) =>
+                    reverse.apply(array, args),
+                shift: (array: any, o: any, shift: any, args: any) =>
+                    shift.apply(array, args),
+                sort: (array: any, o: any, sort: any, args: any) =>
+                    sort.apply(array, args),
+                splice: (array: any, o: any, splice: any, args: any) =>
+                    splice.apply(array, args),
+                unshift: (array: any, o: any, unshift: any, args: any) =>
+                    unshift.apply(array, args),
+            });
+
+            const array = [1, 2, 3, 4, 5];
+            const observer = Observable.getNotifier(array);
+            let delivered: any;
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    delivered = args;
+                },
+            });
+
+            array.length = 0;
+            array.push("new");
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(delivered !== void 0),
+            ]);
+
+            return {
+                count: delivered?.length ?? 0,
+                isCustom: delivered?.[0]?.customMarker === true,
+                isReset: delivered?.[0]?.reset === true,
+            };
+        });
+
+        expect(result).toEqual({ count: 1, isCustom: true, isReset: true });
+    });
+
+    test("delivers a pending drift reset synchronously when lengthOf first subscribes", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const { ArrayObserver, lengthOf, Observable, recordArrayChanges } =
+                await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3, 4, 5];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array.length = 0;
+            array.push("new");
+
+            // The lengthObserver getter subscribes, and DefaultArrayObserver.subscribe
+            // flushes synchronously — so the pending drift is drained here, inside what
+            // would be a binding evaluation.
+            const length = lengthOf(array);
+
+            return { notifications, length };
+        });
+
+        expect(result.notifications).toEqual(["RESET"]);
+        expect(result.length).toBe(1);
+    });
+
+    test("does not reset when a subscriber mutates the array from handleChange", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+
+                    // Re-entrant mutation: queues its own splice against the next flush.
+                    // The baseline must already account for it or this looks like drift.
+                    if (notifications.length === 1) {
+                        array.push("re-entrant");
+                    }
+                },
+            });
+
+            array.push("first");
+
+            await Updates.next();
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 1),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["spl(i=3,-0,+1)", "spl(i=4,-0,+1)"]);
+    });
+
+    test("does not reset for an untracked change made before the observer existed", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3];
+            array.length = 0;
+
+            // The baseline is captured here, so the clear above is ancient history.
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array.push("new");
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["spl(i=0,-0,+1)"]);
+    });
+
+    test("does not reset when an observer is created on an empty array", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array: any[] = [];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            array.push("new");
+
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["spl(i=0,-0,+1)"]);
+    });
+
+    test("delivers the same single reset to every subscriber", async ({ page }) => {
+        await page.goto("/");
+
+        const result = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3, 4, 5];
+            const observer = Observable.getNotifier(array);
+            const first: string[] = [];
+            const second: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(first, args);
+                },
+            });
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(second, args);
+                },
+            });
+
+            array.length = 0;
+            array.push("new");
+
+            await Promise.race([Updates.next(), conditionalTimeout(first.length > 0)]);
+
+            return { first, second };
+        });
+
+        expect(result.first).toEqual(["RESET"]);
+        expect(result.second).toEqual(["RESET"]);
+    });
+
+    test("skips drift detection for an explicit reset but still refreshes the baseline", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array = [1, 2, 3];
+            const observer = Observable.getNotifier(array) as any;
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            // An explicit reset already routes through normalize(); drift must not
+            // hijack it, and the baseline must still be brought up to date.
+            array.length = 1;
+            observer.reset([1, 2, 3]);
+            await Updates.next();
+
+            // A plain tracked mutation now — proof the baseline was refreshed.
+            array.push("b");
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 1),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["RESET", "spl(i=1,-0,+1)"]);
+    });
+
+    // A false-positive drift is far more damaging than a missed one: it forces
+    // repeat to tear down and rebuild every view. Every tracked mutation the default
+    // strategy records must predict the array's real length exactly.
+    for (const scenario of [
+        { title: "a push", method: "push", args: [6] },
+        { title: "a push with no arguments", method: "push", args: [] },
+        { title: "a pop", method: "pop", args: [] },
+        { title: "a shift", method: "shift", args: [] },
+        { title: "an unshift", method: "unshift", args: [0] },
+        { title: "a splice", method: "splice", args: [1, 2, "a"] },
+        {
+            title: "a splice with a deleteCount past the end",
+            method: "splice",
+            args: [1, 999],
+        },
+        {
+            title: "a splice with a negative index",
+            method: "splice",
+            args: [-2, 1, "a", "b"],
+        },
+        { title: "a splice with no arguments", method: "splice", args: [] },
+    ]) {
+        test(`does not reset for ${scenario.title}`, async ({ page }) => {
+            await page.goto("/");
+
+            const notifications = await page.evaluate(
+                async ({ method, args }) => {
+                    // @ts-expect-error: Client module.
+                    const {
+                        ArrayObserver,
+                        conditionalTimeout,
+                        Observable,
+                        recordArrayChanges,
+                        Updates,
+                    } = await import("/main.js");
+
+                    ArrayObserver.enable();
+
+                    const array: any[] = [1, 2, 3, 4, 5];
+                    const observer = Observable.getNotifier(array);
+                    const notifications: string[] = [];
+
+                    observer.subscribe({
+                        handleChange(source: any, args: any) {
+                            recordArrayChanges(notifications, args);
+                        },
+                    });
+
+                    (array as any)[method](...args);
+
+                    await Promise.race([
+                        Updates.next(),
+                        conditionalTimeout(notifications.length > 0),
+                    ]);
+
+                    return notifications;
+                },
+                { method: scenario.method, args: scenario.args },
+            );
+
+            expect(notifications).not.toContain("RESET");
+        });
+    }
+
+    for (const scenario of [
+        { title: "a sort", method: "sort", args: [] },
+        { title: "a reverse", method: "reverse", args: [] },
+    ]) {
+        test(`still delivers a sort, not a reset, for ${scenario.title}`, async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const notifications = await page.evaluate(
+                async ({ method, args }) => {
+                    // @ts-expect-error: Client module.
+                    const {
+                        ArrayObserver,
+                        conditionalTimeout,
+                        Observable,
+                        recordArrayChanges,
+                        Updates,
+                    } = await import("/main.js");
+
+                    ArrayObserver.enable();
+
+                    const array: any[] = [3, 1, 2];
+                    const observer = Observable.getNotifier(array);
+                    const notifications: string[] = [];
+
+                    observer.subscribe({
+                        handleChange(source: any, args: any) {
+                            recordArrayChanges(notifications, args);
+                        },
+                    });
+
+                    (array as any)[method](...args);
+
+                    await Promise.race([
+                        Updates.next(),
+                        conditionalTimeout(notifications.length > 0),
+                    ]);
+
+                    return notifications;
+                },
+                { method: scenario.method, args: scenario.args },
+            );
+
+            expect(notifications).toEqual(["SORT"]);
+        });
+    }
+
+    test("does not notify or drift when popping and shifting an empty array", async ({
+        page,
+    }) => {
+        await page.goto("/");
+
+        const notifications = await page.evaluate(async () => {
+            // @ts-expect-error: Client module.
+            const {
+                ArrayObserver,
+                conditionalTimeout,
+                Observable,
+                recordArrayChanges,
+                Updates,
+            } = await import("/main.js");
+
+            ArrayObserver.enable();
+
+            const array: any[] = [];
+            const observer = Observable.getNotifier(array);
+            const notifications: string[] = [];
+
+            observer.subscribe({
+                handleChange(source: any, args: any) {
+                    recordArrayChanges(notifications, args);
+                },
+            });
+
+            // The strategy records no splice at all for these, so nothing enqueues.
+            array.pop();
+            array.shift();
+            await Updates.next();
+
+            // The next real mutation must still be an ordinary splice.
+            array.push("new");
+            await Promise.race([
+                Updates.next(),
+                conditionalTimeout(notifications.length > 0),
+            ]);
+
+            return notifications;
+        });
+
+        expect(notifications).toEqual(["spl(i=0,-0,+1)"]);
+    });
+
+    // Length-drift detection recovers the cases it can see: a mutation that changes
+    // the array's length by an amount the queued splices do not account for. These
+    // tests pin the cases it deliberately cannot see, so that the boundary is a
+    // decision on record rather than an accident. Closing any of them requires a Proxy
+    // or more method patching, and would turn one of these red.
+    test.describe("the limits of length-drift detection", () => {
+        test("stays silent for an untracked length change with nothing else queued", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const notifications = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    ArrayObserver,
+                    conditionalTimeout,
+                    Observable,
+                    recordArrayChanges,
+                    Updates,
+                } = await import("/main.js");
+
+                ArrayObserver.enable();
+
+                const array = [1, 2, 3, 4, 5];
+                const observer = Observable.getNotifier(array);
+                const notifications: string[] = [];
+
+                observer.subscribe({
+                    handleChange(source: any, args: any) {
+                        recordArrayChanges(notifications, args);
+                    },
+                });
+
+                // Assigning length records no splice, so nothing enqueues a flush and
+                // the length compare never gets to run. Drift is only ever noticed on
+                // a flush some other, tracked mutation asked for.
+                array.length = 0;
+
+                await Promise.race([
+                    Updates.next(),
+                    conditionalTimeout(notifications.length > 0),
+                ]);
+
+                return notifications;
+            });
+
+            expect(notifications).toEqual([]);
+        });
+
+        test("delivers the tracked splice when untracked length changes cancel out in a tick", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const notifications = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    ArrayObserver,
+                    conditionalTimeout,
+                    Observable,
+                    recordArrayChanges,
+                    Updates,
+                } = await import("/main.js");
+
+                ArrayObserver.enable();
+
+                const array = [1, 2, 3, 4, 5];
+                const observer = Observable.getNotifier(array);
+                const notifications: string[] = [];
+
+                observer.subscribe({
+                    handleChange(source: any, args: any) {
+                        recordArrayChanges(notifications, args);
+                    },
+                });
+
+                // The truncation and the regrowth cancel out, so the array's length
+                // still matches what the queued push predicts and no drift is seen.
+                // The five original items are gone — replaced by holes — but the
+                // subscriber is told only about the push.
+                array.length = 0;
+                array.length = 5;
+                array.push("x");
+
+                await Promise.race([
+                    Updates.next(),
+                    conditionalTimeout(notifications.length > 0),
+                ]);
+
+                return notifications;
+            });
+
+            expect(notifications).toEqual(["spl(i=5,-0,+1)"]);
+        });
+
+        test("stays silent for delete, in-bounds index writes, and fill", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const notifications = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const {
+                    ArrayObserver,
+                    conditionalTimeout,
+                    Observable,
+                    recordArrayChanges,
+                    Updates,
+                } = await import("/main.js");
+
+                ArrayObserver.enable();
+
+                const array = [1, 2, 3, 4, 5];
+                const observer = Observable.getNotifier(array);
+                const notifications: string[] = [];
+
+                observer.subscribe({
+                    handleChange(source: any, args: any) {
+                        recordArrayChanges(notifications, args);
+                    },
+                });
+
+                // None of these are patched methods and none of them change the
+                // array's length, so there is no splice to queue and no drift to see.
+                delete array[1];
+                array[0] = "x";
+                array.fill(0);
+
+                await Promise.race([
+                    Updates.next(),
+                    conditionalTimeout(notifications.length > 0),
+                ]);
+
+                return notifications;
+            });
+
+            expect(notifications).toEqual([]);
+        });
+    });
+});
+
 test.describe("The array length observer", () => {
     class Model {
         items: any[];

--- a/packages/fast-element/src/observation/arrays.ts
+++ b/packages/fast-element/src/observation/arrays.ts
@@ -95,6 +95,13 @@ export type SpliceStrategySupport =
 
 /**
  * An approach to tracking changes in an array.
+ * @remarks
+ * Implementations must record splices whose `addedCount - removed.length` equals the
+ * true length delta of the operation being tracked. Array observation sums that delta
+ * across the queued splices to detect mutations it cannot track, such as
+ * `array.length = 0`. A strategy that records splices as mere markers, without an
+ * accurate delta, makes every mutation look like an untracked one and forces a reset
+ * on every flush.
  * @public
  */
 export interface SpliceStrategy {
@@ -108,6 +115,13 @@ export interface SpliceStrategy {
      * @param previous - The previous version of the array if a reset has taken place.
      * @param current - The current version of the array.
      * @param changes - The set of changes tracked against the array.
+     * @remarks
+     * A defined `previous` always means "deliver a reset", but its contents are only
+     * the array's previous version when the reset came from
+     * {@link (ArrayObserver:interface).reset}. When array observation detects an
+     * untracked mutation it has no record of the previous contents and passes a frozen,
+     * empty sentinel array instead. Treat a defined `previous` as the reset signal, do
+     * not assume it holds the previous items, and never write to it.
      */
     normalize(
         previous: unknown[] | undefined,
@@ -855,6 +869,7 @@ class DefaultArrayObserver extends SubscriberSet implements ArrayObserver {
     private splices: Splice[] | undefined = void 0;
     private sorts: Sort[] | undefined = void 0;
     private needsQueue: boolean = true;
+    private lastKnownLength: number = 0;
     private _strategy: SpliceStrategy | null = null;
     private _lengthObserver: LengthObserver | undefined = void 0;
     private _sortObserver: SortObserver | undefined = void 0;
@@ -913,6 +928,7 @@ class DefaultArrayObserver extends SubscriberSet implements ArrayObserver {
 
     constructor(subject: any[]) {
         super(subject);
+        this.lastKnownLength = subject.length;
         setNonEnumerable(subject, "$fastController", this);
     }
 
@@ -960,15 +976,47 @@ class DefaultArrayObserver extends SubscriberSet implements ArrayObserver {
         this.sorts = void 0;
         this.oldCollection = void 0;
 
+        const subject = this.subject;
+        const actualLength = subject.length;
+        const lastKnownLength = this.lastKnownLength;
+        const strategy = this._strategy ?? defaultMutationStrategy;
+
+        // Recorded before notify() because a subscriber may mutate the array from
+        // inside handleChange, and those mutations queue their own splices. The next
+        // flush must not count them against this flush's baseline.
+        this.lastKnownLength = actualLength;
+
+        if (oldCollection === void 0) {
+            // An array's length is a non-configurable own property, so it cannot be
+            // trapped, and array observation deliberately avoids a Proxy, which would
+            // change the identity of the developer's own array. Untracked mutations
+            // such as `array.length = 0` therefore record no splices. Rather than
+            // deliver splices that are provably inconsistent with the array's real
+            // contents, compare the length the queued changes predict against the
+            // length the array actually has and fall back to a reset on a mismatch.
+            // Costs O(queued splices), never O(array length).
+            let predictedLength = lastKnownLength;
+
+            if (splices !== void 0) {
+                for (let i = 0, ii = splices.length; i < ii; ++i) {
+                    const splice = splices[i];
+                    predictedLength += splice.addedCount - splice.removed.length;
+                }
+            }
+
+            if (predictedLength !== actualLength) {
+                // Routed through the strategy rather than notifying resetSplices
+                // directly, so that a custom SpliceStrategy still owns its reset
+                // payload. A defined previous makes the default strategy return
+                // resetSplices, and emptyArray is a shared frozen const.
+                this.notify(strategy.normalize(emptyArray as any, subject, void 0));
+                return;
+            }
+        }
+
         sorts !== void 0
             ? this.notify(sorts)
-            : this.notify(
-                  (this._strategy ?? defaultMutationStrategy).normalize(
-                      oldCollection,
-                      this.subject,
-                      splices,
-                  ),
-              );
+            : this.notify(strategy.normalize(oldCollection, subject, splices));
     }
 
     private enqueue(): void {

--- a/packages/fast-element/src/templating/repeat.pw.spec.ts
+++ b/packages/fast-element/src/templating/repeat.pw.spec.ts
@@ -709,6 +709,73 @@ test.describe("The repeat", () => {
             });
         }
 
+        test("removes rendered HTML for items dropped by setting length to zero", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                const {
+                    Fake,
+                    html,
+                    Observable,
+                    removeWhitespace,
+                    repeat,
+                    toHTML,
+                    Updates,
+                    // @ts-expect-error: Client module.
+                } = await import("/main.js");
+
+                const itemTemplate = html`
+                    ${x => x.name}
+                `;
+
+                class ViewModel {
+                    items = [{ name: "item1" }, { name: "item2" }, { name: "item3" }];
+                }
+                Observable.defineProperty(ViewModel.prototype, "items");
+
+                const parent = document.createElement("div");
+                const location = document.createComment("");
+                const nodeId = "r";
+                const targets = { [nodeId]: location };
+                parent.appendChild(location);
+
+                const unbindables: any[] = [];
+                const vm = new ViewModel();
+                const controller = {
+                    isBound: false,
+                    context: Fake.executionContext(),
+                    onUnbind(object: any) {
+                        unbindables.push(object);
+                    },
+                    source: vm,
+                    targets,
+                    unbind() {
+                        unbindables.forEach(x => x.unbind(this));
+                    },
+                };
+
+                const directive = repeat((x: any) => x.items, itemTemplate);
+                directive.targetNodeId = nodeId;
+                const behavior = directive.createBehavior();
+
+                behavior.bind(controller);
+
+                // The mainstream idiom for clearing an array. `length` cannot be
+                // trapped, so this records no splice; the push is what enqueues the
+                // flush that has to notice the array shrank.
+                vm.items.length = 0;
+                vm.items.push({ name: "newitem" });
+
+                await Updates.next();
+
+                return removeWhitespace(toHTML(parent));
+            });
+
+            expect(result).toBe("newitem");
+        });
+
         for (const size of oneThroughTen) {
             test(`updates rendered HTML when items are reversed in an array of size ${size}`, async ({
                 page,

--- a/packages/fast-element/test/main.ts
+++ b/packages/fast-element/test/main.ts
@@ -71,16 +71,33 @@ export const conditionalTimeout = function (
         }, 5);
     });
 };
+export const recordArrayChanges = function (target: string[], changes: any[]): void {
+    for (const change of changes) {
+        target.push(
+            change.reset
+                ? "RESET"
+                : change.sorted
+                  ? "SORT"
+                  : `spl(i=${change.index},-${change.removed.length},+${change.addedCount})`,
+        );
+    }
+};
 export { Binding } from "../src/binding/binding.js";
 export { oneTime } from "../src/binding/one-time.js";
 export { listener, oneWay } from "../src/binding/one-way.js";
 export { Signal, signal } from "../src/binding/signal.js";
 export { twoWay } from "../src/binding/two-way.js";
-export { Schema } from "../src/components/schema.js";
+export { defsPropertyName, Schema, schemaRegistry } from "../src/components/schema.js";
 export { AttributeMap } from "../src/declarative/attribute-map.js";
+export { ObserverMap } from "../src/declarative/observer-map.js";
 export { isString } from "../src/interfaces.js";
 export { Metadata } from "../src/metadata.js";
-export { ArrayObserver, lengthOf, Splice } from "../src/observation/arrays.js";
+export {
+    ArrayObserver,
+    lengthOf,
+    Splice,
+    SpliceStrategy,
+} from "../src/observation/arrays.js";
 export { ExecutionContext } from "../src/observation/observable.js";
 export { emptyArray, FAST } from "../src/platform.js";
 export { ownedState, reactive, state, watch } from "../src/state/exports.js";

--- a/sites/website/src/docs/3.x/api/fast-element.splicestrategy.normalize.md
+++ b/sites/website/src/docs/3.x/api/fast-element.splicestrategy.normalize.md
@@ -94,3 +94,7 @@ The set of changes tracked against the array.
 **Returns:**
 
 readonly [Splice](../fast-element.splice/)<!-- -->\[\]
+
+## Remarks
+
+A defined `previous` always means "deliver a reset", but its contents are only the array's previous version when the reset came from [ArrayObserver.reset()](../fast-element.arrayobserver.reset/)<!-- -->. When array observation detects an untracked mutation it has no record of the previous contents and passes a frozen, empty sentinel array instead. Treat a defined `previous` as the reset signal, do not assume it holds the previous items, and never write to it.

--- a/sites/website/src/docs/3.x/resources/export-sizes.md
+++ b/sites/website/src/docs/3.x/resources/export-sizes.md
@@ -19,7 +19,7 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 78.61 KB | 23.40 KB | 20.77 KB |
+| CDN Rollup Bundle | 78.91 KB | 23.47 KB | 20.86 KB |
 | FASTElement (@microsoft/fast-element/fast-element.js) | 23.11 KB | 7.12 KB | 6.41 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 290 B |
 | Observable (@microsoft/fast-element/observable.js) | 6.75 KB | 2.51 KB | 2.23 KB |
@@ -31,10 +31,10 @@ Bundle sizes for `@microsoft/fast-element` exports.
 | volatile (@microsoft/fast-element/volatile.js) | 6.84 KB | 2.54 KB | 2.26 KB |
 | when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 589 B |
 | html (@microsoft/fast-element/html.js) | 27.73 KB | 8.96 KB | 8.02 KB |
-| repeat (@microsoft/fast-element/repeat.js) | 31.80 KB | 10.00 KB | 9.03 KB |
+| repeat (@microsoft/fast-element/repeat.js) | 32.09 KB | 10.10 KB | 9.08 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
 | enableHydration (@microsoft/fast-element/hydration.js) | 46.53 KB | 13.91 KB | 12.49 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.15 KB | 19.46 KB | 17.42 KB |
-| ArrayObserver (@microsoft/fast-element/arrays.js) | 12.55 KB | 4.46 KB | 4.03 KB |
-| observerMap (@microsoft/fast-element/observer-map.js) | 21.96 KB | 7.73 KB | 6.97 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.44 KB | 19.54 KB | 17.50 KB |
+| ArrayObserver (@microsoft/fast-element/arrays.js) | 12.84 KB | 4.56 KB | 4.11 KB |
+| observerMap (@microsoft/fast-element/observer-map.js) | 22.04 KB | 7.74 KB | 6.99 KB |
 | attributeMap (@microsoft/fast-element/attribute-map.js) | 15.31 KB | 5.41 KB | 4.88 KB |


### PR DESCRIPTION
## What this does

Makes `myArray.length = 0` — the everyday way to empty an array in JavaScript — actually clear the list on screen.

## Why

FAST notices array changes by wrapping the array's methods (`push`, `splice`, `pop`, and so on). Setting `length` is not a method call, so nothing noticed it. The array really was emptied, but `repeat` kept rendering the old items, and `lengthOf` kept reporting the old count.

The person who reported this put it plainly: *"I cannot use FAST until this is resolved."*

## What changed
<img width="2000" height="1236" alt="01-initial-state" src="https://github.com/user-attachments/assets/815ca5b0-ebaf-4b78-9662-2a4d5a541f8e" />
<img width="2000" height="1574" alt="02-before-bug" src="https://github.com/user-attachments/assets/1c91ecd6-ef29-44c8-8276-2451df58e5f5" />
<img width="2000" height="1338" alt="03-after-fixed" src="https://github.com/user-attachments/assets/deb6fffa-f3ce-4441-807a-22e5521b6521" />
<img width="3800" height="1744" alt="04-side-by-side" src="https://github.com/user-attachments/assets/6197dabe-3bcc-4f20-aba0-e4646397673c" />


- The array observer now remembers how long the array should be after the changes it knows about. When the real length disagrees, it emits a reset instead of change records that no longer describe reality, and the list re-renders from scratch.
- The companion path in the declarative observer map handles a reset the same way.

This same drift check also covers the other silent cases — `delete arr[i]`, writing past the end of the array, and the array methods that were never wrapped.

## An honest limit

`length` cannot be intercepted directly (it is non-configurable, so it cannot be trapped without turning arrays into Proxies, which would be a much larger change). What this does is *detect* the drift and heal from it. So `arr.length = 0` on its own, with no other tracked change afterwards, still does not notify — the array observer has nothing to wake it. In practice the clear is nearly always followed by tracked work, which is when the correction lands.

If maintainers would rather solve this properly with a Proxy-based reactive array, this PR is a stopgap and should be judged that way.

## How to see it

Run the `fast-element` test suite. New tests in `observation/arrays.pw.spec.ts` set `length = 0`, push a new item, and assert a single reset arrives — where `main` produces change records describing an array that no longer exists.

The existing test that asserts `array.splice(0, array.length, ...array)` produces *no* change records is the sharpest guard here: the net length change is zero, so the drift check must not fire. It still passes.

Fixes #7167
