### PR TITLE
fix: allow Azure CI for fork pull requests

### DIFF
--- a/azure-pipelines-ci.yml
+++ b/azure-pipelines-ci.yml
@@ -51,7 +51,6 @@ extends:
 
         steps:
           - checkout: self
-            persistCredentials: "true"
 
           - task: UseNode@1
             inputs:


### PR DESCRIPTION
# Pull Request

## 📖 Description

Allows Azure CI to run for pull requests from forks by removing persisted checkout
credentials from the validation pipeline.

Fork builds do not receive `System.AccessToken`, but `persistCredentials: true` caused the
checkout step to require that unavailable token. The CI job only needs read access and does
not perform authenticated Git operations, so credentials do not need to be persisted.

## 📑 Test Plan

- Confirm a pull request from a fork completes the Azure checkout and enters the build.
- Confirm ordinary pull requests and `main` builds continue to check out and build normally.

## ✅ Checklist

### General

- [ ] I have included a change request file using `$ npm run change`
- [ ] I have added tests for my changes.
- [x] I have tested my changes.
- [ ] I have updated the project documentation to reflect my changes.
- [x] I have read the [CONTRIBUTING](https://github.com/microsoft/fast/blob/main/CONTRIBUTING.md) documentation and followed the [standards](https://github.com/microsoft/fast/blob/main/CODE_OF_CONDUCT.md#our-standards) for this project.

### Agents

- [ ] I have linked to an existing issue in this project that this change addresses
- [x] I have read the skills
- [ ] I have read the DESIGN.md file(s) in packages relevant to my changes
- [ ] I have updated the DESIGN.md file(s) in packages relevant to my changes
