### PR TITLE
Fix: full network isolation pass, strick CFS CLEAN

### DIFF
--- a/azure-pipelines-bench.yml
+++ b/azure-pipelines-bench.yml
@@ -37,7 +37,7 @@ extends:
         image: HostedPoolWindowsImage  # Name of the image in your pool. If not specified, first image of the pool is used
         os: windows  # OS of the image. Allowed values: windows, linux, macOS
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: CFSClean
     stages:
     - stage: Stage
       jobs:

--- a/azure-pipelines-cd.yml
+++ b/azure-pipelines-cd.yml
@@ -38,7 +38,7 @@ extends:
         image: HostedPoolWindowsImage  # Name of the image in your pool. If not specified, first image of the pool is used
         os: windows  # OS of the image. Allowed values: windows, linux, macOS
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: CFSClean
     stages:
 
     # ── Stage 1: Lightweight detection (runs every night, ~1-2 min) ──

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -67,6 +67,10 @@ extends:
             displayName: "Cache npm"
 
           - template: FAST.CFS.PipelineTemplate.yml@fastPipelines
+            parameters:
+              installRust: true
+              rustVersion: "1.93"
+              additionalRustTargets: wasm32-unknown-unknown
 
           - script: |
               npm ci
@@ -74,14 +78,12 @@ extends:
 
           - script: |
               set -euo pipefail
-              rustup show active-toolchain
               rustc --version
               cargo --version
               export PATH="$CARGO_HOME/bin:$PATH"
               echo "##vso[task.prependpath]$CARGO_HOME/bin"
-              rustup target add wasm32-unknown-unknown
               cargo install wasm-pack
-            displayName: "Configure Rust and install wasm-pack"
+            displayName: "Install wasm-pack"
 
           - script: |
               npm run build

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -82,7 +82,7 @@ extends:
               cargo --version
               export PATH="$CARGO_HOME/bin:$PATH"
               echo "##vso[task.prependpath]$CARGO_HOME/bin"
-              cargo install wasm-pack
+              cargo install --registry openSource_PublicPackages wasm-pack
             displayName: "Install wasm-pack"
 
           - script: |

--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -33,7 +33,7 @@ extends:
         image: HostedPoolWindowsImage  # Name of the image in your pool. If not specified, first image of the pool is used
         os: windows  # OS of the image. Allowed values: windows, linux, macOS
     settings:
-      networkIsolationPolicy: Permissive,CFSClean
+      networkIsolationPolicy: CFSClean
     stages:
     - stage: Stage
       jobs:
@@ -73,12 +73,15 @@ extends:
             displayName: "Install package dependencies"
 
           - script: |
-              curl --proto '=https' --tlsv1.2 -sSf https://sh.rustup.rs | sh -s -- -y --default-toolchain stable
+              set -euo pipefail
+              rustup show active-toolchain
+              rustc --version
+              cargo --version
               export PATH="$CARGO_HOME/bin:$PATH"
               echo "##vso[task.prependpath]$CARGO_HOME/bin"
               rustup target add wasm32-unknown-unknown
               cargo install wasm-pack
-            displayName: "Install Rust and wasm-pack"
+            displayName: "Configure Rust and install wasm-pack"
 
           - script: |
               npm run build


### PR DESCRIPTION
# Pull Request

## 📖 Description

Enables strict `CFSClean` network isolation across CI, benchmark, and CD pipelines.

CI now installs the approved Rust toolchain and restores `wasm-pack` through the authenticated CFS Cargo registry.

## 👩‍💻 Reviewer Notes

Verify the pipeline uses `openSource_PublicPackages` for Rust toolchain and Cargo restores without contacting public package feeds.

## 📑 Test Plan

- Validated pipeline YAML syntax.
- Confirmed strict network isolation enters enforcement mode.
- Rerun CI to verify the complete Rust and `wasm-pack` installation path.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Agents

- [ ] I have linked to an existing issue in this project that this change addresses
- [x] I have read the skills
- [ ] I have read the DESIGN.md file(s) in packages relevant to my changes
- [ ] I have updated the DESIGN.md file(s) in packages relevant to my changes

## ⏭ Next Steps

Validate the benchmark and CD workflows under strict network isolation.