### PR TITLE
chore: release packages

### DIFF
--- a/change/@microsoft-fast-element-707b16f5-3d8b-48d2-9c14-63aa1b18a782.json
+++ b/change/@microsoft-fast-element-707b16f5-3d8b-48d2-9c14-63aa1b18a782.json
@@ -1,7 +1,0 @@
-{
-  "type": "patch",
-  "comment": "Restore the built-in Trusted Types policy name to `fast-html`.",
-  "packageName": "@microsoft/fast-element",
-  "email": "7559015+janechu@users.noreply.github.com",
-  "dependentChangeType": "none"
-}

--- a/examples/csr/todo-app/package.json
+++ b/examples/csr/todo-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^3.0.2",
+    "@microsoft/fast-element": "^3.0.3",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "tslib": "^2.6.3"
   },

--- a/examples/csr/todo-mobx-app/package.json
+++ b/examples/csr/todo-mobx-app/package.json
@@ -22,7 +22,7 @@
     "directory": "examples/csr/todo-mobx-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^3.0.2",
+    "@microsoft/fast-element": "^3.0.3",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "mobx": "^6.13.5",
     "tslib": "^2.6.3"

--- a/examples/ssr/chat-app/package.json
+++ b/examples/ssr/chat-app/package.json
@@ -23,7 +23,7 @@
     "directory": "examples/ssr/chat-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^3.0.2",
+    "@microsoft/fast-element": "^3.0.3",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "tslib": "^2.6.3"
   },

--- a/examples/ssr/webui-todo-app/package.json
+++ b/examples/ssr/webui-todo-app/package.json
@@ -25,7 +25,7 @@
     "directory": "examples/ssr/webui-todo-app"
   },
   "dependencies": {
-    "@microsoft/fast-element": "^3.0.2",
+    "@microsoft/fast-element": "^3.0.3",
     "@microsoft/fast-examples-design-system": "^1.0.0",
     "@microsoft/webui": "^0.0.12",
     "tslib": "^2.6.3"

--- a/package-lock.json
+++ b/package-lock.json
@@ -52,7 +52,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^3.0.2",
+        "@microsoft/fast-element": "^3.0.3",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "tslib": "^2.6.3"
       },
@@ -66,7 +66,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^3.0.2",
+        "@microsoft/fast-element": "^3.0.3",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "mobx": "^6.13.5",
         "tslib": "^2.6.3"
@@ -82,7 +82,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^3.0.2",
+        "@microsoft/fast-element": "^3.0.3",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "tslib": "^2.6.3"
       },
@@ -95,7 +95,7 @@
       "version": "1.0.0",
       "license": "MIT",
       "dependencies": {
-        "@microsoft/fast-element": "^3.0.2",
+        "@microsoft/fast-element": "^3.0.3",
         "@microsoft/fast-examples-design-system": "^1.0.0",
         "@microsoft/webui": "^0.0.12",
         "tslib": "^2.6.3"
@@ -6022,7 +6022,7 @@
     },
     "packages/fast-element": {
       "name": "@microsoft/fast-element",
-      "version": "3.0.2",
+      "version": "3.0.3",
       "license": "MIT"
     },
     "packages/fast-router": {
@@ -6033,10 +6033,10 @@
         "tslib": "^2.6.3"
       },
       "devDependencies": {
-        "@microsoft/fast-element": "^3.0.2"
+        "@microsoft/fast-element": "^3.0.3"
       },
       "peerDependencies": {
-        "@microsoft/fast-element": "^3.0.2"
+        "@microsoft/fast-element": "^3.0.3"
       }
     },
     "packages/fast-test-harness": {
@@ -6051,14 +6051,14 @@
       },
       "devDependencies": {
         "@microsoft/fast-build": "^0.10.0",
-        "@microsoft/fast-element": "^3.0.2"
+        "@microsoft/fast-element": "^3.0.3"
       },
       "engines": {
         "node": ">=22.18.0"
       },
       "peerDependencies": {
         "@microsoft/fast-build": "^0.10.0",
-        "@microsoft/fast-element": "^3.0.2",
+        "@microsoft/fast-element": "^3.0.3",
         "@playwright/test": ">=1.40.0",
         "vite": ">=7.0.0"
       },
@@ -6076,7 +6076,7 @@
       "version": "0.0.0",
       "dependencies": {
         "@microsoft/fast-build": "^0.10.0",
-        "@microsoft/fast-element": "^3.0.2"
+        "@microsoft/fast-element": "^3.0.3"
       }
     },
     "sites/website": {
@@ -6091,7 +6091,7 @@
       },
       "devDependencies": {
         "@microsoft/fast-build": "^0.10.0",
-        "@microsoft/fast-element": "^3.0.2"
+        "@microsoft/fast-element": "^3.0.3"
       }
     }
   }

