### PR TITLE
docs: clarify declarative fixture testing guidance

### DIFF
--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -109,14 +109,7 @@ FAST tests are [Playwright](https://playwright.dev/) integration tests that run 
 
 Fixture tests in `@microsoft/fast-element/test/declarative/fixtures` are the primary way to verify declarative template features. Each fixture is a self-contained test case with its own HTML, state, templates, and component definitions.
 
-When changing declarative syntax, directive parsing, template generation,
-hydration behavior, or other user-authored template behavior, add or update a
-declarative fixture and exercise it in browser. Source-level parser tests may
-supplement narrow parsing edge cases, but they should not be the only coverage
-for syntax that users write in `entry.html` or `templates.html`. For directive
-syntax, start with the fixtures under
-`packages/fast-element/test/declarative/fixtures/directives/`; for example,
-`directives/children` covers `f-children`.
+When changing declarative syntax, directive parsing, template generation, hydration behavior, or other user-authored template behavior, add or update a declarative fixture and exercise it in browser. Source-level parser tests may supplement narrow parsing edge cases, but they should not be the only coverage for syntax that users write in `entry.html` or `templates.html`. For directive syntax, start with the fixtures under `packages/fast-element/test/declarative/fixtures/directives/`; for example, `directives/children` covers `f-children`.
 
 For a complete guide on creating fixtures — including how to write `entry.html`, `state.json`, `templates.html`, `main.ts`, and spec files — see:
 

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -109,6 +109,15 @@ FAST tests are [Playwright](https://playwright.dev/) integration tests that run 
 
 Fixture tests in `@microsoft/fast-element/test/declarative/fixtures` are the primary way to verify declarative template features. Each fixture is a self-contained test case with its own HTML, state, templates, and component definitions.
 
+When changing declarative syntax, directive parsing, template generation,
+hydration behavior, or other user-authored template behavior, add or update a
+declarative fixture and exercise it in browser. Source-level parser tests may
+supplement narrow parsing edge cases, but they should not be the only coverage
+for syntax that users write in `entry.html` or `templates.html`. For directive
+syntax, start with the fixtures under
+`packages/fast-element/test/declarative/fixtures/directives/`; for example,
+`directives/children` covers `f-children`.
+
 For a complete guide on creating fixtures — including how to write `entry.html`, `state.json`, `templates.html`, `main.ts`, and spec files — see:
 
 📄 **[Writing Fixtures](../../../packages/fast-element/test/declarative/fixtures/WRITING_FIXTURES.md)**

--- a/.github/skills/testing/SKILL.md
+++ b/.github/skills/testing/SKILL.md
@@ -109,7 +109,7 @@ FAST tests are [Playwright](https://playwright.dev/) integration tests that run 
 
 Fixture tests in `@microsoft/fast-element/test/declarative/fixtures` are the primary way to verify declarative template features. Each fixture is a self-contained test case with its own HTML, state, templates, and component definitions.
 
-When changing declarative syntax, directive parsing, template generation, hydration behavior, or other user-authored template behavior, add or update a declarative fixture and exercise it in browser. Source-level parser tests may supplement narrow parsing edge cases, but they should not be the only coverage for syntax that users write in `entry.html` or `templates.html`. For directive syntax, start with the fixtures under `packages/fast-element/test/declarative/fixtures/directives/`; for example, `directives/children` covers `f-children`.
+When changing declarative syntax, directive parsing, template generation, hydration behavior, or other user-authored template behavior, add or update a declarative fixture and exercise it in browser. Source-level parser tests may supplement narrow parsing edge cases, but they should not be the only coverage for syntax that users write in `entry.html` or `templates.html`. Use the local README files under `packages/fast-element/test/declarative/fixtures/` and each fixture category to choose the right fixture type and follow category-specific examples.
 
 For a complete guide on creating fixtures — including how to write `entry.html`, `state.json`, `templates.html`, `main.ts`, and spec files — see:
 

--- a/change/@microsoft-fast-element-1a06cb78-b971-48a9-8c9c-e3ff31fa0383.json
+++ b/change/@microsoft-fast-element-1a06cb78-b971-48a9-8c9c-e3ff31fa0383.json
@@ -1,0 +1,7 @@
+{
+  "type": "none",
+  "comment": "Document declarative fixture testing guidance.",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/test/declarative/fixtures/WRITING_FIXTURES.md
+++ b/packages/fast-element/test/declarative/fixtures/WRITING_FIXTURES.md
@@ -50,6 +50,21 @@ Fixtures are auto-discovered by scanning category directories for subdirectories
 
 ---
 
+## When to add or update a fixture
+
+Use fixtures for changes to declarative syntax, directive parsing, template
+generation, hydration behavior, or other behavior that users express in
+`entry.html` or `templates.html`. Fixture coverage runs the generated template
+in a browser and catches integration issues that parser-only tests can miss.
+
+Source-level parser tests may still be useful for very narrow edge cases, but
+they should supplement fixture coverage rather than replace it. For directive
+syntax changes, add or update the matching fixture under `directives/` (for
+example, `directives/children` for `f-children`) and assert the behavior from
+the fixture's Playwright spec.
+
+---
+
 ## fast-build.config.json
 
 Each fixture must include a `fast-build.config.json` file that tells the `@microsoft/fast-build` CLI where to find the fixture's source files and how to build them. The build script passes `--config=<path>` to the CLI for each fixture.

--- a/packages/fast-element/test/declarative/fixtures/WRITING_FIXTURES.md
+++ b/packages/fast-element/test/declarative/fixtures/WRITING_FIXTURES.md
@@ -54,7 +54,7 @@ Fixtures are auto-discovered by scanning category directories for subdirectories
 
 Use fixtures for changes to declarative syntax, directive parsing, template generation, hydration behavior, or other behavior that users express in `entry.html` or `templates.html`. Fixture coverage runs the generated template in a browser and catches integration issues that parser-only tests can miss.
 
-Source-level parser tests may still be useful for very narrow edge cases, but they should supplement fixture coverage rather than replace it. For directive syntax changes, add or update the matching fixture under `directives/` (for example, `directives/children` for `f-children`) and assert the behavior from the fixture's Playwright spec.
+Source-level parser tests may still be useful for very narrow edge cases, but they should supplement fixture coverage rather than replace it. Use the local README files in this directory and each fixture category to choose the right fixture type, then add or update the matching fixture and assert the behavior from the fixture's Playwright spec.
 
 ---
 

--- a/packages/fast-element/test/declarative/fixtures/WRITING_FIXTURES.md
+++ b/packages/fast-element/test/declarative/fixtures/WRITING_FIXTURES.md
@@ -52,16 +52,9 @@ Fixtures are auto-discovered by scanning category directories for subdirectories
 
 ## When to add or update a fixture
 
-Use fixtures for changes to declarative syntax, directive parsing, template
-generation, hydration behavior, or other behavior that users express in
-`entry.html` or `templates.html`. Fixture coverage runs the generated template
-in a browser and catches integration issues that parser-only tests can miss.
+Use fixtures for changes to declarative syntax, directive parsing, template generation, hydration behavior, or other behavior that users express in `entry.html` or `templates.html`. Fixture coverage runs the generated template in a browser and catches integration issues that parser-only tests can miss.
 
-Source-level parser tests may still be useful for very narrow edge cases, but
-they should supplement fixture coverage rather than replace it. For directive
-syntax changes, add or update the matching fixture under `directives/` (for
-example, `directives/children` for `f-children`) and assert the behavior from
-the fixture's Playwright spec.
+Source-level parser tests may still be useful for very narrow edge cases, but they should supplement fixture coverage rather than replace it. For directive syntax changes, add or update the matching fixture under `directives/` (for example, `directives/children` for `f-children`) and assert the behavior from the fixture's Playwright spec.
 
 ---
 


### PR DESCRIPTION
# Pull Request

## 📖 Description

Clarifies agent-facing testing guidance for declarative template work:

- Explains that declarative syntax, template generation, hydration behavior, fixture category behavior, and other user-authored template behavior should be covered with browser-backed declarative fixtures.
- Points agents to the local fixture README files so they can choose the right fixture category and follow category-specific examples.
- Reinforces in the fixture writing guide that parser-only tests should supplement fixture coverage rather than replace it.

## 👩‍💻 Reviewer Notes

This follows review feedback on #7638, where declarative syntax coverage should use the existing browser fixture suite instead of only source-level parser tests.

## 📑 Test Plan

- `git diff --check`
- `npm run checkchange`

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Agents

- [ ] I have linked to an existing issue in this project that this change addresses
- [x] I have read the skills
- [ ] I have read the DESIGN.md file(s) in packages relevent to my changes
- [ ] I have updated the DESIGN.md file(s) in packages relevent to my changes
