### PR TITLE
fix(fast-test-harness): preserve attributes on inner template in f-template to webui conversion

### DIFF
--- a/change/@microsoft-fast-test-harness-69ec7ee5-5fa6-4167-9431-f7d613ce6dc5.json
+++ b/change/@microsoft-fast-test-harness-69ec7ee5-5fa6-4167-9431-f7d613ce6dc5.json
@@ -1,6 +1,6 @@
 {
   "type": "patch",
-  "comment": "fix: preserve attributes on inner template in f-template to webui conversion",
+  "comment": "Preserve attributes on inner template in f-template to webui conversion.",
   "packageName": "@microsoft/fast-test-harness",
   "email": "863023+radium-v@users.noreply.github.com",
   "dependentChangeType": "none"

--- a/change/@microsoft-fast-test-harness-69ec7ee5-5fa6-4167-9431-f7d613ce6dc5.json
+++ b/change/@microsoft-fast-test-harness-69ec7ee5-5fa6-4167-9431-f7d613ce6dc5.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "fix: preserve attributes on inner template in f-template to webui conversion",
+  "packageName": "@microsoft/fast-test-harness",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-test-harness/src/build/generate-webui-templates.test.ts
+++ b/packages/fast-test-harness/src/build/generate-webui-templates.test.ts
@@ -3,7 +3,10 @@ import { mkdir, mkdtemp, readFile, rm, writeFile } from "node:fs/promises";
 import { tmpdir } from "node:os";
 import { join } from "node:path";
 import { test } from "node:test";
-import { generateWebuiTemplates } from "@microsoft/fast-test-harness/build/generate-webui-templates.js";
+import {
+    fTemplateToWebui,
+    generateWebuiTemplates,
+} from "@microsoft/fast-test-harness/build/generate-webui-templates.js";
 
 test.describe("generateWebuiTemplates", () => {
     let tempDir: string;
@@ -358,5 +361,80 @@ test.describe("generateWebuiTemplates", () => {
         const html = await readFile(join(sub, "alert.template-webui.html"), "utf8");
         assert.ok(html.includes("role="), `got: ${html}`);
         assert.ok(html.includes("alert"), `got: ${html}`);
+    });
+});
+
+test.describe("fTemplateToWebui", () => {
+    test("should preserve root template attributes and event bindings", () => {
+        const fTemplate = [
+            '<f-template name="contoso-button" shadowrootmode="open">',
+            '    <template @click="{clickHandler($e)}" @keypress="{keypressHandler($e)}">',
+            "        {{styles}}",
+            '        <slot name="start" f-ref="{start}"></slot>',
+            "        <slot></slot>",
+            "    </template>",
+            "</f-template>",
+        ].join("\n");
+
+        const webui = fTemplateToWebui(fTemplate, {});
+
+        assert.ok(
+            webui.includes('shadowrootmode="open"'),
+            `should apply shadowrootmode, got: ${webui}`,
+        );
+        assert.ok(
+            webui.includes('@click="{clickHandler($e)}"'),
+            `should preserve @click binding, got: ${webui}`,
+        );
+        assert.ok(
+            webui.includes('@keypress="{keypressHandler($e)}"'),
+            `should preserve @keypress binding, got: ${webui}`,
+        );
+        assert.ok(!webui.includes("<f-template"), `got: ${webui}`);
+        assert.ok(!webui.includes("{{styles}}"), `got: ${webui}`);
+    });
+
+    test("should merge shadow attributes with preserved bindings", () => {
+        const fTemplate =
+            '<f-template name="contoso-input" shadowrootmode="open"><template @change="{onChange($e)}">{{styles}}<slot></slot></template></f-template>';
+
+        const webui = fTemplateToWebui(fTemplate, { shadowrootdelegatesfocus: "" });
+
+        assert.ok(webui.includes("shadowrootdelegatesfocus"), `got: ${webui}`);
+        assert.ok(webui.includes('shadowrootmode="open"'), `got: ${webui}`);
+        assert.ok(webui.includes('@change="{onChange($e)}"'), `got: ${webui}`);
+    });
+
+    test("should emit a plain template when the root has no attributes", () => {
+        const fTemplate =
+            '<f-template name="contoso-badge" shadowrootmode="open"><template>{{styles}}<slot></slot></template></f-template>';
+
+        const webui = fTemplateToWebui(fTemplate, {});
+
+        assert.ok(webui.includes('<template shadowrootmode="open">'), `got: ${webui}`);
+    });
+
+    test("should adopt shadowrootmode from the f-template wrapper", () => {
+        const fTemplate =
+            '<f-template name="contoso-panel" shadowrootmode="closed"><template>{{styles}}<slot></slot></template></f-template>';
+
+        const webui = fTemplateToWebui(fTemplate, {});
+
+        assert.ok(
+            webui.includes('<template shadowrootmode="closed">'),
+            `should mirror the wrapper's shadowrootmode, got: ${webui}`,
+        );
+    });
+
+    test("should default shadowrootmode to open when the wrapper omits it", () => {
+        const fTemplate =
+            '<f-template name="contoso-panel"><template>{{styles}}<slot></slot></template></f-template>';
+
+        const webui = fTemplateToWebui(fTemplate, {});
+
+        assert.ok(
+            webui.includes('<template shadowrootmode="open">'),
+            `should default to open, got: ${webui}`,
+        );
     });
 });

--- a/packages/fast-test-harness/src/build/generate-webui-templates.ts
+++ b/packages/fast-test-harness/src/build/generate-webui-templates.ts
@@ -245,10 +245,15 @@ export interface GenerateWebuiTemplatesOptions {
 
 /**
  * Transform an f-template string into a webui template by replacing the
- * `<f-template>` wrapper with `<template shadowrootmode="open">` and
- * removing the `{{styles}}` placeholder.
+ * `<f-template>` wrapper with a declarative shadow DOM `<template>` and
+ * removing the `{{styles}}` placeholder. The `shadowrootmode` is adopted from
+ * the `<f-template>` wrapper (defaulting to `"open"` when absent), and the
+ * inner `<template>`'s own attributes (FAST event bindings, `f-ref`, etc.)
+ * are preserved.
+ *
+ * Exported for unit testing.
  */
-function fTemplateToWebui(
+export function fTemplateToWebui(
     fTemplateHtml: string,
     shadowAttrs: Record<string, string>,
 ): string {
@@ -267,6 +272,12 @@ function fTemplateToWebui(
         return fTemplateHtml;
     }
 
+    // Adopt the shadow root mode declared on the <f-template> wrapper rather
+    // than hard-coding it, so the webui <template> stays in sync with the
+    // f-template. Defaults to "open" when the wrapper omits it.
+    const fOpenTag = fTemplateHtml.slice(fOpenStart, fOpenEnd + 1);
+    const shadowRootMode = extractQuotedAttribute(fOpenTag, "shadowrootmode") ?? "open";
+
     let inner = fTemplateHtml.slice(fOpenEnd + 1, fCloseStart).trim();
 
     // Remove {{styles}} placeholder.
@@ -275,15 +286,25 @@ function fTemplateToWebui(
     // Convert FAST declarative template directives to WebUI template directives.
     inner = convertFastDirectivesToWebui(inner);
 
-    // Replace the opening <template> tag with one that includes shadow attributes.
+    // Rewrite the opening <template> tag: apply the f-template's shadow root
+    // mode, add the shadow-root attributes, and preserve the template's own
+    // attributes (FAST event bindings like @click, f-ref, etc.). Only the
+    // wrapping <f-template> carries shadowrootmode, so the inner <template>
+    // never already has it.
     const extraAttrs = Object.entries(shadowAttrs)
         .map(([k, v]) => (v ? ` ${k}="${v}"` : ` ${k}`))
         .join("");
 
-    inner = inner.replace(
-        /^<template[^>]*>/,
-        `<template shadowrootmode="open"${extraAttrs}>`,
-    );
+    const openTagEnd = findTagEnd(inner, 0);
+    if (openTagEnd !== -1 && startsWithTag(inner, 0, "template")) {
+        const openTag = inner.slice(0, openTagEnd + 1);
+        const rest = inner.slice(openTagEnd + 1);
+        // Strip `<template` and the trailing `>`, leaving the raw attribute
+        // text to carry over verbatim.
+        const rawAttrs = openTag.slice("<template".length, -1).trim();
+        const preservedAttrs = rawAttrs ? ` ${rawAttrs}` : "";
+        inner = `<template shadowrootmode="${shadowRootMode}"${extraAttrs}${preservedAttrs}>${rest}`;
+    }
 
     return inner;
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Fixes a bug in `@microsoft/fast-test-harness` in the WebUI template generator where converting an f-template to a WebUI template discarded the root `<template>`'s own attributes. Any FAST bindings declared on the host template (`@click`/`@keypress`, `f-ref`, etc.) were silently dropped, so WebUI consumers lost that behavior during f-template reconstruction.

The conversion now preserves the inner `<template>`'s attributes verbatim while still normalizing the wrapper. As part of the fix, `shadowrootmode` is now adopted from the `<f-template>` wrapper (defaulting to `"open"` when absent) rather than hard-coded, keeping the WebUI output in sync with the f-template. Other `shadowroot*` attributes (e.g. `shadowrootdelegatesfocus`) continue to flow generically from the component's `definition-async.js` shadow options.

## 📑 Test Plan

New unit tests cover the previously-missing behavior via the now-exported `fTemplateToWebui`:

- root `<template>` event bindings (`@click`, `@keypress`) and `f-ref` are preserved
- shadow attributes merge alongside preserved bindings
- `shadowrootmode` is adopted from the wrapper, and defaults to `"open"` when the wrapper omits it (there's no other way for an f-template to provide that property without making its child `<template>` its own shadow root (this is a convention that we've been using downstream).

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Agents

- [ ] I have linked to an existing issue in this project that this change addresses
- [x] I have read the skills
- [ ] I have read the DESIGN.md file(s) in packages relevent to my changes
- [ ] I have updated the DESIGN.md file(s) in packages relevent to my changes

## ⏭ Next Steps

Downstream consumers that commit generated WebUI templates should regenerate their `*.template-webui.html` files after this fix is published to recover the root-template bindings.