--- a/packages/fast-element/CHANGELOG.json
+++ b/packages/fast-element/CHANGELOG.json
@@ -2,6 +2,21 @@
   "name": "@microsoft/fast-element",
   "entries": [
     {
+      "date": "Thu, 10 Sep 2026 02:52:27 GMT",
+      "version": "3.0.3",
+      "tag": "@microsoft/fast-element_v3.0.3",
+      "comments": {
+        "patch": [
+          {
+            "author": "7559015+janechu@users.noreply.github.com",
+            "package": "@microsoft/fast-element",
+            "commit": "896537217c159fecb97f4761645dad8fc31798bb",
+            "comment": "Restore the built-in Trusted Types policy name to `fast-html`."
+          }
+        ]
+      }
+    },
+    {
       "date": "Wed, 29 Jul 2026 19:34:55 GMT",
       "version": "3.0.2",
       "tag": "@microsoft/fast-element_v3.0.2",

--- a/packages/fast-element/CHANGELOG.md
+++ b/packages/fast-element/CHANGELOG.md
@@ -1,8 +1,16 @@
 # Change Log - @microsoft/fast-element
 
-<!-- This log was last generated on Wed, 29 Jul 2026 19:34:55 GMT and should not be manually modified. -->
+<!-- This log was last generated on Thu, 10 Sep 2026 02:52:27 GMT and should not be manually modified. -->
 
 <!-- Start content -->
+
+## 3.0.3
+
+Thu, 10 Sep 2026 02:52:27 GMT
+
+### Patches
+
+- Restore the built-in Trusted Types policy name to `fast-html`. (7559015+janechu@users.noreply.github.com)
 
 ## 3.0.2
 

--- a/packages/fast-element/package.json
+++ b/packages/fast-element/package.json
@@ -1,7 +1,7 @@
 {
   "name": "@microsoft/fast-element",
   "description": "A library for constructing Web Components",
-  "version": "3.0.2",
+  "version": "3.0.3",
   "author": {
     "name": "Microsoft",
     "url": "https://discord.gg/FcSNfg4"

--- a/packages/fast-router/package.json
+++ b/packages/fast-router/package.json
@@ -43,10 +43,10 @@
     "tslib": "^2.6.3"
   },
   "devDependencies": {
-    "@microsoft/fast-element": "^3.0.2"
+    "@microsoft/fast-element": "^3.0.3"
   },
   "peerDependencies": {
-    "@microsoft/fast-element": "^3.0.2"
+    "@microsoft/fast-element": "^3.0.3"
   },
   "beachball": {
     "disallowedChangeTypes": [

--- a/packages/fast-test-harness/package.json
+++ b/packages/fast-test-harness/package.json
@@ -72,14 +72,14 @@
   ],
   "devDependencies": {
     "@microsoft/fast-build": "^0.10.0",
-    "@microsoft/fast-element": "^3.0.2"
+    "@microsoft/fast-element": "^3.0.3"
   },
   "dependencies": {
     "cheerio": "1.2.0"
   },
   "peerDependencies": {
     "@microsoft/fast-build": "^0.10.0",
-    "@microsoft/fast-element": "^3.0.2",
+    "@microsoft/fast-element": "^3.0.3",
     "@playwright/test": ">=1.40.0",
     "vite": ">=7.0.0"
   },

--- a/sites/benchmarks/package.json
+++ b/sites/benchmarks/package.json
@@ -11,6 +11,6 @@
   },
   "dependencies": {
     "@microsoft/fast-build": "^0.10.0",
-    "@microsoft/fast-element": "^3.0.2"
+    "@microsoft/fast-element": "^3.0.3"
   }
 }

--- a/sites/website/package.json
+++ b/sites/website/package.json
@@ -31,6 +31,6 @@
   },
   "devDependencies": {
     "@microsoft/fast-build": "^0.10.0",
-    "@microsoft/fast-element": "^3.0.2"
+    "@microsoft/fast-element": "^3.0.3"
   }
 }


### PR DESCRIPTION
# Pull Request

## 📖 Description

Release `@microsoft/fast-element` 3.0.3 with the patch that restores the built-in Trusted Types policy name to `fast-html`.

This bump consumes the accumulated Beachball change file, updates the FAST Element changelogs, and synchronizes workspace dependency ranges to `^3.0.3`.

## 👩‍💻 Reviewer Notes

Please verify that only `@microsoft/fast-element` is version-bumped and that the dependent workspace ranges, lockfile, and changelogs consistently reference 3.0.3.

## 📑 Test Plan

- `npm run build`
- `npm run test`
- `npm run checkchange`
- `node build/scripts/create-github-releases.mjs --check-only`

The release preview identifies only `@microsoft/fast-element@3.0.3`.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [x] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Agents

- [ ] I have linked to an existing issue in this project that this change addresses
- [x] I have read the skills
- [ ] I have read the DESIGN.md file(s) in packages relevant to my changes
- [ ] I have updated the DESIGN.md file(s) in packages relevant to my changes
