### PR TITLE
docs: document the component lifecycle and pin the attribute contract

### DIFF
--- a/change/@microsoft-fast-element-1f7ac3c2-1afb-44d5-8a96-035d5172221c.json
+++ b/change/@microsoft-fast-element-1f7ac3c2-1afb-44d5-8a96-035d5172221c.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Document the component lifecycle and pin the @attr initialization contract with tests.",
+  "packageName": "@microsoft/fast-element",
+  "email": "144495202+AKnassa@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/src/components/attributes.pw.spec.ts
+++ b/packages/fast-element/src/components/attributes.pw.spec.ts
@@ -316,4 +316,852 @@ test.describe("Attributes", () => {
             }
         });
     });
+
+    // The `@attr` changed callback is not the native attributeChangedCallback. Its
+    // `oldValue` is read back from the backing field (`AttributeDefinition.setValue`),
+    // which the native callback never writes, so the first `oldValue` is `undefined`
+    // rather than the `null` the platform passes. These tests pin that contract, and
+    // the number of times the callback fires during initialization, which varies with
+    // where the value comes from: a default assignment, the tag, or a pre-upgrade
+    // property. They characterize the behavior FAST ships today: whether the first
+    // assignment *should* fire at all is an open design question, and a change to it
+    // is a breaking change to this contract, not a bug fix. See the Component
+    // Lifecycle documentation.
+    test.describe("@attr initialization contract", () => {
+        test("passes `undefined`, not `null`, as the first oldValue", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const calls = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                // `undefined` and `null` both cross the page boundary as `null`.
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name} foo="tag"></${name}>`;
+
+                return calls;
+            });
+
+            expect(calls).toEqual([["@@undefined", "tag"]]);
+            expect(calls[0][0]).toBe("@@undefined");
+            expect(calls[0][0]).not.toBe("@@null");
+        });
+
+        test("receives `undefined` where the native callback receives `null`, for the same mutation", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const nativeCalls: any[][] = [];
+                const attrCalls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    attributeChangedCallback(name: string, oldValue: any, newValue: any) {
+                        nativeCalls.push([name, tag(oldValue), tag(newValue)]);
+                        super.attributeChangedCallback(name, oldValue, newValue);
+                    }
+
+                    fooChanged(oldValue: any, newValue: any) {
+                        attrCalls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                const element = document.createElement(name);
+                element.setAttribute("foo", "tag");
+
+                return { nativeCalls, attrCalls };
+            });
+
+            expect(result.nativeCalls).toEqual([["foo", "@@null", "tag"]]);
+            expect(result.attrCalls).toEqual([["@@undefined", "tag"]]);
+        });
+
+        test("a default value fires the changed callback once, at construction", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    foo = "default";
+
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                const element = document.createElement(name) as any;
+
+                return {
+                    calls,
+                    isConnected: element.isConnected,
+                    // The class-field default must go through the accessor, not
+                    // shadow it with an own property.
+                    hasOwnProperty: Object.prototype.hasOwnProperty.call(element, "foo"),
+                    value: element.foo,
+                };
+            });
+
+            expect(result.calls).toEqual([["@@undefined", "default"]]);
+            expect(result.isConnected).toBe(false);
+            expect(result.hasOwnProperty).toBe(false);
+            expect(result.value).toBe("default");
+        });
+
+        test("a class field default and a constructor default fire identically", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const fieldCalls: any[][] = [];
+                const constructorCalls: any[][] = [];
+
+                class FieldEl extends FASTElement {
+                    foo = "default";
+
+                    fooChanged(oldValue: any, newValue: any) {
+                        fieldCalls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                class ConstructorEl extends FASTElement {
+                    constructor() {
+                        super();
+                        (this as any).foo = "default";
+                    }
+
+                    fooChanged(oldValue: any, newValue: any) {
+                        constructorCalls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const fieldName = uniqueElementName();
+                await FieldEl.define({ name: fieldName, attributes: ["foo"] });
+                const constructorName = uniqueElementName();
+                await ConstructorEl.define({
+                    name: constructorName,
+                    attributes: ["foo"],
+                });
+
+                document.createElement(fieldName);
+                document.createElement(constructorName);
+
+                return { fieldCalls, constructorCalls };
+            });
+
+            expect(result.fieldCalls).toEqual([["@@undefined", "default"]]);
+            expect(result.constructorCalls).toEqual(result.fieldCalls);
+        });
+
+        test("a default value and a tag attribute fire the changed callback twice, and the tag wins", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, Updates, uniqueElementName } = await import(
+                    "/main.js"
+                );
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    foo = "default";
+
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name} foo="tag"></${name}>`;
+
+                const element = host.firstElementChild as any;
+                await Updates.next();
+
+                return {
+                    calls,
+                    value: element.foo,
+                    attribute: element.getAttribute("foo"),
+                };
+            });
+
+            expect(result.calls).toEqual([
+                ["@@undefined", "default"],
+                ["default", "tag"],
+            ]);
+            expect(result.value).toBe("tag");
+            expect(result.attribute).toBe("tag");
+        });
+
+        test("a declared attribute with no default and no tag attribute never fires", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const calls = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, Updates, uniqueElementName } = await import(
+                    "/main.js"
+                );
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([oldValue, newValue]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name}></${name}>`;
+                await Updates.next();
+
+                return calls;
+            });
+
+            expect(calls).toEqual([]);
+        });
+
+        test("an explicit `undefined` default never fires", async ({ page }) => {
+            await page.goto("/");
+
+            const calls = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    foo = undefined;
+
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([oldValue, newValue]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                document.createElement(name);
+
+                return calls;
+            });
+
+            expect(calls).toEqual([]);
+        });
+
+        test("an empty string attribute fires the changed callback", async ({ page }) => {
+            await page.goto("/");
+
+            const calls = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name} foo=""></${name}>`;
+
+                return calls;
+            });
+
+            expect(calls).toEqual([["@@undefined", ""]]);
+        });
+
+        test("a `false` boolean-mode default fires, and a tag attribute fires it again", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const defaultOnlyCalls: any[][] = [];
+                const withTagCalls: any[][] = [];
+
+                class DefaultOnlyEl extends FASTElement {
+                    bool = false;
+
+                    boolChanged(oldValue: any, newValue: any) {
+                        defaultOnlyCalls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                class WithTagEl extends FASTElement {
+                    bool = false;
+
+                    boolChanged(oldValue: any, newValue: any) {
+                        withTagCalls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const attributes = [{ property: "bool", mode: "boolean" }];
+                const defaultOnlyName = uniqueElementName();
+                await DefaultOnlyEl.define({ name: defaultOnlyName, attributes });
+                const withTagName = uniqueElementName();
+                await WithTagEl.define({ name: withTagName, attributes });
+
+                document.createElement(defaultOnlyName);
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${withTagName} bool></${withTagName}>`;
+
+                return { defaultOnlyCalls, withTagCalls };
+            });
+
+            expect(result.defaultOnlyCalls).toEqual([["@@undefined", false]]);
+            expect(result.withTagCalls).toEqual([
+                ["@@undefined", false],
+                [false, true],
+            ]);
+        });
+
+        test("removeAttribute in reflect mode fires the changed callback with `null`", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const calls = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name} foo="tag"></${name}>`;
+                host.firstElementChild!.removeAttribute("foo");
+
+                return calls;
+            });
+
+            // `null` never appears as the first oldValue, but it does appear later:
+            // this is exactly why `if (oldValue !== null)` guards are wrong.
+            expect(calls).toEqual([
+                ["@@undefined", "tag"],
+                ["tag", "@@null"],
+            ]);
+        });
+
+        test("removeAttribute in boolean mode fires the changed callback with `false`, never `null`", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const calls = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    boolChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({
+                    name,
+                    attributes: [{ property: "bool", mode: "boolean" }],
+                });
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name} bool></${name}>`;
+                host.firstElementChild!.removeAttribute("bool");
+
+                return calls;
+            });
+
+            // boolean mode maps the platform's `null` to `false` before setValue, so a
+            // boolean-mode changed callback never sees `null` - not first, not later.
+            expect(calls).toEqual([
+                ["@@undefined", true],
+                [true, false],
+            ]);
+        });
+
+        test("setting the same value through the attribute and the property fires once", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const calls = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                const element = document.createElement(name) as any;
+                element.setAttribute("foo", "same");
+                element.foo = "same";
+
+                return calls;
+            });
+
+            expect(calls).toEqual([["@@undefined", "same"]]);
+        });
+
+        test("a pre-upgrade property beats a tag attribute and reflects back over it", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, Updates, uniqueElementName } = await import(
+                    "/main.js"
+                );
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name} foo="tag"></${name}>`;
+
+                const element = host.firstElementChild as any;
+                element.foo = "preupgrade";
+
+                await TestEl.define({ name, attributes: ["foo"] });
+                await Updates.next();
+
+                return {
+                    calls,
+                    value: element.foo,
+                    attribute: element.getAttribute("foo"),
+                };
+            });
+
+            expect(result.calls).toEqual([
+                ["@@undefined", "tag"],
+                ["tag", "preupgrade"],
+            ]);
+            expect(result.value).toBe("preupgrade");
+            expect(result.attribute).toBe("preupgrade");
+        });
+
+        test("a pre-upgrade property with no tag attribute fires once and is preserved", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, Updates, uniqueElementName } = await import(
+                    "/main.js"
+                );
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name}></${name}>`;
+
+                const element = host.firstElementChild as any;
+                element.foo = "preupgrade";
+
+                await TestEl.define({ name, attributes: ["foo"] });
+                await Updates.next();
+
+                return { calls, value: element.foo };
+            });
+
+            expect(result.calls).toEqual([["@@undefined", "preupgrade"]]);
+            expect(result.value).toBe("preupgrade");
+        });
+
+        test("a default, a tag attribute and a pre-upgrade property fire the changed callback three times, and the property wins", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, Updates, uniqueElementName } = await import(
+                    "/main.js"
+                );
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+
+                class TestEl extends FASTElement {
+                    foo = "default";
+
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                    }
+                }
+
+                const name = uniqueElementName();
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name} foo="tag"></${name}>`;
+
+                const element = host.firstElementChild as any;
+                element.foo = "preupgrade";
+
+                await TestEl.define({ name, attributes: ["foo"] });
+                await Updates.next();
+
+                return {
+                    calls,
+                    value: element.foo,
+                    attribute: element.getAttribute("foo"),
+                };
+            });
+
+            // Three firings, which is the case the documentation table calls out and
+            // the one that surprises people. The pre-upgrade property does not shadow
+            // the default: the ElementController constructor runs during `super()`,
+            // and it deletes the pre-upgrade own property and stashes it before the
+            // subclass's field initializer executes. So the default assignment reaches
+            // the prototype accessor, the tag attribute overwrites it at upgrade, and
+            // the stashed property is replayed through the accessor at connect - last
+            // write wins, and it reflects back over the tag attribute.
+            expect(result.calls).toEqual([
+                ["@@undefined", "default"],
+                ["default", "tag"],
+                ["tag", "preupgrade"],
+            ]);
+            expect(result.value).toBe("preupgrade");
+            expect(result.attribute).toBe("preupgrade");
+        });
+
+        test("the changed callback and the default value both go through the converter", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, uniqueElementName } = await import("/main.js");
+
+                const tag = (value: any) =>
+                    value === undefined
+                        ? "@@undefined"
+                        : value === null
+                          ? "@@null"
+                          : value;
+
+                const calls: any[][] = [];
+                const types: string[] = [];
+
+                // Declared inline: the test harness does not export FAST's converters.
+                const converter = {
+                    toView(value: any) {
+                        return value === null ? null : String(value);
+                    },
+                    fromView(value: any) {
+                        return value === null ? null : Number(value);
+                    },
+                };
+
+                class TestEl extends FASTElement {
+                    // A string default, exactly as it would be authored on the tag.
+                    foo = "42";
+
+                    fooChanged(oldValue: any, newValue: any) {
+                        calls.push([tag(oldValue), tag(newValue)]);
+                        types.push(typeof newValue);
+                    }
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({
+                    name,
+                    attributes: [{ property: "foo", converter }],
+                });
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name} foo="7"></${name}>`;
+
+                return { calls, types, value: (host.firstElementChild as any).foo };
+            });
+
+            expect(result.calls).toEqual([
+                ["@@undefined", 42],
+                [42, 7],
+            ]);
+            expect(result.types).toEqual(["number", "number"]);
+            expect(result.value).toBe(7);
+        });
+
+        test("a reflect-mode default writes the attribute on the next update", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, Updates, uniqueElementName } = await import(
+                    "/main.js"
+                );
+
+                class TestEl extends FASTElement {
+                    foo = "default";
+                }
+
+                const name = uniqueElementName();
+                await TestEl.define({ name, attributes: ["foo"] });
+
+                const element = document.createElement(name);
+                const beforeUpdate = element.getAttribute("foo");
+                await Updates.next();
+
+                return { beforeUpdate, afterUpdate: element.getAttribute("foo") };
+            });
+
+            expect(result.beforeUpdate).toBe(null);
+            expect(result.afterUpdate).toBe("default");
+        });
+
+        test("every initialization firing happens while `$fastController.isConnected` is false", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, Updates, uniqueElementName } = await import(
+                    "/main.js"
+                );
+
+                const observed: boolean[] = [];
+                const applied: string[] = [];
+
+                class TestEl extends FASTElement {
+                    foo = "default";
+
+                    fooChanged() {
+                        observed.push(this.$fastController.isConnected);
+
+                        // The guard the documentation recommends. It drops the value
+                        // rather than deferring it: FAST never re-invokes the callback.
+                        if (!this.$fastController.isConnected) {
+                            return;
+                        }
+
+                        applied.push(this.foo);
+                    }
+                }
+
+                const name = uniqueElementName();
+
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name} foo="tag"></${name}>`;
+
+                const element = host.firstElementChild as any;
+                element.foo = "preupgrade";
+
+                await TestEl.define({ name, attributes: ["foo"] });
+                await Updates.next();
+
+                const duringInitialization = observed.slice();
+                const appliedAfterConnect = applied.slice();
+
+                element.foo = "runtime";
+
+                return {
+                    duringInitialization,
+                    appliedAfterConnect,
+                    applied,
+                    isConnected: element.$fastController.isConnected,
+                };
+            });
+
+            // The default assignment and the tag attribute both land before `connect()`
+            // runs at all, and the pre-upgrade property is replayed while the stage is
+            // still `connecting`, so the guard is `false` for all three.
+            expect(result.duringInitialization).toEqual([false, false, false]);
+            // Which means a guarded changed callback does no work at all for the value
+            // the element was initialized with - `connectedCallback` has to apply it.
+            expect(result.appliedAfterConnect).toEqual([]);
+            // Only mutations after connect get through the guard.
+            expect(result.isConnected).toBe(true);
+            expect(result.applied).toEqual(["runtime"]);
+        });
+    });
 });

