### PR TITLE
Revert trusted types change

### DIFF
--- a/change/@microsoft-fast-element-707b16f5-3d8b-48d2-9c14-63aa1b18a782.json
+++ b/change/@microsoft-fast-element-707b16f5-3d8b-48d2-9c14-63aa1b18a782.json
@@ -1,0 +1,7 @@
+{
+  "type": "patch",
+  "comment": "Restore the built-in Trusted Types policy name to `fast-html`.",
+  "packageName": "@microsoft/fast-element",
+  "email": "7559015+janechu@users.noreply.github.com",
+  "dependentChangeType": "none"
+}

--- a/packages/fast-element/SIZES.md
+++ b/packages/fast-element/SIZES.md
@@ -4,22 +4,22 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 78.79 KB | 23.43 KB | 20.84 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.11 KB | 7.12 KB | 6.41 KB |
+| CDN Rollup Bundle | 78.78 KB | 23.43 KB | 20.84 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.10 KB | 7.12 KB | 6.42 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 290 B |
 | Observable (@microsoft/fast-element/observable.js) | 6.75 KB | 2.51 KB | 2.23 KB |
 | observable (@microsoft/fast-element/observable.js) | 6.79 KB | 2.52 KB | 2.24 KB |
 | attr (@microsoft/fast-element/attr.js) | 477 B | 287 B | 244 B |
-| children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.66 KB |
+| children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.65 KB |
 | ref (@microsoft/fast-element/ref.js) | 3.84 KB | 1.54 KB | 1.34 KB |
 | slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
 | volatile (@microsoft/fast-element/volatile.js) | 6.84 KB | 2.54 KB | 2.26 KB |
 | when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 589 B |
-| html (@microsoft/fast-element/html.js) | 27.91 KB | 8.98 KB | 8.04 KB |
+| html (@microsoft/fast-element/html.js) | 27.91 KB | 8.99 KB | 8.05 KB |
 | repeat (@microsoft/fast-element/repeat.js) | 31.80 KB | 10.00 KB | 9.03 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
 | enableHydration (@microsoft/fast-element/hydration.js) | 46.71 KB | 13.94 KB | 12.51 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.33 KB | 19.49 KB | 17.46 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.33 KB | 19.50 KB | 17.48 KB |
 | ArrayObserver (@microsoft/fast-element/arrays.js) | 12.55 KB | 4.46 KB | 4.03 KB |
 | observerMap (@microsoft/fast-element/observer-map.js) | 21.96 KB | 7.73 KB | 6.97 KB |
 | attributeMap (@microsoft/fast-element/attribute-map.js) | 15.31 KB | 5.41 KB | 4.88 KB |

--- a/packages/fast-element/src/dom-policy.pw.spec.ts
+++ b/packages/fast-element/src/dom-policy.pw.spec.ts
@@ -11,7 +11,7 @@ test.describe("the dom policy helper", () => {
             };
 
             return globalThis.trustedTypes
-                ? globalThis.trustedTypes.createPolicy("fast-element", { createHTML })
+                ? globalThis.trustedTypes.createPolicy("app-fast-html", { createHTML })
                 : { createHTML };
         }
 
