### PR TITLE
chore: mark deploy job as a release job

### DIFF
--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -93,6 +93,9 @@ extends:
         fastTestHarnessReleaseTag: $[ stageDependencies.Check.CheckVersion.outputs['deploymentCheck.fastTestHarnessReleaseTag'] ]
       jobs:
       - job: Deploy
+        templateContext:
+          type: releaseJob
+          isProduction: true
         steps:
           - checkout: self
             persistCredentials: "true"


### PR DESCRIPTION
# Pull Request

## 📖 Description

Marks the npm and crates.io `Deploy` job as a production 1ES release job. This addresses the 1ES PT release-task enforcement finding for the ESRP release task and prevents the job from being blocked when enforcement becomes mandatory.

## 👩‍💻 Reviewer Notes

Confirm that the **Publish tarballs to npm and crates.io** pipeline recognizes `Deploy` as a production release job and no longer reports the release-task enforcement warning.

## 📑 Test Plan

- Parsed `azure-pipelines-cd.yml` and verified the `Deploy` release-job metadata.
- Ran `npm run build`.
- Ran `npm run test`.
- Ran `npm run biome:check`.
- Ran `npm run format:check`.
- Ran `npm run checkchange`.
- Ran `git diff --check`.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Agents

- [ ] I have linked to an existing issue in this project that this change addresses
- [x] I have read the skills
- [ ] I have read the DESIGN.md file(s) in packages relevant to my changes
- [ ] I have updated the DESIGN.md file(s) in packages relevant to my changes
