### PR TITLE
fix: use compatibility fallbacks when generating stylesheets instead of assuming CSS custom state support

### DIFF
--- a/change/@microsoft-fast-test-harness-3f57a8f0-f37b-4c71-b652-e88256b3df07.json
+++ b/change/@microsoft-fast-test-harness-3f57a8f0-f37b-4c71-b652-e88256b3df07.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Use compatibility fallbacks when generating stylesheets instead of assuming CSS custom state support.",
+  "packageName": "@microsoft/fast-test-harness",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-test-harness/DESIGN.md
+++ b/packages/fast-test-harness/DESIGN.md
@@ -69,7 +69,7 @@ flowchart TD
 | `src/fixtures/csr-fixture.ts` | `CSRFixture` class — client-side rendering fixture |
 | `src/fixtures/ssr-fixture.ts` | `SSRFixture` class — server-side rendering fixture (extends `CSRFixture`) |
 | `src/fixtures/assertions.ts` | Custom Playwright assertion `toHaveCustomState` |
-| `src/build/dom-shim.ts` | Minimal DOM shim for running FAST Element's `css` and `html` tagged templates in Node.js |
+| `src/build/dom-shim.ts` | Minimal DOM shim for running FAST Element's `css` and `html` tagged templates in Node.js. CSS feature detection defaults to unsupported so generated artifacts use compatibility fallbacks. |
 | `src/build/generate-stylesheets.ts` | Extracts compiled FAST `ElementStyles` JS modules into plain `.css` files |
 | `src/build/generate-templates.ts` | Converts compiled FAST `ViewTemplate` JS modules into declarative `<f-template>` HTML files. Exports `definitionAsyncResolver`, `shadowOptionsToAttributes`, and the `ShadowOptionsResolver` type for resolving per-component shadow DOM options. Static wrapper stripping and style-marker injection recognize browser-valid `<template>` tags with ASCII whitespace before `>` in opening and closing tags. |
 | `src/build/generate-webui-templates.ts` | Converts compiled FAST `ViewTemplate` JS modules into WebUI-compatible declarative shadow DOM `<template>` HTML files. Shares the shadow-options resolution pipeline with `generate-templates.ts`. |

--- a/packages/fast-test-harness/README.md
+++ b/packages/fast-test-harness/README.md
@@ -244,6 +244,10 @@ CLI flags take precedence over environment variables.
 static wrappers even when the opening or closing tag includes ASCII whitespace
 before `>`.
 
+`generate-stylesheets` evaluates compiled style modules with CSS feature detection
+disabled by default, so generated CSS uses compatibility fallbacks instead of
+assuming target environments support features such as `ElementInternals` custom states.
+
 | Environment variable | Default | Description |
 | -------------------- | ------- | ----------- |
 | `PORT` | `3278` | Server port (overridden by `--port`) |

--- a/packages/fast-test-harness/src/build/dom-shim.test.ts
+++ b/packages/fast-test-harness/src/build/dom-shim.test.ts
@@ -68,10 +68,13 @@ test.describe("installDomShim", () => {
         assert.strictEqual((globalThis as any).window, globalThis);
     });
 
-    test("should provide CSS.supports that returns true", async () => {
+    test("should not assume CSS features are supported", async () => {
         await loadShim();
 
-        assert.strictEqual((globalThis as any).CSS.supports("display", "flex"), true);
+        assert.strictEqual(
+            (globalThis as any).CSS.supports("selector(:state(checked))"),
+            false,
+        );
     });
 
     test("should not overwrite an existing CSS global", async () => {

--- a/packages/fast-test-harness/src/build/dom-shim.ts
+++ b/packages/fast-test-harness/src/build/dom-shim.ts
@@ -2,6 +2,8 @@
  * Minimal DOM shim for running FAST Element's `css` and `html` tagged
  * templates in Node.js. Provides just enough of the DOM API to resolve
  * `ElementStyles.toString()` and compile `html` templates.
+ * CSS feature detection defaults to unsupported so generated artifacts
+ * do not assume capabilities that may be unavailable in their target runtime.
  *
  * This module is idempotent — if `globalThis.window` is already defined,
  * no shims are applied.
@@ -153,5 +155,5 @@ export function installDomShim(): void {
     (globalThis as any).customElements = new ShimCustomElementRegistry();
     (globalThis as any).window = globalThis;
 
-    (globalThis as any).CSS ??= { supports: () => true };
+    (globalThis as any).CSS ??= { supports: () => false };
 }

--- a/packages/fast-test-harness/src/build/generate-stylesheets.test.ts
+++ b/packages/fast-test-harness/src/build/generate-stylesheets.test.ts
@@ -107,6 +107,27 @@ test.describe("generateStylesheets", () => {
         assert.ok(css.includes("span { font-size: 14px; }"));
     });
 
+    test("should not assume CSS custom states are supported", async () => {
+        const distDir = join(tempDir, "dist");
+        await mkdir(distDir, { recursive: true });
+
+        await writeFile(
+            join(distDir, "state.styles.js"),
+            `const stateSelector = CSS.supports("selector(:state(checked))")
+                ? ":state(checked)"
+                : "[state--checked]";
+            export const styles = {
+                styles: [\`:host(\${stateSelector}) { color: green; }\`]
+            };`,
+        );
+
+        await generateStylesheets({ cwd: tempDir });
+
+        const css = await readFile(join(distDir, "state.styles.css"), "utf8");
+        assert.ok(css.includes(":host([state--checked])"));
+        assert.ok(!css.includes(":state(checked)"));
+    });
+
     test("should skip modules without a styles export", async () => {
         const distDir = join(tempDir, "dist");
         await mkdir(distDir, { recursive: true });


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change updates the assumption the `@microsoft/fast-test-harness` script to generate css files uses so that ElementInternals is not assumed to be supported. This allows for the full generation of all necessary CSS for cross browser compatibility, as well as fixing an issue with SSR where ElementInternals has no declarative option and would potentially cause a layout shift after the JS had been loaded.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Agents

- [ ] I have linked to an existing issue in this project that this change addresses
- [ ] I have read the skills
- [ ] I have read the DESIGN.md file(s) in packages relevent to my changes
- [ ] I have updated the DESIGN.md file(s) in packages relevent to my changes