@@ -19,6 +19,44 @@ test.describe("the dom policy helper", () => {
         policy.createHTML("Hello world");
 
         expect(invoked).toBe(true);
+    });
+
+    test("uses the fast-html trusted types policy name by default", async ({ page }) => {
+        await page.addInitScript(() => {
+            const policyNames: string[] = [];
+            const trustedTypes = globalThis.trustedTypes;
+            const createPolicy = (name: string, rules: TrustedTypePolicyOptions) => {
+                policyNames.push(name);
+                return rules;
+            };
+
+            Object.defineProperty(globalThis, "fastPolicyNames", {
+                value: policyNames,
+            });
+
+            if (trustedTypes) {
+                Object.defineProperty(trustedTypes, "createPolicy", {
+                    value: createPolicy,
+                });
+            } else {
+                Object.defineProperty(globalThis, "trustedTypes", {
+                    value: { createPolicy },
+                });
+            }
+        });
+        await page.goto("/");
+
+        const policyNames = await page.evaluate(async () => {
+            // @ts-expect-error: Client modules.
+            const { DOMPolicy } = await import("./main.js");
+            const names = Reflect.get(globalThis, "fastPolicyNames");
+
+            DOMPolicy.create();
+
+            return names;
+        });
+
+        expect(policyNames).toEqual(["fast-html", "fast-html"]);
     });
 
     test("can create a policy with custom element guards", async ({ page }) => {

--- a/packages/fast-element/src/dom-policy.ts
+++ b/packages/fast-element/src/dom-policy.ts
@@ -477,7 +477,7 @@ function createDOMGuards(config: Partial<DOMGuards>, defaults: DOMGuards): DOMGu
 function createTrustedType() {
     const createHTML = html => html;
     return globalThis.trustedTypes
-        ? globalThis.trustedTypes.createPolicy("fast-element", { createHTML })
+        ? globalThis.trustedTypes.createPolicy("fast-html", { createHTML })
         : { createHTML };
 }
 

--- a/packages/fast-element/src/dom.ts
+++ b/packages/fast-element/src/dom.ts
@@ -68,7 +68,7 @@ export interface DOMPolicy extends DOMPolicyDefinition {}
 
 const createHTML = html => html;
 const fastTrustedType: TrustedTypesPolicy = globalThis.trustedTypes
-    ? globalThis.trustedTypes.createPolicy("fast-element", { createHTML })
+    ? globalThis.trustedTypes.createPolicy("fast-html", { createHTML })
     : { createHTML };
 
 let defaultPolicy: DOMPolicyDefinition = Object.freeze({

--- a/sites/website/src/docs/3.x/advanced/dom-policy-and-trusted-types.md
+++ b/sites/website/src/docs/3.x/advanced/dom-policy-and-trusted-types.md
@@ -46,7 +46,7 @@ const trustedType = globalThis.trustedTypes?.createPolicy("app-fast-html", {
 DOM.setPolicy(DOMPolicy.create({ trustedType }));
 ```
 
-If your Content Security Policy uses a `trusted-types` directive, the policy name you create must be allowed by that directive. If you rely on FAST's built-in Trusted Types policy, allow the `fast-element` policy name.
+If your Content Security Policy uses a `trusted-types` directive, the policy name you create must be allowed by that directive. If you rely on FAST's built-in Trusted Types policy, allow the `fast-html` policy name.
 
 :::important
 Application owners should configure the global policy. Reusable component libraries should not call `DOM.setPolicy()` because doing so would prevent the host application from installing its own policy.
@@ -61,7 +61,7 @@ Application owners should configure the global policy. Reusable component librar
 | `createHTML(value)` | Converts the HTML string passed to template compilation into trusted HTML before FAST assigns it to a `<template>` element's `innerHTML`. |
 | `protect(tagName, aspect, aspectName, sink)` | Returns the DOM sink FAST should use when a binding writes to an attribute, property, content node, token list, or event. |
 
-By default, `DOMPolicy.create()` creates a Trusted Types policy named `fast-element` when `globalThis.trustedTypes` is available. It also installs guard rules for common dangerous sinks, including inline event attributes, `innerHTML`, selected URL attributes/properties, script text, and `iframe[srcdoc]`.
+By default, `DOMPolicy.create()` creates a Trusted Types policy named `fast-html` when `globalThis.trustedTypes` is available. It also installs guard rules for common dangerous sinks, including inline event attributes, `innerHTML`, selected URL attributes/properties, script text, and `iframe[srcdoc]`.
 
 You can extend or replace guards for your own application requirements. The guard receives the sink FAST would normally call and returns the sink FAST should call instead.
 

--- a/sites/website/src/docs/3.x/resources/export-sizes.md
+++ b/sites/website/src/docs/3.x/resources/export-sizes.md
@@ -19,22 +19,22 @@ Bundle sizes for `@microsoft/fast-element` exports.
 
 | Export | Minified | Gzip | Brotli |
 |--------|----------|------|--------|
-| CDN Rollup Bundle | 78.79 KB | 23.43 KB | 20.84 KB |
-| FASTElement (@microsoft/fast-element/fast-element.js) | 23.11 KB | 7.12 KB | 6.41 KB |
+| CDN Rollup Bundle | 78.78 KB | 23.43 KB | 20.84 KB |
+| FASTElement (@microsoft/fast-element/fast-element.js) | 23.10 KB | 7.12 KB | 6.42 KB |
 | Updates (@microsoft/fast-element/updates.js) | 473 B | 335 B | 290 B |
 | Observable (@microsoft/fast-element/observable.js) | 6.75 KB | 2.51 KB | 2.23 KB |
 | observable (@microsoft/fast-element/observable.js) | 6.79 KB | 2.52 KB | 2.24 KB |
 | attr (@microsoft/fast-element/attr.js) | 477 B | 287 B | 244 B |
-| children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.66 KB |
+| children (@microsoft/fast-element/children.js) | 4.87 KB | 1.88 KB | 1.65 KB |
 | ref (@microsoft/fast-element/ref.js) | 3.84 KB | 1.54 KB | 1.34 KB |
 | slotted (@microsoft/fast-element/slotted.js) | 4.66 KB | 1.81 KB | 1.59 KB |
 | volatile (@microsoft/fast-element/volatile.js) | 6.84 KB | 2.54 KB | 2.26 KB |
 | when (@microsoft/fast-element/when.js) | 1.88 KB | 731 B | 589 B |
-| html (@microsoft/fast-element/html.js) | 27.91 KB | 8.98 KB | 8.04 KB |
+| html (@microsoft/fast-element/html.js) | 27.91 KB | 8.99 KB | 8.05 KB |
 | repeat (@microsoft/fast-element/repeat.js) | 31.80 KB | 10.00 KB | 9.03 KB |
 | css (@microsoft/fast-element/css.js) | 2.43 KB | 1.00 KB | 911 B |
 | enableHydration (@microsoft/fast-element/hydration.js) | 46.71 KB | 13.94 KB | 12.51 KB |
-| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.33 KB | 19.49 KB | 17.46 KB |
+| declarativeTemplate (@microsoft/fast-element/declarative.js) | 62.33 KB | 19.50 KB | 17.48 KB |
 | ArrayObserver (@microsoft/fast-element/arrays.js) | 12.55 KB | 4.46 KB | 4.03 KB |
 | observerMap (@microsoft/fast-element/observer-map.js) | 21.96 KB | 7.73 KB | 6.97 KB |
 | attributeMap (@microsoft/fast-element/attribute-map.js) | 15.31 KB | 5.41 KB | 4.88 KB |


### PR DESCRIPTION
# Pull Request

## 📖 Description

This change reverts a mistake during the 3.x major changes which changed the trusted types policy from fast-html to fast-element.

## ✅ Checklist

### General

- [x] I have included a change request file using `$ npm run change`
- [x] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.