### PR TITLE
feat: add multi-route support to the FAST test harness

### DIFF
--- a/change/@microsoft-fast-test-harness-00c6dcf7-fba5-4d5a-ae04-e1839e91b89a.json
+++ b/change/@microsoft-fast-test-harness-00c6dcf7-fba5-4d5a-ae04-e1839e91b89a.json
@@ -1,0 +1,7 @@
+{
+  "type": "minor",
+  "comment": "Add multi-route support",
+  "packageName": "@microsoft/fast-test-harness",
+  "email": "863023+radium-v@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-test-harness/DESIGN.md
+++ b/packages/fast-test-harness/DESIGN.md
@@ -91,7 +91,7 @@ The `test.extend` call in `src/fixtures/index.ts` adds five configurable options
 
 | Option | Type | Default | Description |
 | -------- | ------ | --------- | ------------- |
-| `base` | `string` | `"/"` | Base path for the test page and fixture generation endpoint |
+| `base` | `string` | `"/"` | Base path for the test page and fixture generation endpoint, it must end in "/" |
 | `tagName` | `string` | `""` | Custom element tag name used to build the default template and locate the element |
 | `innerHTML` | `string` | `""` | Default inner HTML inserted into the element |
 | `waitFor` | `string[]` | `[]` | Additional custom element tag names to wait for before the test runs |

--- a/packages/fast-test-harness/DESIGN.md
+++ b/packages/fast-test-harness/DESIGN.md
@@ -63,7 +63,7 @@ flowchart TD
 ## Module Map
 
 | File | Role |
-|------|------|
+| ------ | ------ |
 | `src/index.ts` | Package barrel — re-exports fixtures, assertions, build utilities, and SSR renderer |
 | `src/fixtures/index.ts` | Extends Playwright's `test` with `fastPage` fixture and `expect` with custom assertions |
 | `src/fixtures/csr-fixture.ts` | `CSRFixture` class — client-side rendering fixture |
@@ -87,10 +87,11 @@ flowchart TD
 
 ### FixtureOptions
 
-The `test.extend` call in `src/fixtures/index.ts` adds four configurable options to every test:
+The `test.extend` call in `src/fixtures/index.ts` adds five configurable options to every test:
 
 | Option | Type | Default | Description |
-|--------|------|---------|-------------|
+| -------- | ------ | --------- | ------------- |
+| `base` | `string` | `"/"` | Base path for the test page and fixture generation endpoint |
 | `tagName` | `string` | `""` | Custom element tag name used to build the default template and locate the element |
 | `innerHTML` | `string` | `""` | Default inner HTML inserted into the element |
 | `waitFor` | `string[]` | `[]` | Additional custom element tag names to wait for before the test runs |
@@ -99,18 +100,18 @@ The `test.extend` call in `src/fixtures/index.ts` adds four configurable options
 These are configured per test suite with `test.use()`:
 
 ```ts
-test.use({ tagName: "my-button", innerHTML: "Click me" });
+test.use({ base: "/button/", tagName: "my-button", innerHTML: "Click me" });
 ```
 
-The `fastPage` fixture factory reads these options and instantiates either `CSRFixture` or `SSRFixture`. For CSR, it also navigates to `/`, emulates reduced motion, and waits for custom element definitions before handing control to the test.
+The `fastPage` fixture factory reads these options and instantiates either `CSRFixture` or `SSRFixture`. For CSR, it navigates to `base`, emulates reduced motion, and waits for custom element definitions before handing control to the test.
 
 ### CSRFixture
 
 `CSRFixture` is the base class for interacting with a component on a Playwright page.
 
 | Method | Description |
-|--------|-------------|
-| `goto(url)` | Navigates to a URL (defaults to `"/"`) |
+| -------- | ------------- |
+| `goto(url)` | Navigates to a URL (defaults to the fixture `base`) |
 | `setTemplate(templateOrOptions?)` | Injects HTML into `<body>`. Accepts a raw HTML string, an options object (`{ attributes, innerHTML }`), or no argument (uses defaults from `tagName`/`innerHTML`). Waits for stability after injection. |
 | `updateTemplate(locator, options)` | Modifies attributes and/or innerHTML of an already-rendered element in place. Boolean `true` sets the attribute, `false` removes it, strings set the value. |
 | `waitForCustomElement(...tagNames)` | Blocks until all specified elements are defined in `customElements` |
@@ -128,16 +129,16 @@ The `fastPage` fixture factory reads these options and instantiates either `CSRF
 | Override | Description |
 |----------|-------------|
 | `addStyleTag` | Buffers style options into `pendingStyles` until `setTemplate` is called. Only `{ content }` options are preserved — the content strings are serialized into the SSR generation request. Style options using `path` or `url` are not included in the SSR output. After `setTemplate`, calls pass through to the page directly. |
-| `setTemplate` | Builds a request body from the template options, posts it to `/generate-fixture`, navigates to the returned URL, and waits for stability. |
+| `setTemplate` | Builds a request body from the template options, posts it to `<base>/generate-fixture`, navigates to the returned URL, and waits for stability. |
 
 | Property | Description |
 |----------|-------------|
-| `url` | Read-only getter exposing the generated SSR fixture URL after `setTemplate` resolves (e.g. `/ssr-<testId>.html`). `undefined` before the first `setTemplate` call. |
+| `url` | Read-only getter exposing the generated SSR fixture URL after `setTemplate` resolves (e.g. `/button/ssr-<testId>.html`). `undefined` before the first `setTemplate` call. |
 
 **SSR request body construction**: The `setTemplate` override constructs a JSON body with these fields:
 
 | Field | Source |
-|-------|--------|
+| ------- | -------- |
 | `testId` | Derived from `testInfo.titlePath` — sanitized to `[a-z0-9_-]` |
 | `testTitle` | Formatted from the test title path |
 | `tagName` | From fixture options (when not using raw HTML) |
@@ -175,7 +176,7 @@ The server (`server.mjs`) is a plain Node.js HTTP server (using `node:http`) wit
 The harness does **not** contain the SSR entry files itself — they live in the consuming project's test directory. By default, `startServer` looks for files under `<cwd>/test/`:
 
 | File | Owner | Purpose |
-|------|-------|---------|
+| ------ | ------- | --------- |
 | `test/index.html` | Consumer | CSR entry page — loads the component registration script |
 | `test/ssr.html` | Consumer | SSR template with comment placeholders (`<!--fixture-->`, `<!--templates-->`, etc.) |
 | `test/src/entry-server.ts` | Consumer | Exports a `render(queryObj)` function that returns `{ template, fixture, preloadLinks }` |
@@ -185,18 +186,18 @@ The harness does **not** contain the SSR entry files itself — they live in the
 The `startServer(cwd, root, configFile)` function accepts overrides for each path:
 
 | Parameter | Default | Description |
-|-----------|---------|-------------|
+| ----------- | --------- | ------------- |
 | `cwd` | `process.cwd()` | Static file serving root |
 | `root` | `<cwd>/test` | Vite root (contains `index.html`, `ssr.html`) |
 | `configFile` | Vite auto-discovery | Vite config path |
 
 ### Startup
 
-`startServer(cwd, root, configFile, options)` accepts an `options` object with `port`, `base`, and `debug` properties (falling back to `PORT`, `BASE`, and `FAST_DEBUG` environment variables, then defaults). It initializes:
+`startServer(cwd, root, configFile, options)` accepts `port`, `base`, `debug`, and `routes`. The environment variables `PORT`, `BASE`, and `FAST_DEBUG` provide defaults. Each route maps a URL base to a test root. Without `routes`, the server creates one route from `base` and `root`.
 
-1. A Vite dev server in middleware mode, configured to ignore the temp directory and with a `fast-test-harness:resolve-css-links` plugin that resolves bare package CSS specifiers in `<link>` tags to `/@fs/` URLs
-2. A Node.js HTTP server with this request handling order: route handlers (`/generate-fixture`, `/ssr-*.html`) → static file serving from `cwd` → Vite middleware → HTML catch-all
-3. When `debug` is enabled: a `temp/` directory under `root` for writing SSR fixture HTML files (cleaned on startup, useful for post-failure inspection)
+1. One Vite dev server in middleware mode for all routes
+2. Route-scoped CSR shells, SSR endpoints, and `entry-server.ts` modules
+3. A `temp/` directory under each route root when `debug` is enabled
 
 The server listens on `port` (default `3278`).
 
@@ -205,16 +206,16 @@ The server listens on `port` (default `3278`).
 After Vite's middleware processes module transforms and HMR, a fallback handler serves the Vite-transformed `index.html` for navigation requests (those with `Accept: text/html`). The transformed HTML is cached after the first request. Non-HTML requests that Vite doesn't handle receive a 404.
 
 ```
-Browser GET /
+Browser GET <base>/
     → catch-all handler
-    → fs.readFile("index.html")
+    → fs.readFile("<route root>/index.html")
     → vite.transformIndexHtml(url, html)
-    → cache and respond with 200
+    → cache by base path and respond with 200
 ```
 
 ### SSR Request Flow
 
-The `/generate-fixture` POST endpoint handles SSR fixture generation:
+The `<base>/generate-fixture` POST endpoint handles SSR fixture generation:
 
 ```mermaid
 sequenceDiagram
@@ -223,11 +224,11 @@ sequenceDiagram
     participant V as Vite
     participant E as entry-server.ts
 
-    B->>S: POST /generate-fixture { testId, tagName, … }
+    B->>S: POST &lt;base&gt;/generate-fixture { testId, tagName, … }
     S->>S: Validate testId, parse attributes & styles
     S->>S: Check pendingGenerations (dedup)
     S->>S: Read ssr.html template
-    S->>V: ssrLoadModule("/src/entry-server.js")
+    S->>V: ssrLoadModule("&lt;base&gt;/src/entry-server.js")
     V-->>S: entry-server module
     S->>E: render(body)
     E-->>S: { template, fixture, preloadLinks }
@@ -235,8 +236,8 @@ sequenceDiagram
     S->>V: transformIndexHtml(url, assembled)
     V-->>S: Transformed HTML
     S->>S: Cache in fixtureCache
-    S-->>B: { url: "/ssr-testId.html" }
-    B->>S: GET /ssr-testId.html
+    S-->>B: { url: "&lt;base&gt;/ssr-testId.html" }
+    B->>S: GET &lt;base&gt;/ssr-testId.html
     S-->>B: Cached fixture HTML
 ```
 
@@ -245,10 +246,10 @@ When `debug` is enabled, the server also writes fixtures to `temp/ssr-<testId>.h
 ### Caching and Deduplication
 
 | Cache | Purpose |
-|-------|---------|
-| `cachedIndexHtml` | Caches the Vite-transformed `index.html` for CSR — avoids re-reading and re-transforming on every navigation |
-| `fixtureCache` | Maps SSR fixture URLs to their rendered HTML — serves fixtures from memory without filesystem reads |
-| `pendingGenerations` | Deduplicates concurrent SSR generation requests for the same `testId` — if a generation is already in progress, subsequent requests await the same promise. This guards against retries of the same test dispatching overlapping requests before the first completes. |
+| ------- | --------- |
+| `cachedIndexHtml` | Caches one transformed `index.html` per base path |
+| `fixtureCache` | Maps route-scoped SSR fixture URLs to rendered HTML |
+| `pendingGenerations` | Deduplicates concurrent SSR generation requests by route-scoped fixture URL |
 
 ---
 
@@ -263,7 +264,7 @@ The `src/ssr/render.ts` module exports `createSSRRenderer`, a factory that scans
 **Options:**
 
 | Option | Type | Default | Description |
-|--------|------|---------|-------------|
+| -------- | ------ | --------- | ------------- |
 | `tagPrefix` | `string` | — | Tag name prefix for custom elements (e.g., `"fluent"`, `"contoso"`) |
 | `packageName` | `string?` | — | Monolithic package name — scans subdirectories for component artifacts. Mutually exclusive with `components`. |
 | `components` | `ComponentRegistration[]?` | — | Explicit list of per-component packages. Mutually exclusive with `packageName`. |
@@ -304,7 +305,7 @@ The `src/ssr/render.ts` module exports `createSSRRenderer`, a factory that scans
 `playwright.config.ts` provides a shared Playwright configuration for consumers:
 
 | Setting | Value |
-|---------|-------|
+| --------- | ------- |
 | `retries` | `3` in CI, `1` locally |
 | `timeout` | `10_000` in CI, `5_000` locally |
 | `fullyParallel` | `true` locally, `false` in CI |
@@ -320,7 +321,7 @@ The `src/ssr/render.ts` module exports `createSSRRenderer`, a factory that scans
 `vite.config.mjs` provides a shared Vite configuration:
 
 | Setting | Value |
-|---------|-------|
+| --------- | ------- |
 | `clearScreen` | `false` |
 | `resolve.conditions` | `["test"]` — enables the `test` condition in `package.json` exports maps, allowing packages to expose source files (`.ts`) directly to Vite instead of compiled output |
 | `server.port` | `3278` (from `PORT` env var) |
@@ -333,7 +334,7 @@ The `src/ssr/render.ts` module exports `createSSRRenderer`, a factory that scans
 ## Exports
 
 | Specifier | Contents |
-|-----------|----------|
+| ----------- | ---------- |
 | `@microsoft/fast-test-harness` | `test`, `expect`, `CSRFixture`, `SSRFixture`, `createSSRRenderer`, `ComponentRegistration`, `RenderResult`, `SSRRendererOptions`, build utilities (`installDomShim`, `generateStylesheets`, `generateFTemplates`, `generateWebuiTemplates`) |
 | `@microsoft/fast-test-harness/server.mjs` | `startServer` |
 | `@microsoft/fast-test-harness/ssr/render.js` | `createSSRRenderer`, `ComponentRegistration`, `RenderResult`, `SSRRendererOptions`, `renderTemplate`, `buildEntryHtml`, `buildState`, `parseDefaultValue` |

--- a/packages/fast-test-harness/README.md
+++ b/packages/fast-test-harness/README.md
@@ -81,7 +81,8 @@ await expect(element).toHaveCustomState("checked");
 ## Fixture options
 
 | Option | Type | Default | Description |
-|--------|------|---------|-------------|
+| -------- | ------ | --------- | ------------- |
+| `base` | `string` | `"/"` | Base path for the test page and SSR endpoint |
 | `tagName` | `string` | `""` | Custom element tag name |
 | `innerHTML` | `string` | `""` | Default inner HTML |
 | `waitFor` | `string[]` | `[]` | Additional elements to wait for before testing |
@@ -208,6 +209,20 @@ await startServer(process.cwd(), "./test", "./test/vite.config.ts", {
 });
 ```
 
+One server can host several test directories at separate paths. Set the matching
+`base` fixture option for each test group.
+
+```ts
+await startServer(process.cwd(), process.cwd(), "./vite.config.ts", {
+    routes: [
+        { base: "/button/", root: "./packages/button/test" },
+        { base: "/dialog/", root: "./packages/dialog/test" },
+    ],
+});
+
+test.use({ base: "/button/", tagName: "my-button" });
+```
+
 | Parameter | Default | Description |
 | --------- | ------- | ----------- |
 | `cwd` | `process.cwd()` | Static file serving root |
@@ -216,6 +231,7 @@ await startServer(process.cwd(), "./test", "./test/vite.config.ts", {
 | `options.port` | `3278` | Server port |
 | `options.base` | `/` | Base URL path |
 | `options.debug` | `false` | Write SSR fixtures to `temp/` for inspection |
+| `options.routes` | Single route from `root` and `base` | Test roots keyed by URL base path |
 
 ### CLI flags
 
@@ -256,7 +272,7 @@ before `>`.
 **`createSSRRenderer(options)`** scans for component build artifacts and returns a `{ render }` object compatible with the server's `entry-server.ts` contract. It uses the `@microsoft/fast-build` WASM module to parse f-templates and render them into declarative shadow DOM, including wrapper tags whose opening or closing `>` is preceded by ASCII whitespace.
 
 | Option | Type | Description |
-|--------|------|-------------|
+| -------- | ------ | ------------- |
 | `tagPrefix` | `string` | Tag name prefix for custom elements (e.g., `"fluent"`, `"contoso"`) |
 | `packageName` | `string?` | Monolithic package name — scans subdirectories for component artifacts. Mutually exclusive with `components`. |
 | `components` | `ComponentRegistration[]?` | Explicit list of per-component packages. Mutually exclusive with `packageName`. |
@@ -266,7 +282,7 @@ before `>`.
 ## Exports
 
 | Specifier | Contents |
-|-----------|----------|
+| ----------- | ---------- |
 | `@microsoft/fast-test-harness` | `test`, `expect`, `CSRFixture`, `SSRFixture`, `toHaveCustomState`, `installDomShim`, `createSSRRenderer` |
 | `@microsoft/fast-test-harness/build/*.js` | `installDomShim`, `generateStylesheets`, `generateFTemplates`, `generateWebuiTemplates`, `definitionAsyncResolver`, `shadowOptionsToAttributes`, `ShadowOptionsResolver` |
 | `@microsoft/fast-test-harness/fixtures/*.js` | `CSRFixture`, `SSRFixture`, `toHaveCustomState`, extended `test` and `expect` |

--- a/packages/fast-test-harness/server.mjs
+++ b/packages/fast-test-harness/server.mjs
@@ -58,8 +58,7 @@ function htmlResponse(res, statusCode, html) {
 /**
  * Try to serve a static file from `root`. Returns true if served.
  */
-async function tryServeStatic(req, res, root) {
-    const urlPath = new URL(req.url, "http://localhost").pathname;
+async function tryServeStatic(res, root, urlPath) {
     const filePath = resolve(root, `.${urlPath}`);
 
     // Prevent path traversal — reject if the resolved path escapes root.
@@ -136,7 +135,8 @@ function scopeRootRelativeUrls(html, base) {
             if (
                 value?.startsWith("/") &&
                 !value.startsWith("//") &&
-                !value.startsWith("/@")
+                !value.startsWith("/@") &&
+                !value.startsWith(base)
             ) {
                 $(element).attr(attribute, `${base}${value.slice(1)}`);
             }
@@ -445,7 +445,7 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
         if (
             !configuredRoutes?.length &&
             req.method === "GET" &&
-            (await tryServeStatic(req, res, cwd))
+            (await tryServeStatic(res, cwd, pathname))
         ) {
             return;
         }
@@ -454,6 +454,14 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
         // Vite handles its own routes; for anything left over, serve
         // the HTML shell for navigation requests.
         vite.middlewares(req, res, async () => {
+            if (
+                req.method === "GET" &&
+                route &&
+                (await tryServeStatic(res, route.root, `/${routePath}`))
+            ) {
+                return;
+            }
+
             if (!accept.includes("text/html")) {
                 res.writeHead(404).end();
                 return;

--- a/packages/fast-test-harness/server.mjs
+++ b/packages/fast-test-harness/server.mjs
@@ -87,14 +87,116 @@ async function tryServeStatic(req, res, root) {
     }
 }
 
+function normalizeBase(base) {
+    const withLeadingSlash = base.startsWith("/") ? base : `/${base}`;
+    const normalized = withLeadingSlash.replace(/\/{2,}/g, "/");
+    return normalized.endsWith("/") ? normalized : `${normalized}/`;
+}
+
+function createRoutes(root, base, configuredRoutes) {
+    const definitions = configuredRoutes?.length ? configuredRoutes : [{ base, root }];
+    const bases = new Set();
+
+    const routes = definitions.map(definition => {
+        const route = {
+            base: normalizeBase(definition.base ?? "/"),
+            root: resolve(definition.root ?? root),
+        };
+
+        if (bases.has(route.base)) {
+            throw new Error(`Duplicate test route base: ${route.base}`);
+        }
+
+        bases.add(route.base);
+        return route;
+    });
+
+    return routes.sort((a, b) => b.base.length - a.base.length);
+}
+
+function findRoute(routes, pathname) {
+    return routes.find(
+        route => pathname === route.base || pathname.startsWith(route.base),
+    );
+}
+
+function scopeRootRelativeUrls(html, base) {
+    if (base === "/") {
+        return html;
+    }
+
+    const $ = load(html, {
+        xmlMode: false,
+        decodeEntities: false,
+    });
+
+    for (const element of $("[src], [href]").toArray()) {
+        for (const attribute of ["src", "href"]) {
+            const value = $(element).attr(attribute);
+            if (
+                value?.startsWith("/") &&
+                !value.startsWith("//") &&
+                !value.startsWith("/@")
+            ) {
+                $(element).attr(attribute, `${base}${value.slice(1)}`);
+            }
+        }
+    }
+
+    return $.html();
+}
+
+/**
+ * Resolve a route-scoped Vite module ID to a file within that route's root.
+ * JavaScript IDs also fall back to matching TypeScript source files.
+ *
+ * @param {Array<{ base: string; root: string }>} routes - Configured test routes.
+ * @param {string} id - Vite module ID, optionally including a query string.
+ * @returns {Promise<string | undefined>} The resolved file path, if one exists.
+ */
+async function findRouteModule(routes, id) {
+    const pathname = id.split("?", 1)[0];
+    const route = findRoute(routes, pathname);
+    if (!route) {
+        return undefined;
+    }
+
+    const relativePath = decodeURIComponent(pathname.slice(route.base.length));
+    const filePath = resolve(route.root, relativePath);
+    const rel = relative(route.root, filePath);
+    if (rel.startsWith("..") || isAbsolute(rel)) {
+        return undefined;
+    }
+
+    const candidates = [filePath];
+    if (extname(filePath) === ".js") {
+        candidates.push(`${filePath.slice(0, -3)}.ts`);
+    }
+
+    for (const candidate of candidates) {
+        try {
+            const stat = await fs.stat(candidate);
+            if (stat.isFile()) {
+                return candidate;
+            }
+        } catch {
+            // Continue to the next source extension.
+        }
+    }
+
+    return undefined;
+}
+
 export async function startServer(cwd = process.cwd(), root, configFile, options = {}) {
     const {
         port = process.env.PORT ? Number(process.env.PORT) : 3278,
         base = process.env.BASE || "/",
         debug = process.env.FAST_DEBUG === "true",
+        routes: configuredRoutes,
     } = options;
 
-    root = root ?? resolve(cwd, "./test");
+    root = root ?? (configuredRoutes?.length ? cwd : resolve(cwd, "./test"));
+    const routes = createRoutes(root, base, configuredRoutes);
 
     try {
         await fs.access(root);
@@ -118,18 +220,24 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
         }
     }
 
-    const indexPath = resolve(root, "./index.html");
+    for (const route of routes) {
+        try {
+            await fs.access(route.root);
+        } catch {
+            console.error(`Error: Test route root does not exist: ${route.root}`);
+            process.exit(1);
+        }
 
-    let realTempDir;
-    if (debug) {
-        const tempDir = resolve(root, "temp");
-        await fs.rm(tempDir, { recursive: true, force: true });
-        await fs.mkdir(tempDir, { recursive: true });
-        realTempDir = await fs.realpath(tempDir);
+        if (debug) {
+            const tempDir = resolve(route.root, "temp");
+            await fs.rm(tempDir, { recursive: true, force: true });
+            await fs.mkdir(tempDir, { recursive: true });
+            route.tempDir = await fs.realpath(tempDir);
+        }
     }
 
     const pendingGenerations = new Map();
-    let cachedIndexHtml = null;
+    const cachedIndexHtml = new Map();
     const fixtureCache = new Map();
 
     const { createServer } = await import("vite");
@@ -140,21 +248,36 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
         server: {
             middlewareMode: true,
             watch: {
-                ignored: ["**/temp/**", "**/ssr-*.html"],
+                ignored: [
+                    "**/.nyc_output/**",
+                    "**/temp/**",
+                    "**/test-results/**",
+                    "**/visual-changes-results/**",
+                    "**/ssr-*.html",
+                ],
             },
         },
         appType: "custom",
         plugins: [
             {
+                name: "fast-test-harness:resolve-route-modules",
+                enforce: "pre",
+                async resolveId(id) {
+                    return await findRouteModule(routes, id);
+                },
+            },
+            {
                 name: "fast-test-harness:resolve-css-links",
                 transformIndexHtml: {
                     order: "pre",
-                    async handler(html) {
+                    async handler(html, context) {
                         const $ = load(html, {
                             xmlMode: false,
                             decodeEntities: false,
                         });
                         let changed = false;
+                        const route = findRoute(routes, context.path);
+                        const importer = route ? resolve(route.root, "index.html") : root;
 
                         for (const el of $("link[href$='.css']").toArray()) {
                             const href = $(el).attr("href");
@@ -168,7 +291,7 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
                             }
                             const resolved = await vite.pluginContainer.resolveId(
                                 href,
-                                root,
+                                importer,
                             );
                             if (resolved?.id) {
                                 $(el).attr("href", `/@fs/${resolved.id}`);
@@ -186,9 +309,14 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
     const server = createHttpServer(async (req, res) => {
         const url = new URL(req.url, "http://localhost");
         const pathname = url.pathname;
+        const route = findRoute(routes, pathname);
 
-        // POST /generate-fixture — SSR fixture generation.
-        if (req.method === "POST" && pathname === "/generate-fixture") {
+        // POST <base>/generate-fixture — SSR fixture generation.
+        if (
+            req.method === "POST" &&
+            route &&
+            pathname === `${route.base}generate-fixture`
+        ) {
             try {
                 const body = JSON.parse(await readBody(req));
 
@@ -211,20 +339,22 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
                 const testId = body.testId;
                 const filename = `ssr-${testId}.html`;
 
-                const fixtureUrl = `/${filename}`;
+                const fixtureUrl = `${route.base}${filename}`;
 
-                if (pendingGenerations.has(filename)) {
-                    await pendingGenerations.get(filename);
+                if (pendingGenerations.has(fixtureUrl)) {
+                    await pendingGenerations.get(fixtureUrl);
                     return jsonResponse(res, 200, { url: fixtureUrl });
                 }
 
                 const generateTask = (async () => {
                     const templateFile = await fs.readFile(
-                        resolve(root, "./ssr.html"),
+                        resolve(route.root, "./ssr.html"),
                         "utf-8",
                     );
 
-                    const { render } = await vite.ssrLoadModule("/src/entry-server.js");
+                    const { render } = await vite.ssrLoadModule(
+                        `${route.base}src/entry-server.js`,
+                    );
 
                     const { template, fixture, preloadLinks } = render(body);
 
@@ -244,23 +374,26 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
                             () => `${preloadLinks ?? ""}${styleTags}`,
                         );
 
-                    const html = await vite.transformIndexHtml(fixtureUrl, assembled);
+                    const html = await vite.transformIndexHtml(
+                        fixtureUrl,
+                        scopeRootRelativeUrls(assembled, route.base),
+                    );
 
                     fixtureCache.set(fixtureUrl, html);
 
                     if (debug) {
-                        const filePath = resolve(realTempDir, filename);
+                        const filePath = resolve(route.tempDir, filename);
                         await fs.writeFile(filePath, html, "utf-8");
                     }
                 })();
 
-                pendingGenerations.set(filename, generateTask);
+                pendingGenerations.set(fixtureUrl, generateTask);
 
                 try {
                     await generateTask;
                     jsonResponse(res, 200, { url: fixtureUrl });
                 } finally {
-                    pendingGenerations.delete(filename);
+                    pendingGenerations.delete(fixtureUrl);
                 }
             } catch (e) {
                 vite?.ssrFixStacktrace?.(e);
@@ -270,16 +403,50 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
             return;
         }
 
-        // GET /ssr-*.html — serve cached SSR fixtures.
-        if (req.method === "GET" && /^\/ssr-[^/]+\.html$/.test(pathname)) {
+        // GET <base>/ssr-*.html — serve cached SSR fixtures.
+        const routePath = route ? pathname.slice(route.base.length) : "";
+        if (req.method === "GET" && route && /^ssr-[^/]+\.html$/.test(routePath)) {
             const cached = fixtureCache.get(pathname);
             if (cached) {
                 return htmlResponse(res, 200, cached);
             }
         }
 
+        const accept = req.headers.accept || "";
+        if (
+            req.method === "GET" &&
+            route &&
+            accept.includes("text/html") &&
+            (pathname === route.base || pathname === `${route.base}index.html`)
+        ) {
+            try {
+                if (!cachedIndexHtml.has(route.base)) {
+                    const indexFile = await fs.readFile(
+                        resolve(route.root, "index.html"),
+                        "utf-8",
+                    );
+                    const scopedIndex = scopeRootRelativeUrls(indexFile, route.base);
+                    cachedIndexHtml.set(
+                        route.base,
+                        await vite.transformIndexHtml(pathname, scopedIndex),
+                    );
+                }
+
+                return htmlResponse(res, 200, cachedIndexHtml.get(route.base));
+            } catch (e) {
+                vite?.ssrFixStacktrace?.(e);
+                console.log(e.stack);
+                res.writeHead(500).end("Internal Server Error");
+                return;
+            }
+        }
+
         // Try static files from cwd.
-        if (req.method === "GET" && (await tryServeStatic(req, res, cwd))) {
+        if (
+            !configuredRoutes?.length &&
+            req.method === "GET" &&
+            (await tryServeStatic(req, res, cwd))
+        ) {
             return;
         }
 
@@ -287,22 +454,30 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
         // Vite handles its own routes; for anything left over, serve
         // the HTML shell for navigation requests.
         vite.middlewares(req, res, async () => {
-            const accept = req.headers.accept || "";
             if (!accept.includes("text/html")) {
                 res.writeHead(404).end();
                 return;
             }
 
+            if (!route) {
+                res.writeHead(404).end();
+                return;
+            }
+
             try {
-                if (!cachedIndexHtml) {
-                    const indexFile = await fs.readFile(indexPath, "utf-8");
-                    cachedIndexHtml = await vite.transformIndexHtml(
-                        req.url || "/",
-                        indexFile,
+                if (!cachedIndexHtml.has(route.base)) {
+                    const indexFile = await fs.readFile(
+                        resolve(route.root, "index.html"),
+                        "utf-8",
+                    );
+                    const scopedIndex = scopeRootRelativeUrls(indexFile, route.base);
+                    cachedIndexHtml.set(
+                        route.base,
+                        await vite.transformIndexHtml(req.url || "/", scopedIndex),
                     );
                 }
 
-                htmlResponse(res, 200, cachedIndexHtml);
+                htmlResponse(res, 200, cachedIndexHtml.get(route.base));
             } catch (e) {
                 vite?.ssrFixStacktrace?.(e);
                 console.log(e.stack);
@@ -311,7 +486,27 @@ export async function startServer(cwd = process.cwd(), root, configFile, options
         });
     });
 
-    server.listen(port, () => {
-        console.log(`Server started at http://localhost:${port}`);
-    });
+    try {
+        await new Promise((resolve, reject) => {
+            server.once("error", reject);
+            server.listen(port, resolve);
+        });
+    } catch (error) {
+        await vite.close();
+        throw error;
+    }
+
+    const address = server.address();
+    const listeningPort = typeof address === "object" && address ? address.port : port;
+    console.log(`Server started at http://localhost:${listeningPort}`);
+
+    return {
+        port: listeningPort,
+        async close() {
+            await new Promise((resolve, reject) => {
+                server.close(error => (error ? reject(error) : resolve()));
+            });
+            await vite.close();
+        },
+    };
 }

--- a/packages/fast-test-harness/server.test.ts
+++ b/packages/fast-test-harness/server.test.ts
@@ -1,0 +1,82 @@
+import assert from "node:assert/strict";
+import { mkdir, mkdtemp, rm, writeFile } from "node:fs/promises";
+import { tmpdir } from "node:os";
+import { resolve } from "node:path";
+import { test } from "node:test";
+import { startServer } from "./server.mjs";
+
+async function createTestRoot(workspace: string, name: string) {
+    const root = resolve(workspace, name, "test");
+    const source = resolve(root, "src");
+    await mkdir(source, { recursive: true });
+
+    await Promise.all([
+        writeFile(
+            resolve(root, "index.html"),
+            `<!doctype html><title>${name}</title><a href="/@vite/client">Vite</a><script type="module" src="/src/main.js"></script>`,
+        ),
+        writeFile(
+            resolve(root, "ssr.html"),
+            `<!doctype html><title><!--fixturetitle--></title><!--stylespreload--><body><!--fixture--><!--templates--><script type="module" src="/src/entry-client.js"></script></body>`,
+        ),
+        writeFile(resolve(source, "main.js"), `export const route = "${name}";`),
+        writeFile(resolve(source, "entry-client.js"), "export {};"),
+        writeFile(
+            resolve(source, "entry-server.js"),
+            `export function render(body) {
+                return {
+                    template: "",
+                    fixture: \`<p data-route="${name}">\${body.tagName}</p>\`,
+                    preloadLinks: "",
+                };
+            }`,
+        ),
+    ]);
+
+    return root;
+}
+
+test("serves independent CSR and SSR roots under separate routes", async t => {
+    const workspace = await mkdtemp(resolve(tmpdir(), "fast-test-harness-"));
+    const firstRoot = await createTestRoot(workspace, "first");
+    const secondRoot = await createTestRoot(workspace, "second");
+    const harness = await startServer(workspace, workspace, undefined, {
+        port: 0,
+        routes: [
+            { base: "/first/", root: firstRoot },
+            { base: "/second/", root: secondRoot },
+        ],
+    });
+
+    t.after(async () => {
+        await harness.close();
+        await rm(workspace, { recursive: true, force: true });
+    });
+
+    const origin = `http://localhost:${harness.port}`;
+    const navigation = { headers: { Accept: "text/html" } };
+    const firstPage = await fetch(`${origin}/first/`, navigation);
+    const secondPage = await fetch(`${origin}/second/`, navigation);
+
+    assert.equal(firstPage.status, 200);
+    const firstHtml = await firstPage.text();
+    assert.match(firstHtml, /<title>first<\/title>/);
+    assert.match(firstHtml, /href="\/@vite\/client"/);
+    assert.doesNotMatch(firstHtml, /href="\/first\/@vite\/client"/);
+    assert.match(firstHtml, /src="\/first\/src\/main\.js"/);
+    assert.equal(secondPage.status, 200);
+    assert.match(await secondPage.text(), /<title>second<\/title>/);
+
+    for (const route of ["first", "second"]) {
+        const generated = await fetch(`${origin}/${route}/generate-fixture`, {
+            method: "POST",
+            headers: { "Content-Type": "application/json" },
+            body: JSON.stringify({ testId: "shared", tagName: `${route}-element` }),
+        });
+        const result = await generated.json();
+        const fixture = await fetch(`${origin}${result.url}`);
+
+        assert.equal(result.url, `/${route}/ssr-shared.html`);
+        assert.match(await fixture.text(), new RegExp(`data-route="${route}"`));
+    }
+});

--- a/packages/fast-test-harness/server.test.ts
+++ b/packages/fast-test-harness/server.test.ts
@@ -13,11 +13,15 @@ async function createTestRoot(workspace: string, name: string) {
     await Promise.all([
         writeFile(
             resolve(root, "index.html"),
-            `<!doctype html><title>${name}</title><a href="/@vite/client">Vite</a><script type="module" src="/src/main.js"></script>`,
+            `<!doctype html><title>${name}</title><a href="/@vite/client">Vite</a><a href="/${name}/fixture">Fixture</a><script type="module" src="/src/main.js"></script>`,
         ),
         writeFile(
             resolve(root, "ssr.html"),
             `<!doctype html><title><!--fixturetitle--></title><!--stylespreload--><body><!--fixture--><!--templates--><script type="module" src="/src/entry-client.js"></script></body>`,
+        ),
+        writeFile(
+            resolve(root, "asset.svg"),
+            `<svg xmlns="http://www.w3.org/2000/svg"><title>${name}</title></svg>`,
         ),
         writeFile(resolve(source, "main.js"), `export const route = "${name}";`),
         writeFile(resolve(source, "entry-client.js"), "export {};"),
@@ -63,9 +67,16 @@ test("serves independent CSR and SSR roots under separate routes", async t => {
     assert.match(firstHtml, /<title>first<\/title>/);
     assert.match(firstHtml, /href="\/@vite\/client"/);
     assert.doesNotMatch(firstHtml, /href="\/first\/@vite\/client"/);
+    assert.match(firstHtml, /href="\/first\/fixture"/);
+    assert.doesNotMatch(firstHtml, /href="\/first\/first\/fixture"/);
     assert.match(firstHtml, /src="\/first\/src\/main\.js"/);
     assert.equal(secondPage.status, 200);
     assert.match(await secondPage.text(), /<title>second<\/title>/);
+
+    const firstAsset = await fetch(`${origin}/first/asset.svg`);
+    assert.equal(firstAsset.status, 200);
+    assert.equal(firstAsset.headers.get("content-type"), "image/svg+xml");
+    assert.match(await firstAsset.text(), /<title>first<\/title>/);
 
     for (const route of ["first", "second"]) {
         const generated = await fetch(`${origin}/${route}/generate-fixture`, {

--- a/packages/fast-test-harness/src/fixtures/base.test.ts
+++ b/packages/fast-test-harness/src/fixtures/base.test.ts
@@ -1,0 +1,59 @@
+import assert from "node:assert/strict";
+import { test } from "node:test";
+import type { Page } from "@playwright/test";
+import { CSRFixture } from "@microsoft/fast-test-harness/fixtures/csr-fixture.js";
+import { SSRFixture } from "@microsoft/fast-test-harness/fixtures/ssr-fixture.js";
+
+class TestSSRFixture extends SSRFixture {
+    protected override async waitForStability(): Promise<void> {}
+}
+
+test("CSRFixture navigates to its normalized base path", async () => {
+    let navigatedTo: string | undefined;
+    const page = {
+        goto: async (url: string) => {
+            navigatedTo = url;
+        },
+        locator: () => ({}),
+    } as unknown as Page;
+    const fixture = new CSRFixture(page, "test-element", "", [], "components/test");
+
+    await fixture.goto();
+
+    assert.equal(navigatedTo, "/components/test/");
+});
+
+test("SSRFixture generates and opens a fixture under its base path", async () => {
+    let navigatedTo: string | undefined;
+    let postedTo: string | undefined;
+    const fixtureUrl = "/components/test/ssr-fixture.html";
+    const page = {
+        goto: async (url: string) => {
+            navigatedTo = url;
+        },
+        locator: () => ({}),
+        request: {
+            post: async (url: string) => {
+                postedTo = url;
+                return {
+                    json: async () => ({ url: fixtureUrl }),
+                    ok: () => true,
+                };
+            },
+        },
+    } as unknown as Page;
+    const fixture = new TestSSRFixture(
+        page,
+        "test-element",
+        "",
+        [],
+        "fixture",
+        undefined,
+        "components/test",
+    );
+
+    await fixture.setTemplate();
+
+    assert.equal(postedTo, "/components/test/generate-fixture");
+    assert.equal(navigatedTo, fixtureUrl);
+});

--- a/packages/fast-test-harness/src/fixtures/csr-fixture.ts
+++ b/packages/fast-test-harness/src/fixtures/csr-fixture.ts
@@ -1,5 +1,10 @@
 import type { Locator, Page } from "@playwright/test";
 
+function normalizeBase(base: string): string {
+    const withLeadingSlash = base.startsWith("/") ? base : `/${base}`;
+    return withLeadingSlash.endsWith("/") ? withLeadingSlash : `${withLeadingSlash}/`;
+}
+
 export type ThemeTokens = Record<string, string | number | boolean>;
 
 /**
@@ -77,23 +82,31 @@ export class CSRFixture {
     protected readonly waitFor: string[];
 
     /**
+     * The base path for the fixture page.
+     */
+    protected readonly base: string;
+
+    /**
      * Creates an instance of the CSRFixture.
      *
      * @param page - The Playwright page object.
      * @param tagName - The tag name of the custom element.
      * @param innerHTML - The inner HTML of the custom element.
      * @param waitFor - Additional custom elements to wait for.
+     * @param base - The base path for the fixture page.
      */
     constructor(
         public readonly page: Page,
         tagName: string,
         innerHTML: string,
         waitFor: string[] = [],
+        base: string = "/",
     ) {
         this.tagName = tagName;
         this.innerHTML = innerHTML;
         this.element = this.page.locator(this.tagName);
         this.waitFor = waitFor;
+        this.base = normalizeBase(base);
     }
 
     /**
@@ -109,9 +122,9 @@ export class CSRFixture {
     /**
      * Navigates to the specified URL.
      *
-     * @param url - The URL to navigate to. Defaults to "/".
+     * @param url - The URL to navigate to. Defaults to the fixture's base path.
      */
-    async goto(url: string = "/") {
+    async goto(url: string = this.base) {
         await this.page.goto(url);
     }
 

--- a/packages/fast-test-harness/src/fixtures/index.ts
+++ b/packages/fast-test-harness/src/fixtures/index.ts
@@ -5,7 +5,12 @@ import { SSRFixture } from "./ssr-fixture.js";
 
 const isSSR = process.env.PLAYWRIGHT_TEST_SSR === "true";
 
-type FixtureOptions = {
+export type TestOptions = {
+    /**
+     * The base path of the test page and fixture generation endpoint.
+     */
+    base: string;
+
     /**
      * Additional HTML to insert into the element.
      */
@@ -31,7 +36,12 @@ export type Fixtures = {
     fastPage: CSRFixture | SSRFixture;
 };
 
-export const test = baseTest.extend<Fixtures & FixtureOptions>({
+export const test = baseTest.extend<Fixtures & TestOptions>({
+    /**
+     * The base path of the test page and fixture generation endpoint.
+     */
+    base: ["/", { option: true }],
+
     /**
      * The inner HTML to set on the fixture's custom element. This can be used
      * to provide slotted content or otherwise customize the fixture's template.
@@ -59,7 +69,7 @@ export const test = baseTest.extend<Fixtures & FixtureOptions>({
     ssr: [!!isSSR, { option: true }],
 
     async fastPage(
-        { page, innerHTML, ssr, tagName, waitFor },
+        { base, page, innerHTML, ssr, tagName, waitFor },
         use,
         testInfo,
     ): Promise<void> {
@@ -71,8 +81,8 @@ export const test = baseTest.extend<Fixtures & FixtureOptions>({
         const testTitle = ssr ? `${testInfo.titlePath.join(" › ")}` : undefined;
 
         const fastPage = ssr
-            ? new SSRFixture(page, tagName, innerHTML, waitFor, testId, testTitle)
-            : new CSRFixture(page, tagName, innerHTML, waitFor);
+            ? new SSRFixture(page, tagName, innerHTML, waitFor, testId, testTitle, base)
+            : new CSRFixture(page, tagName, innerHTML, waitFor, base);
 
         if (!ssr) {
             await fastPage.goto();

--- a/packages/fast-test-harness/src/fixtures/ssr-fixture.ts
+++ b/packages/fast-test-harness/src/fixtures/ssr-fixture.ts
@@ -34,6 +34,7 @@ export class SSRFixture extends CSRFixture {
      * @param waitFor - Additional custom elements to wait for.
      * @param testId - The test ID for the SSR fixture.
      * @param testTitle - The test title for the SSR fixture.
+     * @param base - The base path for the fixture page.
      */
     constructor(
         page: Page,
@@ -42,8 +43,9 @@ export class SSRFixture extends CSRFixture {
         waitFor: string[] = [],
         private readonly testId?: string,
         private readonly testTitle?: string,
+        base: string = "/",
     ) {
-        super(page, tagName, innerHTML, waitFor);
+        super(page, tagName, innerHTML, waitFor, base);
     }
 
     /**
@@ -122,7 +124,7 @@ export class SSRFixture extends CSRFixture {
             );
         }
 
-        const response = await this.page.request.post("/generate-fixture", {
+        const response = await this.page.request.post(`${this.base}generate-fixture`, {
             data: body,
         });
 

--- a/packages/fast-test-harness/src/index.ts
+++ b/packages/fast-test-harness/src/index.ts
@@ -9,7 +9,7 @@ export {
     type TemplateOrOptions,
     type ThemeTokens,
 } from "./fixtures/csr-fixture.js";
-export { expect, type Fixtures, test } from "./fixtures/index.js";
+export { expect, type Fixtures, type TestOptions, test } from "./fixtures/index.js";
 export { SSRFixture } from "./fixtures/ssr-fixture.js";
 export {
     type ComponentRegistration,


### PR DESCRIPTION
# Pull Request

## 📖 Description

Add multi-package routing to `@microsoft/fast-test-harness` so one server can host multiple component test roots. Each route gets its own CSR shell, SSR endpoint, fixture cache, and static assets.

Tests select a route with `test.use({ base })`, while server consumers configure matching `{ base, root }` entries through `startServer(..., { routes })`. Existing single-root configuration remains the default.

### 🎫 Issues

- Closes [#7678](https://github.com/microsoft/fast/issues/7678)

## 📑 Test Plan

- Run `npm run test:node -w @microsoft/fast-test-harness`.
- Verify CSR and SSR fixtures resolve under separate route bases, including route-local static assets.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Agents

- [x] I have linked to an existing issue in this project that this change addresses
- [x] I have read the skills
- [x] I have read the DESIGN.md file(s) in packages relevant to my changes
- [x] I have updated the DESIGN.md file(s) in packages relevant to my changes