--- a/packages/fast-element/src/components/element-controller.pw.spec.ts
+++ b/packages/fast-element/src/components/element-controller.pw.spec.ts
@@ -163,6 +163,169 @@ test.describe("The ElementController", () => {
 
             expect(childCount).toBe(0);
         });
+
+        test("completes the constructor before connectedCallback runs", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const order = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, FASTElementDefinition, uniqueElementName } =
+                    await import("/main.js");
+
+                const order: string[] = [];
+                const name = uniqueElementName();
+                (
+                    await FASTElementDefinition.compose(
+                        class ControllerTest extends FASTElement {
+                            static definition = { name };
+
+                            constructor() {
+                                super();
+                                order.push("constructor-start");
+                                order.push("constructor-end");
+                            }
+
+                            connectedCallback() {
+                                super.connectedCallback();
+                                order.push("connected");
+                            }
+                        },
+                    )
+                ).define();
+
+                // Upgrading an element that is already in the tree is the only path
+                // that could interleave the two: the constructor and the
+                // connectedCallback run back to back, as upgrade reactions.
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name}></${name}>`;
+
+                return order;
+            });
+
+            expect(order).toEqual(["constructor-start", "constructor-end", "connected"]);
+        });
+
+        test("reports isConnected from the constructor based on where the element is created", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                // @ts-expect-error: Client module.
+                const { FASTElement, FASTElementDefinition, uniqueElementName } =
+                    await import("/main.js");
+
+                const observed: boolean[] = [];
+                const name = uniqueElementName();
+                (
+                    await FASTElementDefinition.compose(
+                        class ControllerTest extends FASTElement {
+                            static definition = { name };
+
+                            constructor() {
+                                super();
+                                observed.push(this.isConnected);
+                            }
+                        },
+                    )
+                ).define();
+
+                document.createElement(name);
+
+                // `innerHTML` runs the HTML *fragment* parsing algorithm, which does
+                // not execute script, so the element is created in the "undefined"
+                // custom element state and only upgraded when it is inserted - by
+                // which time it is already in a connected tree.
+                const host = document.createElement("div");
+                document.body.append(host);
+                host.innerHTML = `<${name}></${name}>`;
+
+                return { detached: observed[0], upgradedInTree: observed[1] };
+            });
+
+            expect(result.detached).toBe(false);
+            expect(result.upgradedInTree).toBe(true);
+        });
+
+        test("is not connected in the constructor when the document parser creates the element from an already-registered definition", async ({
+            page,
+        }) => {
+            await page.goto("/");
+
+            const result = await page.evaluate(async () => {
+                const done = new Promise<any>(resolve => {
+                    (window as any).__parserResult = resolve;
+                });
+
+                // A same-origin frame gives us a document whose real HTML parser we
+                // can drive. `document.write()` parses with scripting enabled, unlike
+                // `innerHTML`, so the custom element is constructed as the parser
+                // creates it - before it is inserted into the tree.
+                const frame = document.createElement("iframe");
+                frame.src = "/";
+                document.body.append(frame);
+
+                await new Promise(resolve =>
+                    frame.addEventListener("load", resolve, { once: true }),
+                );
+
+                const frameDocument = frame.contentDocument!;
+                const script = frameDocument.createElement("script");
+                script.type = "module";
+                script.textContent = `
+                    try {
+                        const { FASTElement, FASTElementDefinition, uniqueElementName } =
+                            await import("/main.js");
+
+                        const observed = [];
+                        const name = uniqueElementName();
+
+                        (await FASTElementDefinition.compose(
+                            class ParserTest extends FASTElement {
+                                static definition = { name };
+
+                                constructor() {
+                                    super();
+                                    observed.push(this.isConnected);
+                                }
+                            },
+                        )).define();
+
+                        // The definition is registered before the parser reaches the
+                        // tag, so the parser constructs the element at creation time.
+                        document.open();
+                        document.write("<" + name + "></" + name + ">");
+                        document.close();
+
+                        parent.__parserResult({
+                            observed: observed.slice(),
+                            connectedAfterParse:
+                                document.querySelector(name).isConnected,
+                        });
+                    } catch (error) {
+                        parent.__parserResult({ error: String(error) });
+                    }
+                `;
+                frameDocument.head.append(script);
+
+                const raw = await done;
+
+                return {
+                    error: raw.error ?? null,
+                    observed: raw.observed ? Array.from(raw.observed, Boolean) : null,
+                    connectedAfterParse: raw.connectedAfterParse ?? null,
+                };
+            });
+
+            expect(result.error).toBe(null);
+            // The constructor runs before insertion, so `isConnected` is `false` even
+            // though the element is being parsed straight into a connected document.
+            expect(result.observed).toEqual([false]);
+            expect(result.connectedAfterParse).toBe(true);
+        });
     });
 
     test.describe("during connect", () => {

--- a/sites/website/src/docs/3.x/advanced/component-lifecycle.md
+++ b/sites/website/src/docs/3.x/advanced/component-lifecycle.md
@@ -1,0 +1,195 @@
+---
+id: component-lifecycle
+title: Component Lifecycle
+layout: 3x
+eleventyNavigation:
+  key: component-lifecycle3x
+  parent: advanced3x
+  title: Component Lifecycle
+navigationOptions:
+  activeKey: component-lifecycle3x
+description: How a FASTElement is constructed, upgraded and connected, when attribute changed callbacks fire, and what is safe to touch at each point.
+keywords:
+  - lifecycle
+  - connectedCallback
+  - attributeChangedCallback
+  - attr
+  - changed handler
+  - hydration
+---
+
+# Component Lifecycle
+
+The [`FASTElement`](../../getting-started/fast-element/) page lists the lifecycle callbacks. This page is about the parts that surprise people: how many times a `@attr` changed callback runs before your component is even connected, what its `oldValue` actually is, and what is safe to touch at each stage.
+
+## Prerequisite: `useDefineForClassFields`
+
+Everything on this page assumes the compiler settings from the [Quick Start](../../getting-started/quick-start/). In particular `useDefineForClassFields` must be `false`. FAST's property decorators install accessors on the prototype and rely on field-assignment semantics; with `useDefineForClassFields: true` a class field defines an *own* property that shadows the accessor, and a default value ends up clobbering the value that came from the tag.
+
+## Two callbacks, two contracts
+
+An element that declares `@attr foo` has two different callbacks in play, and they do not agree on `oldValue`.
+
+```ts
+export class MyElement extends FASTElement {
+  @attr foo?: string;
+
+  // The native custom element callback. `oldValue` is `null` on the first call.
+  // Values are raw attribute strings.
+  attributeChangedCallback(name: string, oldValue: string | null, newValue: string | null) {
+    super.attributeChangedCallback(name, oldValue, newValue);
+  }
+
+  // FAST's changed callback for `foo`. The first `oldValue` is `undefined`.
+  // Values have already been through the converter.
+  fooChanged(oldValue: string | undefined, newValue: string) {}
+}
+```
+
+For a *single* mutation on a *single* element — say the parser reading `<my-element foo="tag">` — the native callback receives `("foo", null, "tag")` while `fooChanged` receives `(undefined, "tag")`.
+
+They differ because they read different things. FAST forwards only the *new* value to the attribute definition; the definition then re-derives `oldValue` by reading the property's backing field, which starts out `undefined` because nothing has written it yet. The native callback's `null` never reaches your changed callback.
+
+:::important
+`if (oldValue !== null)` does **not** guard the first call of a changed callback. The first `oldValue` is `undefined`. Use `if (oldValue !== undefined)`, or better, do not guard on `oldValue` at all — write a changed callback that is correct for every value it can receive.
+:::
+
+### When `null` *can* show up
+
+`null` is never the *first* `oldValue`, but whether it appears later depends entirely on the attribute's mode and converter:
+
+| Mode | `removeAttribute()` gives your changed callback |
+| --- | --- |
+| `reflect` / `fromView`, no converter | `(previousValue, null)` — `null` is real |
+| `mode: "boolean"` | `(true, false)` — the platform's `null` is mapped to `false` before it reaches you; you never see `null` |
+| custom converter | whatever your `fromView` returns for `null` |
+
+So a `null` check is not merely useless — it is wrong in two different directions depending on the mode you chose.
+
+## How many times does my changed callback run?
+
+There are three points at which FAST can push a value through a `@attr` accessor, and therefore three points at which your changed callback can fire before you have done anything:
+
+1. **Construction** — a default value assigned in the constructor (or as a class field, which compiles to the same assignment) goes *through* the accessor.
+2. **Upgrade / parse** — the attribute present on the tag arrives via the native `attributeChangedCallback`.
+3. **Connect** — `connectedCallback` replays properties that were set on the element *before* it was upgraded, and synchronizes late-registered attributes.
+
+Which combination applies depends on where the value comes from:
+
+| Setup | Calls | Sequence |
+| --- | --- | --- |
+| No default, attribute absent | 0 | — |
+| Default value only | 1 | `(undefined, default)` at construction |
+| Attribute on the tag only | 1 | `(undefined, tagValue)` at upgrade |
+| Default value **and** attribute on the tag | 2 | `(undefined, default)`, then `(default, tagValue)` — **the tag wins** |
+| Attribute on the tag **and** property set before upgrade | 2 | `(undefined, tagValue)`, then `(tagValue, propValue)` — **the property wins**, and it reflects back over the attribute |
+| Default **and** attribute **and** pre-upgrade property | 3 | all of the above, in that order |
+
+A few consequences worth spelling out:
+
+- A falsy default is not a silent one. `bool = false` on a `mode: "boolean"` attribute still fires `(undefined, false)`, because `undefined !== false`. If the tag also carries the attribute you get `(undefined, false)` and then `(false, true)`.
+- `foo = undefined` fires **zero** times: the accessor compares old and new and both are `undefined`.
+- An empty string attribute is not an absent one. `<my-element foo="">` fires `(undefined, "")`.
+- For a field you only want to *type*, prefer `declare foo: string;`. A bare `foo: string;` may or may not emit `this.foo = void 0` depending on your compiler, and with a converter that phantom assignment becomes a visible call.
+
+:::note
+On a `reflect`-mode attribute, a default value **writes an attribute onto the host** — asynchronously, on the next update tick. Immediately after `document.createElement()` the attribute is still absent; it appears after `await Updates.next()`. Any assertion about attribute state has to await an update first.
+:::
+
+## What is ready, and when
+
+**In the constructor.** The constructor body always runs to completion before `connectedCallback`. It cannot be interrupted by connection. What *can* surprise you is:
+
+- The `shadowRoot` exists but is **empty**. The template has not been rendered into it yet.
+- Asynchronous work started in the constructor will settle *after* `connectedCallback`, not before it.
+- The native `this.isConnected` is not a reliable "am I being constructed?" signal, and its value in the constructor depends on *how the element was created* — not on whether the markup was in the document:
+
+| Creation path | `this.isConnected` in the constructor |
+| --- | --- |
+| Detached `document.createElement()` | `false` |
+| The document parser reaches `<my-element>` and the definition is **already registered** | `false` — the parser constructs the element as it *creates* it, before inserting it |
+| An element already in the tree is upgraded by a later `define()` — a late definition, or markup written with `innerHTML` | `true` — the constructor runs as an upgrade reaction, and the element is already in the tree |
+
+The middle row is the one that catches people: an element parsed straight into a connected document reports `isConnected === false` in its constructor whenever its definition was registered eagerly. And in *no* case does `isConnected` tell you that the view exists — the shadow root is still empty.
+
+**In `connectedCallback`, after `super.connectedCallback()`.** For a client-side-rendered element the template has been rendered, styles are applied, and the view is bound. If server-side rendering is in play, see [Hydration](#hydration-and-ssr) below — use `$fastController.isHydrated` rather than assuming.
+
+**In a changed callback.** Assume nothing. It can run at construction time, when the shadow root is empty and the view does not exist.
+
+The controller's own `this.$fastController.isConnected` — *not* the native `this.isConnected` — is the flag that tracks the view: it is `true` only from the end of `connect()`, once the template has been rendered and bound. But be precise about what that buys you, because it is a smaller guarantee than it looks:
+
+**Every one of the initialization firings counted earlier happens while `$fastController.isConnected` is `false`.** The default value and the tag attribute both arrive before `connect()` runs at all, and the pre-upgrade property is replayed while the controller is still *connecting*. FAST does not re-invoke the callback afterwards. So a changed callback that returns early on that guard **drops** the initial value — it does not defer it.
+
+The guard is therefore only half a pattern. The other half is applying the current value in `connectedCallback`:
+
+```ts
+export class MyElement extends FASTElement {
+  @attr foo?: string;
+
+  connectedCallback() {
+    super.connectedCallback();
+
+    // The initialization firings were all dropped by the guard below, so the
+    // value the element booted with has to be applied here.
+    this.applyFoo();
+  }
+
+  fooChanged(oldValue: string | undefined, newValue: string) {
+    // Not "wait until connected" - the callback will not run again for this
+    // value. Dropped here, applied in connectedCallback above.
+    if (!this.$fastController.isConnected) {
+      return;
+    }
+
+    this.applyFoo();
+  }
+
+  private applyFoo() {
+    // Safe to read the rendered view here.
+  }
+}
+```
+
+The practical rule: **do not touch shadow DOM content from a changed callback** unless you write both halves. The simpler option is usually to not need them: let the changed callback update only state that your template already binds to, and let the view refresh itself.
+
+## Hydration and SSR
+
+When hydration is enabled and an element arrives with prerendered shadow DOM, FAST binds the existing markup rather than re-rendering it. During that window it deliberately suppresses attribute work: the controller's attribute changed callback is swapped for a no-op, and attribute *bindings* on the view are skipped. Attribute mutations that happen while the prerendered view is being bound therefore do **not** re-enter your changed callback.
+
+Two promises on the controller are the supported way to wait for readiness:
+
+- `this.$fastController.isPrerendered` — resolves `true` if the element had an existing shadow root at connect time.
+- `this.$fastController.isHydrated` — resolves `true` once prerendered content has actually been hydrated, `false` for a client-side render.
+
+```ts
+export class MyElement extends FASTElement {
+  async connectedCallback() {
+    super.connectedCallback();
+
+    // Settles for a client-side render and for a hydrated SSR render alike, so
+    // this cannot hang, and the view is bound once it settles. It only *resolves
+    // true* for hydrated prerendered content - a client-side render resolves
+    // `false`. Await it for the timing; do not branch on it expecting `true`.
+    await this.$fastController.isHydrated;
+  }
+}
+```
+
+The legacy `defer-hydration` attribute is **not** part of this lifecycle. FAST no longer reads it: nothing in the framework gates connection or hydration on it. The string is still exported as `deferHydrationAttribute` (`@beta`) from `@microsoft/fast-element/hydration.js` for application code that still drives its own deferral (viewport-based hydration, for example), but new server-rendered markup should omit the attribute — see the [hydration migration guide](../../migration-guide/hydration/).
+
+## Do not throw from a changed callback
+
+An exception thrown out of a changed callback is worse than it looks, and how it fails depends on how the value was set:
+
+- **Property path** (`element.foo = "x"`): the exception propagates out of the setter to your call site. You will see it.
+- **Attribute path** (`element.setAttribute("foo", "x")`, the parser, upgrade): the exception does **not** reach the caller. It is swallowed by the custom element reaction queue and surfaces only on `window.onerror`.
+
+In both cases the backing field has *already* been written, and the notification to observers is skipped. Every binding and subscriber on that property is left permanently stale — on the attribute path, with no exception at the call site to tell you. Catch inside the changed callback and handle the failure there.
+
+## A note on cost
+
+`connectedCallback` already walks every own property of the element and searches the prototype chain for a matching accessor, so that properties set before upgrade can be replayed through the accessor. That is the mechanism that rescues a pre-upgrade property, and it is the cost that any further "fix the initialization contract in the framework" proposal would be adding to. The contract described on this page is the one to code against, not one to work around.
+
+## Out of scope
+
+Whether an observed property *should* skip its changed callback on the very first assignment is a live design question, and this page deliberately does not answer it. It documents what FAST does today — and `attributes.pw.spec.ts` pins that behavior, so changing it is an explicit, breaking decision rather than an accident.

--- a/sites/website/src/docs/3.x/getting-started/fast-element.md
+++ b/sites/website/src/docs/3.x/getting-started/fast-element.md
@@ -194,6 +194,8 @@ export class MyElement extends FASTElement {
 Overriding `connectedCallback` can affect the timing of when your template is bound and when behaviors run, so it's generally recommended to call `super.connectedCallback()` at the beginning of your override. Conversely, for `disconnectedCallback` and `attributeChangedCallback`, it's usually best to call the super method at the end of your override to ensure that your custom logic runs while the element is still in a consistent state.
 :::
 
+The `attributeChangedCallback` above is the *native* one, and the `oldValue` it logs is `null` on the first change. The `fooChanged` callback that FAST generates for an `@attr foo` is a **different** callback with different semantics: its first `oldValue` is `undefined`, not `null`, and its values have already been through the attribute's converter rather than being raw strings. It can also fire more than once before the element is ever connected. See [Component Lifecycle](../../advanced/component-lifecycle/) for the full contract.
+
 ## Defining the Element
 
 ### `define()`


### PR DESCRIPTION
## What this does

Adds a component lifecycle guide, and turns the surprising parts of element initialization into tests that will fail if the behavior ever changes.

## Why

The lifecycle docs were a bare table of callback names with no guidance about how to actually use them. Meanwhile the genuinely surprising parts of initialization were both undocumented **and** untested:

- **The first `oldValue` an `@attr` changed callback receives is `undefined`, not `null`.** Everyone expects `null`, because that is what the native `attributeChangedCallback` gives you. People write `if (oldValue !== null)` guards against a value that never arrives.
- **A changed callback fires zero, one, or two times during startup**, depending on whether the property has a default and whether the attribute is present in markup. Assigning a default in the constructor fires the callback by itself, because the class field initializer goes through the attribute's setter. If the tag also carries the attribute, it fires again.

Nobody had written this down, and nothing pinned it, so it could drift silently.

## What changed
<img width="2800" height="1800" alt="00-control-stale-guide-frontmatter" src="https://github.com/user-attachments/assets/65e6eb61-d33f-4b1c-9caa-8ff287fac1a6" />
<img width="2800" height="1800" alt="01-sidebar-new-entry" src="https://github.com/user-attachments/assets/ffcae9ec-1574-4ac8-8667-aedca015c969" />
<img width="600" height="1680" alt="02-sidebar-advanced-closeup" src="https://github.com/user-attachments/assets/45fba910-82f8-4027-9222-e09736de77a0" />
<img width="2800" height="1800" alt="03-content-code-samples" src="https://github.com/user-attachments/assets/24486b40-1c5a-4f24-9cf3-9b386a27f8cf" />
<img width="2800" height="1800" alt="04-console-clean" src="https://github.com/user-attachments/assets/4b75d43e-84cd-4f7f-8c24-83e1c7b054b0" />



- **New guide:** `sites/website/src/docs/3.x/advanced/component-lifecycle.md`, linked from the existing lifecycle section.
- **Tests:** `components/attributes.pw.spec.ts` grows from two tests into an executable specification of the initialization contract — the `undefined` first `oldValue`, the zero/one/two firing counts, and the ordering of the constructor against `connectedCallback`.

## Two corrections

The issue body contains two claims that are not true, and writing them down would have shipped an authoritative but wrong document. Both are corrected in the guide, and both are now pinned by tests:

1. **"`connectedCallback` may fire while the constructor is still executing"** — it does not. A synchronous constructor body always completes first. The real behaviors worth knowing are that *asynchronous* work started in a constructor settles after `connectedCallback`, and that `this.isConnected` is already `true` inside the constructor when upgrading an element that is already in the page.
2. **"attributes go `null` → value"** — they go `undefined` → value.

The guide uses **"default value"** throughout rather than "initial value", following the terminology already agreed on the issue thread.

## Deliberately left open

The issue also raises a design question — should an observed property skip its changed callback on the first run? That is a maintainer's call, and this PR does not decide it.

## How to see it

Run the `fast-element` test suite; the new tests in `components/attributes.pw.spec.ts` fail if you "correct" the first `oldValue` to `null` or change the firing counts. Then preview the docs site: **Advanced → Component lifecycle**.

Fixes #7516
